### PR TITLE
perf(mavp): bound each ma() pass at its period's last use

### DIFF
--- a/src/ta_func/ta_MAVP.c
+++ b/src/ta_func/ta_MAVP.c
@@ -84,12 +84,14 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
                                double        outReal[] )
 {
    int i;
-   int j;
    int lookbackTotal;
    int outputSize;
    int tempInt;
    int curPeriod;
+   int lastOccurrence;
+   int chainIdx;
    int *localPeriodArray;
+   int *periodIndex;
    double *localOutputArray;
    double *localFinalArray;
    int finalIsAllocated;
@@ -167,6 +169,19 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
    /* Allocate intermediate local buffer. */
    localOutputArray = malloc(outputSize * sizeof(double));
    localPeriodArray = malloc(outputSize * sizeof(int));
+   /* Occurrence index for the period grouping below, one pair of entries per
+    * representable period: periodIndex[period] is the first output using that
+    * period and periodIndex[optInMaxPeriod+1+period] the last one.
+    */
+   periodIndex = malloc(2 * (optInMaxPeriod + 1) * sizeof(int));
+   if( periodIndex == NULL )
+   {
+      free(localOutputArray);
+      free(localPeriodArray);
+      *outBegIdx= 0;
+      *outNBElement= 0;
+      return TA_ALLOC_ERR;
+   }
    /* In-place defence (issue #130): each ma() pass below re-reads inReal over
     * the full range, so with outReal==inReal the results are staged in a
     * scratch buffer and copied once at the end. A regular call writes
@@ -181,9 +196,17 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
    {
       localFinalArray = outReal;
    }
-   /* Copy caller array of period into local buffer.
-    * At the same time, truncate to min/max.
+   /* Read the caller array of period, truncate to min/max, and group the
+    * outputs by that truncated period in the same pass. localPeriodArray now
+    * holds, for each output, the next output using the same period (-1 ends
+    * the chain), so the outputs of one period form a linked list rooted at
+    * periodIndex[period]. This replaces the flag-and-rescan below, which
+    * walked the rest of the range once per distinct period.
     */
+   for( i = 0; i <= optInMaxPeriod; i += 1 )
+   {
+      periodIndex[i] = 0 - 1;
+   }
    for( i = 0; i < outputSize; i += 1 )
    {
       tempInt = (int)inPeriods[startIdx + i];
@@ -194,31 +217,39 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
       {
          tempInt = optInMaxPeriod;
       }
-      localPeriodArray[i] = tempInt;
+      if( periodIndex[tempInt] == 0 - 1 )
+      {
+         periodIndex[tempInt] = i;
+      } else 
+      {
+         localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+      }
+      periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+      localPeriodArray[i] = 0 - 1;
    }
-   /* Process each element of the input.
+   /* Process each period actually requested.
     * For each possible period value, the MA is calculated
-    * only once.
+    * only once, and only as far as the last output using it.
     * The outReal is then fill up for all element with
-    * the same period.
-    * A local flag (value 0) is set in localPeriodArray
-    * to avoid doing a second time the same calculation.
+    * the same period by walking that period's chain.
     */
-   for( i = 0; i < outputSize; i += 1 )
+   for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 )
    {
-      curPeriod = localPeriodArray[i];
-      if( curPeriod != 0 )
+      if( periodIndex[curPeriod] != 0 - 1 )
       {
          /* TODO: This portion of the function can be slightly speed
           *       optimized by making the function without unstable period
-          *       start their calculation at 'startIdx+i' instead of startIdx.
+          *       start their calculation at the first output using this
+          *       period instead of startIdx.
           */
+         lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
          /* Calculation of the MA required. */
-         retCode = TA_MA_Unguarded(startIdx,endIdx,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
+         retCode = TA_MA_Unguarded(startIdx,startIdx + lastOccurrence,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
          if( retCode != TA_SUCCESS )
          {
             free(localOutputArray);
             free(localPeriodArray);
+            free(periodIndex);
             if( finalIsAllocated )
             {
                free(localFinalArray);
@@ -227,15 +258,11 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
             *outNBElement= 0;
             return retCode;
          }
-         localFinalArray[i] = localOutputArray[i];
-         for( j = i + 1; j < outputSize; j += 1 )
+         chainIdx = periodIndex[curPeriod];
+         while( chainIdx != 0 - 1 )
          {
-            if( localPeriodArray[j] == curPeriod )
-            {
-               localPeriodArray[j] = 0;
-               /* Flag to avoid recalculation */
-               localFinalArray[j] = localOutputArray[j];
-            }
+            localFinalArray[chainIdx] = localOutputArray[chainIdx];
+            chainIdx = localPeriodArray[chainIdx];
          }
       }
    }
@@ -249,6 +276,7 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
    }
    free(localOutputArray);
    free(localPeriodArray);
+   free(periodIndex);
    if( finalIsAllocated )
    {
       free(localFinalArray);
@@ -271,12 +299,14 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
                                          double        outReal[] )
 {
    int i;
-   int j;
    int lookbackTotal;
    int outputSize;
    int tempInt;
    int curPeriod;
+   int lastOccurrence;
+   int chainIdx;
    int *localPeriodArray;
+   int *periodIndex;
    double *localOutputArray;
    double *localFinalArray;
    int finalIsAllocated;
@@ -317,6 +347,15 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
    outputSize = endIdx - tempInt + 1;
    localOutputArray = malloc(outputSize * sizeof(double));
    localPeriodArray = malloc(outputSize * sizeof(int));
+   periodIndex = malloc(2 * (optInMaxPeriod + 1) * sizeof(int));
+   if( periodIndex == NULL )
+   {
+      free(localOutputArray);
+      free(localPeriodArray);
+      *outBegIdx= 0;
+      *outNBElement= 0;
+      return TA_ALLOC_ERR;
+   }
    finalIsAllocated = 0;
    if( outReal == inReal )
    {
@@ -325,6 +364,10 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
    } else 
    {
       localFinalArray = outReal;
+   }
+   for( i = 0; i <= optInMaxPeriod; i += 1 )
+   {
+      periodIndex[i] = 0 - 1;
    }
    for( i = 0; i < outputSize; i += 1 )
    {
@@ -336,18 +379,27 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
       {
          tempInt = optInMaxPeriod;
       }
-      localPeriodArray[i] = tempInt;
-   }
-   for( i = 0; i < outputSize; i += 1 )
-   {
-      curPeriod = localPeriodArray[i];
-      if( curPeriod != 0 )
+      if( periodIndex[tempInt] == 0 - 1 )
       {
-         retCode = TA_MA_Unguarded(startIdx,endIdx,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
+         periodIndex[tempInt] = i;
+      } else 
+      {
+         localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+      }
+      periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+      localPeriodArray[i] = 0 - 1;
+   }
+   for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 )
+   {
+      if( periodIndex[curPeriod] != 0 - 1 )
+      {
+         lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+         retCode = TA_MA_Unguarded(startIdx,startIdx + lastOccurrence,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
          if( retCode != TA_SUCCESS )
          {
             free(localOutputArray);
             free(localPeriodArray);
+            free(periodIndex);
             if( finalIsAllocated )
             {
                free(localFinalArray);
@@ -356,14 +408,11 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
             *outNBElement= 0;
             return retCode;
          }
-         localFinalArray[i] = localOutputArray[i];
-         for( j = i + 1; j < outputSize; j += 1 )
+         chainIdx = periodIndex[curPeriod];
+         while( chainIdx != 0 - 1 )
          {
-            if( localPeriodArray[j] == curPeriod )
-            {
-               localPeriodArray[j] = 0;
-               localFinalArray[j] = localOutputArray[j];
-            }
+            localFinalArray[chainIdx] = localOutputArray[chainIdx];
+            chainIdx = localPeriodArray[chainIdx];
          }
       }
    }
@@ -373,6 +422,7 @@ TA_LIB_API TA_RetCode TA_MAVP_Unguarded( int    startIdx,
    }
    free(localOutputArray);
    free(localPeriodArray);
+   free(periodIndex);
    if( finalIsAllocated )
    {
       free(localFinalArray);
@@ -394,12 +444,14 @@ TA_RetCode TA_S_MAVP( int    startIdx,
                       double        outReal[] )
 {
    int i;
-   int j;
    int lookbackTotal;
    int outputSize;
    int tempInt;
    int curPeriod;
+   int lastOccurrence;
+   int chainIdx;
    int *localPeriodArray;
+   int *periodIndex;
    double *localOutputArray;
    double *localFinalArray;
    int finalIsAllocated;
@@ -462,6 +514,15 @@ TA_RetCode TA_S_MAVP( int    startIdx,
    outputSize = endIdx - tempInt + 1;
    localOutputArray = malloc(outputSize * sizeof(double));
    localPeriodArray = malloc(outputSize * sizeof(int));
+   periodIndex = malloc(2 * (optInMaxPeriod + 1) * sizeof(int));
+   if( periodIndex == NULL )
+   {
+      free(localOutputArray);
+      free(localPeriodArray);
+      *outBegIdx= 0;
+      *outNBElement= 0;
+      return TA_ALLOC_ERR;
+   }
    finalIsAllocated = 0;
    if( 0 )
    {
@@ -470,6 +531,10 @@ TA_RetCode TA_S_MAVP( int    startIdx,
    } else 
    {
       localFinalArray = outReal;
+   }
+   for( i = 0; i <= optInMaxPeriod; i += 1 )
+   {
+      periodIndex[i] = 0 - 1;
    }
    for( i = 0; i < outputSize; i += 1 )
    {
@@ -481,18 +546,27 @@ TA_RetCode TA_S_MAVP( int    startIdx,
       {
          tempInt = optInMaxPeriod;
       }
-      localPeriodArray[i] = tempInt;
-   }
-   for( i = 0; i < outputSize; i += 1 )
-   {
-      curPeriod = localPeriodArray[i];
-      if( curPeriod != 0 )
+      if( periodIndex[tempInt] == 0 - 1 )
       {
-         retCode = TA_S_MA_Unguarded(startIdx,endIdx,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
+         periodIndex[tempInt] = i;
+      } else 
+      {
+         localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+      }
+      periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+      localPeriodArray[i] = 0 - 1;
+   }
+   for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 )
+   {
+      if( periodIndex[curPeriod] != 0 - 1 )
+      {
+         lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+         retCode = TA_S_MA_Unguarded(startIdx,startIdx + lastOccurrence,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
          if( retCode != TA_SUCCESS )
          {
             free(localOutputArray);
             free(localPeriodArray);
+            free(periodIndex);
             if( finalIsAllocated )
             {
                free(localFinalArray);
@@ -501,14 +575,11 @@ TA_RetCode TA_S_MAVP( int    startIdx,
             *outNBElement= 0;
             return retCode;
          }
-         localFinalArray[i] = localOutputArray[i];
-         for( j = i + 1; j < outputSize; j += 1 )
+         chainIdx = periodIndex[curPeriod];
+         while( chainIdx != 0 - 1 )
          {
-            if( localPeriodArray[j] == curPeriod )
-            {
-               localPeriodArray[j] = 0;
-               localFinalArray[j] = localOutputArray[j];
-            }
+            localFinalArray[chainIdx] = localOutputArray[chainIdx];
+            chainIdx = localPeriodArray[chainIdx];
          }
       }
    }
@@ -518,6 +589,7 @@ TA_RetCode TA_S_MAVP( int    startIdx,
    }
    free(localOutputArray);
    free(localPeriodArray);
+   free(periodIndex);
    if( finalIsAllocated )
    {
       free(localFinalArray);
@@ -539,12 +611,14 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
                                 double        outReal[] )
 {
    int i;
-   int j;
    int lookbackTotal;
    int outputSize;
    int tempInt;
    int curPeriod;
+   int lastOccurrence;
+   int chainIdx;
    int *localPeriodArray;
+   int *periodIndex;
    double *localOutputArray;
    double *localFinalArray;
    int finalIsAllocated;
@@ -585,6 +659,15 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
    outputSize = endIdx - tempInt + 1;
    localOutputArray = malloc(outputSize * sizeof(double));
    localPeriodArray = malloc(outputSize * sizeof(int));
+   periodIndex = malloc(2 * (optInMaxPeriod + 1) * sizeof(int));
+   if( periodIndex == NULL )
+   {
+      free(localOutputArray);
+      free(localPeriodArray);
+      *outBegIdx= 0;
+      *outNBElement= 0;
+      return TA_ALLOC_ERR;
+   }
    finalIsAllocated = 0;
    if( 0 )
    {
@@ -593,6 +676,10 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
    } else 
    {
       localFinalArray = outReal;
+   }
+   for( i = 0; i <= optInMaxPeriod; i += 1 )
+   {
+      periodIndex[i] = 0 - 1;
    }
    for( i = 0; i < outputSize; i += 1 )
    {
@@ -604,18 +691,27 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
       {
          tempInt = optInMaxPeriod;
       }
-      localPeriodArray[i] = tempInt;
-   }
-   for( i = 0; i < outputSize; i += 1 )
-   {
-      curPeriod = localPeriodArray[i];
-      if( curPeriod != 0 )
+      if( periodIndex[tempInt] == 0 - 1 )
       {
-         retCode = TA_S_MA_Unguarded(startIdx,endIdx,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
+         periodIndex[tempInt] = i;
+      } else 
+      {
+         localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+      }
+      periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+      localPeriodArray[i] = 0 - 1;
+   }
+   for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 )
+   {
+      if( periodIndex[curPeriod] != 0 - 1 )
+      {
+         lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+         retCode = TA_S_MA_Unguarded(startIdx,startIdx + lastOccurrence,inReal,curPeriod,optInMAType,&localBegIdx,&localNbElement,localOutputArray);
          if( retCode != TA_SUCCESS )
          {
             free(localOutputArray);
             free(localPeriodArray);
+            free(periodIndex);
             if( finalIsAllocated )
             {
                free(localFinalArray);
@@ -624,14 +720,11 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
             *outNBElement= 0;
             return retCode;
          }
-         localFinalArray[i] = localOutputArray[i];
-         for( j = i + 1; j < outputSize; j += 1 )
+         chainIdx = periodIndex[curPeriod];
+         while( chainIdx != 0 - 1 )
          {
-            if( localPeriodArray[j] == curPeriod )
-            {
-               localPeriodArray[j] = 0;
-               localFinalArray[j] = localOutputArray[j];
-            }
+            localFinalArray[chainIdx] = localOutputArray[chainIdx];
+            chainIdx = localPeriodArray[chainIdx];
          }
       }
    }
@@ -641,6 +734,7 @@ TA_RetCode TA_S_MAVP_Unguarded( int    startIdx,
    }
    free(localOutputArray);
    free(localPeriodArray);
+   free(periodIndex);
    if( finalIsAllocated )
    {
       free(localFinalArray);

--- a/ta_codegen/input/mavp/mavp.c
+++ b/ta_codegen/input/mavp/mavp.c
@@ -27,8 +27,10 @@ TA_RetCode mavp(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
-   int i, j, lookbackTotal, outputSize, tempInt, curPeriod;
+   int i, lookbackTotal, outputSize, tempInt, curPeriod;
+   int lastOccurrence, chainIdx;
    int *localPeriodArray;
+   int *periodIndex;
    double *localOutputArray;
    double *localFinalArray;
    int finalIsAllocated;
@@ -85,6 +87,20 @@ TA_RetCode mavp(int startIdx, int endIdx,
    double *localOutputArray = malloc((outputSize) * sizeof(double));
    int *localPeriodArray = malloc((outputSize) * sizeof(int));
 
+   /* Occurrence index for the period grouping below, one pair of entries per
+    * representable period: periodIndex[period] is the first output using that
+    * period and periodIndex[optInMaxPeriod+1+period] the last one.
+    */
+   periodIndex = malloc((2*(optInMaxPeriod+1)) * sizeof(int));
+   if( periodIndex == NULL )
+   {
+      free(localOutputArray);
+      free(localPeriodArray);
+      *outBegIdx = 0;
+      *outNBElement = 0;
+      return TA_ALLOC_ERR;
+   }
+
    /* In-place defence (issue #130): each ma() pass below re-reads inReal over
     * the full range, so with outReal==inReal the results are staged in a
     * scratch buffer and copied once at the end. A regular call writes
@@ -100,9 +116,16 @@ TA_RetCode mavp(int startIdx, int endIdx,
       localFinalArray = outReal;
    }
 
-   /* Copy caller array of period into local buffer.
-    * At the same time, truncate to min/max.
+   /* Read the caller array of period, truncate to min/max, and group the
+    * outputs by that truncated period in the same pass. localPeriodArray now
+    * holds, for each output, the next output using the same period (-1 ends
+    * the chain), so the outputs of one period form a linked list rooted at
+    * periodIndex[period]. This replaces the flag-and-rescan below, which
+    * walked the rest of the range once per distinct period.
     */
+   for( i=0; i <= optInMaxPeriod; i++ )
+      periodIndex[i] = -1;
+
    for( i=0; i < outputSize; i++ )
    {
       tempInt = (int)(inPeriods[startIdx+i]);
@@ -110,29 +133,35 @@ TA_RetCode mavp(int startIdx, int endIdx,
          tempInt = optInMinPeriod;
       else if( tempInt > optInMaxPeriod )
          tempInt = optInMaxPeriod;
-      localPeriodArray[i] = tempInt;
+
+      if( periodIndex[tempInt] == -1 )
+         periodIndex[tempInt] = i;
+      else
+         localPeriodArray[periodIndex[optInMaxPeriod+1+tempInt]] = i;
+      periodIndex[optInMaxPeriod+1+tempInt] = i;
+      localPeriodArray[i] = -1;
    }
 
-   /* Process each element of the input.
+   /* Process each period actually requested.
     * For each possible period value, the MA is calculated
-    * only once.
+    * only once, and only as far as the last output using it.
     * The outReal is then fill up for all element with
-    * the same period.
-    * A local flag (value 0) is set in localPeriodArray
-    * to avoid doing a second time the same calculation.
+    * the same period by walking that period's chain.
     */
-   for( i=0; i < outputSize; i++ )
+   for( curPeriod=optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod++ )
    {
-      curPeriod = localPeriodArray[i];
-      if( curPeriod != 0 )
+      if( periodIndex[curPeriod] != -1 )
       {
          /* TODO: This portion of the function can be slightly speed
           *       optimized by making the function without unstable period
-          *       start their calculation at 'startIdx+i' instead of startIdx.
+          *       start their calculation at the first output using this
+          *       period instead of startIdx.
           */
 
+         lastOccurrence = periodIndex[optInMaxPeriod+1+curPeriod];
+
          /* Calculation of the MA required. */
-         retCode = ma( startIdx, endIdx, inReal,
+         retCode = ma( startIdx, startIdx+lastOccurrence, inReal,
             curPeriod, optInMAType,
             &localBegIdx,&localNbElement,localOutputArray );
 
@@ -140,20 +169,18 @@ TA_RetCode mavp(int startIdx, int endIdx,
          {
             free(localOutputArray);
             free(localPeriodArray);
+            free(periodIndex);
             if( finalIsAllocated ) { free(localFinalArray); }
                *outBegIdx = 0;
             *outNBElement = 0;
             return retCode;
          }
 
-         localFinalArray[i] = localOutputArray[i];
-         for( j=i+1; j < outputSize; j++ )
+         chainIdx = periodIndex[curPeriod];
+         while( chainIdx != -1 )
          {
-            if( localPeriodArray[j] == curPeriod )
-            {
-               localPeriodArray[j] = 0; /* Flag to avoid recalculation */
-               localFinalArray[j] = localOutputArray[j];
-            }
+            localFinalArray[chainIdx] = localOutputArray[chainIdx];
+            chainIdx = localPeriodArray[chainIdx];
          }
       }
    }
@@ -168,6 +195,7 @@ TA_RetCode mavp(int startIdx, int endIdx,
 
    free(localOutputArray);
    free(localPeriodArray);
+   free(periodIndex);
    if( finalIsAllocated ) { free(localFinalArray); }
 
       /* Done. Inform the caller of the success. */

--- a/ta_codegen/output/java/library/fragments/Core_MAVP.java
+++ b/ta_codegen/output/java/library/fragments/Core_MAVP.java
@@ -40,12 +40,14 @@
                                                double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -110,6 +112,11 @@
       /* Allocate intermediate local buffer. */
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      /* Occurrence index for the period grouping below, one pair of entries per
+       * representable period: periodIndex[period] is the first output using that
+       * period and periodIndex[optInMaxPeriod+1+period] the last one.
+       */
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       /* In-place defence (issue #130): each ma() pass below re-reads inReal over
        * the full range, so with outReal==inReal the results are staged in a
        * scratch buffer and copied once at the end. A regular call writes
@@ -122,9 +129,16 @@
       } else {
          localFinalArray = outReal;
       }
-      /* Copy caller array of period into local buffer.
-       * At the same time, truncate to min/max.
+      /* Read the caller array of period, truncate to min/max, and group the
+       * outputs by that truncated period in the same pass. localPeriodArray now
+       * holds, for each output, the next output using the same period (-1 ends
+       * the chain), so the outputs of one period form a linked list rooted at
+       * periodIndex[period]. This replaces the flag-and-rescan below, which
+       * walked the rest of the range once per distinct period.
        */
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
+      }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)inPeriods[startIdx + i];
          if( tempInt < optInMinPeriod ) {
@@ -132,25 +146,30 @@
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      /* Process each element of the input.
+      /* Process each period actually requested.
        * For each possible period value, the MA is calculated
-       * only once.
+       * only once, and only as far as the last output using it.
        * The outReal is then fill up for all element with
-       * the same period.
-       * A local flag (value 0) is set in localPeriodArray
-       * to avoid doing a second time the same calculation.
+       * the same period by walking that period's chain.
        */
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
             /* TODO: This portion of the function can be slightly speed
              *       optimized by making the function without unstable period
-             *       start their calculation at 'startIdx+i' instead of startIdx.
+             *       start their calculation at the first output using this
+             *       period instead of startIdx.
              */
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
             /* Calculation of the MA required. */
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -158,13 +177,10 @@
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  /* Flag to avoid recalculation */
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -194,12 +210,14 @@
                                                         double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -233,12 +251,16 @@
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( outReal == inReal ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)inPeriods[startIdx + i];
@@ -247,12 +269,18 @@
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -260,12 +288,10 @@
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -290,12 +316,14 @@
                                                double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -345,12 +373,16 @@
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( false ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)(double)inPeriods[startIdx + i];
@@ -359,12 +391,18 @@
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -372,12 +410,10 @@
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -402,12 +438,14 @@
                                                         double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -441,12 +479,16 @@
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( false ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)(double)inPeriods[startIdx + i];
@@ -455,12 +497,18 @@
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -468,12 +516,10 @@
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }

--- a/ta_codegen/output/java/library/src/com/tictactec/ta/lib/Core.java
+++ b/ta_codegen/output/java/library/src/com/tictactec/ta/lib/Core.java
@@ -107521,12 +107521,14 @@ public class Core {
                                                double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -107591,6 +107593,11 @@ public class Core {
       /* Allocate intermediate local buffer. */
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      /* Occurrence index for the period grouping below, one pair of entries per
+       * representable period: periodIndex[period] is the first output using that
+       * period and periodIndex[optInMaxPeriod+1+period] the last one.
+       */
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       /* In-place defence (issue #130): each ma() pass below re-reads inReal over
        * the full range, so with outReal==inReal the results are staged in a
        * scratch buffer and copied once at the end. A regular call writes
@@ -107603,9 +107610,16 @@ public class Core {
       } else {
          localFinalArray = outReal;
       }
-      /* Copy caller array of period into local buffer.
-       * At the same time, truncate to min/max.
+      /* Read the caller array of period, truncate to min/max, and group the
+       * outputs by that truncated period in the same pass. localPeriodArray now
+       * holds, for each output, the next output using the same period (-1 ends
+       * the chain), so the outputs of one period form a linked list rooted at
+       * periodIndex[period]. This replaces the flag-and-rescan below, which
+       * walked the rest of the range once per distinct period.
        */
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
+      }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)inPeriods[startIdx + i];
          if( tempInt < optInMinPeriod ) {
@@ -107613,25 +107627,30 @@ public class Core {
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      /* Process each element of the input.
+      /* Process each period actually requested.
        * For each possible period value, the MA is calculated
-       * only once.
+       * only once, and only as far as the last output using it.
        * The outReal is then fill up for all element with
-       * the same period.
-       * A local flag (value 0) is set in localPeriodArray
-       * to avoid doing a second time the same calculation.
+       * the same period by walking that period's chain.
        */
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
             /* TODO: This portion of the function can be slightly speed
              *       optimized by making the function without unstable period
-             *       start their calculation at 'startIdx+i' instead of startIdx.
+             *       start their calculation at the first output using this
+             *       period instead of startIdx.
              */
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
             /* Calculation of the MA required. */
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -107639,13 +107658,10 @@ public class Core {
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  /* Flag to avoid recalculation */
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -107675,12 +107691,14 @@ public class Core {
                                                         double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -107714,12 +107732,16 @@ public class Core {
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( outReal == inReal ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)inPeriods[startIdx + i];
@@ -107728,12 +107750,18 @@ public class Core {
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -107741,12 +107769,10 @@ public class Core {
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -107771,12 +107797,14 @@ public class Core {
                                                double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -107826,12 +107854,16 @@ public class Core {
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( false ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)(double)inPeriods[startIdx + i];
@@ -107840,12 +107872,18 @@ public class Core {
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -107853,12 +107891,10 @@ public class Core {
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }
@@ -107883,12 +107919,14 @@ public class Core {
                                                         double outReal[] )
    {
       int i = 0;
-      int j = 0;
       int lookbackTotal = 0;
       int outputSize = 0;
       int tempInt = 0;
       int curPeriod = 0;
+      int lastOccurrence = 0;
+      int chainIdx = 0;
       int[] localPeriodArray;
+      int[] periodIndex;
       double[] localOutputArray;
       double[] localFinalArray;
       int finalIsAllocated = 0;
@@ -107922,12 +107960,16 @@ public class Core {
       outputSize = endIdx - tempInt + 1;
       localOutputArray = new double[(int)(outputSize * 1)];
       localPeriodArray = new int[(int)(outputSize * 1)];
+      periodIndex = new int[(int)(2 * (optInMaxPeriod + 1) * 1)];
       finalIsAllocated = 0;
       if( false ) {
          finalIsAllocated = 1;
          localFinalArray = new double[(int)(outputSize * 1)];
       } else {
          localFinalArray = outReal;
+      }
+      for( i = 0; i <= optInMaxPeriod; i += 1 ) {
+         periodIndex[i] = 0 - 1;
       }
       for( i = 0; i < outputSize; i += 1 ) {
          tempInt = (int)(double)inPeriods[startIdx + i];
@@ -107936,12 +107978,18 @@ public class Core {
          } else if( tempInt > optInMaxPeriod ) {
             tempInt = optInMaxPeriod;
          }
-         localPeriodArray[i] = tempInt;
+         if( periodIndex[tempInt] == 0 - 1 ) {
+            periodIndex[tempInt] = i;
+         } else {
+            localPeriodArray[periodIndex[optInMaxPeriod + 1 + tempInt]] = i;
+         }
+         periodIndex[optInMaxPeriod + 1 + tempInt] = i;
+         localPeriodArray[i] = 0 - 1;
       }
-      for( i = 0; i < outputSize; i += 1 ) {
-         curPeriod = localPeriodArray[i];
-         if( curPeriod != 0 ) {
-            retCode = movingAverageUnguarded(startIdx, endIdx, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
+      for( curPeriod = optInMinPeriod; curPeriod <= optInMaxPeriod; curPeriod += 1 ) {
+         if( periodIndex[curPeriod] != 0 - 1 ) {
+            lastOccurrence = periodIndex[optInMaxPeriod + 1 + curPeriod];
+            retCode = movingAverageUnguarded(startIdx, startIdx + lastOccurrence, inReal, curPeriod, optInMAType, localBegIdx, localNbElement, localOutputArray);
             if( retCode != RetCode.Success ) {
                if( (finalIsAllocated) != 0 ) {
                }
@@ -107949,12 +107997,10 @@ public class Core {
                outNBElement.value = 0;
                return retCode ;
             }
-            localFinalArray[i] = localOutputArray[i];
-            for( j = i + 1; j < outputSize; j += 1 ) {
-               if( localPeriodArray[j] == curPeriod ) {
-                  localPeriodArray[j] = 0;
-                  localFinalArray[j] = localOutputArray[j];
-               }
+            chainIdx = periodIndex[curPeriod];
+            while( chainIdx != 0 - 1 ) {
+               localFinalArray[chainIdx] = localOutputArray[chainIdx];
+               chainIdx = localPeriodArray[chainIdx];
             }
          }
       }

--- a/ta_codegen/output/rust/library/src/ta_func/mavp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mavp.rs
@@ -190,12 +190,14 @@ impl Core {
         }
         let mut startIdx = startIdx;
         let mut i: usize = 0_usize;
-        let mut j: usize = 0_usize;
         let mut lookbackTotal: usize = 0_usize;
         let mut outputSize: usize = 0_usize;
         let mut tempInt: usize = 0_usize;
         let mut curPeriod: usize = 0_usize;
+        let mut lastOccurrence: usize = 0_usize;
+        let mut chainIdx: usize = 0_usize;
         let mut localPeriodArray: Vec<i32> = Vec::new();
+        let mut periodIndex: Vec<i32> = Vec::new();
         let mut localOutputArray: Vec<f64> = Vec::new();
         let mut localFinalArray: Vec<f64> = Vec::new();
         let mut finalIsAllocated: usize = 0_usize;
@@ -241,6 +243,10 @@ impl Core {
         // Allocate intermediate local buffer.
         localOutputArray = vec![0.0_f64; (outputSize * 1) as usize];
         localPeriodArray = vec![0_i32; (outputSize * 1) as usize];
+        // Occurrence index for the period grouping below, one pair of entries per
+        // representable period: periodIndex[period] is the first output using that
+        // period and periodIndex[optInMaxPeriod+1+period] the last one.
+        periodIndex = vec![0_i32; ((2 * (optInMaxPeriod + 1)) as usize * 1) as usize];
         // In-place defence (issue #130): each ma() pass below re-reads inReal over
         // the full range, so with outReal==inReal the results are staged in a
         // scratch buffer and copied once at the end. A regular call writes
@@ -252,8 +258,16 @@ impl Core {
         } else {
             localFinalArray = outReal.to_vec();
         }
-        // Copy caller array of period into local buffer.
-        // At the same time, truncate to min/max.
+        // Read the caller array of period, truncate to min/max, and group the
+        // outputs by that truncated period in the same pass. localPeriodArray now
+        // holds, for each output, the next output using the same period (-1 ends
+        // the chain), so the outputs of one period form a linked list rooted at
+        // periodIndex[period]. This replaces the flag-and-rescan below, which
+        // walked the rest of the range once per distinct period.
+        for i in (0 as usize)..(optInMaxPeriod as usize) + 1 {
+            periodIndex[i] = (0 - 1) as i32;
+        }
+        i = (optInMaxPeriod as usize) + 1;
         // for( i = 0; i < outputSize; i += 1 )
         i = 0;
         while i < outputSize {
@@ -263,26 +277,29 @@ impl Core {
             } else if tempInt > (optInMaxPeriod) as usize {
                 tempInt = (optInMaxPeriod) as usize;
             }
-            localPeriodArray[i] = (tempInt) as i32;
+            if (periodIndex[tempInt]) as i32 == 0 - 1 {
+                periodIndex[tempInt] = (i) as i32;
+            } else {
+                localPeriodArray[(periodIndex[((optInMaxPeriod + 1) as usize + tempInt) as usize]) as usize] = (i) as i32;
+            }
+            periodIndex[((optInMaxPeriod + 1) as usize + tempInt) as usize] = (i) as i32;
+            localPeriodArray[i] = (0 - 1) as i32;
             i += 1;
         }
-        // Process each element of the input.
+        // Process each period actually requested.
         // For each possible period value, the MA is calculated
-        // only once.
+        // only once, and only as far as the last output using it.
         // The outReal is then fill up for all element with
-        // the same period.
-        // A local flag (value 0) is set in localPeriodArray
-        // to avoid doing a second time the same calculation.
-        // for( i = 0; i < outputSize; i += 1 )
-        i = 0;
-        while i < outputSize {
-            curPeriod = (localPeriodArray[i]) as usize;
-            if curPeriod != 0 {
+        // the same period by walking that period's chain.
+        for curPeriod in (optInMinPeriod as usize)..(optInMaxPeriod as usize) + 1 {
+            if (periodIndex[curPeriod]) as i32 != 0 - 1 {
                 // TODO: This portion of the function can be slightly speed
                 //       optimized by making the function without unstable period
-                //       start their calculation at 'startIdx+i' instead of startIdx.
+                //       start their calculation at the first output using this
+                //       period instead of startIdx.
+                lastOccurrence = (periodIndex[((optInMaxPeriod + 1) as usize + curPeriod) as usize]) as usize;
                 // Calculation of the MA required.
-                retCode = self.ma_unguarded(startIdx, endIdx, inReal, (curPeriod) as i32, optInMAType, &mut localBegIdx, &mut localNbElement, &mut localOutputArray[..]);
+                retCode = self.ma_unguarded(startIdx, startIdx + lastOccurrence, inReal, (curPeriod) as i32, optInMAType, &mut localBegIdx, &mut localNbElement, &mut localOutputArray[..]);
                 if retCode != RetCode::Success {
                     if finalIsAllocated != 0 {
                     }
@@ -290,20 +307,14 @@ impl Core {
                     (*outNBElement) = 0;
                     return retCode;
                 }
-                localFinalArray[i] = localOutputArray[i];
-                // for( j = i + 1; j < outputSize; j += 1 )
-                j = i + 1;
-                while j < outputSize {
-                    if (localPeriodArray[j]) as usize == curPeriod {
-                        localPeriodArray[j] = 0;
-                        // Flag to avoid recalculation
-                        localFinalArray[j] = localOutputArray[j];
-                    }
-                    j += 1;
+                chainIdx = (periodIndex[curPeriod]) as usize;
+                while (chainIdx) as i32 != 0 - 1 {
+                    localFinalArray[chainIdx] = localOutputArray[chainIdx];
+                    chainIdx = (localPeriodArray[chainIdx]) as usize;
                 }
             }
-            i += 1;
         }
+        curPeriod = (optInMaxPeriod as usize) + 1;
         // Pointer-inequality guard, not finalIsAllocated: in backends where the
         // scratch election materializes as a copy (Rust), the copy-back must
         // always run; in C/Java the non-aliased self-copy is skipped.
@@ -343,12 +354,14 @@ impl Core {
         outReal: &mut [f64],
     ) -> RetCode {
         let mut i: usize = 0_usize;
-        let mut j: usize = 0_usize;
         let mut lookbackTotal: usize = 0_usize;
         let mut outputSize: usize = 0_usize;
         let mut tempInt: usize = 0_usize;
         let mut curPeriod: usize = 0_usize;
+        let mut lastOccurrence: usize = 0_usize;
+        let mut chainIdx: usize = 0_usize;
         let mut localPeriodArray: Vec<i32> = Vec::new();
+        let mut periodIndex: Vec<i32> = Vec::new();
         let mut localOutputArray: Vec<f64> = Vec::new();
         let mut localFinalArray: Vec<f64> = Vec::new();
         let mut finalIsAllocated: usize = 0_usize;
@@ -387,6 +400,7 @@ impl Core {
         outputSize = endIdx - tempInt + 1;
         localOutputArray = vec![0.0_f64; (outputSize * 1) as usize];
         localPeriodArray = vec![0_i32; (outputSize * 1) as usize];
+        periodIndex = vec![0_i32; ((2 * (optInMaxPeriod + 1)) as usize * 1) as usize];
         finalIsAllocated = 0;
         if outReal.as_ptr() == inReal.as_ptr() {
             finalIsAllocated = 1;
@@ -394,6 +408,10 @@ impl Core {
         } else {
             localFinalArray = outReal.to_vec();
         }
+        for i in (0 as usize)..(optInMaxPeriod as usize) + 1 {
+            periodIndex[i] = (0 - 1) as i32;
+        }
+        i = (optInMaxPeriod as usize) + 1;
         // for( i = 0; i < outputSize; i += 1 )
         i = 0;
         while i < outputSize {
@@ -403,15 +421,19 @@ impl Core {
             } else if tempInt > (optInMaxPeriod) as usize {
                 tempInt = (optInMaxPeriod) as usize;
             }
-            localPeriodArray[i] = (tempInt) as i32;
+            if (periodIndex[tempInt]) as i32 == 0 - 1 {
+                periodIndex[tempInt] = (i) as i32;
+            } else {
+                localPeriodArray[(periodIndex[((optInMaxPeriod + 1) as usize + tempInt) as usize]) as usize] = (i) as i32;
+            }
+            periodIndex[((optInMaxPeriod + 1) as usize + tempInt) as usize] = (i) as i32;
+            localPeriodArray[i] = (0 - 1) as i32;
             i += 1;
         }
-        // for( i = 0; i < outputSize; i += 1 )
-        i = 0;
-        while i < outputSize {
-            curPeriod = (localPeriodArray[i]) as usize;
-            if curPeriod != 0 {
-                retCode = self.ma_unguarded(startIdx, endIdx, inReal, (curPeriod) as i32, optInMAType, &mut localBegIdx, &mut localNbElement, &mut localOutputArray[..]);
+        for curPeriod in (optInMinPeriod as usize)..(optInMaxPeriod as usize) + 1 {
+            if (periodIndex[curPeriod]) as i32 != 0 - 1 {
+                lastOccurrence = (periodIndex[((optInMaxPeriod + 1) as usize + curPeriod) as usize]) as usize;
+                retCode = self.ma_unguarded(startIdx, startIdx + lastOccurrence, inReal, (curPeriod) as i32, optInMAType, &mut localBegIdx, &mut localNbElement, &mut localOutputArray[..]);
                 if retCode != RetCode::Success {
                     if finalIsAllocated != 0 {
                     }
@@ -419,19 +441,14 @@ impl Core {
                     (*outNBElement) = 0;
                     return retCode;
                 }
-                localFinalArray[i] = localOutputArray[i];
-                // for( j = i + 1; j < outputSize; j += 1 )
-                j = i + 1;
-                while j < outputSize {
-                    if (localPeriodArray[j]) as usize == curPeriod {
-                        localPeriodArray[j] = 0;
-                        localFinalArray[j] = localOutputArray[j];
-                    }
-                    j += 1;
+                chainIdx = (periodIndex[curPeriod]) as usize;
+                while (chainIdx) as i32 != 0 - 1 {
+                    localFinalArray[chainIdx] = localOutputArray[chainIdx];
+                    chainIdx = (localPeriodArray[chainIdx]) as usize;
                 }
             }
-            i += 1;
         }
+        curPeriod = (optInMaxPeriod as usize) + 1;
         if localFinalArray.as_ptr() != outReal.as_ptr() {
             {
             let _n = (outputSize * 1) as usize;


### PR DESCRIPTION
## What this changes

`TA_MAVP` normalizes every requested period into `localPeriodArray`, then walks that array:
for each output whose period is still flagged, it calls `ma()` over the **whole remaining
range** and scans the rest of `localPeriodArray` to find and copy every other output sharing
that period. Two independent inefficiencies live there: the selection scan is `O(U*n)` for `U`
distinct periods over `n` outputs, and every `ma()` pass runs all the way to `endIdx` even when
its period's last user is much earlier.

This change makes the existing normalization pass group the outputs, and then uses that
grouping to bound each `ma()` pass:

* `localPeriodArray` now holds, for each output, the index of the **next** output using the
  same period (`-1` ends the chain). It is the same allocation as before, reused.
* A new `periodIndex` array holds the **first** and **last** occurrence of each representable
  period (`periodIndex[period]` and `periodIndex[optInMaxPeriod+1+period]`).
* Selection becomes one `O(n)` build plus one `O(n)` total chain traversal, replacing the
  per-period rescan.
* Each `ma()` call now ends at the last output that uses its period, rather than at `endIdx`.

Both parts contribute measurable time, and the second is described on its own below because it
is the one change that goes beyond restructuring the period selection.

### Each `ma()` call now ends at the last output that uses its period, not at `endIdx`

Every moving average in TA-Lib warms up before `startIdx` and then fills forward, so an output
at index *k* depends only on input up to bar `startIdx + k`; ending the call earlier cannot
change any output at or before that point. The inner call's own `outBegIdx`/`outNBElement` are
written but never read by `TA_MAVP`, and the values `TA_MAVP` reports to *its* caller are
unchanged.

This is worth roughly a fifth of the improvement below: without it, the same patch measures
≈0.78 rather than ≈0.73 against the same control. It pays off on period series whose values
stop being used before the end of the range (as wandering or regime-driven period inputs
produce); on layouts where every period is used until the end it does strictly less or equal
work and changes nothing.

Because the `ma()` range is now bounded, `localOutputArray` is only partially written (indices
`0..lastOccurrence`). Every index read is on that period's chain and is therefore
`<= lastOccurrence`, so there is no uninitialized read; this was checked under ASan, UBSan and
LSan across the full comparison matrix.

## Result agreement

One `ma()` call per distinct clamped period is still made and the arithmetic inside those
passes is untouched, so no summation, division or accumulation order changes anywhere. The
calls are now issued in ascending period order rather than first-occurrence order, and each
output is written from the same pass that produced it before, so the outputs are
**bit-identical** rather than merely within tolerance.

Direct comparison against the unpatched library over 20,000-bar random walks — max periods
30/100/500, seven price regimes, and batch, in-place (`outReal == inReal`) and subrange calls —
is **bitwise identical: max absolute delta 0.0**, comfortably inside the 1e-12 agreement bar.
This was verified twice with two independently written harnesses: 10,804,965 values compared
over nine MA types, and 8,904,640 values compared over **all ten MA types reachable through
`TA_MAVP`** — `SMA, EMA, WMA, DEMA, TEMA, TRIMA, KAMA, MAMA, T3, HMA`. Zero differing values
in both, including every return code, `outBegIdx` and `outNBElement`. The second harness also
repeated its full matrix under a non-default `TA_SetUnstablePeriod(TA_FUNC_UNST_ALL, 7)`, with
zero differences, which is the sharpest check on the bounded `ma()` range described above.

## Measured improvement

Paired p50 wall-clock ratio against the unpatched build, measured under the protocol requested
in #128 — random-walk inputs, swept over eight code layouts, fresh per-sample seeds, 84
`TA_MAVP` SMA calls over 20,000-bar series across seven price regimes, four series seeds and
max periods 30/100/500:

| Variant | Paired p50 ratio (lower is better) | vs control |
| --- | --- | --- |
| Untouched control | ≈1.00 | — |
| Period grouping only | ≈0.782 | ≈22% |
| Grouping + bounded `ma()` range (this PR) | ≈0.730 | ≈27% |

The shipped patch measures a mean of **0.7304** across five repeats (0.7292–0.7313), against a
control of ≈1.00 measured in the same window on the same host. The three groups are cleanly
separated: none of their ranges overlap, and each group's spread is an order of magnitude
smaller than the gaps between them.

> **The timing figures in this section are being re-verified.** They were measured on a
> shared host where a concurrent job could perturb wall-clock results, so I do not want them
> standing here as settled. They are being re-measured under exclusive single-tenant
> measurement and this section will be updated with the confirmed numbers — including if they
> differ from what is written above. The correctness results are unaffected: the bit-identical
> comparison, the test suites and the codegen verification are exact checks, not timings.

## Verification

* `scripts/build.py test` — full C reference suite passes, including the 200-pair in-place
  alias gate and the 168-function four-variant parity gate (bit-identical).
* `ta_regtest --function=Moving` — the `All Moving Averages` group (which is what covers
  `TA_MAVP`) passes.
* `ta_regtest --codegen-only --language=c,rust` — codegen verification passes for both,
  161/161 functions each, against the frozen `reference-pre-cutover` oracle.
* `scripts/build.py generate` is idempotent: a second run produces a byte-identical tree.
* Regenerated surfaces committed alongside the template: the C library, the Rust crate and
  the Java `Core_MAVP` fragment plus `Core.java`. The Rust crate compiles (`cargo build`).
* Java and .NET server verification was **not** run — this machine has no JDK or .NET SDK, so
  those two server builds fail here on the unpatched tree as well. The Java source is
  regenerated and committed; it has not been compiled.

## Notes for review

* The added allocation is `2*(optInMaxPeriod+1)` ints. It is sized by the configured period
  range rather than by the data, so for a very large `optInMaxPeriod` with a very short output
  range it is larger than the previous scratch. It is null-checked and returns `TA_ALLOC_ERR`
  with full cleanup of the earlier allocations.
* The `TA_MAVP_Unguarded` / `TA_S_MAVP_Unguarded` entry points skip the guarded API's
  `optInMinPeriod >= 1` range check by design. A caller passing `optInMinPeriod <= 0` through
  those would now reach a negative `periodIndex` index, where the baseline instead passed the
  same nonsensical period into `TA_MA_Unguarded`. Both are undefined on that input and the
  guarded public API rejects it; flagging it since it is the one new memory-unsafe shape.
* `ta_codegen/input/mavp/mavp.c` is the only hand-edited file; everything else in the diff is
  generator output.

Follow-on to #128, which invited algorithmic changes worth more than 15% with output agreement
within 1e-12, random-walk inputs and code-layout sweeps.

Supplementary autoresearch: the optimization direction was explored with an automated search over the same sealed benchmark — one authoritative run, 11 integrity-valid scalar-emitting steps, best node a 27.0% improvement against the paired-ratio baseline: [public trajectory](https://dashboard.weco.ai/share/BL2XnwhXLK6H-nUDu7ASKQjtbmK9uheb). The submitted patch is a manual minimal rebuild of that best node's idea, independently re-verified as above.

