### PR TITLE
fix(ta_codegen): #148 — range-check real optional params in the Rust backend

### DIFF
--- a/docs/param-boundary-audit.md
+++ b/docs/param-boundary-audit.md
@@ -73,6 +73,11 @@ so the change is comment-only there.
   lookback formula) are left to the ASan/UBSan job rather than forced by the
   boundary sweep: they are values no caller passes and are unsafe to provoke in a
   plain build. The sweep uses an overflow-safe "large" period near the data length.
-- **Real-parameter range rejection**: the library does not range-check real
-  optional parameters, so the sweep exercises real endpoints for the finite-output
-  scan only, not for `TA_BAD_PARAM` behavior.
+- **Real-parameter range rejection**: the library *does* range-check real optional
+  parameters that declare a finite bound — 19 parameters across 11 functions
+  (`ta_T3.c:76-79` is the shape; the emitter is `backends/c.rs`, mirrored in
+  `backends/java.rs` and `backends/rust_lang.rs`). The remaining 5 real optional
+  parameters declare `[TA_REAL_MIN, TA_REAL_MAX]`, which constrains nothing and
+  emits no check. The sweep still exercises real endpoints for the finite-output
+  scan only, not for `TA_BAD_PARAM` behavior — extending it to assert the rejection
+  is open work, not a property the library lacks.

--- a/src/tools/ta_regtest/CLAUDE.md
+++ b/src/tools/ta_regtest/CLAUDE.md
@@ -365,36 +365,109 @@ Architecture (see `fuzz_data.h`, the Rust port in
 - **Coverage:** every function × 9 shapes × 3 seeds × 3 sizes × parameter
   vectors × 3 subranges ≈ 182k comparisons **per server**, ~94% with non-empty
   output (a non-vacuity guard fails the run if nothing produced output — an empty
-  output hashes the same on both sides).
+  output hashes the same on both sides). Plus the rejection leg below.
 
-Scope rules (deliberate):
-- **No 0.6.4, no waivers; one tolerance + one ill-conditioning skip.** This is
-  current-vs-current across languages, so — unlike `--fuzz-064` — there are none
-  of the `#98`/`#107`/FMA-transition carve-outs. Every case is bitwise except
-  Java's transcendental calls (1e-9, above). A non-tolerated mismatch is a real
-  fusion-site / codegen divergence to fix.
-- **The one ill-conditioning skip: HT_DCPHASE / HT_SINE on the constant shape,
-  Java only.** These two derive their output from `atan2` of the Hilbert
-  transform's in-phase/quadrature components. On `FUZZ_CONSTANT` (flat O=H=L=C,
-  zero variance) those components are floating-point noise (~0), so the phase is
-  `atan2(≈0,≈0)` — chaotically sensitive to the last bit of every transcendental
-  step. C and Rust share the system libm and stay **bit-identical** there (Rust:
-  0 mismatches on every shape); Java's fdlibm differs by ~1 ULP and this
-  ill-conditioning amplifies it to whole *degrees* (~2.9° on HT_DCPHASE). It is
-  not a codegen bug — all 8 non-degenerate shapes agree within 1e-9, and `atan2`
-  of a null signal is mathematically undefined — so no fixed tolerance can
-  separate it from fdlibm noise. `xlang_java_illcond` skips exactly these two
-  functions on exactly the constant shape for the Java leg; the count is reported
-  in the summary. Rust still gates HT_DCPHASE/HT_SINE bitwise on the constant
-  shape, so the C computation itself stays covered there.
-- **period == 1 is in scope** (no 0.6.4 to trip on it), though the shared
-  `fuzz_build_vectors` currently floors periods at 2; period-1 parity is also
-  covered by the `--codegen` edge sweeps.
-- Why this is expected GREEN (PR #96): every backend fuses the identical `a*b+c`
-  sites via the shared `backends/fma.rs` detector and builds with
-  `-ffp-contract=off`, and `fma`/`mul_add` are IEEE correctly-rounded → bit-
-  identical for equal operands (Java `Math.fma` included; only its fdlibm
-  transcendentals need the tolerance).
+### The parameter-contract legs — both classes, both tiers (issue #148)
+
+Everything above compares **values**. Until #148 nothing compared what a call is
+supposed to *do with its parameters*, because `fuzz_build_vectors` never produced
+a vector that exercised either half of the contract: integer candidates are
+clamped into `[min, max]`, real candidates are the `suggested_*` values (in-range
+by construction), and no candidate was ever a `TA_*_DEFAULT` sentinel. That blind
+spot let the Rust backend ship with **no validation at all** for `real` optional
+parameters — neither range check nor default substitution, at any tier — through
+every gate in this file. The whole verification table of the fix passed equally
+well *without* the fix.
+
+Two candidate classes now close it, both metadata-driven off `ta_abstract`, so
+they cover every range-typed parameter today and anything added later on the day
+it lands:
+
+| Class | Candidates | Contract |
+|---|---|---|
+| `FUZZ_VEC_REJECT` (`fuzz_add_out_of_range`) | below-min, above-max — per **bounded** side | the call must be **rejected** (`TA_BAD_PARAM` / an invalid lookback) |
+| `FUZZ_VEC_SENTINEL` (`fuzz_add_default_sentinel`) | `TA_REAL_DEFAULT` (`-4e37`), `TA_INTEGER_DEFAULT` (`INT_MIN`) — per **Range** parameter, bounded or not | the call must **succeed with the declared default's result** |
+
+- **Scope: `--xlang-hash` only.** `fuzz_build_vectors(..., frozenOracle=1)` — the
+  `--fuzz-064` path — emits neither class. That oracle certifies *numeric*
+  agreement with a shipped binary; the parameter contract is a separate question
+  and is deliberately not tangled into it. (`--fuzz-064`'s comparison counts are
+  byte-identical before and after this feature, which is the check that proves
+  the separation.)
+- **An unconstrained side contributes no reject candidate.** `TA_REAL_MIN/MAX`,
+  `TA_INTEGER_MIN/MAX` reach the backends as the widest representable value and
+  every backend skips the comparison for them (the shared unbounded-range
+  magnitude test in `backends/c.rs`, `rust_lang.rs`, `java.rs`), so there is no
+  rejection to compare. `optInPenetration` is `[0, TA_REAL_MAX]`: below-min is a
+  real gate, above-max is not. The **sentinel** class has no such exemption —
+  which is exactly what gates the five `[TA_REAL_MIN, TA_REAL_MAX]` reals
+  (`BBANDS.optInNbDevUp/Dn`, `STDDEV`/`VAR.optInNbDev`, `SAREXT.optInStartValue`):
+  substitution is their *only* contract.
+- **`IntegerList` (the MAType-style enums) is excluded from both**, for different
+  reasons. It declares no range, so there is no bound to exceed (the equivalent
+  out-of-**list** injection lives in the stream vector builder). And C maps
+  `TA_INTEGER_DEFAULT` to the declared default for enums while the Rust backend
+  does not — a known residual divergence tracked in
+  `ta_codegen/generator/CLAUDE.md`, on a different set of functions.
+- **Both tiers.** The lookback entry point carries its own copy of the validation,
+  so a backend can diverge at one tier and not the other. `xlang_lookback_leg`
+  sweeps `abstract_get_lookback` once per parameter vector (lookback is a pure
+  function of the parameters, so it needs no data). C and Java signal rejection
+  with `-1`, the Rust crate with `usize::MAX`; both normalize to `-1` before
+  comparing.
+
+**How each class is asserted**
+
+- *Reject* — against the C golden, reusing the existing verdict machinery:
+  `codegen_hash_compare` / `codegen_compare_tol` diff `retCode` first and
+  short-circuit to MATCH once both sides agree on the same non-success code, so a
+  language that computes a number where C returns `TA_BAD_PARAM` is a hard
+  mismatch.
+- *Sentinel* — **inside each server**, not against the golden: the same call with
+  the sentinel and with the explicit default must agree bit-for-bit
+  (`xlang_hash_call` twice). "The sentinel selects the default" is a property of
+  one implementation, and asserting it language-internally needs no tolerance, so
+  Java's fdlibm transcendentals stay bitwise here like everything else. Nothing is
+  lost: the cross-language correctness of the *default* result is already gated by
+  `vec[0]` in the same sweep, so
+  `server(sentinel) == server(default) ≈ golden(default) == golden(sentinel)`
+  closes the loop transitively.
+
+**Three self-checks keep it from passing vacuously**
+
+1. An out-of-range vector the in-process C library *accepts* fails the run — the
+   candidate, not the implementation, is wrong (the `ta_abstract` range has
+   drifted from what the generated code validates).
+2. A sentinel vector where C does *not* reproduce the explicit default's result
+   fails the run — otherwise "both languages agree" would stop meaning the
+   contract holds.
+3. An unfiltered run that produces **zero** cases in either class, at either tier,
+   fails as `VACUOUS CONTRACT LEG`.
+
+**Contract vectors always take the hash path, and only the full range.** Hash mode
+(`want_hash` / `gen_present`) makes the server return right after the **guarded**
+call; the tolerance path instead falls through to the server's *unguarded* timing
+rerun, where "every optional parameter resolved (never a sentinel) and in-range"
+is a **precondition** (see the VARIANT gate above) that both classes violate by
+construction. Sending them down that path killed the Java server twice —
+`ArrayIndexOutOfBoundsException: Index 40` (below-min period) and
+`Index -2147483634` (the raw `INT_MIN` sentinel), both inside
+`linearRegAngleUnguardedInternal`. The servers would be more robust skipping the
+unguarded rerun when the guarded call failed; that is a generator change across
+four backends, so this gate simply does not ask them to do it. And because
+validation runs before any `startIdx`/`endIdx` logic, the contract is
+subrange-independent — the contract vectors run on the full range only (still 81
+repetitions each across shapes × seeds × sizes), which keeps the added cost to
+about +14% wall clock on a two-server run.
+
+**Sabotage-proven, both halves independently.** Against `dev` +
+`--language=rust`:
+
+| `rust_lang.rs::gen_opt_param_validation_with` | Result |
+|---|---|
+| as merged | `PASS`, `Rust: 226470 cases, 0 mismatch(es)` |
+| `ParamType::Real` arm deleted (the `dev` state) | `FAIL — 3129 output mismatch(es) ... across 13 function(s)` |
+| Real arm kept, **sentinel substitution only** removed | `FAIL — 1855 output mismatch(es) ... across 13 function(s)` |
 
 ## `server_verify` — bitwise C⇄server on the hard-coded tests (issue #115)
 

--- a/src/tools/ta_regtest/test_codegen.c
+++ b/src/tools/ta_regtest/test_codegen.c
@@ -3445,15 +3445,154 @@ static unsigned long long fuzz_parse_hash(const char *resp)
     return strtoull(h, NULL, 16);
 }
 
