### PR TITLE
Allow for Debian 11 and Ubuntu 22.04 LTS support with lower version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.18)
 
 project(ta-lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
+if (CMAKE_VERSION VERSION_LESS "3.30" AND WIN32)
+    message(FATAL_ERROR "For Windows systems you need CMake Version 3.30")
+endif (CMAKE_VERSION VERSION_LESS "3.30" AND WIN32)
 
 project(ta-lib)
 


### PR DESCRIPTION
CMake 3.30 is too strict and the code builds just fine on Cmake 3.18 and 3.22 which are on Debian 11 and Ubuntu 22.04 LTS. 

The library has been in existence for  decades and forcing it to only work on most recent CMake's is a detriment to long term users and downstream applications that use this library.