### PR TITLE
Fix a warning

### DIFF
--- a/src/tools/ta_regtest/ta_test_func/test_per_ema.c
+++ b/src/tools/ta_regtest/ta_test_func/test_per_ema.c
@@ -194,6 +194,7 @@ static TA_RetCode rangeTestFunction( TA_Integer    startIdx,
                          outNbElement,
                          outputBuffer );
       *lookback = TA_TRIX_Lookback( testParam->test->optInTimePeriod );
+      break;
    default:
       retCode = TA_INTERNAL_ERROR(131);
    } 


### PR DESCRIPTION
Clang-tydy produces a lot of warnings but only this one seems to be a bug. 
retCode is always TA_INTERNAL_ERROR(131);