-/* Parameter vectors: defaults + one-param-varied boundary/list sweeps. */
+/* Parameter-contract vector classes (issue #148). A vector is either an ordinary
+ * value sweep, or one of the two CONTRACT classes below -- the ones a correct
+ * implementation must do something specific with rather than merely compute. */
+#define FUZZ_VEC_NORMAL   0
+#define FUZZ_VEC_REJECT   1  /* below-min / above-max: must be REJECTED          */
+#define FUZZ_VEC_SENTINEL 2  /* TA_*_DEFAULT: must resolve to the declared default */
+
+/* Out-of-range candidates for one bounded optional parameter: exactly the two
+ * values the documented range excludes at its edges -- below-min and above-max.
+ *
+ * They are the ONLY candidates this builder produces that a correct
+ * implementation must REJECT. Every other candidate is deliberately pulled
+ * INSIDE the range (integers clamp to [min,max]; reals take suggested values,
+ * which are in-range by construction, and `continue` otherwise), so the sweep
+ * could only ever assert that VALUES agree -- never that REJECTIONS agree.
+ * That blind spot is why #148 (the Rust backend emitting no validation at all
+ * for `real` optional parameters, at any tier) survived every cross-language
+ * gate in this file.
+ *
+ * Emitted for the current-vs-current path only (frozenOracle == 0). Error-path
+ * parity against the frozen v0.6.4 binary is a separate question from the
+ * numeric agreement that oracle exists to certify.
+ *
+ * A side is skipped when the metadata declares it unconstrained
+ * (TA_INTEGER_MIN/TA_INTEGER_MAX, TA_REAL_MIN/TA_REAL_MAX): such a bound
+ * reaches the backends as the widest representable value and every backend
+ * skips the comparison for it (the shared "unbounded range" magnitude test in
+ * backends/c.rs, rust_lang.rs and java.rs), so there is no rejection to
+ * compare. optInPenetration is [0, TA_REAL_MAX]: below-min is a real gate,
+ * above-max is not. Nothing emitted here can collide with the "use the
+ * default" sentinels (TA_INTEGER_DEFAULT == INT_MIN, TA_REAL_DEFAULT ==
+ * -4e37) -- both lie outside the clamps below.
+ *
+ * IntegerList/RealList (the MAType-style enums) declare no range at all, so
+ * they have no bound to exceed and contribute nothing here; the equivalent
+ * out-of-LIST injection lives in the stream vector builder. Range parameters
+ * are exactly the population the "below-min / above-max" contract applies to.
+ *
+ * Metadata-driven: every bounded parameter is covered today, and any bounded
+ * parameter added later is covered the day it lands, with no list to maintain. */
+static void fuzz_add_out_of_range(const TA_OptInputParameterInfo *oi,
+                                  double cand[FUZZ_MAX_CAND],
+                                  char candKind[FUZZ_MAX_CAND],
+                                  int *nc, int *overflow)
+{
+    double oor[2];
+    int    noor = 0;
+
+    if( oi->type == TA_OptInput_IntegerRange )
+    {
+        const TA_IntegerRange *r = (const TA_IntegerRange *)oi->dataSet;
+        if( !r ) return;
+        if( (long long)r->min - 1 >= (long long)TA_INTEGER_MIN )
+            oor[noor++] = (double)((long long)r->min - 1);
+        if( (long long)r->max + 1 <= (long long)TA_INTEGER_MAX )
+            oor[noor++] = (double)((long long)r->max + 1);
+    }
+    else if( oi->type == TA_OptInput_RealRange )
+    {
+        const TA_RealRange *r = (const TA_RealRange *)oi->dataSet;
+        if( !r ) return;
+        /* The `- 1.0 < min` / `+ 1.0 > max` guards keep a candidate that the
+         * bound's own magnitude would absorb from being emitted as a silent
+         * in-range value. */
+        if( r->min > TA_REAL_MIN && r->min - 1.0 < r->min )
+            oor[noor++] = r->min - 1.0;
+        if( r->max < TA_REAL_MAX && r->max + 1.0 > r->max )
+            oor[noor++] = r->max + 1.0;
+    }
+    else
+        return;
+
+    for( int b = 0; b < noor; b++ )
+    {
+        /* Same loud-overflow contract as the in-range candidates: a dropped
+         * candidate silently un-gates a parameter. */
+        if( *nc >= FUZZ_MAX_CAND ) { (*overflow)++; continue; }
+        candKind[*nc] = FUZZ_VEC_REJECT;
+        cand[(*nc)++] = oor[b];
+    }
+}
+
+/* The "use the default" sentinel for one optional parameter: TA_REAL_DEFAULT
+ * (-4e37) for a real, TA_INTEGER_DEFAULT (INT_MIN) for an integer.
+ *
+ * This is the OTHER half of the parameter contract, and until #148 it was as
+ * untested as the range half: no vector this builder produced was ever a
+ * sentinel, so nothing anywhere asserted that `-4e37` resolves to the declared
+ * default. It is also the half most likely to be "simplified" away by someone
+ * reading the Rust API as sentinel-free -- Rust has no out-parameter convention
+ * that makes a magic value look necessary, yet `Core::t3(x, 5, -4e37)` must
+ * produce exactly `Core::t3(x, 5, 0.7)`, as `TA_T3` has always done
+ * (src/ta_func/ta_T3.c:76-77).
+ *
+ * Unlike the reject class this is NOT an error-path assertion: the call
+ * SUCCEEDS, and what must hold is that it succeeds with the default's result.
+ * The driver asserts exactly that, by re-running the same call with the
+ * parameter set explicitly to its default and requiring an identical result.
+ *
+ * Emitted for every Range parameter that declares a default, bounded or not --
+ * which is what gates the five [TA_REAL_MIN, TA_REAL_MAX] reals
+ * (BBANDS.optInNbDevUp/Dn, STDDEV/VAR.optInNbDev, SAREXT.optInStartValue): they
+ * take sentinel substitution and no range check, so this is their ONLY contract.
+ *
+ * IntegerList (the MAType-style enums) is deliberately excluded: C maps
+ * TA_INTEGER_DEFAULT to the declared default for them and the Rust backend does
+ * not (its dispatch falls through to the `_` arm instead), a known residual
+ * divergence tracked separately in ta_codegen/generator/CLAUDE.md. Asserting it
+ * here would gate a different behavior change on a different set of functions. */
+static void fuzz_add_default_sentinel(const TA_OptInputParameterInfo *oi,
+                                      double cand[FUZZ_MAX_CAND],
+                                      char candKind[FUZZ_MAX_CAND],
+                                      int *nc, int *overflow)
+{
+    double sentinel;
+
+    if( oi->type == TA_OptInput_IntegerRange )
+        sentinel = (double)TA_INTEGER_DEFAULT;
+    else if( oi->type == TA_OptInput_RealRange )
+        sentinel = TA_REAL_DEFAULT;
+    else
+        return;
+
+    if( *nc >= FUZZ_MAX_CAND ) { (*overflow)++; return; }
+    candKind[*nc] = FUZZ_VEC_SENTINEL;
+    cand[(*nc)++] = sentinel;
+}
+
+/* Parameter vectors: defaults + one-param-varied boundary/list sweeps, plus
+ * (current-vs-current only) the two CONTRACT classes -- the out-of-range values
+ * every tier must REJECT, and the sentinel every tier must resolve to the
+ * declared default. */
 /* frozenOracle: 1 when the vectors feed a frozen oracle (--fuzz-064's
  * ta_064_serve) -- IntegerList values the freeze predates are then excluded
- * (see FROZEN_ORACLE_MATYPE_MAX). --xlang-hash is current-vs-current and
- * passes 0, so the new values stay bitwise-gated there. */
+ * (see FROZEN_ORACLE_MATYPE_MAX), and no out-of-range candidate is emitted at
+ * all (see fuzz_add_out_of_range). --xlang-hash is current-vs-current and
+ * passes 0, so the new values stay bitwise-gated there.
+ *
+ * kind: optional, one FUZZ_VEC_* class per returned vector. FUZZ_VEC_REJECT
+ * marks a vector the library must REJECT (TA_BAD_PARAM / an invalid lookback)
+ * rather than compute; FUZZ_VEC_SENTINEL marks one it must resolve to the
+ * declared default. The caller uses these both to assert the contract across
+ * languages and to prove each leg is non-vacuous. Pass NULL when not needed. */
 static int fuzz_build_vectors(const TA_FuncInfo *fi,
                               double vec[FUZZ_MAX_VEC][FUZZ_MAX_OPT],
                               int *overflow,
-                              int frozenOracle)
+                              int frozenOracle,
+                              char kind[FUZZ_MAX_VEC])
 {
     *overflow = 0;
     double def[FUZZ_MAX_OPT];
@@ -3468,6 +3607,7 @@ static int fuzz_build_vectors(const TA_FuncInfo *fi,
 
     int nvec = 0;
     for( i = 0; i < fi->nbOptInput && i < FUZZ_MAX_OPT; i++ ) vec[0][i] = def[i];
+    if( kind ) kind[0] = FUZZ_VEC_NORMAL;
     nvec = 1;
 
     for( i = 0; i < fi->nbOptInput && i < FUZZ_MAX_OPT; i++ )
@@ -3475,6 +3615,8 @@ static int fuzz_build_vectors(const TA_FuncInfo *fi,
         const TA_OptInputParameterInfo *oi;
         TA_GetOptInputParameterInfo(fi->handle, i, &oi);
         double cand[FUZZ_MAX_CAND]; int nc = 0, c;
+        char candKind[FUZZ_MAX_CAND];
+        memset(candKind, FUZZ_VEC_NORMAL, sizeof(candKind));
 
         if( oi->type == TA_OptInput_IntegerRange )
         {
@@ -3529,6 +3671,13 @@ static int fuzz_build_vectors(const TA_FuncInfo *fi,
             }
         }
 
+        /* The two contract legs (current-vs-current only). */
+        if( !frozenOracle )
+        {
+            fuzz_add_out_of_range(oi, cand, candKind, &nc, overflow);
+            fuzz_add_default_sentinel(oi, cand, candKind, &nc, overflow);
+        }
+
         for( c = 0; c < nc; c++ )
         {
             /* Silent truncation would quietly stop comparing parameter values
@@ -3537,6 +3686,7 @@ static int fuzz_build_vectors(const TA_FuncInfo *fi,
             for( unsigned int j = 0; j < fi->nbOptInput && j < FUZZ_MAX_OPT; j++ )
                 vec[nvec][j] = def[j];
             vec[nvec][i] = cand[c];
+            if( kind ) kind[nvec] = candKind[c];
             nvec++;
         }
     }
@@ -3939,7 +4089,11 @@ static void fuzz_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
 
     double vec[FUZZ_MAX_VEC][FUZZ_MAX_OPT];
     int vecOverflow = 0;
-    int nvec = fuzz_build_vectors(funcInfo, vec, &vecOverflow, 1);
+    /* frozenOracle=1: no contract candidates (out-of-range, sentinel) — the
+     * v0.6.4 oracle certifies NUMERIC agreement with a shipped binary; the
+     * parameter contract is deliberately left to the current-vs-current gate.
+     * NULL kind: nothing to flag. */
+    int nvec = fuzz_build_vectors(funcInfo, vec, &vecOverflow, 1, NULL);
     if( vecOverflow > 0 )
     {
         printf("FUZZ VECTOR OVERFLOW [TA_%s]: %d parameter value(s) dropped by "
@@ -4263,6 +4417,26 @@ typedef struct {
     long long    illcondSkipped;     /* Java HT_DCPHASE/HT_SINE calls skipped on
                                       * the zero-variance constant shape (phase of
                                       * a null signal — see xlang_java_illcond)    */
+    long long    oorGolden;          /* golden cases run on an out-of-range vector
+                                      * (subset of `comparisons`; they produce no
+                                      * output by design, so they are excluded from
+                                      * the nonEmpty ratio). Non-vacuity: must be >0 */
+    long long    oorCases;           /* per-server comparisons on an out-of-range
+                                      * parameter vector — the retCode-parity leg
+                                      * (batch tier)                               */
+    long long    oorNotRejected;     /* out-of-range vectors the in-process C
+                                      * library ACCEPTED — the candidate was not
+                                      * out of range, so its parity assertion was
+                                      * vacuous. Fails the run.                    */
+    long long    sentGolden;         /* golden cases run on a default-sentinel
+                                      * vector. Non-vacuity: must be > 0.          */
+    long long    sentCases;          /* per-server comparisons on a sentinel vector */
+    long long    sentNotDefault;     /* sentinel vectors where the in-process C
+                                      * library did NOT reproduce the explicit
+                                      * default's result. Fails the run.           */
+    long long    lbCases;            /* per-server lookback-tier comparisons       */
+    long long    lbOorCases;         /* ... of which on an out-of-range vector     */
+    long long    lbSentCases;        /* ... of which on a default-sentinel vector  */
     int          reportedThisFunc;
     int          funcsWithFailures;
     ErrorNumber  error;
@@ -4621,6 +4795,216 @@ static void xlang_build_hex_request(char *buf, const TA_FuncInfo *fi,
     codegen_appendf(buf, JSON_BUF_SIZE, pos, "}}");
 }
 
+/* Load one parameter vector into the ta_abstract holder (shared by the batch
+ * leg, the sentinel's explicit-default re-run, and the lookback leg). */
+static void xlang_set_opt_params(TA_ParamHolder *paramHolder, const TA_FuncInfo *fi,
+                                 const double *vals)
+{
+    for( unsigned int i = 0; i < fi->nbOptInput && i < FUZZ_MAX_OPT; i++ )
+    {
+        const TA_OptInputParameterInfo *oi;
+        TA_GetOptInputParameterInfo(fi->handle, i, &oi);
+        if( oi->type == TA_OptInput_RealRange || oi->type == TA_OptInput_RealList )
+            TA_SetOptInputParamReal(paramHolder, i, vals[i]);
+        else
+            TA_SetOptInputParamInteger(paramHolder, i, (int)vals[i]);
+    }
+}
+
+/* Print one parameter vector for a diagnostic line. */
+static void xlang_print_params(const TA_FuncInfo *fi, const double *vals)
+{
+    for( unsigned int q = 0; q < fi->nbOptInput; q++ )
+    {
+        const TA_OptInputParameterInfo *oi;
+        TA_GetOptInputParameterInfo(fi->handle, q, &oi);
+        printf(" %s=%.15g", oi->paramName, vals[q]);
+    }
+}
+
+/* ---- Lookback tier (issue #148) --------------------------------------------
+ * The lookback entry point validates the same optional parameters as the batch
+ * call, from its own copy of the check, and a backend can therefore diverge at
+ * one tier and not the other. #148 was missing at BOTH: the Rust backend's
+ * single validation helper feeds lookback, batch and stream, so an absent arm
+ * silently un-gated all of them. This leg compares the lookback each language
+ * reports for the SAME parameter vector, including the out-of-range vectors —
+ * where the answer must be "rejected", not a number.
+ *
+ * Lookback is a pure function of the optional parameters, so it is swept once
+ * per parameter vector rather than once per (shape, seed, size, subrange).
+ * `abstract_get_lookback` is the RPC every generated server already implements
+ * (test_abstract.c drives it at default parameters). */
+static void xlang_build_lookback_request(char *buf, const TA_FuncInfo *fi,
+                                         const double *optVals)
+{
+    int pos = codegen_appendf(buf, JSON_BUF_SIZE, 0,
+        "{\"method\":\"abstract_get_lookback\",\"params\":{\"funcName\":\"%s\"", fi->name);
+    for( unsigned int i = 0; i < fi->nbOptInput; i++ )
+    {
+        const TA_OptInputParameterInfo *oi;
+        TA_GetOptInputParameterInfo(fi->handle, i, &oi);
+        if( oi->type == TA_OptInput_RealRange || oi->type == TA_OptInput_RealList )
+            pos = codegen_appendf(buf, JSON_BUF_SIZE, pos, ",\"%s\":%.15g", oi->paramName, optVals[i]);
+        else
+            pos = codegen_appendf(buf, JSON_BUF_SIZE, pos, ",\"%s\":%d", oi->paramName, (int)optVals[i]);
+    }
+    codegen_appendf(buf, JSON_BUF_SIZE, pos, "}}");
+}
+
+/* Normalize a server's `lookback` reply to the C convention: >= 0 is a real
+ * lookback, -1 means "parameters rejected". C and Java return -1 directly; the
+ * Rust crate's `<fn>_lookback` returns `usize::MAX`, which prints as a value far
+ * above any representable TA lookback — so "negative, or above INT_MAX" is the
+ * usize-width-independent invalid test rather than a hardcoded 2^64-1.
+ * *present = 0 when the field is absent (server error / unknown method). */
+static long long xlang_lookback_norm(const char *resp, int *present)
+{
+    int len;
+    const char *v = json_find_field(resp, "lookback", &len);
+    if( !v ) { if( present ) *present = 0; return -1; }
+    if( present ) *present = 1;
+    if( *v == '"' ) v++;
+    if( *v == '-' ) return -1;
+    unsigned long long u = strtoull(v, NULL, 10);
+    return (u > (unsigned long long)INT_MAX) ? -1 : (long long)u;
+}
+
+/* One lookback-tier sweep for a function: every parameter vector, every server. */
+static void xlang_lookback_leg(const TA_FuncInfo *funcInfo, XlangCtx *ctx,
+                               TA_ParamHolder *paramHolder,
+                               const double vec[FUZZ_MAX_VEC][FUZZ_MAX_OPT],
+                               const char *kind, int nvec)
+{
+    /* Match the batch leg's ambient state so the two tiers are comparable and
+     * the servers' unstable period (0 at spawn) agrees with ours. */
+    TA_SetUnstablePeriod(TA_FUNC_UNST_ALL, 0);
+
+    /* vec[0] is the all-defaults vector by construction — the value a sentinel
+     * must resolve to. */
+    xlang_set_opt_params(paramHolder, funcInfo, vec[0]);
+    TA_Integer defRaw = -1;
+    if( TA_GetLookback(paramHolder, &defRaw) != TA_SUCCESS ) defRaw = -1;
+    long long defLb = (defRaw < 0) ? -1 : (long long)defRaw;
+
+    for( int k = 0; k < nvec; k++ )
+    {
+        xlang_set_opt_params(paramHolder, funcInfo, vec[k]);
+
+        TA_Integer goldRaw = -1;
+        if( TA_GetLookback(paramHolder, &goldRaw) != TA_SUCCESS ) goldRaw = -1;
+        long long gold = (goldRaw < 0) ? -1 : (long long)goldRaw;
+
+        /* Self-check, same contract as the batch leg: an out-of-range vector the
+         * C lookback ACCEPTS is not out of range, and any parity we assert on it
+         * is vacuous. */
+        if( kind[k] == FUZZ_VEC_REJECT && gold >= 0 )
+        {
+            ctx->oorNotRejected++;
+            if( ctx->reportedThisFunc < 3 )
+            {
+                ctx->reportedThisFunc++;
+                printf("  XLANG OUT-OF-RANGE ACCEPTED BY C (lookback) TA_%s: lookback=%lld  params:",
+                       funcInfo->name, gold);
+                xlang_print_params(funcInfo, vec[k]);
+                printf("\n");
+            }
+        }
+        /* Sentinel self-check: `<param> = TA_*_DEFAULT` must give the SAME
+         * lookback as the explicit default. If C ever stopped substituting, the
+         * cross-language comparison below would still pass (both sides equally
+         * wrong), so this is what keeps the sentinel leg honest. */
+        if( kind[k] == FUZZ_VEC_SENTINEL && gold != defLb )
+        {
+            ctx->sentNotDefault++;
+            if( ctx->reportedThisFunc < 3 )
+            {
+                ctx->reportedThisFunc++;
+                printf("  XLANG SENTINEL != DEFAULT IN C (lookback) TA_%s: lookback %lld "
+                       "with the sentinel vs %lld with the explicit default  params:",
+                       funcInfo->name, gold, defLb);
+                xlang_print_params(funcInfo, vec[k]);
+                printf("\n");
+            }
+        }
+
+        xlang_build_lookback_request(ctx->reqBuf, funcInfo, vec[k]);
+
+        for( int sIdx = 0; sIdx < ctx->nsv; sIdx++ )
+        {
+            XlangServer *sv = &ctx->sv[sIdx];
+            if( !sv->open ) continue;
+            if( !xlang_call(sv, ctx->reqBuf, ctx->respBuf) )
+            {
+                if( ctx->error == TA_TEST_PASS ) ctx->error = TA_CODEGEN_PIPE_READ_FAILED;
+                sv->mism++;
+                continue;
+            }
+            int present = 0;
+            long long srv = xlang_lookback_norm(ctx->respBuf, &present);
+            sv->cases++;
+            ctx->lbCases++;
+            if( kind[k] == FUZZ_VEC_REJECT )   ctx->lbOorCases++;
+            if( kind[k] == FUZZ_VEC_SENTINEL ) ctx->lbSentCases++;
+
+            if( !present )
+            {
+                printf("  XLANG LOOKBACK PROTOCOL MISSING [%s] TA_%s: response has no "
+                       "lookback field (%.120s)\n", sv->display, funcInfo->name, ctx->respBuf);
+                if( ctx->error == TA_TEST_PASS ) ctx->error = TA_CODEGEN_OUTPUT_MISMATCH;
+                sv->mism++;
+                continue;
+            }
+            if( srv != gold )
+            {
+                sv->mism++;
+                if( ctx->reportedThisFunc < 3 )
+                {
+                    ctx->reportedThisFunc++;
+                    printf("  XLANG LOOKBACK MISMATCH TA_%s  C(golden) vs %s%s  params:",
+                           funcInfo->name, sv->display,
+                           kind[k] == FUZZ_VEC_REJECT
+                               ? "  [out-of-range vector: both tiers must REJECT]"
+                           : kind[k] == FUZZ_VEC_SENTINEL
+                               ? "  [sentinel vector: both tiers must resolve it to the default]"
+                               : "");
+                    xlang_print_params(funcInfo, vec[k]);
+                    printf("\n    lookback %lld/%lld (golden/%s; -1 = parameters rejected)\n",
+                           gold, srv, sv->display);
+                }
+            }
+        }
+    }
+}
+
+/* Issue ONE hash-mode call for `optVals` against `sv` and parse the reply
+ * (retCode / outBegIdx / outNBElement / out_hash). Hash mode is what makes the
+ * server return right after the GUARDED call, so this is also the only safe way
+ * to send a parameter the unguarded rerun could not accept. Returns 0 on a pipe
+ * failure or a reply with no out_hash (the caller reports and fails). */
+static int xlang_hash_call(XlangCtx *ctx, XlangServer *sv, const TA_FuncInfo *fi,
+                           const TA_History *hist, int n, int s, int e,
+                           int shape, int seed, const double *optVals,
+                           XHashParsed *out)
+{
+    if( sv->usesSeed )
+        fuzz_build_request(ctx->reqBuf, fi, s, e, shape, seed, n, optVals, 0);
+    else
+        xlang_build_hex_request(ctx->reqBuf, fi, hist, n, s, e, optVals, 1);
+
+    if( !xlang_call(sv, ctx->reqBuf, ctx->respBuf) )
+    {
+        if( ctx->error == TA_TEST_PASS ) ctx->error = TA_CODEGEN_PIPE_READ_FAILED;
+        return 0;
+    }
+    int present = 0;
+    out->rc        = json_get_int(ctx->respBuf, "retCode");
+    out->begIdx    = json_get_int(ctx->respBuf, "outBegIdx");
+    out->nbElement = json_get_int(ctx->respBuf, "outNBElement");
+    out->hash      = xlang_parse_hash(ctx->respBuf, "out_hash", &present);
+    return present;
+}
+
 /* Per-function bitwise comparison: golden in-process C vs each server. */
 static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
 {
@@ -4666,8 +5050,12 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
     setup_outputs(&p);
 
     double vec[FUZZ_MAX_VEC][FUZZ_MAX_OPT];
+    char kind[FUZZ_MAX_VEC];
     int vecOverflow = 0;
-    int nvec = fuzz_build_vectors(funcInfo, vec, &vecOverflow, 0);
+    /* frozenOracle=0: the current-vs-current path, so the sweep also carries the
+     * two contract classes flagged in `kind` (issue #148). */
+    memset(kind, FUZZ_VEC_NORMAL, sizeof(kind));
+    int nvec = fuzz_build_vectors(funcInfo, vec, &vecOverflow, 0, kind);
     if( vecOverflow > 0 )
     {
         printf("XLANG VECTOR OVERFLOW [TA_%s]: %d parameter value(s) dropped\n",
@@ -4685,6 +5073,10 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
     long long mismBefore = 0;
     for( int s = 0; s < ctx->nsv; s++ ) mismBefore += ctx->sv[s].mism;
 
+    /* Lookback tier first — same vectors, no data needed (issue #148). */
+    xlang_lookback_leg(funcInfo, ctx, paramHolder, (const double (*)[FUZZ_MAX_OPT])vec,
+                       kind, nvec);
+
     for( int shape = 0; shape < FUZZ_NSHAPES; shape++ )
     for( int si = 0; si < (int)(sizeof(seeds)/sizeof(seeds[0])); si++ )
     for( int zi = 0; zi < (int)(sizeof(sizes)/sizeof(sizes[0])); zi++ )
@@ -4697,15 +5089,7 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
 
         for( int k = 0; k < nvec; k++ )
         {
-            for( i = 0; i < funcInfo->nbOptInput && i < FUZZ_MAX_OPT; i++ )
-            {
-                const TA_OptInputParameterInfo *oi;
-                TA_GetOptInputParameterInfo(funcInfo->handle, i, &oi);
-                if( oi->type == TA_OptInput_RealRange || oi->type == TA_OptInput_RealList )
-                    TA_SetOptInputParamReal(paramHolder, i, vec[k][i]);
-                else
-                    TA_SetOptInputParamInteger(paramHolder, i, (int)vec[k][i]);
-            }
+            xlang_set_opt_params(paramHolder, funcInfo, vec[k]);
 
             /* subranges: full + two deterministic random windows (as --fuzz-064) */
             unsigned long long rs = 0xF0F0ULL ^ ((unsigned long long)shape<<8)
@@ -4725,6 +5109,14 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
             for( int ri = 0; ri < 3; ri++ )
             {
                 int s = ranges[ri][0], e = ranges[ri][1];
+                /* The parameter contract is validated BEFORE any startIdx/endIdx
+                 * logic runs, so it is subrange-independent by construction:
+                 * sweeping the contract vectors across all three windows triples
+                 * their cost and adds no discrimination. Full range only —
+                 * shapes x seeds x sizes still repeats each 81 times, and the
+                 * full range is also the window most likely to produce real
+                 * output for the sentinel comparison to bite on. */
+                if( kind[k] != FUZZ_VEC_NORMAL && ri != 0 ) continue;
                 TA_SetUnstablePeriod(TA_FUNC_UNST_ALL, 0);
 
                 TA_Integer curBeg = 0, curNb = 0;
@@ -4735,10 +5127,81 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                     else
                         TA_SetOutputParamRealPtr(paramHolder, o, p.outRealBufs[o]);
                 }
+                /* Sentinel leg (issue #148): run the SAME call with the
+                 * parameter set explicitly to its default first, so "the
+                 * sentinel selects the default" is asserted directly rather
+                 * than inferred. Without this the cross-language comparison
+                 * below would still pass if C stopped substituting too — both
+                 * sides equally wrong. Same buffers, so it must run BEFORE the
+                 * real call, whose hash is taken straight after. */
+                unsigned long long defHash = 0;
+                TA_RetCode defRc = TA_SUCCESS;
+                TA_Integer defBeg = 0, defNb = 0;
+                if( kind[k] == FUZZ_VEC_SENTINEL )
+                {
+                    xlang_set_opt_params(paramHolder, funcInfo, vec[0]);
+                    defRc = TA_CallFunc(paramHolder, s, e, &defBeg, &defNb);
+                    defHash = fuzz_hash_local(&p, (defRc == TA_SUCCESS) ? defNb : 0);
+                    xlang_set_opt_params(paramHolder, funcInfo, vec[k]);
+                    for( unsigned int o = 0; o < funcInfo->nbOutput; o++ )
+                    {
+                        if( p.outputIsInteger[o] )
+                            TA_SetOutputParamIntegerPtr(paramHolder, o, p.outIntBufs[o]);
+                        else
+                            TA_SetOutputParamRealPtr(paramHolder, o, p.outRealBufs[o]);
+                    }
+                }
+
                 TA_RetCode curRc = TA_CallFunc(paramHolder, s, e, &curBeg, &curNb);
                 unsigned long long curHash =
                     fuzz_hash_local(&p, (curRc == TA_SUCCESS) ? curNb : 0);
-                if( curRc == TA_SUCCESS && curNb > 0 ) ctx->nonEmpty++;
+                if( curRc == TA_SUCCESS && curNb > 0 && kind[k] != FUZZ_VEC_REJECT )
+                    ctx->nonEmpty++;
+
+                if( kind[k] == FUZZ_VEC_SENTINEL )
+                {
+                    ctx->sentGolden++;
+                    if( curRc != defRc || curBeg != defBeg || curNb != defNb ||
+                        curHash != defHash )
+                    {
+                        ctx->sentNotDefault++;
+                        if( ctx->reportedThisFunc < 3 )
+                        {
+                            ctx->reportedThisFunc++;
+                            printf("  XLANG SENTINEL != DEFAULT IN C TA_%s  shape=%d seed=%d "
+                                   "n=%d range=[%d,%d]  params:",
+                                   funcInfo->name, shape, seeds[si], n, s, e);
+                            xlang_print_params(funcInfo, vec[k]);
+                            printf("\n    sentinel retCode %d begIdx %d nbElem %d hash %016llx"
+                                   "  vs explicit default retCode %d begIdx %d nbElem %d hash %016llx\n",
+                                   (int)curRc, curBeg, curNb, curHash,
+                                   (int)defRc, defBeg, defNb, defHash);
+                        }
+                    }
+                }
+
+                /* Self-check for the rejection leg (issue #148): an out-of-range
+                 * vector the C library ACCEPTS is not out of range, and the
+                 * retCode parity asserted on it below would be vacuous — the two
+                 * languages would merely agree on a successful call. Fail loudly.
+                 * (The parity assertion itself is codegen_hash_compare /
+                 * codegen_compare_tol: both diff retCode first and short-circuit
+                 * to MATCH once the two sides agree on the same non-success
+                 * code, so an implementation that returns Success where C
+                 * returns TA_BAD_PARAM is a hard mismatch.) */
+                if( kind[k] == FUZZ_VEC_REJECT ) ctx->oorGolden++;
+                if( kind[k] == FUZZ_VEC_REJECT && curRc != TA_BAD_PARAM )
+                {
+                    ctx->oorNotRejected++;
+                    if( ctx->reportedThisFunc < 3 )
+                    {
+                        ctx->reportedThisFunc++;
+                        printf("  XLANG OUT-OF-RANGE ACCEPTED BY C TA_%s: retCode=%d "
+                               "(expected TA_BAD_PARAM)  params:", funcInfo->name, (int)curRc);
+                        xlang_print_params(funcInfo, vec[k]);
+                        printf("\n");
+                    }
+                }
 
                 /* C golden output buffers in logical order — the tolerance path
                  * (Java transcendentals) element-compares against these; the
@@ -4755,6 +5218,63 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                     XlangServer *sv = &ctx->sv[sIdx];
                     if( !sv->open ) continue;
 
+                    /* ---- Sentinel leg (issue #148) --------------------
+                     * The contract is "TA_*_DEFAULT selects the declared
+                     * default", which is a property of ONE implementation, so
+                     * it is asserted INSIDE each server: the same call with the
+                     * sentinel and with the explicit default must agree
+                     * bit-for-bit. That is stronger and cleaner than routing it
+                     * through the C golden:
+                     *   - it needs no tolerance, so Java's fdlibm transcendentals
+                     *     are gated bitwise here like everything else;
+                     *   - the cross-language correctness of the DEFAULT result is
+                     *     already gated by vec[0] in this same sweep, so
+                     *     server(sentinel) == server(default) == golden(default)
+                     *     == golden(sentinel) closes the loop transitively;
+                     *   - both calls are hash mode, which returns right after the
+                     *     GUARDED call. The tolerance path instead falls through
+                     *     to the server's UNGUARDED rerun, and "every optional
+                     *     parameter resolved (never a sentinel) and in-range" is
+                     *     an unguarded PRECONDITION (see the VARIANT gate section
+                     *     of src/tools/ta_regtest/CLAUDE.md). Sending the raw
+                     *     sentinel down that path killed the Java server with
+                     *     ArrayIndexOutOfBoundsException: Index -2147483634. */
+                    if( kind[k] == FUZZ_VEC_SENTINEL )
+                    {
+                        XHashParsed sent, dflt;
+                        int okS = xlang_hash_call(ctx, sv, funcInfo, &hist, n, s, e,
+                                                  shape, seeds[si], vec[k], &sent);
+                        int okD = okS && xlang_hash_call(ctx, sv, funcInfo, &hist, n, s, e,
+                                                         shape, seeds[si], vec[0], &dflt);
+                        if( !okS || !okD )
+                        {
+                            sv->mism++;
+                            if( ctx->error == TA_TEST_PASS ) ctx->error = TA_CODEGEN_OUTPUT_MISMATCH;
+                            continue;
+                        }
+                        sv->cases++;
+                        ctx->sentCases++;
+                        if( sent.rc != dflt.rc || sent.begIdx != dflt.begIdx ||
+                            sent.nbElement != dflt.nbElement || sent.hash != dflt.hash )
+                        {
+                            sv->mism++;
+                            if( ctx->reportedThisFunc < 3 )
+                            {
+                                ctx->reportedThisFunc++;
+                                printf("  XLANG SENTINEL MISMATCH TA_%s [%s]: the default "
+                                       "sentinel does not select the declared default  "
+                                       "shape=%d seed=%d n=%d range=[%d,%d]  params:",
+                                       funcInfo->name, sv->display, shape, seeds[si], n, s, e);
+                                xlang_print_params(funcInfo, vec[k]);
+                                printf("\n    sentinel retCode %d begIdx %d nbElem %d hash %016llx\n"
+                                       "    default  retCode %d begIdx %d nbElem %d hash %016llx\n",
+                                       sent.rc, sent.begIdx, sent.nbElement, sent.hash,
+                                       dflt.rc, dflt.begIdx, dflt.nbElement, dflt.hash);
+                            }
+                        }
+                        continue;
+                    }
+
                     /* Each server's request follows its transport. Seed servers
                      * (Rust) regenerate inputs from (shape,seed,n) via
                      * gen_present; hex servers (Java, no fuzz_gen port) get the
@@ -4766,8 +5286,32 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                         fuzz_build_request(ctx->reqBuf, funcInfo, s, e, shape, seeds[si], n, vec[k], 0);
                     else
                     {
-                        tolPath = codegen_call_is_transcendental(funcInfo->handle, vec[k],
+                        tolPath = kind[k] != FUZZ_VEC_REJECT &&
+                                  codegen_call_is_transcendental(funcInfo->handle, vec[k],
                                                                  (int)funcInfo->nbOptInput);
+                        /* An out-of-range vector always takes the hash path, even
+                         * on a transcendental. Two reasons, both load-bearing:
+                         *   1. A rejected call emits no output, so there is
+                         *      nothing for the fdlibm tolerance to relax — the
+                         *      only thing to compare is the retCode, and
+                         *      codegen_hash_compare compares that FIRST and
+                         *      short-circuits to MATCH once both sides agree on
+                         *      the same non-success code.
+                         *   2. want_hash makes the server return right after the
+                         *      GUARDED call; the tolerance path instead falls
+                         *      through to the server's unguarded timing rerun,
+                         *      which is UB here — "every optional parameter
+                         *      resolved and in-range" is an unguarded
+                         *      PRECONDITION (see the VARIANT gate section of
+                         *      src/tools/ta_regtest/CLAUDE.md), and unguarded
+                         *      does not validate. Sending a rejected parameter
+                         *      down that path made the Java server die with an
+                         *      ArrayIndexOutOfBoundsException inside
+                         *      linearRegAngleUnguardedInternal. The servers
+                         *      would be more robust skipping the unguarded rerun
+                         *      when the guarded call failed; that is a generator
+                         *      change across four backends, so this gate simply
+                         *      does not ask them to do it. */
                         /* Chaotic phase of a null signal — not comparable across
                          * libms; C==Rust bitwise, all other shapes gated. */
                         if( tolPath && xlang_java_illcond(funcInfo->name, shape) )
@@ -4783,6 +5327,8 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                     }
                     sv->cases++;
                     if( tolPath ) ctx->tolCases++;
+                    if( kind[k] == FUZZ_VEC_REJECT )   ctx->oorCases++;
+                    if( kind[k] == FUZZ_VEC_SENTINEL ) ctx->sentCases++;
 
                     if( tolPath )
                     {
@@ -4797,15 +5343,14 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                             if( ctx->reportedThisFunc < 3 )
                             {
                                 ctx->reportedThisFunc++;
-                                printf("  XLANG TOL MISMATCH TA_%s  C(golden) vs %s  "
+                                printf("  XLANG TOL MISMATCH TA_%s  C(golden) vs %s%s  "
                                        "shape=%d seed=%d n=%d range=[%d,%d]  params:",
-                                       funcInfo->name, sv->display, shape, seeds[si], n, s, e);
-                                for( unsigned int q = 0; q < funcInfo->nbOptInput; q++ )
-                                {
-                                    const TA_OptInputParameterInfo *oi;
-                                    TA_GetOptInputParameterInfo(funcInfo->handle, q, &oi);
-                                    printf(" %s=%.15g", oi->paramName, vec[k][q]);
-                                }
+                                       funcInfo->name, sv->display,
+                                       kind[k] == FUZZ_VEC_SENTINEL
+                                           ? "  [sentinel vector: the two languages must "
+                                             "agree on resolving it to the default]" : "",
+                                       shape, seeds[si], n, s, e);
+                                xlang_print_params(funcInfo, vec[k]);
                                 printf("\n    retCode %d/%d  begIdx %d/%d  nbElem %d/%d",
                                        (int)curRc, d.rc, curBeg, d.begIdx, curNb, d.nbElement);
                                 if( cv == CTOL_VALUE && !d.isInt )
@@ -4838,15 +5383,17 @@ static void xlang_one_function(const TA_FuncInfo *funcInfo, void *opaqueData)
                             if( ctx->reportedThisFunc < 3 )
                             {
                                 ctx->reportedThisFunc++;
-                                printf("  XLANG MISMATCH TA_%s  C(golden) vs %s  "
+                                printf("  XLANG MISMATCH TA_%s  C(golden) vs %s%s  "
                                        "shape=%d seed=%d n=%d range=[%d,%d]  params:",
-                                       funcInfo->name, sv->display, shape, seeds[si], n, s, e);
-                                for( unsigned int q = 0; q < funcInfo->nbOptInput; q++ )
-                                {
-                                    const TA_OptInputParameterInfo *oi;
-                                    TA_GetOptInputParameterInfo(funcInfo->handle, q, &oi);
-                                    printf(" %s=%.15g", oi->paramName, vec[k][q]);
-                                }
+                                       funcInfo->name, sv->display,
+                                       kind[k] == FUZZ_VEC_REJECT
+                                           ? "  [out-of-range vector: the two languages "
+                                             "must agree on REJECTING it]"
+                                       : kind[k] == FUZZ_VEC_SENTINEL
+                                           ? "  [sentinel vector: the two languages must "
+                                             "agree on resolving it to the default]" : "",
+                                       shape, seeds[si], n, s, e);
+                                xlang_print_params(funcInfo, vec[k]);
                                 printf("\n");
                                 codegen_hash_report(sv->display, curRc, curBeg, curNb, curHash, &hp);
                             }
@@ -4941,9 +5488,17 @@ ErrorNumber xlang_hash(const char *functionFilter, const char *languageFilter)
 
     long long totalMism = 0, totalCases = 0, totalRestarts = 0;
     printf("\n---------------------------------------------\n");
-    printf("golden cases: %lld   (in-process C library; %lld with non-empty output = %.0f%% non-vacuous)\n",
-           ctx.comparisons, ctx.nonEmpty,
-           ctx.comparisons ? 100.0 * (double)ctx.nonEmpty / (double)ctx.comparisons : 0.0);
+    /* The out-of-range cases produce no output BY DESIGN (they are the rejection
+     * leg), so they are excluded from the non-vacuity ratio rather than diluting
+     * it — the ratio still measures what it was written to measure: how much of
+     * the VALUE comparison is backed by real output. Sentinel cases DO produce
+     * output (they are successful calls) and stay in. */
+    long long valueCases = ctx.comparisons - ctx.oorGolden;
+    printf("golden cases: %lld   (in-process C library; %lld value case(s), %lld with "
+           "non-empty output = %.0f%% non-vacuous; %lld out-of-range case(s) empty by design)\n",
+           ctx.comparisons, valueCases, ctx.nonEmpty,
+           valueCases ? 100.0 * (double)ctx.nonEmpty / (double)valueCases : 0.0,
+           ctx.oorGolden);
     for( int s = 0; s < nsv; s++ )
     {
         if( servers[s].cases == 0 && !servers[s].open && !languageFilter ) continue;
@@ -4963,6 +5518,15 @@ ErrorNumber xlang_hash(const char *functionFilter, const char *languageFilter)
         printf("  (%lld Java HT_DCPHASE/HT_SINE call(s) skipped on the constant "
                "shape: atan2 phase of a null signal, ill-conditioned across libms "
                "— C==Rust bitwise there)\n", ctx.illcondSkipped);
+    printf("lookback tier: %lld case(s) compared (%lld out-of-range, %lld sentinel)\n",
+           ctx.lbCases, ctx.lbOorCases, ctx.lbSentCases);
+    printf("parameter-contract parity (issue #148):\n");
+    printf("  rejection — %lld batch + %lld lookback case(s) on below-min / above-max values "
+           "of every bounded optional parameter; C rejected all of them\n",
+           ctx.oorCases, ctx.lbOorCases);
+    printf("  sentinel  — %lld batch + %lld lookback case(s) on TA_REAL_DEFAULT / "
+           "TA_INTEGER_DEFAULT; C resolved every one to the explicit default's result\n",
+           ctx.sentCases, ctx.lbSentCases);
 
     free(ctx.reqBuf); free(ctx.respBuf);
 
@@ -4980,11 +5544,53 @@ ErrorNumber xlang_hash(const char *functionFilter, const char *languageFilter)
                "match all-empty==all-empty. Check the fuzz sizes/params.\n");
         return TA_CODEGEN_OUTPUT_MISMATCH;
     }
+    /* Contract-leg integrity (issue #148). An out-of-range candidate the C
+     * library accepts proves the candidate — not the implementation — is wrong,
+     * and every parity assertion made on it was vacuous. */
+    if( ctx.oorNotRejected > 0 )
+    {
+        printf("FAIL — %lld out-of-range parameter vector(s) were ACCEPTED by the "
+               "in-process C library. The candidates fuzz_add_out_of_range derives "
+               "from the ta_abstract range no longer match what the generated code "
+               "validates; the rejection-parity leg is vacuous until they agree.\n",
+               ctx.oorNotRejected);
+        return TA_CODEGEN_OUTPUT_MISMATCH;
+    }
+    /* Likewise for the sentinel: if C itself stopped resolving TA_*_DEFAULT to
+     * the declared default, "both languages agree" would no longer mean the
+     * contract holds. */
+    if( ctx.sentNotDefault > 0 )
+    {
+        printf("FAIL — %lld sentinel vector(s) did not reproduce the explicit default's "
+               "result in the in-process C library. TA_REAL_DEFAULT / TA_INTEGER_DEFAULT "
+               "must select the declared default (src/ta_func/ta_T3.c:76-77); until it "
+               "does, the sentinel-parity leg is vacuous.\n", ctx.sentNotDefault);
+        return TA_CODEGEN_OUTPUT_MISMATCH;
+    }
+    /* Non-vacuity: without a single rejected vector, and without a single
+     * sentinel vector, this gate is back to what it was before #148 — asserting
+     * only that VALUES agree, never that the parameter CONTRACT holds. Only
+     * meaningful on an unfiltered run: --function= can legitimately select
+     * functions that have no range-typed optional parameter at all. */
+    if( !functionFilter && ctx.comparisons > 0 &&
+        (ctx.oorGolden == 0 || ctx.oorCases == 0 || ctx.lbOorCases == 0 ||
+         ctx.sentGolden == 0 || ctx.sentCases == 0 || ctx.lbSentCases == 0) )
+    {
+        printf("FAIL — VACUOUS CONTRACT LEG: rejection %lld golden / %lld batch / %lld "
+               "lookback; sentinel %lld golden / %lld batch / %lld lookback. The sweep "
+               "produced no vector any language had to reject or resolve, so the "
+               "parameter contract is not being gated at all.\n",
+               ctx.oorGolden, ctx.oorCases, ctx.lbOorCases,
+               ctx.sentGolden, ctx.sentCases, ctx.lbSentCases);
+        return TA_CODEGEN_OUTPUT_MISMATCH;
+    }
     if( totalMism == 0 && inFails == 0 && ctx.error == TA_TEST_PASS )
     {
         printf("PASS — every server matches the in-process C library: BIT-IDENTICAL "
                "(zero tolerance), Java transcendentals within %g "
-               "(current-vs-current, all shapes, period>=2).\n",
+               "(current-vs-current, all shapes, period>=2); retCode and lookback "
+               "agree on every out-of-range parameter, and every default sentinel "
+               "resolves to the same value at both tiers.\n",
                CODEGEN_JAVA_TRANSCENDENTAL_TOL);
         return TA_TEST_PASS;
     }

--- a/ta_codegen/generator/CLAUDE.md
+++ b/ta_codegen/generator/CLAUDE.md
@@ -207,7 +207,11 @@ on `attempt to subtract with overflow`.
 ### Known Code Quality Issues (non-blocking)
 
 1. **`collect_for_loop_vars`** doesn't recurse into nested structures
-2. **`gen_opt_param_validation`** silently skips Real/Enum optional params
+2. **`gen_opt_param_validation`** silently skips Enum optional params: the `-4e37`
+   / range half is done (issue #148), but the `i32::MIN` default substitution the
+   C backend emits for `enum:MAType` params is still missing on the Rust side, so
+   `Core::ma(.., i32::MIN)` falls through the `match` instead of selecting SMA.
+   Range checking is not part of this — no enum optional param declares a `range:`.
 
 ## Linting
 

--- a/ta_codegen/generator/src/backends/rust_doc.rs
+++ b/ta_codegen/generator/src/backends/rust_doc.rs
@@ -78,13 +78,9 @@ pub fn guarded_docs(
             output_desc(&output.name, doc)
         ));
     }
-    if func
-        .optional_inputs
-        .iter()
-        .any(|o| matches!(o.param_type, ParamType::Integer))
-    {
+    if let Some(sentence) = default_sentinel_sentence(func) {
         d.blank();
-        d.paragraph("Integer parameters accept `i32::MIN` to select their default value.");
+        d.paragraph(sentence);
     }
 
     d.blank();
@@ -174,13 +170,40 @@ pub fn lookback_docs(func: &FuncDef, snake: &str, enums: &HashMap<String, EnumDe
             d.bullet(&param_doc(opt, doc, enums));
         }
         d.blank();
-        d.paragraph(
-            "Returns `usize::MAX` when a parameter is out of range. Integer parameters \
-             accept `i32::MIN` to select their default value.",
-        );
+        let mut sentence = String::from("Returns `usize::MAX` when a parameter is out of range.");
+        if let Some(extra) = default_sentinel_sentence(func) {
+            sentence.push(' ');
+            sentence.push_str(extra);
+        }
+        d.paragraph(&sentence);
     }
 
     d.finish()
+}
+
+/// How a caller asks for a parameter's default value, phrased for whichever kinds
+/// the function actually takes. Gated per kind because the two sentinels differ and
+/// several functions take only one kind: SAR and MAMA have no integer optional
+/// parameter at all, so an unconditional `i32::MIN` sentence documents an API they
+/// do not have. Returns `None` for a function whose optional parameters are all
+/// enums (no sentinel substitution is emitted for those).
+fn default_sentinel_sentence(func: &FuncDef) -> Option<&'static str> {
+    let takes = |want: fn(&ParamType) -> bool| {
+        func.optional_inputs
+            .iter()
+            .any(|o| want(&o.param_type) && o.default.is_some())
+    };
+    let has_int = takes(|t| matches!(t, ParamType::Integer));
+    let has_real = takes(|t| matches!(t, ParamType::Real));
+    match (has_int, has_real) {
+        (true, true) => Some(
+            "Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select \
+             their default value.",
+        ),
+        (true, false) => Some("Integer parameters accept `i32::MIN` to select their default value."),
+        (false, true) => Some("Real parameters accept `-4e37` to select their default value."),
+        (false, false) => None,
+    }
 }
 
 /// Rustdoc block for the `_unguarded` / `_private` variants.

--- a/ta_codegen/generator/src/backends/rust_lang.rs
+++ b/ta_codegen/generator/src/backends/rust_lang.rs
@@ -1018,22 +1018,51 @@ pub(crate) fn gen_opt_param_validation_with(opt: &OptInput, pad: &str, err_retur
     let mut out = String::new();
     let name = &opt.name;
 
-    if opt.param_type == ParamType::Integer {
-        if let Some(default) = opt.default {
-            out.push_str(&format!("{pad}if (({name}) as i32) == (i32::MIN) {{\n"));
-            #[allow(clippy::cast_possible_truncation)]
-            let default_i64 = default as i64;
-            out.push_str(&format!("{pad}    {name} = {default_i64};\n"));
+    match &opt.param_type {
+        ParamType::Integer => {
+            if let Some(default) = opt.default {
+                out.push_str(&format!("{pad}if (({name}) as i32) == (i32::MIN) {{\n"));
+                #[allow(clippy::cast_possible_truncation)]
+                let default_i64 = default as i64;
+                out.push_str(&format!("{pad}    {name} = {default_i64};\n"));
 
-            if let Some((lo, hi)) = opt.range {
-                out.push_str(&format!(
-                    "{pad}}} else if ((({name}) as i32) < {lo}) || ((({name}) as i32) > {hi}) {{\n"
-                ));
-                out.push_str(&format!("{pad}    {err_return}\n"));
+                if let Some((lo, hi)) = opt.range {
+                    out.push_str(&format!(
+                        "{pad}}} else if ((({name}) as i32) < {lo}) || ((({name}) as i32) > {hi}) {{\n"
+                    ));
+                    out.push_str(&format!("{pad}    {err_return}\n"));
+                }
+
+                out.push_str(&format!("{pad}}}\n"));
             }
-
-            out.push_str(&format!("{pad}}}\n"));
         }
+        ParamType::Real => {
+            if let Some(default) = opt.default {
+                // `-4e37` is the cross-language "use the default" sentinel (`TA_REAL_DEFAULT`);
+                // the bounds are emitted in exponent form so they are `f64` literals, not
+                // integers, on the comparison's right-hand side.
+                out.push_str(&format!("{pad}if {name} == -4e37 {{\n"));
+                out.push_str(&format!("{pad}    {name} = {default:e};\n"));
+
+                if let Some((lo, hi)) = opt.range {
+                    // Skip unbounded ranges: `TA_REAL_MIN`/`TA_REAL_MAX` reach the IR as
+                    // `f64::MIN`/`f64::MAX` and constrain nothing. Same magnitude test the
+                    // C and Java backends use.
+                    if lo > f64::MIN / 2.0 || hi < f64::MAX / 2.0 {
+                        out.push_str(&format!(
+                            "{pad}}} else if ({name} < {lo:e}) || ({name} > {hi:e}) {{\n"
+                        ));
+                        out.push_str(&format!("{pad}    {err_return}\n"));
+                    }
+                }
+
+                out.push_str(&format!("{pad}}}\n"));
+            }
+        }
+        // Enum optional params declare no `range:` in the YAML (see `doc_meta::RangeMeta`),
+        // so there is no bound to check. Price params expand to arrays validated
+        // separately; no scalar validation applies.
+        ParamType::Enum(_) | ParamType::Price(_) => {}
     }
 
     out

--- a/ta_codegen/generator/src/main.rs
+++ b/ta_codegen/generator/src/main.rs
@@ -1839,7 +1839,9 @@ path = "src/lib.rs"
 //!   written. An indicator consumes a number of leading values (its *lookback*)
 //!   before producing output — query it with the matching `*_lookback` method
 //!   (e.g. [`Core::sma_lookback`]).
-//! * Integer parameters accept `i32::MIN` to select their default value.
+//! * Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their
+//!   default value. A parameter outside its documented range returns
+//!   [`RetCode::BadParam`].
 //! * Every call returns a [`RetCode`]; anything other than [`RetCode::Success`]
 //!   means no output was produced.
 //!

--- a/ta_codegen/output/rust/library/src/lib.rs
+++ b/ta_codegen/output/rust/library/src/lib.rs
@@ -36,7 +36,9 @@
 //!   written. An indicator consumes a number of leading values (its *lookback*)
 //!   before producing output — query it with the matching `*_lookback` method
 //!   (e.g. [`Core::sma_lookback`]).
-//! * Integer parameters accept `i32::MIN` to select their default value.
+//! * Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their
+//!   default value. A parameter outside its documented range returns
+//!   [`RetCode::BadParam`].
 //! * Every call returns a [`RetCode`]; anything other than [`RetCode::Success`]
 //!   means no output was produced.
 //!

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -93,14 +93,20 @@ impl Core {
     /// * `optInMAType` — Moving-average type for the middle band (default 0 = SMA, values: 0=SMA,
     ///   1=EMA, 2=WMA, 3=DEMA, 4=TEMA, 5=TRIMA, 6=KAMA, 7=MAMA, 8=T3, 9=HMA, 10=DISABLED)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`,
+    /// and real parameters `-4e37`, to select their default value.
     #[inline]
     pub fn bbands_lookback(&self, mut optInTimePeriod: i32, mut optInNbDevUp: f64, mut optInNbDevDn: f64, mut optInMAType: i32) -> usize {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 20;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return usize::MAX;
+        }
+        if optInNbDevUp == -4e37 {
+            optInNbDevUp = 2e0;
+        }
+        if optInNbDevDn == -4e37 {
+            optInNbDevDn = 2e0;
         }
         let mut maLookback: usize = 0_usize;
         let mut stddevLookback: usize = 0_usize;
@@ -163,7 +169,8 @@ impl Core {
     /// * `outRealMiddleBand` — The moving average.
     /// * `outRealLowerBand` — Middle band minus nbDevDn standard deviations.
     ///
-    /// Integer parameters accept `i32::MIN` to select their default value.
+    /// Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their default
+    /// value.
     ///
     /// # Errors
     ///
@@ -231,6 +238,12 @@ impl Core {
             optInTimePeriod = 20;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
+        }
+        if optInNbDevUp == -4e37 {
+            optInNbDevUp = 2e0;
+        }
+        if optInNbDevDn == -4e37 {
+            optInNbDevDn = 2e0;
         }
         if outRealUpperBand.as_ptr() == outRealMiddleBand.as_ptr() || outRealUpperBand.as_ptr() == outRealLowerBand.as_ptr() || outRealMiddleBand.as_ptr() == outRealLowerBand.as_ptr() {
             return RetCode::BadParam;
@@ -765,6 +778,12 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
         }
+        if optInNbDevUp == -4e37 {
+            optInNbDevUp = 2e0;
+        }
+        if optInNbDevDn == -4e37 {
+            optInNbDevDn = 2e0;
+        }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -921,6 +940,12 @@ impl Core {
             optInTimePeriod = 20;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
+        }
+        if optInNbDevUp == -4e37 {
+            optInNbDevUp = 2e0;
+        }
+        if optInNbDevDn == -4e37 {
+            optInNbDevDn = 2e0;
         }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -71,10 +71,15 @@ impl Core {
     /// * `optInPenetration` — Fraction of the 1st candle's real body the 3rd close must penetrate
     ///   (default 0.3, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdlabandonedbaby_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type;
         #[allow(non_snake_case)]
@@ -119,6 +124,8 @@ impl Core {
     /// * `outInteger` — +100 at a bullish abandoned baby bottom (3rd candle white), -100 at a
     ///   bearish abandoned baby top (3rd candle black), 0 otherwise; sign = color of the 3rd
     ///   candle.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -181,6 +188,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyDojiPeriodTotal: f64 = 0.0_f64;
@@ -909,6 +921,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1283,6 +1300,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -72,10 +72,15 @@ impl Core {
     ///   penetrate below close\[i-1]; larger values require deeper penetration (default 0.5,
     ///   minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdldarkcloudcover_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type;
         #[allow(non_snake_case)]
@@ -108,6 +113,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — -100 when the pattern is detected (always bearish), 0 otherwise; never
     ///   emits +100.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -169,6 +176,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyLongPeriodTotal: f64 = 0.0_f64;
@@ -524,6 +536,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -742,6 +759,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -71,10 +71,15 @@ impl Core {
     /// * `optInPenetration` — Fraction of the 1st real body the 3rd candle's close must
     ///   penetrate; larger demands a deeper close into the first body (default 0.3, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdleveningdojistar_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type;
         #[allow(non_snake_case)]
@@ -117,6 +122,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — -100 when the pattern is detected, 0 otherwise. Always bearish; never
     ///   emits +100.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -179,6 +186,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyDojiPeriodTotal: f64 = 0.0_f64;
@@ -911,6 +923,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1286,6 +1303,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -71,10 +71,15 @@ impl Core {
     /// * `optInPenetration` — Fraction of the 1st candle's real body the 3rd close must penetrate
     ///   below the 1st close; larger requires deeper penetration (default 0.3, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdleveningstar_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type;
         #[allow(non_snake_case)]
@@ -112,6 +117,8 @@ impl Core {
     /// * `outBegIdx` — Set to the input index of the first output value.
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — -100 when detected (always bearish), 0 otherwise. Never emits +100.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -174,6 +181,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyShortPeriodTotal: f64 = 0.0_f64;
@@ -853,6 +865,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1214,6 +1231,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -71,10 +71,15 @@ impl Core {
     /// * `optInPenetration` — Max fraction of the 1st white body the reaction days (3rd, 4th) may
     ///   penetrate (default 0.5, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdlmathold_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type;
         #[allow(non_snake_case)]
@@ -114,6 +119,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — +100 when the bullish Mat Hold is detected, 0 otherwise. Never emits
     ///   -100.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -174,6 +181,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyPeriodTotal: [f64; 5 as usize] = [0.0_f64; 5 as usize];
@@ -860,6 +872,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1271,6 +1288,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 5e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -72,10 +72,15 @@ impl Core {
     ///   above close\[i-2]; larger values demand deeper penetration into the black body (default
     ///   0.3, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdlmorningdojistar_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type;
         #[allow(non_snake_case)]
@@ -122,6 +127,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — +100 when the pattern is detected, 0 otherwise. Always bullish; never
     ///   emits -100.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -184,6 +191,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyDojiPeriodTotal: f64 = 0.0_f64;
@@ -916,6 +928,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1291,6 +1308,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -71,10 +71,15 @@ impl Core {
     /// * `optInPenetration` — Fraction of the 1st candle's body the 3rd close must exceed above
     ///   the 1st close; larger = deeper penetration required (default 0.3, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn cdlmorningstar_lookback(&self, mut optInPenetration: f64) -> usize {
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         #[allow(non_snake_case)]
         let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type;
         #[allow(non_snake_case)]
@@ -114,6 +119,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outInteger` — +100 when the morning star is detected, 0 otherwise. Never negative
     ///   (pattern is exclusively bullish)
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -176,6 +183,11 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut BodyShortPeriodTotal: f64 = 0.0_f64;
@@ -855,6 +867,11 @@ impl Core {
         if inOpen.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inOpen.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1216,6 +1233,11 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inOpen.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInPenetration == -4e37 {
+            optInPenetration = 3e-1;
+        } else if (optInPenetration < 0e0) || (optInPenetration > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inOpen.len();

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -75,10 +75,20 @@ impl Core {
     /// * `optInSlowLimit` — Lower bound on the adaptive smoothing factor (default 0.05, range
     ///   0.01..=0.99)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn mama_lookback(&self, mut optInFastLimit: f64, mut optInSlowLimit: f64) -> usize {
+        if optInFastLimit == -4e37 {
+            optInFastLimit = 5e-1;
+        } else if (optInFastLimit < 1e-2) || (optInFastLimit > 9.9e-1) {
+            return usize::MAX;
+        }
+        if optInSlowLimit == -4e37 {
+            optInSlowLimit = 5e-2;
+        } else if (optInSlowLimit < 1e-2) || (optInSlowLimit > 9.9e-1) {
+            return usize::MAX;
+        }
         // The two parameters are not a factor to determine
         // the lookback, but are still requested for
         // consistency with all other Lookback functions.
@@ -125,6 +135,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outMAMA` — Adaptive moving average (fast line)
     /// * `outFAMA` — Following adaptive moving average, using half the alpha (slow line)
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -185,6 +197,16 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInFastLimit == -4e37 {
+            optInFastLimit = 5e-1;
+        } else if (optInFastLimit < 1e-2) || (optInFastLimit > 9.9e-1) {
+            return RetCode::BadParam;
+        }
+        if optInSlowLimit == -4e37 {
+            optInSlowLimit = 5e-2;
+        } else if (optInSlowLimit < 1e-2) || (optInSlowLimit > 9.9e-1) {
+            return RetCode::BadParam;
         }
         if outMAMA.as_ptr() == outFAMA.as_ptr() {
             return RetCode::BadParam;
@@ -1153,6 +1175,16 @@ impl Core {
         if inReal.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInFastLimit == -4e37 {
+            optInFastLimit = 5e-1;
+        } else if (optInFastLimit < 1e-2) || (optInFastLimit > 9.9e-1) {
+            return Err(RetCode::BadParam);
+        }
+        if optInSlowLimit == -4e37 {
+            optInSlowLimit = 5e-2;
+        } else if (optInSlowLimit < 1e-2) || (optInSlowLimit > 9.9e-1) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1627,6 +1659,16 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if outMAMA.as_ptr() == outFAMA.as_ptr() {
+            return Err(RetCode::BadParam);
+        }
+        if optInFastLimit == -4e37 {
+            optInFastLimit = 5e-1;
+        } else if (optInFastLimit < 1e-2) || (optInFastLimit > 9.9e-1) {
+            return Err(RetCode::BadParam);
+        }
+        if optInSlowLimit == -4e37 {
+            optInSlowLimit = 5e-2;
+        } else if (optInSlowLimit < 1e-2) || (optInSlowLimit > 9.9e-1) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inReal.len();

--- a/ta_codegen/output/rust/library/src/ta_func/sar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sar.rs
@@ -74,10 +74,20 @@ impl Core {
     ///   (default 0.02, minimum 0)
     /// * `optInMaximum` — Ceiling on the acceleration factor (default 0.2, minimum 0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn sar_lookback(&self, mut optInAcceleration: f64, mut optInMaximum: f64) -> usize {
+        if optInAcceleration == -4e37 {
+            optInAcceleration = 2e-2;
+        } else if (optInAcceleration < 0e0) || (optInAcceleration > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInMaximum == -4e37 {
+            optInMaximum = 2e-1;
+        } else if (optInMaximum < 0e0) || (optInMaximum > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         // SAR always sacrify one price bar to establish the
         // initial extreme price.
         return (1) as usize;
@@ -107,6 +117,8 @@ impl Core {
     /// * `outBegIdx` — Set to the input index of the first output value.
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outReal` — Parabolic SAR stop/reverse level per bar.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -168,6 +180,16 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInAcceleration == -4e37 {
+            optInAcceleration = 2e-2;
+        } else if (optInAcceleration < 0e0) || (optInAcceleration > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInMaximum == -4e37 {
+            optInMaximum = 2e-1;
+        } else if (optInMaximum < 0e0) || (optInMaximum > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut retCode: RetCode = RetCode::Success;
@@ -712,6 +734,16 @@ impl Core {
         if inHigh.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInAcceleration == -4e37 {
+            optInAcceleration = 2e-2;
+        } else if (optInAcceleration < 0e0) || (optInAcceleration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInMaximum == -4e37 {
+            optInMaximum = 2e-1;
+        } else if (optInMaximum < 0e0) || (optInMaximum > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inHigh.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -985,6 +1017,16 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inHigh.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInAcceleration == -4e37 {
+            optInAcceleration = 2e-2;
+        } else if (optInAcceleration < 0e0) || (optInAcceleration > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInMaximum == -4e37 {
+            optInMaximum = 2e-1;
+        } else if (optInMaximum < 0e0) || (optInMaximum > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inHigh.len();

--- a/ta_codegen/output/rust/library/src/ta_func/sarext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sarext.rs
@@ -88,10 +88,48 @@ impl Core {
     /// * `optInAccelerationMaxShort` — Cap on the short acceleration factor (default 0.2, minimum
     ///   0)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Real parameters accept `-4e37` to
+    /// select their default value.
     #[inline]
     pub fn sarext_lookback(&self, mut optInStartValue: f64, mut optInOffsetOnReverse: f64, mut optInAccelerationInitLong: f64, mut optInAccelerationLong: f64, mut optInAccelerationMaxLong: f64, mut optInAccelerationInitShort: f64, mut optInAccelerationShort: f64, mut optInAccelerationMaxShort: f64) -> usize {
+        if optInStartValue == -4e37 {
+            optInStartValue = 0e0;
+        }
+        if optInOffsetOnReverse == -4e37 {
+            optInOffsetOnReverse = 0e0;
+        } else if (optInOffsetOnReverse < 0e0) || (optInOffsetOnReverse > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationInitLong == -4e37 {
+            optInAccelerationInitLong = 2e-2;
+        } else if (optInAccelerationInitLong < 0e0) || (optInAccelerationInitLong > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationLong == -4e37 {
+            optInAccelerationLong = 2e-2;
+        } else if (optInAccelerationLong < 0e0) || (optInAccelerationLong > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationMaxLong == -4e37 {
+            optInAccelerationMaxLong = 2e-1;
+        } else if (optInAccelerationMaxLong < 0e0) || (optInAccelerationMaxLong > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationInitShort == -4e37 {
+            optInAccelerationInitShort = 2e-2;
+        } else if (optInAccelerationInitShort < 0e0) || (optInAccelerationInitShort > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationShort == -4e37 {
+            optInAccelerationShort = 2e-2;
+        } else if (optInAccelerationShort < 0e0) || (optInAccelerationShort > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
+        if optInAccelerationMaxShort == -4e37 {
+            optInAccelerationMaxShort = 2e-1;
+        } else if (optInAccelerationMaxShort < 0e0) || (optInAccelerationMaxShort > 1.7976931348623157e308) {
+            return usize::MAX;
+        }
         // SAR always sacrifices one price bar to establish the
         // initial extreme price.
         return (1) as usize;
@@ -130,6 +168,8 @@ impl Core {
     /// * `outBegIdx` — Set to the input index of the first output value.
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outReal` — SAR stop level; positive while long, negative while short.
+    ///
+    /// Real parameters accept `-4e37` to select their default value.
     ///
     /// # Errors
     ///
@@ -191,6 +231,44 @@ impl Core {
     ) -> RetCode {
         if endIdx < startIdx {
             return RetCode::OutOfRangeStartIndex;
+        }
+        if optInStartValue == -4e37 {
+            optInStartValue = 0e0;
+        }
+        if optInOffsetOnReverse == -4e37 {
+            optInOffsetOnReverse = 0e0;
+        } else if (optInOffsetOnReverse < 0e0) || (optInOffsetOnReverse > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationInitLong == -4e37 {
+            optInAccelerationInitLong = 2e-2;
+        } else if (optInAccelerationInitLong < 0e0) || (optInAccelerationInitLong > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationLong == -4e37 {
+            optInAccelerationLong = 2e-2;
+        } else if (optInAccelerationLong < 0e0) || (optInAccelerationLong > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationMaxLong == -4e37 {
+            optInAccelerationMaxLong = 2e-1;
+        } else if (optInAccelerationMaxLong < 0e0) || (optInAccelerationMaxLong > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationInitShort == -4e37 {
+            optInAccelerationInitShort = 2e-2;
+        } else if (optInAccelerationInitShort < 0e0) || (optInAccelerationInitShort > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationShort == -4e37 {
+            optInAccelerationShort = 2e-2;
+        } else if (optInAccelerationShort < 0e0) || (optInAccelerationShort > 1.7976931348623157e308) {
+            return RetCode::BadParam;
+        }
+        if optInAccelerationMaxShort == -4e37 {
+            optInAccelerationMaxShort = 2e-1;
+        } else if (optInAccelerationMaxShort < 0e0) || (optInAccelerationMaxShort > 1.7976931348623157e308) {
+            return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
         let mut retCode: RetCode = RetCode::Success;
@@ -843,6 +921,44 @@ impl Core {
         if inHigh.len() > i32::MAX as usize {
             return Err(RetCode::BadParam);
         }
+        if optInStartValue == -4e37 {
+            optInStartValue = 0e0;
+        }
+        if optInOffsetOnReverse == -4e37 {
+            optInOffsetOnReverse = 0e0;
+        } else if (optInOffsetOnReverse < 0e0) || (optInOffsetOnReverse > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationInitLong == -4e37 {
+            optInAccelerationInitLong = 2e-2;
+        } else if (optInAccelerationInitLong < 0e0) || (optInAccelerationInitLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationLong == -4e37 {
+            optInAccelerationLong = 2e-2;
+        } else if (optInAccelerationLong < 0e0) || (optInAccelerationLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationMaxLong == -4e37 {
+            optInAccelerationMaxLong = 2e-1;
+        } else if (optInAccelerationMaxLong < 0e0) || (optInAccelerationMaxLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationInitShort == -4e37 {
+            optInAccelerationInitShort = 2e-2;
+        } else if (optInAccelerationInitShort < 0e0) || (optInAccelerationInitShort > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationShort == -4e37 {
+            optInAccelerationShort = 2e-2;
+        } else if (optInAccelerationShort < 0e0) || (optInAccelerationShort > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationMaxShort == -4e37 {
+            optInAccelerationMaxShort = 2e-1;
+        } else if (optInAccelerationMaxShort < 0e0) || (optInAccelerationMaxShort > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inHigh.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -1180,6 +1296,44 @@ impl Core {
             return Err(RetCode::BadParam);
         }
         if inHigh.len() > i32::MAX as usize {
+            return Err(RetCode::BadParam);
+        }
+        if optInStartValue == -4e37 {
+            optInStartValue = 0e0;
+        }
+        if optInOffsetOnReverse == -4e37 {
+            optInOffsetOnReverse = 0e0;
+        } else if (optInOffsetOnReverse < 0e0) || (optInOffsetOnReverse > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationInitLong == -4e37 {
+            optInAccelerationInitLong = 2e-2;
+        } else if (optInAccelerationInitLong < 0e0) || (optInAccelerationInitLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationLong == -4e37 {
+            optInAccelerationLong = 2e-2;
+        } else if (optInAccelerationLong < 0e0) || (optInAccelerationLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationMaxLong == -4e37 {
+            optInAccelerationMaxLong = 2e-1;
+        } else if (optInAccelerationMaxLong < 0e0) || (optInAccelerationMaxLong > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationInitShort == -4e37 {
+            optInAccelerationInitShort = 2e-2;
+        } else if (optInAccelerationInitShort < 0e0) || (optInAccelerationInitShort > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationShort == -4e37 {
+            optInAccelerationShort = 2e-2;
+        } else if (optInAccelerationShort < 0e0) || (optInAccelerationShort > 1.7976931348623157e308) {
+            return Err(RetCode::BadParam);
+        }
+        if optInAccelerationMaxShort == -4e37 {
+            optInAccelerationMaxShort = 2e-1;
+        } else if (optInAccelerationMaxShort < 0e0) || (optInAccelerationMaxShort > 1.7976931348623157e308) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inHigh.len();

--- a/ta_codegen/output/rust/library/src/ta_func/stddev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stddev.rs
@@ -74,14 +74,17 @@ impl Core {
     /// * `optInTimePeriod` — Window length (default 5, range 2..=100000)
     /// * `optInNbDev` — Multiplier applied to the standard deviation (default 1)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`,
+    /// and real parameters `-4e37`, to select their default value.
     #[inline]
     pub fn stddev_lookback(&self, mut optInTimePeriod: i32, mut optInNbDev: f64) -> usize {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return usize::MAX;
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         // Lookback is driven by the variance.
         return self.var_lookback(optInTimePeriod, optInNbDev);
@@ -111,7 +114,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outReal` — Standard deviation at each bar, scaled by optInNbDev.
     ///
-    /// Integer parameters accept `i32::MIN` to select their default value.
+    /// Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their default
+    /// value.
     ///
     /// # Errors
     ///
@@ -171,6 +175,9 @@ impl Core {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         let mut startIdx = startIdx;
         let mut i: usize = 0_usize;
@@ -337,6 +344,9 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
         }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
+        }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -441,6 +451,9 @@ impl Core {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -83,13 +83,18 @@ impl Core {
     /// * `optInVFactor` — Volume factor weighting the coefficients (0 = plain triple EMA, higher
     ///   = more DEMA-like sharpening) (default 0.7, range 0..=1)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`,
+    /// and real parameters `-4e37`, to select their default value.
     #[inline]
     pub fn t3_lookback(&self, mut optInTimePeriod: i32, mut optInVFactor: f64) -> usize {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
+            return usize::MAX;
+        }
+        if optInVFactor == -4e37 {
+            optInVFactor = 7e-1;
+        } else if (optInVFactor < 0e0) || (optInVFactor > 1e0) {
             return usize::MAX;
         }
         return (6 * (optInTimePeriod - 1) + self.unstable_period[FuncUnstId::T3 as usize]) as usize;
@@ -123,7 +128,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outReal` — T3 smoothed line.
     ///
-    /// Integer parameters accept `i32::MIN` to select their default value.
+    /// Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their default
+    /// value.
     ///
     /// # Errors
     ///
@@ -183,6 +189,11 @@ impl Core {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
+            return RetCode::BadParam;
+        }
+        if optInVFactor == -4e37 {
+            optInVFactor = 7e-1;
+        } else if (optInVFactor < 0e0) || (optInVFactor > 1e0) {
             return RetCode::BadParam;
         }
         let mut startIdx = startIdx;
@@ -576,6 +587,11 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
         }
+        if optInVFactor == -4e37 {
+            optInVFactor = 7e-1;
+        } else if (optInVFactor < 0e0) || (optInVFactor > 1e0) {
+            return Err(RetCode::BadParam);
+        }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -815,6 +831,11 @@ impl Core {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
+            return Err(RetCode::BadParam);
+        }
+        if optInVFactor == -4e37 {
+            optInVFactor = 7e-1;
+        } else if (optInVFactor < 0e0) || (optInVFactor > 1e0) {
             return Err(RetCode::BadParam);
         }
         let historyLen: usize = inReal.len();

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -76,14 +76,17 @@ impl Core {
     /// * `optInNbDev` — Deviation count accepted by the API but never used in the computation
     ///   (default 1)
     ///
-    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`
-    /// to select their default value.
+    /// Returns `usize::MAX` when a parameter is out of range. Integer parameters accept `i32::MIN`,
+    /// and real parameters `-4e37`, to select their default value.
     #[inline]
     pub fn var_lookback(&self, mut optInTimePeriod: i32, mut optInNbDev: f64) -> usize {
         if ((optInTimePeriod) as i32) == (i32::MIN) {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
             return usize::MAX;
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         return (optInTimePeriod - 1) as usize;
     }
@@ -114,7 +117,8 @@ impl Core {
     /// * `outNBElement` — Set to the number of output values written.
     /// * `outReal` — Rolling population variance.
     ///
-    /// Integer parameters accept `i32::MIN` to select their default value.
+    /// Integer parameters accept `i32::MIN`, and real parameters `-4e37`, to select their default
+    /// value.
     ///
     /// # Errors
     ///
@@ -169,6 +173,9 @@ impl Core {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         let mut startIdx = startIdx;
         let mut tempReal: f64 = 0.0_f64;
@@ -523,6 +530,9 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
         }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
+        }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;
         let mut startIdx = startIdx;
@@ -716,6 +726,9 @@ impl Core {
             optInTimePeriod = 5;
         } else if (((optInTimePeriod) as i32) < 1) || (((optInTimePeriod) as i32) > 100000) {
             return Err(RetCode::BadParam);
+        }
+        if optInNbDev == -4e37 {
+            optInNbDev = 1e0;
         }
         let historyLen: usize = inReal.len();
         let endIdx: usize = historyLen - 1;


### PR DESCRIPTION
Closes the Rust half of the gap reported in #148, and with it item 2 of
`ta_codegen/generator/CLAUDE.md`'s own **Known Code Quality Issues** list —
*"`gen_opt_param_validation` silently skips Real/Enum optional params"*.

## What this changes

`backends/rust_lang.rs::gen_opt_param_validation_with` wrapped its entire body in
`if opt.param_type == ParamType::Integer` (`:1021` on `dev`), so every `real` optional
parameter reached the generated Rust with no validation at all — no range check, and no
default-sentinel substitution either. The C backend has had the arm the whole time
(`backends/c.rs:266-282`), as has Java (`backends/java.rs:552-570`).

The `if` becomes a `match` and gains the `ParamType::Real` arm, emitting the same shape
the other two backends emit:

```rust
if optInVFactor == -4e37 {
    optInVFactor = 7e-1;
} else if (optInVFactor < 0e0) || (optInVFactor > 1e0) {
    return RetCode::BadParam;
}
```

against C's

```c
if( optInVFactor == -4e37 )
   optInVFactor = 0.7;
else if( optInVFactor < 0e0 || optInVFactor > 1e0 )
   return TA_BAD_PARAM;
```

The "skip unbounded ranges" magnitude test (`c.rs:275`) comes across unchanged, so the
five parameters declared `[TA_REAL_MIN, TA_REAL_MAX]` get the sentinel substitution and
no range check — exactly as in C.

Bounds are emitted in exponent form (`0e0`, `9.9e-1`) rather than plain Display, because
`0` and `1` would be integer literals on the right-hand side of an `f64` comparison and
would not compile.

## Scope, measured from the regenerated output

**24** real optional parameters now honour the `-4e37` sentinel. **19** of them, across
**11** functions, additionally reject out-of-range values:

| Function(s) | Parameter(s) | Declared range |
| --- | --- | --- |
| `CDLABANDONEDBABY`, `CDLDARKCLOUDCOVER`, `CDLEVENINGDOJISTAR`, `CDLEVENINGSTAR`, `CDLMATHOLD`, `CDLMORNINGDOJISTAR`, `CDLMORNINGSTAR` | `optInPenetration` (7) | `[0, TA_REAL_MAX]` |
| `MAMA` | `optInFastLimit`, `optInSlowLimit` | `[0.01, 0.99]` |
| `SAR` | `optInAcceleration`, `optInMaximum` | `[0, TA_REAL_MAX]` |
| `SAREXT` | `optInOffsetOnReverse`, `optInAccelerationInitLong`, `optInAccelerationLong`, `optInAccelerationMaxLong`, `optInAccelerationInitShort`, `optInAccelerationShort`, `optInAccelerationMaxShort` (7) | `[0, TA_REAL_MAX]` |
| `T3` | `optInVFactor` | `[0, 1]` |

The remaining five — `BBANDS.optInNbDevUp`/`optInNbDevDn`, `STDDEV.optInNbDev`,
`VAR.optInNbDev`, `SAREXT.optInStartValue` — are `[TA_REAL_MIN, TA_REAL_MAX]` and get
sentinel substitution only.

Every validated entry point is covered: `*_lookback` (which fails with `usize::MAX`), the
batch call, and both streaming entry points. The `_unguarded` variants stay validation-free
by design, exactly as they already were for integer parameters.

## Behavior change

**This rejects input that previously succeeded, and it is worth calling out explicitly for
the `ta-lib` crate's semver.** A real optional value outside a documented bound now returns
`RetCode::BadParam` (or `usize::MAX` from a lookback) instead of `RetCode::Success` and a
number. The rejection itself is not new to the library — the C implementation has always
performed it — but it is new to the Rust crate.

Measured on the built artifacts, same 60-point sine series, before and after this commit,
plus the C library from this tree for reference (`TA_SUCCESS = 0`, `TA_BAD_PARAM = 2`):

| Call | Rust before | Rust after | C |
| --- | --- | --- | --- |
| `t3(x, 5, 1.05)` | `Success`, 36 values | `BadParam` | `2` |
| `t3_lookback(5, 1.05)` | `24` | `usize::MAX` | `-1` |
| `sar(h, l, -1.0, 0.2)` | `Success`, max\|out\| = **6.29e66** | `BadParam` | `2` |
| `mama(x, 5.0, 0.05)` | `Success`, 28 values | `BadParam` | `2` |
| `cdldarkcloudcover(…, -3.0)` | `Success`, 49 values | `BadParam` | `2` |
| `t3(x, 5, -4e37)` | `Success`, first = **1.005e112** | `Success`, first = 108.38931656904083 | first = 108.38931656904 |

The last row is the second half of the change, and it goes beyond the direction suggested
in the issue. The issue argued Rust needed only the range check, since the generated docs
said only integer parameters accept a default sentinel. That reading was circular: the docs
said so *because* reals had no handling at all. Adding the range check alone would have made
`-4e37` — the value every other binding accepts as "use the default" — start returning
`BadParam`, replacing one cross-language divergence with a new one. With the sentinel branch,
`t3(x, 5, -4e37)` now produces exactly what `t3(x, 5, 0.7)` produces, matching C.

## Docs corrected in the same pass

Two statements in the tree were false, both about this code path:

1. The per-function rustdoc sentence *"Integer parameters accept `i32::MIN` to select their
   default value"* was emitted unconditionally for any function with optional parameters.
   SAR and MAMA have **no** integer optional parameter, so both documented an API they do not
   have. It is now gated on the kinds a function actually takes and names the real sentinel
   where one applies (`rust_doc.rs::default_sentinel_sentence`, shared by the batch and
   lookback doc emitters). The crate-level doc in `main.rs` gets the same treatment.

2. `docs/param-boundary-audit.md` closed with *"the library does not range-check real optional
   parameters"*. That was never true of C (`src/ta_func/ta_T3.c:76-79`;
   `backends/c.rs:266-282`). Rewritten to say what the library does and what the boundary
   sweep does not yet assert.

Note that the generated `# Errors` section already promised `RetCode::BadParam` *"when an
optional parameter is outside its documented range"*, and `t3.rs` already documented
`optInVFactor` as *"range 0..=1"*. The docs were describing the intended contract; only the
emitter was missing.

## Why `Enum` is not covered

`CLAUDE.md`'s note says "Real/Enum". This PR does Real only, deliberately.

All **13** enum optional parameters in `ta_codegen/input/*/*.yaml` (`optInMAType` and friends)
declare **no `range:` key**. C's `ParamType::Integer | ParamType::Enum(_)` arm therefore emits
no range check for any of them either — `ta_MA.c:73-74` is default substitution and nothing
else. An enum arm in the Rust backend would emit dead code.

What *is* genuinely missing for enums is the `i32::MIN` default substitution: C maps
`0x80000000` to the declared default, Rust does not, so `Core::ma(.., i32::MIN)` falls through
the dispatch `match` to the `_` arm instead of selecting SMA. That is a different behavior
change (sentinel semantics, not bounds) on a different set of functions, so it does not belong
in a PR titled "range-check real optional params". The known-issues note in
`ta_codegen/generator/CLAUDE.md` is narrowed to exactly that residue rather than deleted. Happy
to send it as a follow-up if you want it.

## Tests — the gate for both halves of the parameter contract (`test_codegen.c`)

You were right that the verification table below passed equally well without the
generator change. It does not any more. `ta_regtest --xlang-hash` now goes from
`PASS / 0 mismatches` to `FAIL / 13 functions` if either half of the arm is removed,
and each half is proven independently.

Everything is inside `ta_regtest`; the existing `fuzz_build_vectors` sweep is extended,
no new harness. Two candidate classes, both driven off `ta_abstract` metadata:

| Class | Candidates | Contract |
| --- | --- | --- |
| `FUZZ_VEC_REJECT` (`fuzz_add_out_of_range`) | below-min, above-max — per **bounded** side, integer ranges as well as real | the call must be **rejected** (`TA_BAD_PARAM` / an invalid lookback) |
| `FUZZ_VEC_SENTINEL` (`fuzz_add_default_sentinel`) | `TA_REAL_DEFAULT` (`-4e37`), `TA_INTEGER_DEFAULT` (`INT_MIN`) — per **Range** parameter, bounded or not | the call must **succeed with the declared default's result** |

Because it stays metadata-driven, the 19 bounded reals and every bounded integer range
come for free, and so does anything bounded added later.

**Pointed at `:4670` only.** `fuzz_build_vectors(..., frozenOracle=1)` — the `:3942`
v0.6.4 path — emits neither class, exactly as you asked. Evidence that they are really
separated: `--fuzz-064` reports `comparisons: 171230   matches: 148119   benign: 30
cci-tolerated: 8434   fma-tolerated: 14647   failures: 0` **byte-identical** with and
without this commit.

**Both tiers**, since lookback carries its own copy of the validation. The batch call
reuses the existing verdict machinery (`codegen_hash_compare` / `codegen_compare_tol`
diff `retCode` first and short-circuit to MATCH once both sides agree on the same
non-success code). The lookback tier gets `xlang_lookback_leg`, one
`abstract_get_lookback` per parameter vector — lookback is a pure function of the
parameters, so it needs no data. C and Java report a rejected lookback as `-1`, the Rust
crate as `usize::MAX`; both normalize to `-1` before comparing.

**The sentinel is asserted inside each server**, not against the C golden: the same call
with the sentinel and with the explicit default must agree bit-for-bit. "The sentinel
selects the default" is a property of one implementation, and asserting it
language-internally needs no tolerance, so Java's fdlibm transcendentals (MAMA,
LINEARREG_ANGLE) stay bitwise here like everything else. Nothing is lost — `vec[0]`
already gates the *default's* result across languages in the same sweep, so
`server(sentinel) == server(default) ≈ golden(default) == golden(sentinel)` closes the
loop transitively.

**Three self-checks keep it from passing vacuously:** an out-of-range vector the
in-process C library *accepts* fails the run (the candidate has drifted from what the
generated code validates, so its parity assertion would be meaningless); a sentinel
vector where C does not reproduce the explicit default's result fails the run; and an
unfiltered run producing zero cases in either class at either tier fails as
`VACUOUS CONTRACT LEG`.

Summary line on a clean run:

```
lookback tier: 1128 case(s) compared (192 out-of-range, 109 sentinel)
parameter-contract parity (issue #148):
  rejection — 15552 batch + 192 lookback case(s) on below-min / above-max values of every bounded optional parameter; C rejected all of them
  sentinel  — 8829 batch + 109 lookback case(s) on TA_REAL_DEFAULT / TA_INTEGER_DEFAULT; C resolved every one to the explicit default's result
```

### The new assertion fails without the backend change

Each half proven separately, `ta_regtest --xlang-hash --language=rust`, on the same
tree with only `backends/rust_lang.rs::gen_opt_param_validation_with` varied and
`scripts/build.py generate` re-run:

| `ParamType::Real` arm | Result |
| --- | --- |
| **as merged** | `PASS — … Rust: 226470 cases, 0 mismatch(es)` (exit 0) |
| **deleted** (the `dev` state) | `FAIL — 3129 output mismatch(es) + 0 input-port mismatch(es) across 13 function(s)` (exit 84) |
| **range check kept, sentinel substitution removed** (#148's original proposal) | `FAIL — 1855 output mismatch(es) + 0 input-port mismatch(es) across 13 function(s)` (exit 84) |

Full output is in the PR comment below. The 13 functions are the 11 with a bounded real
parameter plus **BBANDS** and **STDDEV**, whose reals are `[TA_REAL_MIN, TA_REAL_MAX]` —
substitution is their only contract, so they are reachable only by the sentinel class.

### Two things worth flagging

1. **A latent server hazard this surfaced, not fixed here.** Every generated server runs
   an *unguarded* timing rerun after the guarded call, unconditionally — and "every
   optional parameter resolved (never a sentinel) and in-range" is an unguarded
   **precondition** (`src/tools/ta_regtest/CLAUDE.md`, VARIANT gate). Both contract
   classes violate it by construction, and the Java server duly died twice:
   `ArrayIndexOutOfBoundsException: Index 40` (below-min period) and `Index -2147483634`
   (the raw `INT_MIN` sentinel), both inside `linearRegAngleUnguardedInternal`. The gate
   works around it by always taking the hash path for contract vectors, which returns
   right after the guarded call. The robust fix is for the servers to skip the unguarded
   rerun when the guarded call failed — a generator change across four backends, so I
   left it out of this PR. Happy to send it separately.
2. **Cost.** Contract vectors run on the full range only (validation precedes all
   `startIdx`/`endIdx` logic, so the contract is subrange-independent; shapes × seeds ×
   sizes still repeats each 81 times). Full two-server `--xlang-hash` goes 63.8s → 72.8s
   on this host, +14%.

`src/tools/ta_regtest/CLAUDE.md` is updated with the spec for all of the above.

## Verification

Run on macOS (Apple clang 21), toolchain 1.97.0 as pinned by `rust-toolchain.toml`.

| # | Check | Result |
| --- | --- | --- |
| 1 | `python3 scripts/build.py generate`, then `git status --porcelain` | Clean at HEAD (the CI `regen-check` gate). Before commit: **15** Rust output files changed, **0** files under `src/`, `include/`, `ta_codegen/output/java`, `ta_codegen/output/dotnet` |
| 2 | `cargo test` (generator) | `47 passed; 0 failed` |
| 3 | `cargo test` (`ta_codegen/output/rust`) | `23 passed; 0 failed` + `340 passed; 0 failed` doctests |
| 4 | `python3 scripts/build.py clippy` | `Clippy clean (generator + generated crate).` — `--all-targets -D warnings`, pedantic |
| 5 | `python3 scripts/build.py test` | `* All tests succeeded. *` — includes the `PERIOD1/BOUNDARY`, `MAVP/GROUPING`, all-candlesticks and `UNGUARDED,TA_S_,VARIANT` legs |
| 6 | `ta_regtest --codegen-only --language=c,rust,java` vs the frozen `reference-pre-cutover` oracle | `C-ref 161/0`, `C 161/0`, `Rust 161/0`, `Java 161/0` — *"All 3 language(s) passed codegen verification"* |
| 7 | Behavior before/after + C reference | The table under **Behavior change**, above |
| 8 | `ta_regtest --xlang-hash --language=rust` (the new gate) | `PASS`, `Rust: 226470 cases, 0 mismatch(es)`; **fails on both sabotages** — see **Tests**, above |
| 9 | `ta_regtest --xlang-hash` (Rust + Java) | Rust `0 mismatch(es)`; Java `14 mismatch(es)`, **identical to the same run without this commit** — a pre-existing `HT_TRENDMODE` integer-output divergence on this host's Temurin 17.0.20 fdlibm, on shape 3 only. Not introduced or masked here |
| 10 | `ta_regtest --fuzz-064` | `comparisons: 171230 … failures: 0`, **byte-identical** with and without this commit — the frozen v0.6.4 oracle at `:3942` is provably untouched |
| — | `cargo doc --no-deps` | Warning-free (the doc emitter changed) |
| — | `python3 scripts/build.py format-check` | `all 171 input file(s) already formatted` |
| — | `python3 scripts/build.py check-source-lists` | `lists agree across CMake and autotools (38 files). OK.` |

Check 6 needed `git fetch origin tag reference-pre-cutover` first; a shallow or
single-branch clone does not carry the tag, and `scripts/regtest.py` builds the oracle
worktree from it.

### Declared limitation

**.NET was not compiled locally** — this host has .NET SDK 7.0.200 against a `net10.0`
target, so that leg of `scripts/build.py servers` fails. The same limitation was declared
in #143 and accepted. It is low-risk: .NET P/Invokes the C library, it is not a row in
`--xlang-hash`, and check 1 shows its output bytes are untouched.

**Java was** — since this PR now adds a test that drives the Java server, leaving it
unverified would have been a poor trade. A Temurin 17.0.20 JDK was fetched into a scratch
directory (no system install) so `scripts/build.py servers` completes the Java legs, and
checks 6 and 9 above are real Java runs. That is how the pre-existing `HT_TRENDMODE`
divergence was identified as pre-existing rather than mine.

## How this surfaced

We vendored `ta_codegen/output/rust/library` into a Rust trading engine and ran all 161
functions point-by-point against python TA-Lib 0.7.1 across three parameter sets each. T3's
non-default set produced 564 points where python raised and Rust returned a value. Chasing
that one function led to the backend, where it turned out not to be a T3 problem at all.

