### PR TITLE
perf(minmax): unroll batch rescan loops

### DIFF
--- a/include/ta_common.h
+++ b/include/ta_common.h
@@ -151,7 +151,7 @@ TA_LIB_API TA_RetCode TA_Shutdown( void );
  * This value is updated whenever a make, cmake or any source files
  * modification should trig a repackaging of TA-Lib.
  */
-#define TA_LIB_SOURCES_DIGEST 2f2afcea23151d63b3957a0636e8df83
+#define TA_LIB_SOURCES_DIGEST 25d4faee56d7415dac044d8591341c80
 
 #ifdef __cplusplus
 }

--- a/src/ta_func/ta_MAX.c
+++ b/src/ta_func/ta_MAX.c
@@ -135,6 +135,11 @@ TA_LIB_API TA_RetCode TA_MAX( int    startIdx,
          highestIdx = trailingIdx;
          highest = inReal[highestIdx];
          i = highestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = inReal[i];
@@ -202,6 +207,11 @@ TA_LIB_API TA_RetCode TA_MAX_Unguarded( int    startIdx,
          highestIdx = trailingIdx;
          highest = inReal[highestIdx];
          i = highestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = inReal[i];
@@ -280,6 +290,11 @@ TA_RetCode TA_S_MAX( int    startIdx,
          highestIdx = trailingIdx;
          highest = (double)inReal[highestIdx];
          i = highestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = (double)inReal[i];
@@ -344,6 +359,11 @@ TA_RetCode TA_S_MAX_Unguarded( int    startIdx,
          highestIdx = trailingIdx;
          highest = (double)inReal[highestIdx];
          i = highestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = (double)inReal[i];

--- a/src/ta_func/ta_MIN.c
+++ b/src/ta_func/ta_MIN.c
@@ -135,6 +135,11 @@ TA_LIB_API TA_RetCode TA_MIN( int    startIdx,
          lowestIdx = trailingIdx;
          lowest = inReal[lowestIdx];
          i = lowestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = inReal[i];
@@ -202,6 +207,11 @@ TA_LIB_API TA_RetCode TA_MIN_Unguarded( int    startIdx,
          lowestIdx = trailingIdx;
          lowest = inReal[lowestIdx];
          i = lowestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = inReal[i];
@@ -280,6 +290,11 @@ TA_RetCode TA_S_MIN( int    startIdx,
          lowestIdx = trailingIdx;
          lowest = (double)inReal[lowestIdx];
          i = lowestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = (double)inReal[i];
@@ -344,6 +359,11 @@ TA_RetCode TA_S_MIN_Unguarded( int    startIdx,
          lowestIdx = trailingIdx;
          lowest = (double)inReal[lowestIdx];
          i = lowestIdx;
+#if defined(__clang__)
+#pragma clang loop unroll_count(4)
+#elif defined(__GNUC__) && __GNUC__ >= 8
+#pragma GCC unroll 4
+#endif
          while( ++i <= today )
          {
             tmp = (double)inReal[i];

--- a/ta_codegen/generator/src/backends/c.rs
+++ b/ta_codegen/generator/src/backends/c.rs
@@ -71,7 +71,28 @@ struct CRenderCtx<'a> {
     /// so callers may pass NULL to discard it. Empty for every non-body render
     /// pass (helpers, lookback) and every function without a nullable output.
     nullable_outputs: &'a [String],
+    /// MIN/MAX batch bodies only: emit an explicit unroll hint on the
+    /// expired-extreme rescan loop. `false` everywhere else, including every
+    /// stream-transition render, so streaming output is untouched.
+    unroll_rescan: bool,
 }
+
+/// Loop condition that identifies the expired-extreme rescan in MIN/MAX.
+const RESCAN_LOOP_CONDITION: &str = "++i <= today";
+
+/// Explicit unroll hint for the MIN/MAX expired-extreme rescan.
+///
+/// The rescan already exists; it runs only when the cached extreme leaves the
+/// window. Giving GCC/Clang an explicit unroll count cuts its loop-control
+/// overhead without adding a comparison to the per-sample tight loop. MSVC has
+/// no equivalent pragma with this spelling, so nothing is emitted for it.
+const RESCAN_UNROLL_PRAGMA: &str = concat!(
+    "#if defined(__clang__)\n",
+    "#pragma clang loop unroll_count(4)\n",
+    "#elif defined(__GNUC__) && __GNUC__ >= 8\n",
+    "#pragma GCC unroll 4\n",
+    "#endif\n",
+);
 
 #[allow(clippy::implicit_hasher)]
 pub fn generate(
@@ -510,12 +531,15 @@ fn gen_func_inner(
         .filter(|o| o.is_nullable())
         .map(|o| o.name.clone())
         .collect();
+    // Only MIN and MAX carry the cached-extreme rescan this hint applies to.
+    let unroll_rescan = matches!(func.name.as_str(), "MIN" | "MAX");
     let ctx = &CRenderCtx {
         single_precision,
         inline_counter: &inline_counter,
         stream_scalar_candles: false,
         fma: Some(&fma_sets),
         nullable_outputs: &nullable_outputs,
+        unroll_rescan,
     };
 
     // For S_ variants with explicit _private: emit private_param_init as local VarDecls.
@@ -712,6 +736,18 @@ fn gen_func_inner(
         out.insert_str(0, "TA_FMA_MULTIVERSION\n");
     }
 
+    // Fail closed: if MIN/MAX ever stops having exactly one expired-extreme
+    // rescan loop, the hint has silently landed on the wrong loop (or on none),
+    // so refuse to generate rather than emit misplaced or missing directives.
+    if unroll_rescan {
+        let emitted = out.matches("#pragma GCC unroll 4").count();
+        let name = &func.name;
+        assert!(
+            emitted == 1,
+            "{name}: expected exactly one expired-extreme rescan loop to unroll, found {emitted}"
+        );
+    }
+
     out
 }
 
@@ -789,6 +825,7 @@ pub fn render_statement(
             stream_scalar_candles: false,
             fma: fma_sets.as_ref(),
             nullable_outputs: nullable,
+            unroll_rescan: false,
         };
         render_stmt(stmt, indent, &ctx, enums, registry, helpers)
     })
@@ -814,6 +851,7 @@ pub fn render_statement_stream(
             stream_scalar_candles: true,
             fma: fma_sets.as_ref(),
             nullable_outputs: nullable,
+            unroll_rescan: false,
         };
         render_stmt(stmt, indent, &ctx, enums, registry, helpers)
     })
@@ -1089,12 +1127,11 @@ impl StatementEmitter for CStmt<'_> {
         out.push_str(&render_hoisted_blocks(
             &hoisted, indent, self.ctx, self.enums, self.registry, self.helpers,
         ));
-        out.push_str(&format!(
-            "{}while( {} )\n{}{{\n",
-            pad,
-            render_expr(&new_cond, self.ctx, self.registry, self.helpers),
-            pad
-        ));
+        let rendered_cond = render_expr(&new_cond, self.ctx, self.registry, self.helpers);
+        if self.ctx.unroll_rescan && rendered_cond == RESCAN_LOOP_CONDITION {
+            out.push_str(RESCAN_UNROLL_PRAGMA);
+        }
+        out.push_str(&format!("{pad}while( {rendered_cond} )\n{pad}{{\n"));
         for s in body {
             out.push_str(&self.walk_stmt(s, indent + 3));
         }
@@ -1709,6 +1746,7 @@ pub(crate) fn render_expression(
             stream_scalar_candles: false,
             fma: fma_sets.as_ref(),
             nullable_outputs: &[],
+            unroll_rescan: false,
         };
         render_expr(expr, &ctx, registry, helpers)
     })
@@ -2029,7 +2067,7 @@ fn render_lookback_code(
     let inline_counter = Cell::new(0);
     // Lookback bodies are pure integer index arithmetic (the first-valid-output
     // count) — no float multiply-add, so fusion never applies here.
-    let ctx = &CRenderCtx { single_precision: false, inline_counter: &inline_counter, stream_scalar_candles: false, fma: None, nullable_outputs: &[] };
+    let ctx = &CRenderCtx { single_precision: false, inline_counter: &inline_counter, stream_scalar_candles: false, fma: None, nullable_outputs: &[], unroll_rescan: false };
 
     // Declare local variables (deduplicated)
     let mut declared_vars: Vec<String> = Vec::new();


### PR DESCRIPTION
## What changed

This replaces the earlier monotonic fast-path proposal in this PR, which you
correctly rejected as a synthetic case. The rework targets the common
random-walk domain instead and does **not** change the algorithm.

`TA_MIN`/`TA_MAX` already cache the current window extreme and rescan the
window only when that extreme expires. On random-walk input that rescan runs
regularly, and it is where the batch functions spend a large share of their
time. This change emits an explicit unroll hint (`#pragma clang loop
unroll_count(4)` / `#pragma GCC unroll 4`, guarded to Clang and GCC >= 8) on
that existing rescan loop, cutting its loop-control overhead:

- no comparison is added anywhere, in particular not in the per-sample tight
  loop;
- the algorithm, outputs, and streaming implementation are untouched — the
  generated streaming source is byte-identical;
- MSVC and older GCC see no pragma and compile exactly the code they compile
  today.

The hint is emitted by the C backend of `ta_codegen` for MIN/MAX batch bodies
only, and generation fails closed unless each MIN/MAX batch body contains
exactly one rescan-unroll site, so the directive cannot silently land on the
wrong loop or vanish. `src/ta_func/ta_MIN.c`, `ta_MAX.c`, and the sources
digest are regenerated with the official generator; generation is idempotent.

## Measurements (instruction counts, not wall-clock)

Setup: x86_64, GCC 13.3.0 `-O2` Release, Callgrind (valgrind 3.22.0)
instruction counts (Ir), which are deterministic. Baseline is pristine `dev`
(`cae231d8`). 168 paired cases: MIN and MAX, periods 14/30/50, n=20,000,
seven random-walk regimes (plain, low-vol, high-vol, drift up/down,
mean-reverting, tick-quantized), four seeds — two of which were held out and
never used while tuning.

- Total: 134,392,343 -> 119,490,628 instructions (**-11.09%**)
- Regressed cases: 0 of 168
- Per-regime range: -9.38% (mean-reverting) to -12.22% (drift up)

Wall-clock samples on this host were too noisy to be meaningful (baseline
spread up to 43% across repetitions), so we make no wall-clock claim — this
is an instruction-count result on x86_64 GCC. Happy to run any benchmark
setup you prefer.

Correctness evidence: 3,150 double-API semantic pairs plus 2,016 float-API pairs were bit-exact vs pristine `dev` (all
seven random-walk regimes plus NaN, infinities, ties, plateaus, signed zero,
in-place aliasing, sub-ranges, guarded/unguarded, periods
1..257); full `ta_regtest` under GCC 13.3 and Clang 18.1 (`-Werror`);
ASan+UBSan `ta_regtest --function=MIN,MAX`; generator test suite and clippy
clean; two idempotent generation passes.

## On an alternative algorithm

We looked, and the honest answer is that we did not find one that beats the
current cached-extreme algorithm under your (correct) constraint that the
tight loop must not gain comparisons:

- **Branchless rescan** (ternary compare/select so the compiler can emit
  cmov): GCC already generates equivalent code — measured instruction counts
  were identical to baseline.
- **Latest-index tie-keeping** (keep the most recent extreme on ties so it
  survives longer and rescans trigger less often on tick-quantized data):
  changes which index the cached extreme tracks, and failed our bit-exact
  matrix on tie/zero patterns, so it silently alters behaviour.
- **Pairwise/tournament rescan** (halve the compare-update dependency chain):
  failed bit-exactness on NaN patterns due to reordered comparisons.
- Dequeue and Van Herk/Gil-Werman you had already ruled out; we agree — their
  per-sample bookkeeping is exactly the added tight-loop work that hurts.

So this PR deliberately keeps your algorithm and only tightens the code the
compiler emits for the rescan that already exists.
