### PR TITLE
Fix a warning

### DIFF
--- a/src/tools/gen_code/gen_code.c
+++ b/src/tools/gen_code/gen_code.c
@@ -3613,9 +3613,9 @@ static void printFuncHeaderDoc( FILE *out,
    int first;
 
    fprintf( out, "%sTA_%s - %s\n", prefix, funcInfo->name, funcInfo->hint );
-   fprintf( out, prefix );
+   fprintf( out, "%s\n", prefix );
 
-   fprintf( out, "\n" );
+
    fprintf( out, "%sInput  = ", prefix );
    for( paramNb=0; paramNb < funcInfo->nbInput; paramNb++ )
    {


### PR DESCRIPTION
This change fixes a warning in gen_code.c:
```
$ gcc -ldl -I /usr/local/include  -I ../../../include -I ../../ta_common -I ../../ta_abstract -I ../../ta_abstract/tables -I ../../ta_abstract/frames -D TA_GEN_CODE  *.c ../../ta_abstract/ta_abstract.c ../../ta_abstract/ta_def_ui.c ../../ta_abstract/tables/*.c ../../ta_common/*.c  -o ../../../bin/gen_code

gen_code.c: In function ‘printFuncHeaderDoc’:
gen_code.c:3615:4: warning: format not a string literal and no format arguments [-Wformat-security]
 3615 |    fprintf( out, prefix );
      |    ^~~~~~~
```

It replaces a pair of ` fprintf( out, prefix );  fprintf( out, "\n" );` with ` fprintf( out, "%s\n", prefix );`.
The problem is that on [some](https://stackoverflow.com/questions/73631645/ta-lib-replit-python-install-problem-error-no-matching-distribution-found-for/73648628?noredirect=1#comment130161893_73648628) systems the build process may be configured by default in a way it treats warnings as errors ( [-Wall](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wall) and [-Werror](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wall) compiler options). In this case build process fails. The TA-Lib library still can be used as gen_code tool is compiling after it and it's not need for TA-Lib library itself (only for a new technical indicators generation). So users may skip this error and continue, but it's hard to explain to them.
