### PR TITLE
perf(ta_codegen): #146 — resolve pointer scratch elections in the Rust backend

### DIFF
--- a/ta_codegen/generator/CLAUDE.md
+++ b/ta_codegen/generator/CLAUDE.md
@@ -36,6 +36,15 @@ include/ta_func.h        (generated public header)
 (which holds only the indicator definitions) and out of `output/` (100% generated):
 - `templates/rust/types.rs` — the `Core` / `RetCode` / `CoreBuilder` / `CandleSettings`
   scaffolding, copied verbatim into the Rust crate (`output/rust/library/src/ta_func/types.rs`).
+- `templates/rust/scratch_election.rs` — the value gate for the scratch-buffer
+  election (issue #146), copied verbatim and declared `#[cfg(test)]` in the
+  generated `mod.rs`, so it never ships in a release build. Run by
+  `cargo test --lib -p ta-lib`.
+
+Both Rust templates are listed in `main.rs`'s `RUST_TEMPLATE_MODULES` (and the
+test-only ones in `RUST_TEST_ONLY_MODULES`) and in `RustBackend::clean_keep`, so
+`generate` copies them in and never deletes them. Adding another one means
+touching all three.
 - `templates/c/ta_retcode.c.template` — spliced with `src/ta_common/ta_retcode.csv`
   (`backends/retcode.rs`) → `src/ta_common/ta_retcode.c`.
 - `templates/c/ta_abstract_serve.c` — hand-written abstract-serve handlers `#include`d
@@ -89,6 +98,11 @@ cd ta_codegen/generator && cargo clippy          # Strict pedantic lints enabled
 ```
 
 Tests are in `tests/backend_suite.rs` and `tests/integration_test.rs` — they verify IR-to-backend rendering, expression types, function signatures, and function variants across all backends.
+
+Value gates that need the *generated* library live in the crate itself, as
+`#[cfg(test)]` modules copied from `templates/rust/` (see
+`RUST_TEMPLATE_MODULES`); run them with `cargo test --lib -p ta-lib` in
+`ta_codegen/output/rust/`.
 
 ## Cross-Language Testing Architecture
 
@@ -196,6 +210,50 @@ asserts `Success`). Crate-level docs, Cargo.toml package metadata, and the crate
 README.md are emitted by `generate_rust_crate_scaffolding` in `main.rs`. Verify
 with `cargo doc --no-deps` (must be warning-free — prose escaping of `[`/`<` is
 load-bearing) and `cargo test --doc` in `ta_codegen/output/rust/`.
+
+### Scratch-buffer election (issue #146)
+
+Several C bodies elect one of their own *output* buffers as the scratch the
+calculation runs in — `BBANDS` opens with `tempBuffer1 = outRealMiddleBand;` so it
+needs no allocation at all. In C that is a pointer assignment. Rust has no pointer
+to assign, so a naive rendering emits `outRealMiddleBand.to_vec()`: an allocation
+plus a copy of bytes that are overwritten before they are read, sized by the
+*caller's slice* rather than by the data range.
+
+`backends::rust_lang::ScratchElection` (a Rust-only pass, applied to both batch
+bodies at the top of `gen_impl_block`) restores C's shape by renaming the local to
+the elected output. It leans on Rust's own aliasing rules — `&[T]` and `&mut [T]`
+parameters can never overlap, and neither can two `&mut [T]` — which is also what
+makes C's aliasing arms, its input-alias guard and its copy-back statically dead
+here.
+
+The rule is stated over the IR, and nothing in the pass names a function, a buffer
+or an MA type: match an `if`/`else if`/…/`else` chain whose *every* condition is an
+input↔output pointer equality and whose *every* arm is only `scratch = someOutput;`
+elections; take the terminal `else`'s mapping; delete the chain and rename through
+the rest of the enclosing block; drop any guard that became a self-comparison.
+Clause 4 is load-bearing rather than cosmetic — left in place, `BBANDS`' copy-back
+would read and write the same `&mut` slice in one statement, which is E0502.
+
+Being general is not the same as being greedy. Requiring *every* arm to be an
+election is what declines `STOCH`, `STOCHF` and `MAVP`: each mixes an allocation
+and a `…IsAllocated = 1;` flag into a branch, which is a genuine in-place defence,
+not an election (`MAVP` is inverted too — allocation in the `then`, election in the
+`else`). Tolerating one allocating arm would reach them; that would be a widening
+of this rule for a later change, never a per-function case. An election also stops
+at the end of the block holding it, so `BBANDS`' general MA path and both stream
+paths keep their real `vec![0.0; ...]` allocations, and the pass backs off entirely
+if the local is assigned again while still in scope.
+
+`BBANDS` is currently the only function in `input/` written in this shape.
+`rust_scratch_election_declines_arms_that_allocate` in `tests/backend_suite.rs`
+pins that by sweeping every indicator and asserting the pass fires for `bbands`
+alone.
+
+The C, Java and .NET backends need none of this — they assign the pointer or
+reference directly — so the transform must never change their output. `generate`
+followed by `git diff` over `src/ta_func/`, `output/java/` and `output/dotnet/` is
+the check. `templates/rust/scratch_election.rs` is the value gate.
 
 ### Debug-safe decrements
 

--- a/ta_codegen/generator/src/backends/mod.rs
+++ b/ta_codegen/generator/src/backends/mod.rs
@@ -181,7 +181,9 @@ impl LanguageBackend for RustBackend {
         ("", ".rs")
     }
     fn clean_keep(&self) -> &'static [&'static str] {
-        &["types.rs", "mod.rs"]
+        // Hand-written modules copied from `templates/rust/` (see
+        // `RUST_TEMPLATE_MODULES`) plus the generated `mod.rs`.
+        &["types.rs", "scratch_election.rs", "mod.rs"]
     }
     fn generate_server(
         &self,

--- a/ta_codegen/generator/src/backends/rust_lang.rs
+++ b/ta_codegen/generator/src/backends/rust_lang.rs
@@ -198,6 +198,15 @@ fn gen_impl_block(func: &FuncDef, enums: &HashMap<String, EnumDef>, registry: &R
     let mut out = String::new();
     let snake = func.name.to_lowercase();
 
+    // C's pointer-based scratch-buffer election becomes a rename here, so the
+    // batch bodies below run the calculation directly in the caller's output
+    // slices instead of allocating and copying (issue #146). Rust-only: the C,
+    // Java and .NET backends assign the pointer/reference and need no rewrite,
+    // and the stream tier keeps the untransformed `func` (it composes its own
+    // scratch buffers). See [`ScratchElection`].
+    let elected = elect_output_scratch(func);
+    let func = &elected;
+
     out.push_str(
         "// Allow non-snake-case names to maintain TA-Lib API compatibility\n\
          #[allow(non_snake_case)]\n\
@@ -4127,6 +4136,623 @@ fn is_vec_local_var(name: &str) -> bool {
         || name.starts_with("buffer")
         || name.starts_with("localOutput")
         || name.starts_with("tempOutput")
+}
+
+// ---------------------------------------------------------------------------
+// Scratch-buffer election by name (issue #146)
+// ---------------------------------------------------------------------------
+
+/// Elections in force: local array variable → the output parameter it was
+/// elected to. Valid for the remainder of the block the election was written in
+/// (and the blocks nested inside it), which is exactly C's scope for it.
+type ElectionMap = HashMap<String, String>;
+
+/// Turns C's *pointer-based* scratch-buffer election into a rename, so the Rust
+/// body runs the calculation directly in the caller's output slices.
+///
+/// `BBANDS` opens with `tempBuffer1 = outRealMiddleBand;` and calls it out in a
+/// comment: *"Identify TWO temporary buffers among the outputs so the calculation
+/// needs no memory allocation"*. In C that is a pointer assignment, so the
+/// function allocates nothing and the copy-back below it is skipped. Rust has no
+/// pointer to assign, so the statement renders as `.to_vec()` — an allocation
+/// plus a copy of bytes that are overwritten before they are ever read, and one
+/// sized by the *caller's slice* rather than by the data range, so a caller that
+/// allocates its outputs once at capacity and then calls per window pays for the
+/// capacity on every call (issue #146).
+///
+/// What licenses the rename is Rust's own aliasing rule, which is also what makes
+/// C's aliasing branches dead code here:
+///
+/// * `inX: &[T]` and `outY: &mut [T]` are distinct parameters and can never
+///   overlap, so every `inX == outY` pointer test is statically false and the
+///   aliasing arms of C's election chain are unreachable.
+/// * two `&mut [T]` parameters can never overlap either, so electing a *second*
+///   output as scratch needs no further check — the entry point's distinctness
+///   test on the outputs is C parity, not the licence for this.
+///
+/// The rule, stated over the IR and over nothing else — no function name, no
+/// buffer name, no MA type appears anywhere in this pass:
+///
+/// 1. match an `if`/`else if`/…/`else` chain whose *every* condition is an
+///    input↔output pointer equality and whose *every* arm is only
+///    `scratch = someOutput;` elections ([`Self::election_chain`]);
+/// 2. take the terminal `else`'s mapping — the binding safe Rust always reaches;
+/// 3. delete the chain and rename those scratch names to their elected outputs
+///    through the rest of the enclosing block;
+/// 4. drop any guard the rename has turned into a self-comparison.
+///
+/// Being general is not the same as being greedy, and clause 1 is where the
+/// restraint lives:
+///
+/// * `STOCH`, `STOCHF` and `MAVP` mix an allocation and an `…IsAllocated = 1;`
+///   flag into a branch, so their arms are not elections and the chain is
+///   rejected. Their output is byte-for-byte unchanged. Tolerating one allocating
+///   arm would reach them, and is a widening of *this rule* for a later change —
+///   never a per-function case.
+/// * an election reaches only the end of its own block. `BBANDS` elects inside
+///   `if( optInMAType == TA_MAType_SMA ) { ... }`, so the general MA path that
+///   follows keeps its genuine `vec![0.0; ...]` allocations, and so do both
+///   stream paths.
+/// * clause 4 fires only where the rename actually rewrote a name, so a function
+///   that elected nothing is never touched. It is also load-bearing rather than
+///   cosmetic: `BBANDS`' copy-back guard collapses to
+///   `if o.as_ptr() != o.as_ptr() { o[..n].copy_from_slice(&o[..n]) }`, which is
+///   E0502 — the optimiser never gets the chance to fold it.
+/// * if the local is assigned again anywhere still in scope, the election is left
+///   alone, because the rename would then be wrong. The fallback is exactly
+///   today's `.to_vec()`.
+///
+/// `BBANDS` is currently the only function in `input/` written in this shape, but
+/// the pass never asks which function it is looking at; anything added in that
+/// shape benefits automatically, and the other three backends stay byte-identical
+/// because the pass does not run for them.
+struct ScratchElection<'a> {
+    /// Read-only array parameters (`&[T]`).
+    inputs: &'a std::collections::HashSet<String>,
+    /// Writable array parameters (`&mut [T]`).
+    outputs: &'a std::collections::HashSet<String>,
+    /// Array locals declared in the body (C `double *` / `int *`).
+    locals: &'a std::collections::HashSet<String>,
+}
+
+/// Apply [`ScratchElection`] to both bodies the Rust batch tier renders. The
+/// stream tier keeps the original `func` — it composes its own scratch buffers.
+pub(crate) fn elect_output_scratch(func: &FuncDef) -> FuncDef {
+    let inputs: std::collections::HashSet<String> =
+        func.inputs.iter().map(|i| i.name.clone()).collect();
+    let outputs: std::collections::HashSet<String> =
+        func.outputs.iter().map(|o| o.name.clone()).collect();
+    let mut out = func.clone();
+    for body in [&mut out.body, &mut out.private_body] {
+        let mut locals = std::collections::HashSet::new();
+        collect_array_locals(body, &mut locals);
+        let pass = ScratchElection { inputs: &inputs, outputs: &outputs, locals: &locals };
+        *body = pass.block(body, &ElectionMap::new());
+    }
+    out
+}
+
+/// Names declared in the body as C `double *` / `int *` — the only candidates for
+/// an election (a fixed-size array cannot be re-pointed).
+fn collect_array_locals(body: &[Statement], out: &mut std::collections::HashSet<String>) {
+    visit_stmts(body, &mut |stmt| {
+        if let Statement::VarDecl { var_type, name, .. } = stmt {
+            if matches!(var_type, VarType::RealPointer | VarType::IntPointer) {
+                out.insert(name.clone());
+            }
+        }
+    });
+}
+
+/// The comment that stands in for C's pointer assignment. The C comments around
+/// it keep naming the local — they are shared with every other backend — so the
+/// note maps each local onto the output it became.
+fn election_note(elected: &[(String, String)]) -> Vec<String> {
+    let mut lines = vec![
+        "Rust: C's pointer election here is a rename, so the calculation runs".to_string(),
+        "directly in the caller's slices:".to_string(),
+    ];
+    for (local, out) in elected {
+        lines.push(format!("  C's `{local}` is `{out}`"));
+    }
+    lines.push("This function therefore allocates nothing, exactly as the C does.".to_string());
+    lines.push("The aliasing arms, the input-alias guard and the copy-back are all".to_string());
+    lines.push("unreachable here: `&[T]` and `&mut [T]` parameters can never".to_string());
+    lines.push("overlap, and neither can two `&mut [T]`. See issue #146.".to_string());
+    lines
+}
+
+/// Pre-order walk over a statement tree, nested blocks included.
+///
+/// Exhaustive over `Statement` on purpose — no `_ => {}` arm. A catch-all here
+/// would silently skip the body-bearing variants, so the walk would miss the
+/// statements that matter most and would go on missing them the next time a
+/// variant is added. Let the compiler raise it instead.
+fn visit_stmts(stmts: &[Statement], f: &mut impl FnMut(&Statement)) {
+    for stmt in stmts {
+        f(stmt);
+        match stmt {
+            Statement::While { body, .. }
+            | Statement::DoWhile { body, .. }
+            | Statement::For { body, .. }
+            | Statement::Block { body } => visit_stmts(body, f),
+            Statement::If { then_body, else_body, .. } => {
+                visit_stmts(then_body, f);
+                visit_stmts(else_body, f);
+            }
+            Statement::Switch { cases, default, .. } => {
+                for (_, body) in cases {
+                    visit_stmts(body, f);
+                }
+                visit_stmts(default, f);
+            }
+            Statement::ForC { init, update, body, .. } => {
+                f(init);
+                f(update);
+                visit_stmts(body, f);
+            }
+            // Leaves: no nested statements to walk into.
+            Statement::VarDecl { .. }
+            | Statement::Assign { .. }
+            | Statement::UnrollHint { .. }
+            | Statement::Return { .. }
+            | Statement::Break
+            | Statement::Continue
+            | Statement::Expr(_)
+            | Statement::CircBuf(_)
+            | Statement::Comment(_) => {}
+        }
+    }
+}
+
+impl ScratchElection<'_> {
+    /// Rewrite one block. `elections` are the ones inherited from enclosing blocks.
+    fn block(&self, stmts: &[Statement], elections: &ElectionMap) -> Vec<Statement> {
+        let mut elections = elections.clone();
+        let mut queue: std::collections::VecDeque<Statement> = stmts.iter().cloned().collect();
+        let mut out: Vec<Statement> = Vec::new();
+        while let Some(stmt) = queue.pop_front() {
+            // The elections in force rename this statement's own expressions. The
+            // nested bodies are renamed when `descend` walks into them, so
+            // `rewritten` stays a fact about *this* statement.
+            let (stmt, rewritten) = rename_shallow(&stmt, &elections);
+            // An election chain: install the terminal arm's mapping, delete the
+            // chain, rename the uses that follow. This is the pass's *only* way
+            // to create an election — see [`ScratchElection::election_chain`].
+            if let Some(elected) = self.election_chain(&stmt) {
+                if elected.iter().all(|(local, _)| {
+                    !elections.contains_key(local)
+                        && references_var(queue.iter(), local)
+                        && !assigns_whole_var(queue.iter(), local)
+                }) {
+                    for (local, src) in &elected {
+                        elections.insert(local.clone(), src.clone());
+                    }
+                    out.push(Statement::Comment(election_note(&elected)));
+                    continue;
+                }
+            }
+            // A guard the rename turned into a self-comparison, which this
+            // backend can now decide. Folding it is load-bearing, not tidiness:
+            // left in place, `BBANDS`' copy-back would read and write the same
+            // `&mut` slice in one statement, which is E0502.
+            if rewritten {
+                if let Statement::If { condition, then_body, else_body, .. } = &stmt {
+                    if let Some(value) = self.static_ptr_cond(condition) {
+                        let taken = if value { then_body } else { else_body };
+                        if taken.iter().all(|s| matches!(s, Statement::Comment(_))) {
+                            // The statement is gone; so is the comment that
+                            // introduced it.
+                            if matches!(out.last(), Some(Statement::Comment(_))) {
+                                out.pop();
+                            }
+                        }
+                        for s in taken.iter().rev() {
+                            queue.push_front(s.clone());
+                        }
+                        continue;
+                    }
+                }
+            }
+            out.push(self.descend(stmt, &elections));
+        }
+        out
+    }
+
+    /// Match a whole `if`/`else if`/…/`else` chain that is *nothing but* a
+    /// scratch-buffer election, and return the terminal `else`'s mapping — the
+    /// binding safe Rust always reaches. `None` leaves the statement alone.
+    ///
+    /// All four conditions have to hold at once:
+    ///
+    /// 1. every link's condition is a bare pointer equality between an array
+    ///    *parameter* pair Rust decides statically (an input against an output);
+    /// 2. every `then` arm consists only of `local = someOutput;` elections
+    ///    (comments aside) and elects at least one;
+    /// 3. the chain ends in an `else` that does the same;
+    /// 4. nothing else appears in any arm.
+    ///
+    /// (4) is what keeps the pass conservative rather than greedy, and it is the
+    /// clause that declines `STOCH`, `STOCHF` and `MAVP`: their arms mix an
+    /// allocation and a `…IsAllocated = 1;` flag into the branch, so they are not
+    /// elections — they are a genuine in-place defence with a real buffer to
+    /// allocate. `MAVP` is inverted as well (the allocation in the `then`, the
+    /// election in the `else`), so (2) rejects it on the first link. Reaching those
+    /// needs a matcher that tolerates one allocating arm; that is a widening of
+    /// this rule, not a special case bolted onto it.
+    ///
+    /// Matching happens *before* [`Self::descend`] recurses (see
+    /// [`ScratchElection`]): a pass that walked the child blocks first would
+    /// collapse an inner `else if` link and silently truncate the chain.
+    fn election_chain(&self, stmt: &Statement) -> Option<Vec<(String, String)>> {
+        let Statement::If { condition, then_body, else_body, .. } = stmt else {
+            return None;
+        };
+        // (1) the link's own condition.
+        if !self.is_alias_test(condition) {
+            return None;
+        }
+        // (2) the `then` arm elects, and does nothing else.
+        self.arm_elections(then_body)?;
+        // (3)/(4) either the chain continues, or this `else` is the terminal arm.
+        let executable: Vec<&Statement> = else_body
+            .iter()
+            .filter(|s| !matches!(s, Statement::Comment(_)))
+            .collect();
+        if let [inner @ Statement::If { .. }] = executable[..] {
+            return self.election_chain(inner);
+        }
+        self.arm_elections(else_body)
+    }
+
+    /// A bare pointer-identity test between two array parameters that Rust's
+    /// aliasing rules settle at generation time — `inX == outY`. Deliberately
+    /// narrower than [`Self::static_ptr_cond`]: an election chain's conditions are
+    /// simple equalities, and admitting `&&`/`||`/`!=` here would let arbitrary
+    /// guards license an election.
+    fn is_alias_test(&self, cond: &Expr) -> bool {
+        let Expr::BinOp(l, BinOp::Eq, r) = cond else {
+            return false;
+        };
+        let (Expr::Var(a), Expr::Var(b)) = (&**l, &**r) else {
+            return false;
+        };
+        let paired = (self.inputs.contains(a.as_str()) && self.outputs.contains(b.as_str()))
+            || (self.outputs.contains(a.as_str()) && self.inputs.contains(b.as_str()));
+        paired && self.same_buffer(a, b) == Some(false)
+    }
+
+    /// The elections this arm performs, or `None` if the arm is not *purely* an
+    /// election — a single non-election statement disqualifies the whole chain.
+    /// Comments are ignored; an arm that elects nothing returns `None`.
+    fn arm_elections(&self, arm: &[Statement]) -> Option<Vec<(String, String)>> {
+        let mut elected = Vec::new();
+        for stmt in arm {
+            match stmt {
+                Statement::Comment(_) => {}
+                Statement::Assign {
+                    target: Expr::Var(local),
+                    value: Expr::Var(src),
+                    compound: false,
+                } if self.locals.contains(local) && self.outputs.contains(src) => {
+                    elected.push((local.clone(), src.clone()));
+                }
+                _ => return None,
+            }
+        }
+        (!elected.is_empty()).then_some(elected)
+    }
+
+    /// Evaluate a pointer-identity condition that Rust's parameter aliasing rules
+    /// settle at generation time. `None` = not decidable, leave the code alone.
+    fn static_ptr_cond(&self, cond: &Expr) -> Option<bool> {
+        match cond {
+            Expr::BinOp(l, BinOp::Or, r) => {
+                match (self.static_ptr_cond(l), self.static_ptr_cond(r)) {
+                    (Some(true), _) | (_, Some(true)) => Some(true),
+                    (Some(false), Some(false)) => Some(false),
+                    _ => None,
+                }
+            }
+            Expr::BinOp(l, BinOp::And, r) => {
+                match (self.static_ptr_cond(l), self.static_ptr_cond(r)) {
+                    (Some(false), _) | (_, Some(false)) => Some(false),
+                    (Some(true), Some(true)) => Some(true),
+                    _ => None,
+                }
+            }
+            Expr::Not(inner) => self.static_ptr_cond(inner).map(|v| !v),
+            Expr::BinOp(l, op @ (BinOp::Eq | BinOp::NotEq), r) => {
+                let (Expr::Var(a), Expr::Var(b)) = (&**l, &**r) else {
+                    return None;
+                };
+                let same = self.same_buffer(a, b)?;
+                Some(if matches!(op, BinOp::Eq) { same } else { !same })
+            }
+            _ => None,
+        }
+    }
+
+    /// Whether two array *parameters* can be the same buffer. Both names must
+    /// already be resolved through the elections in force.
+    fn same_buffer(&self, a: &str, b: &str) -> Option<bool> {
+        let known = |n: &str| self.inputs.contains(n) || self.outputs.contains(n);
+        if !known(a) || !known(b) {
+            return None;
+        }
+        if a == b {
+            return Some(true);
+        }
+        // `&[T]` vs `&mut [T]`, and two distinct `&mut [T]`, can never overlap.
+        // Two distinct `&[T]` can — the caller may pass one slice twice — so that
+        // pair stays undecided.
+        if self.inputs.contains(a) && self.inputs.contains(b) {
+            return None;
+        }
+        Some(false)
+    }
+
+    /// Rebuild `stmt` with its nested blocks rewritten under `elections`.
+    ///
+    /// Exhaustive over `Statement` on purpose — no `_ => stmt` arm. A catch-all
+    /// here is the sharpest failure mode this pass has: a body-bearing variant it
+    /// skipped would keep the *old* local name inside a loop body while the
+    /// election had already replaced the local with an output. That output is
+    /// well-typed, so the result compiles cleanly and only fails at run time, on
+    /// the first index into a `Vec` that is still empty. The compiler must be the
+    /// one to notice a new variant, not a fuzz run.
+    fn descend(&self, stmt: Statement, elections: &ElectionMap) -> Statement {
+        let go = |body: &[Statement]| self.block(body, elections);
+        match stmt {
+            Statement::While { condition, body } => Statement::While { condition, body: go(&body) },
+            Statement::DoWhile { condition, body } => Statement::DoWhile { condition, body: go(&body) },
+            Statement::For { var, count, body } => Statement::For { var, count, body: go(&body) },
+            Statement::If { condition, then_body, else_body, cond_comments } => Statement::If {
+                condition,
+                then_body: go(&then_body),
+                else_body: go(&else_body),
+                cond_comments,
+            },
+            Statement::Switch { expr, cases, default } => Statement::Switch {
+                expr,
+                cases: cases.into_iter().map(|(label, body)| (label, go(&body))).collect(),
+                default: go(&default),
+            },
+            Statement::ForC { init, condition, update, body } => {
+                let init = Box::new(descend_leaf(&init, elections));
+                let update = Box::new(descend_leaf(&update, elections));
+                Statement::ForC { init, condition, update, body: go(&body) }
+            }
+            Statement::Block { body } => Statement::Block { body: go(&body) },
+            // Leaves: `rename_shallow` has already rewritten every expression
+            // these own, and they hold no nested statements.
+            stmt @ (Statement::VarDecl { .. }
+            | Statement::Assign { .. }
+            | Statement::UnrollHint { .. }
+            | Statement::Return { .. }
+            | Statement::Break
+            | Statement::Continue
+            | Statement::Expr(_)
+            | Statement::CircBuf(_)
+            | Statement::Comment(_)) => stmt,
+        }
+    }
+}
+
+/// A `ForC` init/update is a single statement, not a block: rename it in place
+/// (it can never hold an election of its own).
+fn descend_leaf(stmt: &Statement, elections: &ElectionMap) -> Statement {
+    rename_shallow(stmt, elections).0
+}
+
+/// True if `name` is still read or written somewhere in `rest`. An election with
+/// no uses left in scope is dead code — `STOCH`/`STOCHF` write theirs on the
+/// unreachable aliasing arm — and eliding it would change the generated text
+/// without removing any work, so those are left exactly as they are.
+fn references_var<'a, I: Iterator<Item = &'a Statement>>(rest: I, name: &str) -> bool {
+    let stmts: Vec<Statement> = rest.cloned().collect();
+    let mut found = false;
+    visit_stmts(&stmts, &mut |stmt| {
+        let mut probe = |e: &Expr| {
+            if !found {
+                found = expr_mentions_var(e, name);
+            }
+        };
+        match stmt {
+            Statement::Assign { target, value, .. } => {
+                probe(target);
+                probe(value);
+            }
+            Statement::While { condition, .. }
+            | Statement::DoWhile { condition, .. }
+            | Statement::If { condition, .. }
+            | Statement::ForC { condition, .. } => probe(condition),
+            Statement::VarDecl { init: Some(e), .. }
+            | Statement::Return { value: Some(e) }
+            | Statement::For { count: e, .. }
+            | Statement::Switch { expr: e, .. }
+            | Statement::Expr(e)
+            | Statement::CircBuf(CircBuf::Init { size: e, .. }) => probe(e),
+            _ => {}
+        }
+    });
+    found
+}
+
+/// Whether `name` appears anywhere in `expr`, scalar or indexed.
+fn expr_mentions_var(expr: &Expr, name: &str) -> bool {
+    let mut hit = false;
+    let renamed = ElectionMap::from([(name.to_string(), name.to_string())]);
+    walk_rename(expr, &renamed, &mut hit);
+    hit
+}
+
+/// True if any statement in `rest` assigns the whole of `name` (an indexed write
+/// is fine — that is the calculation running in the elected buffer).
+fn assigns_whole_var<'a, I: Iterator<Item = &'a Statement>>(rest: I, name: &str) -> bool {
+    let mut found = false;
+    let stmts: Vec<Statement> = rest.cloned().collect();
+    visit_stmts(&stmts, &mut |stmt| {
+        if let Statement::Assign { target: Expr::Var(t), .. } = stmt {
+            if t == name {
+                found = true;
+            }
+        }
+        if let Statement::VarDecl { name: t, .. } = stmt {
+            if t == name {
+                found = true;
+            }
+        }
+    });
+    found
+}
+
+/// Rename the expressions a statement owns directly, leaving its nested blocks to
+/// the caller. Returns whether anything was rewritten.
+///
+/// Exhaustive over `Statement` on purpose — no `other => other.clone()` arm, for
+/// the same reason as [`ScratchElection::descend`]: a variant whose expressions
+/// went un-renamed would keep referring to a local the election has retired, and
+/// that miss is invisible until run time.
+fn rename_shallow(stmt: &Statement, elections: &ElectionMap) -> (Statement, bool) {
+    if elections.is_empty() {
+        return (stmt.clone(), false);
+    }
+    let mut hit = false;
+    let mut e = |x: &Expr| {
+        let (out, changed) = rename_expr(x, elections);
+        hit |= changed;
+        out
+    };
+    let out = match stmt {
+        Statement::VarDecl { var_type, name, init } => Statement::VarDecl {
+            var_type: var_type.clone(),
+            name: name.clone(),
+            init: init.as_ref().map(&mut e),
+        },
+        Statement::Assign { target, value, compound } => Statement::Assign {
+            target: e(target),
+            value: e(value),
+            compound: *compound,
+        },
+        Statement::While { condition, body } => Statement::While {
+            condition: e(condition),
+            body: body.clone(),
+        },
+        Statement::DoWhile { condition, body } => Statement::DoWhile {
+            condition: e(condition),
+            body: body.clone(),
+        },
+        Statement::For { var, count, body } => Statement::For {
+            var: var.clone(),
+            count: e(count),
+            body: body.clone(),
+        },
+        Statement::If { condition, then_body, else_body, cond_comments } => Statement::If {
+            condition: e(condition),
+            then_body: then_body.clone(),
+            else_body: else_body.clone(),
+            cond_comments: cond_comments.clone(),
+        },
+        Statement::Return { value } => Statement::Return {
+            value: value.as_ref().map(&mut e),
+        },
+        Statement::Switch { expr, cases, default } => Statement::Switch {
+            expr: e(expr),
+            cases: cases.clone(),
+            default: default.clone(),
+        },
+        Statement::ForC { init, condition, update, body } => Statement::ForC {
+            init: init.clone(),
+            condition: e(condition),
+            update: update.clone(),
+            body: body.clone(),
+        },
+        Statement::Expr(expr) => Statement::Expr(e(expr)),
+        Statement::CircBuf(CircBuf::Init { id, layout, size }) => {
+            Statement::CircBuf(CircBuf::Init {
+                id: id.clone(),
+                layout: layout.clone(),
+                size: e(size),
+            })
+        }
+        // Own no expressions, so there is nothing here to rename. `Block`'s body
+        // belongs to `descend`, and the remaining `CircBuf` operations carry only
+        // identifiers and layouts.
+        Statement::UnrollHint { .. }
+        | Statement::Break
+        | Statement::Continue
+        | Statement::Block { .. }
+        | Statement::Comment(_)
+        | Statement::CircBuf(
+            CircBuf::Prolog { .. }
+            | CircBuf::InitLocalOnly { .. }
+            | CircBuf::Next { .. }
+            | CircBuf::Destroy { .. },
+        ) => stmt.clone(),
+    };
+    (out, hit)
+}
+
+/// Substitute elected locals for the output parameters they were elected to.
+fn rename_expr(expr: &Expr, elections: &ElectionMap) -> (Expr, bool) {
+    let mut hit = false;
+    let out = walk_rename(expr, elections, &mut hit);
+    (out, hit)
+}
+
+fn walk_rename(expr: &Expr, elections: &ElectionMap, hit: &mut bool) -> Expr {
+    match expr {
+        Expr::Var(name) => match elections.get(name) {
+            Some(elected) => {
+                *hit = true;
+                Expr::Var(elected.clone())
+            }
+            None => expr.clone(),
+        },
+        Expr::ArrayAccess(name, idx) => {
+            let renamed = match elections.get(name) {
+                Some(elected) => {
+                    *hit = true;
+                    elected.clone()
+                }
+                None => name.clone(),
+            };
+            Expr::ArrayAccess(renamed, Box::new(walk_rename(idx, elections, hit)))
+        }
+        Expr::BinOp(l, op, r) => Expr::BinOp(
+            Box::new(walk_rename(l, elections, hit)),
+            op.clone(),
+            Box::new(walk_rename(r, elections, hit)),
+        ),
+        Expr::Cast(t, inner) => {
+            Expr::Cast(t.clone(), Box::new(walk_rename(inner, elections, hit)))
+        }
+        Expr::Not(inner) => Expr::Not(Box::new(walk_rename(inner, elections, hit))),
+        Expr::FuncCall(name, args) => Expr::FuncCall(
+            name.clone(),
+            args.iter().map(|a| walk_rename(a, elections, hit)).collect(),
+        ),
+        Expr::AddressOf(inner) => Expr::AddressOf(Box::new(walk_rename(inner, elections, hit))),
+        Expr::PostIncrement(inner) => {
+            Expr::PostIncrement(Box::new(walk_rename(inner, elections, hit)))
+        }
+        Expr::PostDecrement(inner) => {
+            Expr::PostDecrement(Box::new(walk_rename(inner, elections, hit)))
+        }
+        Expr::PreIncrement(inner) => {
+            Expr::PreIncrement(Box::new(walk_rename(inner, elections, hit)))
+        }
+        Expr::PreDecrement(inner) => {
+            Expr::PreDecrement(Box::new(walk_rename(inner, elections, hit)))
+        }
+        Expr::Ternary(c, t, f) => Expr::Ternary(
+            Box::new(walk_rename(c, elections, hit)),
+            Box::new(walk_rename(t, elections, hit)),
+            Box::new(walk_rename(f, elections, hit)),
+        ),
+        Expr::Literal(_) | Expr::IntLiteral(_) | Expr::PointerDeref(_) => expr.clone(),
+    }
 }
 
 /// Check if an expression returns usize (e.g., lookback function calls, UNSTABLE_PERIOD).

--- a/ta_codegen/generator/src/main.rs
+++ b/ta_codegen/generator/src/main.rs
@@ -588,8 +588,8 @@ fn generate(func_filter: Option<&str>, backend_filter: Option<&str>) {
     // `--func=X` run cannot rewrite mod.rs down to the filtered subset and
     // break the crate.
     if backends_to_run.contains(&"rust") {
-        let types_src = root.join("ta_codegen/generator/templates/rust/types.rs");
-        generate_rust_crate_scaffolding(&out_base, all_funcs, &types_src);
+        let templates = root.join("ta_codegen/generator/templates/rust");
+        generate_rust_crate_scaffolding(&out_base, all_funcs, &templates);
     }
 
     backends::func_list::generate(all_funcs, &root.join("ta_func_list.txt"));
@@ -1725,7 +1725,19 @@ fn format_yaml_num(v: f64) -> String {
     }
 }
 
-fn generate_rust_crate_scaffolding(out_base: &Path, funcs: &[ir::FuncDef], types_src: &Path) {
+/// The hand-written Rust library sources that ship inside the generated crate,
+/// copied verbatim from `ta_codegen/generator/templates/rust/`. `types.rs` holds
+/// `Core`/`CoreBuilder` and its API tests (issue #144); `scratch_election.rs` is
+/// a `#[cfg(test)]`-only module holding the value gate for the batch bodies'
+/// scratch-buffer election (issue #146). Both are listed in the Rust backend's
+/// `clean_keep`, so `generate` never deletes them.
+const RUST_TEMPLATE_MODULES: &[&str] = &["types", "scratch_election"];
+
+/// Of [`RUST_TEMPLATE_MODULES`], the ones that exist only for `cargo test` and so
+/// are declared `#[cfg(test)]` in the generated `mod.rs`.
+const RUST_TEST_ONLY_MODULES: &[&str] = &["scratch_election"];
+
+fn generate_rust_crate_scaffolding(out_base: &Path, funcs: &[ir::FuncDef], templates: &Path) {
     // Single source of truth for the crate version: the VERSION file at the
     // repo root (kept in sync across all packaging by scripts/sync.py).
     // Hardcoding it here once made a release bump fail the regen-check gate.
@@ -1959,11 +1971,14 @@ BSD-3-Clause — see [LICENSE](https://github.com/TA-Lib/ta-lib/blob/main/LICENS
     std::fs::write(&readme_path, readme).unwrap();
     println!("  Scaffolding -> {}", readme_path.display());
 
-    // --- Copy hand-written types.rs from ta_codegen/generator/templates/rust/ ---
-    if types_src.exists() {
-        let types_dest = ta_func_dir.join("types.rs");
-        std::fs::copy(types_src, &types_dest).unwrap();
-        println!("  Copied types.rs -> {}", types_dest.display());
+    // --- Copy the hand-written modules from ta_codegen/generator/templates/rust/ ---
+    for module in RUST_TEMPLATE_MODULES {
+        let src = templates.join(format!("{module}.rs"));
+        if src.exists() {
+            let dest = ta_func_dir.join(format!("{module}.rs"));
+            std::fs::copy(&src, &dest).unwrap();
+            println!("  Copied {module}.rs -> {}", dest.display());
+        }
     }
 
     // --- src/ta_func/mod.rs (generated: imports types + declares indicator modules) ---
@@ -1975,10 +1990,20 @@ BSD-3-Clause — see [LICENSE](https://github.com/TA-Lib/ta-lib/blob/main/LICENS
 // Types and Core struct are in types.rs (hand-written, not generated).
 mod types;
 pub use types::*;
-
-// Generated indicator modules:
 "#,
     );
+
+    // Hand-written test-only modules (not generated; see templates/rust/).
+    if !RUST_TEST_ONLY_MODULES.is_empty() {
+        mod_rs.push_str(
+            "\n// Hand-written test-only modules (not generated; see templates/rust/).\n",
+        );
+        for module in RUST_TEST_ONLY_MODULES {
+            mod_rs.push_str(&format!("#[cfg(test)]\nmod {module};\n"));
+        }
+    }
+
+    mod_rs.push_str("\n// Generated indicator modules:\n");
 
     // Add mod declarations for each generated indicator
     let mut func_names: Vec<String> = funcs

--- a/ta_codegen/generator/templates/rust/scratch_election.rs
+++ b/ta_codegen/generator/templates/rust/scratch_election.rs
@@ -1,0 +1,307 @@
+//! Value gate for the batch bodies' scratch-buffer election (issue #146).
+//!
+//! Hand-written, not generated: this file lives in
+//! `ta_codegen/generator/templates/rust/scratch_election.rs` and is copied
+//! verbatim into the crate by `generate` (the Rust backend's `clean_keep` holds
+//! it, so `generate` never deletes it). It is declared `#[cfg(test)]` in
+//! `mod.rs`, so nothing here ships in a release build.
+//!
+//! `BBANDS` elects two of its own output slices as the scratch buffers the
+//! calculation runs in, so it allocates nothing. The Rust backend
+//! implements that election as a *rename* — the standard deviation is written
+//! into `outRealUpperBand` and read back out of it by the band loop, and the
+//! moving average is written straight into `outRealMiddleBand`. The whole point
+//! of the transform is that it changes **no value**, and that is what these
+//! tests pin: they pass identically before and after it, because they check
+//! numeric invariance, not the absence of an allocation.
+//!
+//! Three independent properties, each of which a mis-election would break:
+//!
+//! 1. **Composition.** `BBANDS` must be bit-identical to `MA` + `STDDEV`
+//!    recomposed through the public API — a genuinely separate code path. This
+//!    covers the SMA fast path (`optInMAType == 0`, where the election happens)
+//!    and the general MA path (every other type, which must stay untouched).
+//! 2. **No dependence on prior output contents.** Electing an output as scratch
+//!    means the calculation reads a buffer the caller owned. Running the same
+//!    call over slices pre-filled with different garbage must give the same bits.
+//! 3. **No dependence on output slice capacity.** The pre-#146 shape sized its
+//!    scratch from the caller's slice length rather than the data range, so a
+//!    caller who allocates once at capacity and calls per window paid for the
+//!    capacity every call. Results must not vary with the capacity either.
+
+use super::*;
+
+/// Every optional-parameter combination the gate sweeps.
+const PERIODS: [i32; 6] = [2, 3, 5, 20, 33, 100];
+/// `(optInNbDevUp, optInNbDevDn)`. Equal and unequal pairs take different band
+/// loops in the source (the unequal one fuses with `mul_add`), and the zero and
+/// negative multipliers are in range but unusual.
+const DEVS: [(f64, f64); 4] = [(2.0, 2.0), (0.0, 3.0), (-1.0, 2.0), (1.5, 2.5)];
+/// `SMA` (the fast path that elects) plus `EMA`/`WMA`/`DEMA`/`T3` (the general
+/// path, which keeps its own allocations and must be unaffected).
+const MATYPES: [i32; 5] = [0, 1, 2, 3, 8];
+
+/// Bar counts from 1 to 5000: every small length (so the lookback clamps, the
+/// empty-output returns and the single-bar cases are all hit) plus a spread of
+/// larger ones. Above ~32*period the fast path's variance recurrence reseeds, so
+/// the large lengths are not redundant.
+fn bar_counts() -> Vec<usize> {
+    let mut ns: Vec<usize> = (1..=40).collect();
+    ns.extend_from_slice(&[100, 250, 500, 999, 1000, 2000, 5000]);
+    ns
+}
+
+/// Deterministic input, no dependencies: a drifting series with enough spread to
+/// keep the standard deviation away from the fast path's degenerate branches.
+fn series(n: usize, seed: u64) -> Vec<f64> {
+    let mut s = seed
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    (0..n)
+        .map(|i| {
+            s = s
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let u = ((s >> 11) as f64) / ((1u64 << 53) as f64);
+            100.0 + (i as f64) * 0.01 + u * 5.0
+        })
+        .collect()
+}
+
+struct Bands {
+    rc: RetCode,
+    beg: usize,
+    nb: usize,
+    upper: Vec<f64>,
+    middle: Vec<f64>,
+    lower: Vec<f64>,
+}
+
+/// Run `BBANDS` over `0..=n-1` with output slices of `cap` elements pre-filled
+/// with `fill`, and return the first `outNBElement` of each band.
+fn bbands(
+    core: &Core,
+    input: &[f64],
+    period: i32,
+    dev_up: f64,
+    dev_dn: f64,
+    matype: i32,
+    cap: usize,
+    fill: f64,
+) -> Bands {
+    let mut upper = vec![fill; cap];
+    let mut middle = vec![fill; cap];
+    let mut lower = vec![fill; cap];
+    let mut beg = 0usize;
+    let mut nb = 0usize;
+    let rc = core.bbands(
+        0,
+        input.len() - 1,
+        input,
+        period,
+        dev_up,
+        dev_dn,
+        matype,
+        &mut beg,
+        &mut nb,
+        &mut upper,
+        &mut middle,
+        &mut lower,
+    );
+    upper.truncate(nb);
+    middle.truncate(nb);
+    lower.truncate(nb);
+    Bands { rc, beg, nb, upper, middle, lower }
+}
+
+/// `BBANDS` recomposed from `MA` and `STDDEV` through the public API, following
+/// the source's own realignment and band arithmetic. `None` when either leg
+/// declines the parameters.
+fn bbands_from_ma_and_stddev(
+    core: &Core,
+    input: &[f64],
+    period: i32,
+    dev_up: f64,
+    dev_dn: f64,
+    matype: i32,
+) -> Option<Bands> {
+    let n = input.len();
+    let mut ma = vec![f64::NAN; n];
+    let mut ma_beg = 0usize;
+    let mut ma_nb = 0usize;
+    if core.ma(0, n - 1, input, period, matype, &mut ma_beg, &mut ma_nb, &mut ma) != RetCode::Success
+    {
+        return None;
+    }
+    if ma_nb == 0 {
+        return None;
+    }
+    let mut sd = vec![f64::NAN; n];
+    let mut sd_beg = 0usize;
+    let mut sd_nb = 0usize;
+    if core.stddev(ma_beg, n - 1, input, period, 1.0, &mut sd_beg, &mut sd_nb, &mut sd)
+        != RetCode::Success
+    {
+        return None;
+    }
+    // The standard deviation can clamp to a later bar than the moving average
+    // did; the source shifts the MA forward so each band pairs the two at the
+    // same bar.
+    let shift = sd_beg.saturating_sub(ma_beg);
+    let nb = sd_nb;
+    let mut upper = Vec::with_capacity(nb);
+    let mut middle = Vec::with_capacity(nb);
+    let mut lower = Vec::with_capacity(nb);
+    for i in 0..nb {
+        let m = ma[i + shift];
+        let s = sd[i];
+        // Mirrors the two band loops: the equal-multiplier one shares a single
+        // product, the unequal one fuses the upper band's multiply-add.
+        let (up, lo) = if dev_up == dev_dn {
+            let t = s * dev_up;
+            (m + t, m - t)
+        } else {
+            (s.mul_add(dev_up, m), m - s * dev_dn)
+        };
+        upper.push(up);
+        middle.push(m);
+        lower.push(lo);
+    }
+    Some(Bands { rc: RetCode::Success, beg: sd_beg, nb, upper, middle, lower })
+}
+
+/// Bit-for-bit, not approximate: this is an identity gate, so `NaN` must match
+/// `NaN` and `-0.0` must not match `0.0`.
+fn assert_same_bits(what: &str, got: &[f64], want: &[f64], ctx: &str) {
+    assert_eq!(got.len(), want.len(), "{what} length differs ({ctx})");
+    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+        assert_eq!(
+            g.to_bits(),
+            w.to_bits(),
+            "{what}[{i}] differs ({ctx}): {g:?} ({:#018x}) vs {w:?} ({:#018x})",
+            g.to_bits(),
+            w.to_bits()
+        );
+    }
+}
+
+#[test]
+fn bbands_is_bit_identical_to_ma_plus_stddev() {
+    let core = Core::new();
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in bar_counts() {
+                    let input = series(n, (period as u64) * 1_000_003 + n as u64);
+                    let got = bbands(&core, &input, period, dev_up, dev_dn, matype, n, f64::NAN);
+                    let Some(want) =
+                        bbands_from_ma_and_stddev(&core, &input, period, dev_up, dev_dn, matype)
+                    else {
+                        continue;
+                    };
+                    if got.rc != RetCode::Success || got.nb == 0 {
+                        continue;
+                    }
+                    let ctx =
+                        format!("matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n}");
+                    assert_eq!(got.beg, want.beg, "outBegIdx differs ({ctx})");
+                    assert_eq!(got.nb, want.nb, "outNBElement differs ({ctx})");
+                    assert_same_bits("middle", &got.middle, &want.middle, &ctx);
+                    assert_same_bits("upper", &got.upper, &want.upper, &ctx);
+                    assert_same_bits("lower", &got.lower, &want.lower, &ctx);
+                    compared += 1;
+                }
+            }
+        }
+    }
+    // A silently-empty sweep would make this test vacuous.
+    eprintln!("BBANDS vs MA+STDDEV: {compared} bit-exact comparisons");
+    assert!(compared > 500, "only {compared} comparisons ran");
+}
+
+#[test]
+fn bbands_ignores_the_prior_contents_of_its_output_slices() {
+    let core = Core::new();
+    // The election writes the standard deviation into outRealUpperBand and reads
+    // it back, so whatever the caller left in the output buffers must not leak
+    // into the result.
+    let fills = [0.0, f64::NAN, -1.0, 1e300, f64::INFINITY];
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in [1usize, 2, 3, 5, 34, 101, 500, 5000] {
+                    let input = series(n, (period as u64) * 7 + n as u64);
+                    let base = bbands(&core, &input, period, dev_up, dev_dn, matype, n, fills[0]);
+                    if base.rc != RetCode::Success || base.nb == 0 {
+                        continue;
+                    }
+                    for &fill in &fills[1..] {
+                        let other =
+                            bbands(&core, &input, period, dev_up, dev_dn, matype, n, fill);
+                        let ctx = format!(
+                            "matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n} fill={fill:?}"
+                        );
+                        assert_eq!(other.rc, base.rc, "retCode differs ({ctx})");
+                        assert_eq!(other.beg, base.beg, "outBegIdx differs ({ctx})");
+                        assert_eq!(other.nb, base.nb, "outNBElement differs ({ctx})");
+                        assert_same_bits("middle", &other.middle, &base.middle, &ctx);
+                        assert_same_bits("upper", &other.upper, &base.upper, &ctx);
+                        assert_same_bits("lower", &other.lower, &base.lower, &ctx);
+                        compared += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("BBANDS vs prior output contents: {compared} bit-exact comparisons");
+    assert!(compared > 500, "only {compared} comparisons ran");
+}
+
+#[test]
+fn bbands_is_independent_of_output_slice_capacity() {
+    let core = Core::new();
+    // The caller pattern the pre-#146 shape penalised: allocate the outputs once
+    // at capacity, then call per window. The values must not move with the
+    // capacity, in either direction.
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in [3usize, 34, 500] {
+                    let input = series(n, (period as u64) * 13 + n as u64);
+                    let base = bbands(&core, &input, period, dev_up, dev_dn, matype, n, f64::NAN);
+                    if base.rc != RetCode::Success || base.nb == 0 {
+                        continue;
+                    }
+                    for mult in [10usize, 100] {
+                        let wide = bbands(
+                            &core,
+                            &input,
+                            period,
+                            dev_up,
+                            dev_dn,
+                            matype,
+                            n * mult,
+                            f64::NAN,
+                        );
+                        let ctx = format!(
+                            "matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n} cap={}",
+                            n * mult
+                        );
+                        assert_eq!(wide.rc, base.rc, "retCode differs ({ctx})");
+                        assert_eq!(wide.beg, base.beg, "outBegIdx differs ({ctx})");
+                        assert_eq!(wide.nb, base.nb, "outNBElement differs ({ctx})");
+                        assert_same_bits("middle", &wide.middle, &base.middle, &ctx);
+                        assert_same_bits("upper", &wide.upper, &base.upper, &ctx);
+                        assert_same_bits("lower", &wide.lower, &base.lower, &ctx);
+                        compared += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("BBANDS vs output slice capacity: {compared} bit-exact comparisons");
+    assert!(compared > 200, "only {compared} comparisons ran");
+}

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -6965,3 +6965,138 @@ fn test_period_scaled_arithmetic_is_double_not_int32() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Scratch-buffer election (issue #146)
+// ---------------------------------------------------------------------------
+
+/// The scratch election must reach the SMA fast path and *only* the SMA fast path:
+/// the calculation writes straight into the caller's slices, while the general MA
+/// path below it keeps its two genuine allocations.
+#[test]
+fn rust_bbands_elects_output_scratch_only_in_the_sma_fast_path() {
+    let (func, enums) = load_indicator("bbands");
+    let registry = make_registry();
+    let helpers = make_helpers();
+    let out = generate_all(&func, &enums);
+    let rust_out = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+
+    // No allocation-and-copy of an output slice survives anywhere.
+    assert!(
+        !rust_out.contains(".to_vec()"),
+        "BBANDS Rust should not copy an output slice into a scratch Vec: {rust_out}"
+    );
+    // The SMA and the standard deviation are written into the outputs by name.
+    assert!(
+        rust_out.contains("outRealMiddleBand[_outIdx] = maTotal /"),
+        "BBANDS Rust should write the SMA straight into outRealMiddleBand: {rust_out}"
+    );
+    assert!(
+        rust_out.contains("outRealUpperBand[_outIdx] = (variance).sqrt();"),
+        "BBANDS Rust should write the standard deviation into outRealUpperBand: {rust_out}"
+    );
+    assert!(
+        rust_out.contains("tempReal = outRealUpperBand[i] * optInNbDevUp;"),
+        "the band loop should read its deviation back out of outRealUpperBand: {rust_out}"
+    );
+    // The dead aliasing arms, the input-alias guard and the copy-back are gone.
+    assert!(
+        !rust_out.contains("inReal.as_ptr() == outRealUpperBand.as_ptr()"),
+        "BBANDS Rust should not test inReal against an output: {rust_out}"
+    );
+    assert!(
+        !rust_out.contains("tempBuffer1.as_ptr()"),
+        "BBANDS Rust should have no pointer tests left on tempBuffer1: {rust_out}"
+    );
+    // The general MA path's allocations are real and must survive — one pair in
+    // each of the guarded and unguarded batch variants, plus the stream tier's.
+    let allocs = rust_out.matches("tempBuffer1 = vec![0.0_f64;").count();
+    assert!(
+        allocs >= 2,
+        "the general MA path must keep its tempBuffer1 allocation in every variant \
+         (found {allocs}): {rust_out}"
+    );
+    assert_eq!(
+        allocs,
+        rust_out.matches("tempBuffer2 = vec![0.0_f64;").count(),
+        "tempBuffer1 and tempBuffer2 must be allocated in the same places: {rust_out}"
+    );
+    // Rust-only: the other backends assign the pointer/reference and keep C's
+    // election chain verbatim.
+    assert!(
+        out.c.contains("tempBuffer1 = outRealMiddleBand;"),
+        "the C backend must keep C's pointer election: {}",
+        out.c
+    );
+    assert!(
+        out.java.contains("tempBuffer1 = outRealMiddleBand;"),
+        "the Java backend must keep C's reference election: {}",
+        out.java
+    );
+}
+
+/// Being general is not the same as being greedy. The matcher requires *every* arm
+/// of the chain to be nothing but `scratch = someOutput;` elections, and that one
+/// clause is what declines `STOCH`, `STOCHF` and `MAVP`: each mixes an allocation
+/// and a `…IsAllocated = 1;` flag into a branch, so the branch is a genuine
+/// in-place defence with a real buffer to allocate rather than an election.
+/// `MAVP` is inverted as well — the allocation sits in the `then` and the election
+/// in the `else` — so it is rejected on the very first link.
+///
+/// Their generated Rust must come out byte-for-byte as it was. That non-firing is
+/// what lets the PR assert the other three backends were untouched, so it is
+/// pinned here rather than left to `git diff`.
+#[test]
+fn rust_scratch_election_declines_arms_that_allocate() {
+    let registry = make_registry();
+    let helpers = make_helpers();
+
+    for name in ["stoch", "stochf"] {
+        let (func, enums) = load_indicator(name);
+        let rust_out = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+        assert!(
+            rust_out.contains("tempBuffer = outSlowK.to_vec();")
+                || rust_out.contains("tempBuffer = outFastK.to_vec();"),
+            "{name}'s election arm must be untouched: {rust_out}"
+        );
+        assert!(
+            rust_out.contains("tempBuffer = vec![0.0_f64;"),
+            "{name} must keep the allocation on its other arm: {rust_out}"
+        );
+    }
+
+    // `MAVP` is the inverted case, and the one a looser matcher reaches first.
+    let (func, enums) = load_indicator("mavp");
+    let rust_out = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+    assert!(
+        rust_out.contains("localFinalArray = outReal.to_vec();"),
+        "MAVP's election must be left as it is: {rust_out}"
+    );
+    assert!(
+        rust_out.contains("localFinalArray = vec![0.0_f64;"),
+        "MAVP must keep the allocation in its `then` arm: {rust_out}"
+    );
+    assert!(
+        rust_out.contains("localFinalArray.as_ptr() != outReal.as_ptr()"),
+        "MAVP must keep its copy-back guard: {rust_out}"
+    );
+
+    // The pass must not have fired for a single function other than `BBANDS`. The
+    // election note is emitted exactly when an election is installed, so its
+    // absence across the whole `input/` tree is the non-firing proof — and it is
+    // proven over every indicator rather than a hand-picked list, so a widening of
+    // the rule cannot slip past by naming a function this test forgot.
+    const NOTE: &str = "C's pointer election here is a rename";
+    let mut fired = Vec::new();
+    for name in discover_indicators() {
+        let (func, enums) = load_indicator(&name);
+        if backends::rust_lang::generate(&func, &enums, &registry, &helpers).contains(NOTE) {
+            fired.push(name);
+        }
+    }
+    assert_eq!(
+        fired,
+        vec!["bbands".to_string()],
+        "the scratch election must fire for BBANDS and nothing else"
+    );
+}

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -273,24 +273,14 @@ impl Core {
             // Identify TWO temporary buffers among the outputs so the calculation
             // needs no memory allocation; whenever possible make tempBuffer1 be the
             // middle band output, saving one copy operation.
-            if inReal.as_ptr() == outRealUpperBand.as_ptr() {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealLowerBand.to_vec();
-            } else if inReal.as_ptr() == outRealLowerBand.as_ptr() {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            } else if inReal.as_ptr() == outRealMiddleBand.as_ptr() {
-                tempBuffer1 = outRealLowerBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            } else {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            }
-            // Check that the caller is not doing tricky things.
-            // (like using the input buffer in two output!)
-            if tempBuffer1.as_ptr() == inReal.as_ptr() || tempBuffer2.as_ptr() == inReal.as_ptr() {
-                return RetCode::BadParam;
-            }
+            // Rust: C's pointer election here is a rename, so the calculation runs
+            // directly in the caller's slices:
+            //   C's `tempBuffer1` is `outRealMiddleBand`
+            //   C's `tempBuffer2` is `outRealUpperBand`
+            // This function therefore allocates nothing, exactly as the C does.
+            // The aliasing arms, the input-alias guard and the copy-back are all
+            // unreachable here: `&[T]` and `&mut [T]` parameters can never
+            // overlap, and neither can two `&mut [T]`. See issue #146.
             // One pass with two independent recurrences: the SMA running sum (maTotal,
             // mean -> tempBuffer1, bit-identical to TA_MA(SMA)) and the shifted-data
             // variance (-> tempBuffer2, bit-identical to TA_STDDEV/TA_VAR - see var.c).
@@ -347,7 +337,7 @@ impl Core {
                 varTotal2 += _tempReal;
                 meanValue1 = varTotal1 * _invPeriod;
                 variance = varTotal2 * _invPeriod - meanValue1 * meanValue1;
-                tempBuffer1[_outIdx] = maTotal / ((optInTimePeriod) as f64);
+                outRealMiddleBand[_outIdx] = maTotal / ((optInTimePeriod) as f64);
                 maTotal -= inReal[_trailingIdx];
                 _tempReal = inReal[_trailingIdx] - shift;
                 varTotal1 -= _tempReal;
@@ -381,9 +371,9 @@ impl Core {
                     varTotal2 -= _tempReal;
                 }
                 if !((variance) < 1e-14) {
-                    tempBuffer2[_outIdx] = (variance).sqrt();
+                    outRealUpperBand[_outIdx] = (variance).sqrt();
                 } else {
-                    tempBuffer2[_outIdx] = 0.0;
+                    outRealUpperBand[_outIdx] = 0.0;
                 }
                 _outIdx += 1;
                 _i += 1;
@@ -391,22 +381,12 @@ impl Core {
             }
             (*outNBElement) = _outIdx;
             (*outBegIdx) = startIdx;
-            // Copy the MA calculation into the middle band ouput, unless
-            // the calculation was done into it already!
-            if tempBuffer1.as_ptr() != outRealMiddleBand.as_ptr() {
-                {
-            let _n = ((*outNBElement) * 1) as usize;
-            let _di = (0) as usize;
-            let _si = (0) as usize;
-            outRealMiddleBand[_di.._di + _n].copy_from_slice(&tempBuffer1[_si.._si + _n]);
-        };
-            }
             // Now do a tight loop to calculate the upper/lower band at the same time.
             if optInNbDevUp == optInNbDevDn {
                 // for( i = 0; i < (((*outNBElement) as usize)) as usize; i += 1 )
                 i = 0;
                 while i < (((*outNBElement) as usize)) as usize {
-                    tempReal = tempBuffer2[i] * optInNbDevUp;
+                    tempReal = outRealUpperBand[i] * optInNbDevUp;
                     tempReal2 = outRealMiddleBand[i];
                     outRealUpperBand[i] = tempReal2 + tempReal;
                     outRealLowerBand[i] = tempReal2 - tempReal;
@@ -416,7 +396,7 @@ impl Core {
                 // for( i = 0; i < (((*outNBElement) as usize)) as usize; i += 1 )
                 i = 0;
                 while i < (((*outNBElement) as usize)) as usize {
-                    tempReal = tempBuffer2[i];
+                    tempReal = outRealUpperBand[i];
                     tempReal2 = outRealMiddleBand[i];
                     outRealUpperBand[i] = (tempReal as f64).mul_add(optInNbDevUp, tempReal2);
                     outRealLowerBand[i] = tempReal2 - tempReal * optInNbDevDn;
@@ -524,22 +504,6 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealMiddleBand.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealLowerBand.len());
         if (optInMAType) as usize == 0 {
-            if inReal.as_ptr() == outRealUpperBand.as_ptr() {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealLowerBand.to_vec();
-            } else if inReal.as_ptr() == outRealLowerBand.as_ptr() {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            } else if inReal.as_ptr() == outRealMiddleBand.as_ptr() {
-                tempBuffer1 = outRealLowerBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            } else {
-                tempBuffer1 = outRealMiddleBand.to_vec();
-                tempBuffer2 = outRealUpperBand.to_vec();
-            }
-            if tempBuffer1.as_ptr() == inReal.as_ptr() || tempBuffer2.as_ptr() == inReal.as_ptr() {
-                return RetCode::BadParam;
-            }
             let mut maTotal: f64 = 0.0_f64;
             let mut shift: f64 = 0.0_f64;
             let mut varTotal1: f64 = 0.0_f64;
@@ -591,7 +555,7 @@ impl Core {
                 varTotal2 += _tempReal;
                 meanValue1 = varTotal1 * _invPeriod;
                 variance = varTotal2 * _invPeriod - meanValue1 * meanValue1;
-                tempBuffer1[_outIdx] = maTotal / ((optInTimePeriod) as f64);
+                outRealMiddleBand[_outIdx] = maTotal / ((optInTimePeriod) as f64);
                 maTotal -= inReal[_trailingIdx];
                 _tempReal = inReal[_trailingIdx] - shift;
                 varTotal1 -= _tempReal;
@@ -625,9 +589,9 @@ impl Core {
                     varTotal2 -= _tempReal;
                 }
                 if !((variance) < 1e-14) {
-                    tempBuffer2[_outIdx] = (variance).sqrt();
+                    outRealUpperBand[_outIdx] = (variance).sqrt();
                 } else {
-                    tempBuffer2[_outIdx] = 0.0;
+                    outRealUpperBand[_outIdx] = 0.0;
                 }
                 _outIdx += 1;
                 _i += 1;
@@ -635,19 +599,11 @@ impl Core {
             }
             (*outNBElement) = _outIdx;
             (*outBegIdx) = startIdx;
-            if tempBuffer1.as_ptr() != outRealMiddleBand.as_ptr() {
-                {
-            let _n = ((*outNBElement) * 1) as usize;
-            let _di = (0) as usize;
-            let _si = (0) as usize;
-            outRealMiddleBand[_di.._di + _n].copy_from_slice(&tempBuffer1[_si.._si + _n]);
-        };
-            }
             if optInNbDevUp == optInNbDevDn {
                 // for( i = 0; i < (((*outNBElement) as usize)) as usize; i += 1 )
                 i = 0;
                 while i < (((*outNBElement) as usize)) as usize {
-                    tempReal = tempBuffer2[i] * optInNbDevUp;
+                    tempReal = outRealUpperBand[i] * optInNbDevUp;
                     tempReal2 = outRealMiddleBand[i];
                     outRealUpperBand[i] = tempReal2 + tempReal;
                     outRealLowerBand[i] = tempReal2 - tempReal;
@@ -657,7 +613,7 @@ impl Core {
                 // for( i = 0; i < (((*outNBElement) as usize)) as usize; i += 1 )
                 i = 0;
                 while i < (((*outNBElement) as usize)) as usize {
-                    tempReal = tempBuffer2[i];
+                    tempReal = outRealUpperBand[i];
                     tempReal2 = outRealMiddleBand[i];
                     outRealUpperBand[i] = (tempReal as f64).mul_add(optInNbDevUp, tempReal2);
                     outRealLowerBand[i] = tempReal2 - tempReal * optInNbDevDn;

--- a/ta_codegen/output/rust/library/src/ta_func/mod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mod.rs
@@ -5,6 +5,10 @@
 mod types;
 pub use types::*;
 
+// Hand-written test-only modules (not generated; see templates/rust/).
+#[cfg(test)]
+mod scratch_election;
+
 // Generated indicator modules:
 mod accbands;
 mod acos;

--- a/ta_codegen/output/rust/library/src/ta_func/scratch_election.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/scratch_election.rs
@@ -1,0 +1,307 @@
+//! Value gate for the batch bodies' scratch-buffer election (issue #146).
+//!
+//! Hand-written, not generated: this file lives in
+//! `ta_codegen/generator/templates/rust/scratch_election.rs` and is copied
+//! verbatim into the crate by `generate` (the Rust backend's `clean_keep` holds
+//! it, so `generate` never deletes it). It is declared `#[cfg(test)]` in
+//! `mod.rs`, so nothing here ships in a release build.
+//!
+//! `BBANDS` elects two of its own output slices as the scratch buffers the
+//! calculation runs in, so it allocates nothing. The Rust backend
+//! implements that election as a *rename* — the standard deviation is written
+//! into `outRealUpperBand` and read back out of it by the band loop, and the
+//! moving average is written straight into `outRealMiddleBand`. The whole point
+//! of the transform is that it changes **no value**, and that is what these
+//! tests pin: they pass identically before and after it, because they check
+//! numeric invariance, not the absence of an allocation.
+//!
+//! Three independent properties, each of which a mis-election would break:
+//!
+//! 1. **Composition.** `BBANDS` must be bit-identical to `MA` + `STDDEV`
+//!    recomposed through the public API — a genuinely separate code path. This
+//!    covers the SMA fast path (`optInMAType == 0`, where the election happens)
+//!    and the general MA path (every other type, which must stay untouched).
+//! 2. **No dependence on prior output contents.** Electing an output as scratch
+//!    means the calculation reads a buffer the caller owned. Running the same
+//!    call over slices pre-filled with different garbage must give the same bits.
+//! 3. **No dependence on output slice capacity.** The pre-#146 shape sized its
+//!    scratch from the caller's slice length rather than the data range, so a
+//!    caller who allocates once at capacity and calls per window paid for the
+//!    capacity every call. Results must not vary with the capacity either.
+
+use super::*;
+
+/// Every optional-parameter combination the gate sweeps.
+const PERIODS: [i32; 6] = [2, 3, 5, 20, 33, 100];
+/// `(optInNbDevUp, optInNbDevDn)`. Equal and unequal pairs take different band
+/// loops in the source (the unequal one fuses with `mul_add`), and the zero and
+/// negative multipliers are in range but unusual.
+const DEVS: [(f64, f64); 4] = [(2.0, 2.0), (0.0, 3.0), (-1.0, 2.0), (1.5, 2.5)];
+/// `SMA` (the fast path that elects) plus `EMA`/`WMA`/`DEMA`/`T3` (the general
+/// path, which keeps its own allocations and must be unaffected).
+const MATYPES: [i32; 5] = [0, 1, 2, 3, 8];
+
+/// Bar counts from 1 to 5000: every small length (so the lookback clamps, the
+/// empty-output returns and the single-bar cases are all hit) plus a spread of
+/// larger ones. Above ~32*period the fast path's variance recurrence reseeds, so
+/// the large lengths are not redundant.
+fn bar_counts() -> Vec<usize> {
+    let mut ns: Vec<usize> = (1..=40).collect();
+    ns.extend_from_slice(&[100, 250, 500, 999, 1000, 2000, 5000]);
+    ns
+}
+
+/// Deterministic input, no dependencies: a drifting series with enough spread to
+/// keep the standard deviation away from the fast path's degenerate branches.
+fn series(n: usize, seed: u64) -> Vec<f64> {
+    let mut s = seed
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    (0..n)
+        .map(|i| {
+            s = s
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let u = ((s >> 11) as f64) / ((1u64 << 53) as f64);
+            100.0 + (i as f64) * 0.01 + u * 5.0
+        })
+        .collect()
+}
+
+struct Bands {
+    rc: RetCode,
+    beg: usize,
+    nb: usize,
+    upper: Vec<f64>,
+    middle: Vec<f64>,
+    lower: Vec<f64>,
+}
+
+/// Run `BBANDS` over `0..=n-1` with output slices of `cap` elements pre-filled
+/// with `fill`, and return the first `outNBElement` of each band.
+fn bbands(
+    core: &Core,
+    input: &[f64],
+    period: i32,
+    dev_up: f64,
+    dev_dn: f64,
+    matype: i32,
+    cap: usize,
+    fill: f64,
+) -> Bands {
+    let mut upper = vec![fill; cap];
+    let mut middle = vec![fill; cap];
+    let mut lower = vec![fill; cap];
+    let mut beg = 0usize;
+    let mut nb = 0usize;
+    let rc = core.bbands(
+        0,
+        input.len() - 1,
+        input,
+        period,
+        dev_up,
+        dev_dn,
+        matype,
+        &mut beg,
+        &mut nb,
+        &mut upper,
+        &mut middle,
+        &mut lower,
+    );
+    upper.truncate(nb);
+    middle.truncate(nb);
+    lower.truncate(nb);
+    Bands { rc, beg, nb, upper, middle, lower }
+}
+
+/// `BBANDS` recomposed from `MA` and `STDDEV` through the public API, following
+/// the source's own realignment and band arithmetic. `None` when either leg
+/// declines the parameters.
+fn bbands_from_ma_and_stddev(
+    core: &Core,
+    input: &[f64],
+    period: i32,
+    dev_up: f64,
+    dev_dn: f64,
+    matype: i32,
+) -> Option<Bands> {
+    let n = input.len();
+    let mut ma = vec![f64::NAN; n];
+    let mut ma_beg = 0usize;
+    let mut ma_nb = 0usize;
+    if core.ma(0, n - 1, input, period, matype, &mut ma_beg, &mut ma_nb, &mut ma) != RetCode::Success
+    {
+        return None;
+    }
+    if ma_nb == 0 {
+        return None;
+    }
+    let mut sd = vec![f64::NAN; n];
+    let mut sd_beg = 0usize;
+    let mut sd_nb = 0usize;
+    if core.stddev(ma_beg, n - 1, input, period, 1.0, &mut sd_beg, &mut sd_nb, &mut sd)
+        != RetCode::Success
+    {
+        return None;
+    }
+    // The standard deviation can clamp to a later bar than the moving average
+    // did; the source shifts the MA forward so each band pairs the two at the
+    // same bar.
+    let shift = sd_beg.saturating_sub(ma_beg);
+    let nb = sd_nb;
+    let mut upper = Vec::with_capacity(nb);
+    let mut middle = Vec::with_capacity(nb);
+    let mut lower = Vec::with_capacity(nb);
+    for i in 0..nb {
+        let m = ma[i + shift];
+        let s = sd[i];
+        // Mirrors the two band loops: the equal-multiplier one shares a single
+        // product, the unequal one fuses the upper band's multiply-add.
+        let (up, lo) = if dev_up == dev_dn {
+            let t = s * dev_up;
+            (m + t, m - t)
+        } else {
+            (s.mul_add(dev_up, m), m - s * dev_dn)
+        };
+        upper.push(up);
+        middle.push(m);
+        lower.push(lo);
+    }
+    Some(Bands { rc: RetCode::Success, beg: sd_beg, nb, upper, middle, lower })
+}
+
+/// Bit-for-bit, not approximate: this is an identity gate, so `NaN` must match
+/// `NaN` and `-0.0` must not match `0.0`.
+fn assert_same_bits(what: &str, got: &[f64], want: &[f64], ctx: &str) {
+    assert_eq!(got.len(), want.len(), "{what} length differs ({ctx})");
+    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+        assert_eq!(
+            g.to_bits(),
+            w.to_bits(),
+            "{what}[{i}] differs ({ctx}): {g:?} ({:#018x}) vs {w:?} ({:#018x})",
+            g.to_bits(),
+            w.to_bits()
+        );
+    }
+}
+
+#[test]
+fn bbands_is_bit_identical_to_ma_plus_stddev() {
+    let core = Core::new();
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in bar_counts() {
+                    let input = series(n, (period as u64) * 1_000_003 + n as u64);
+                    let got = bbands(&core, &input, period, dev_up, dev_dn, matype, n, f64::NAN);
+                    let Some(want) =
+                        bbands_from_ma_and_stddev(&core, &input, period, dev_up, dev_dn, matype)
+                    else {
+                        continue;
+                    };
+                    if got.rc != RetCode::Success || got.nb == 0 {
+                        continue;
+                    }
+                    let ctx =
+                        format!("matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n}");
+                    assert_eq!(got.beg, want.beg, "outBegIdx differs ({ctx})");
+                    assert_eq!(got.nb, want.nb, "outNBElement differs ({ctx})");
+                    assert_same_bits("middle", &got.middle, &want.middle, &ctx);
+                    assert_same_bits("upper", &got.upper, &want.upper, &ctx);
+                    assert_same_bits("lower", &got.lower, &want.lower, &ctx);
+                    compared += 1;
+                }
+            }
+        }
+    }
+    // A silently-empty sweep would make this test vacuous.
+    eprintln!("BBANDS vs MA+STDDEV: {compared} bit-exact comparisons");
+    assert!(compared > 500, "only {compared} comparisons ran");
+}
+
+#[test]
+fn bbands_ignores_the_prior_contents_of_its_output_slices() {
+    let core = Core::new();
+    // The election writes the standard deviation into outRealUpperBand and reads
+    // it back, so whatever the caller left in the output buffers must not leak
+    // into the result.
+    let fills = [0.0, f64::NAN, -1.0, 1e300, f64::INFINITY];
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in [1usize, 2, 3, 5, 34, 101, 500, 5000] {
+                    let input = series(n, (period as u64) * 7 + n as u64);
+                    let base = bbands(&core, &input, period, dev_up, dev_dn, matype, n, fills[0]);
+                    if base.rc != RetCode::Success || base.nb == 0 {
+                        continue;
+                    }
+                    for &fill in &fills[1..] {
+                        let other =
+                            bbands(&core, &input, period, dev_up, dev_dn, matype, n, fill);
+                        let ctx = format!(
+                            "matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n} fill={fill:?}"
+                        );
+                        assert_eq!(other.rc, base.rc, "retCode differs ({ctx})");
+                        assert_eq!(other.beg, base.beg, "outBegIdx differs ({ctx})");
+                        assert_eq!(other.nb, base.nb, "outNBElement differs ({ctx})");
+                        assert_same_bits("middle", &other.middle, &base.middle, &ctx);
+                        assert_same_bits("upper", &other.upper, &base.upper, &ctx);
+                        assert_same_bits("lower", &other.lower, &base.lower, &ctx);
+                        compared += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("BBANDS vs prior output contents: {compared} bit-exact comparisons");
+    assert!(compared > 500, "only {compared} comparisons ran");
+}
+
+#[test]
+fn bbands_is_independent_of_output_slice_capacity() {
+    let core = Core::new();
+    // The caller pattern the pre-#146 shape penalised: allocate the outputs once
+    // at capacity, then call per window. The values must not move with the
+    // capacity, in either direction.
+    let mut compared = 0usize;
+    for &matype in &MATYPES {
+        for &period in &PERIODS {
+            for &(dev_up, dev_dn) in &DEVS {
+                for n in [3usize, 34, 500] {
+                    let input = series(n, (period as u64) * 13 + n as u64);
+                    let base = bbands(&core, &input, period, dev_up, dev_dn, matype, n, f64::NAN);
+                    if base.rc != RetCode::Success || base.nb == 0 {
+                        continue;
+                    }
+                    for mult in [10usize, 100] {
+                        let wide = bbands(
+                            &core,
+                            &input,
+                            period,
+                            dev_up,
+                            dev_dn,
+                            matype,
+                            n * mult,
+                            f64::NAN,
+                        );
+                        let ctx = format!(
+                            "matype={matype} period={period} dev=({dev_up},{dev_dn}) n={n} cap={}",
+                            n * mult
+                        );
+                        assert_eq!(wide.rc, base.rc, "retCode differs ({ctx})");
+                        assert_eq!(wide.beg, base.beg, "outBegIdx differs ({ctx})");
+                        assert_eq!(wide.nb, base.nb, "outNBElement differs ({ctx})");
+                        assert_same_bits("middle", &wide.middle, &base.middle, &ctx);
+                        assert_same_bits("upper", &wide.upper, &base.upper, &ctx);
+                        assert_same_bits("lower", &wide.lower, &base.lower, &ctx);
+                        compared += 1;
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("BBANDS vs output slice capacity: {compared} bit-exact comparisons");
+    assert!(compared > 200, "only {compared} comparisons ran");
+}


### PR DESCRIPTION
Closes the zero-allocation half of #146.

> **Stacked on #149.** At the time of opening, `dev` is at `a8272d0c2` and #149's two
> commits are not on it, so GitHub shows all three commits here. This PR's own commit
> is `perf(ta_codegen): #146 — resolve pointer scratch elections in the Rust backend`;
> the other two are #149's, unchanged. Once #149 lands the diff converges to the
> zero-alloc commit on its own — nothing to rebase. The two do not overlap in
> `rust_lang.rs` (#149 is in `gen_opt_param_validation_with`, this is a new pass plus
> the `gen_impl_block` hook).

Thank you for prototyping the shape before asking for it, and for the three traps —
they were the expensive part, exactly as you said. Trap 2 in particular is the one I
would not have found from a green test run.

## The rule

Stated over the IR, not over `BBANDS`. `backends::rust_lang::ScratchElection` is a
Rust-only pass hooked at the top of `gen_impl_block` and applied to both batch bodies:

1. match an `if`/`else if`/…/`else` chain whose **every** condition is an input↔output
   pointer equality and whose **every** arm consists only of `scratch = someOutput;`
   elections;
2. take the terminal `else`'s mapping — the binding safe Rust always reaches;
3. delete the chain and rename those scratch names to their elected outputs through
   the rest of the enclosing block;
4. drop any guard the rename has turned into a self-comparison.

What licenses it is Rust's own aliasing rule, which is also what makes C's aliasing
branches dead code: `inX: &[T]` and `outY: &mut [T]` are distinct parameters and can
never overlap, so every `inX == outY` test is statically false; two `&mut [T]` can
never overlap either, so electing a *second* output needs no further check. The entry
point's distinctness test on the three outputs is C parity, not the licence.

**Being general is not being greedy.** Requiring *every* arm to be an election is the
clause that declines `STOCH`, `STOCHF` and `MAVP` — each mixes an allocation and a
`…IsAllocated = 1;` flag into a branch, which is a genuine in-place defence with a
real buffer to allocate, not an election. `MAVP` is inverted as well, so it is
rejected on the first link before the `else` is even reached. I had `MAVP` folded in
on the first pass, by a matcher that only inspected the arm that *runs*; narrowing
the rule to your formulation dropped it, and the `MAVP` legs of the gate went with
it. Tolerating one allocating arm is a widening of the rule for a later change, not
something I bolted on here.

## The four red lines

Verified mechanically over the pass's 424 lines of executable code, doc comments
stripped (they do name `BBANDS`/`MAVP` explanatorily):

| red line | status |
|---|---|
| no function name in the transform or its conditions | **clean** — no `BBANDS`/`STOCH`/`STOCHF`/`MAVP`, any case |
| no per-function table, allowlist or `match func.name` | **clean** — no `func.name`, no name comparison, no table |
| no `tempBuffer1`/`tempBuffer2`/`outRealMiddleBand`/`outRealUpperBand` literals | **clean** — also no `outReal`/`inReal`/`localFinalArray` |
| nothing keyed on `optInMAType == TA_MAType_SMA` | **clean** — no `optInMAType`, `TA_MAType`, `MAType` or `SMA` |

The pass reads only `func.inputs`, `func.outputs`, the `VarType::RealPointer` /
`IntPointer` locals it collects from the body, and statement structure.

`BBANDS` is currently the only function in `input/` written in this shape, and that
is asserted rather than asserted-about: `rust_scratch_election_declines_arms_that_allocate`
sweeps **every** indicator and requires the pass to fire for `bbands` alone. A
hand-picked list would have let a future widening slip past a function the test
forgot.

## The three traps

**1. Match before you recurse.** `ScratchElection::block` runs `election_chain` on the
statement before `descend` walks into any child block, so an inner `else if` link can
never be collapsed out from under the chain. `election_chain` walks the `else` spine
itself rather than relying on the child walk.

**2. No catch-all in the renaming walker.** This one needed a second pass — my first
version had `other => other.clone()` in `rename_shallow`, `other => other` in
`descend` and `_ => {}` in `visit_stmts`. All three are now exhaustive over
`Statement`'s 16 variants, with the leaf variants spelled out. Proof that it bites:
adding a `ProbeLoop { body: Vec<Statement> }` variant to `Statement` produces E0004
at all three sites (`rust_lang.rs:4248`, `:4480`, `:4601`) instead of compiling. Your
description of the failure mode is why I went back for it — a skipped body-bearing
variant is well-typed, generates and compiles cleanly, and only fails on the first
index into a still-empty `Vec`.

**3. The copy-back has to be deleted, not left as dead code.** Clause 4 above.
Confirmed as E0502 rather than something the optimiser folds: after the rename the
guard is `if o.as_ptr() != o.as_ptr() { o[..n].copy_from_slice(&o[..n]) }`, so
dropping the statement is load-bearing. Clause 4 fires only where the rename actually
rewrote a name, which is how a function that elected nothing is never touched.

## Scope: one generated file

`generate` across all 168 functions changes exactly one generated indicator file.

```
$ python3 scripts/build.py generate && git diff --name-only <parent>
ta_codegen/generator/CLAUDE.md
ta_codegen/generator/src/backends/mod.rs
ta_codegen/generator/src/backends/rust_lang.rs
ta_codegen/generator/src/main.rs
ta_codegen/generator/templates/rust/scratch_election.rs
ta_codegen/generator/tests/backend_suite.rs
ta_codegen/output/rust/library/src/ta_func/bbands.rs      <- the only indicator
ta_codegen/output/rust/library/src/ta_func/mod.rs         <- +4, the test module decl
ta_codegen/output/rust/library/src/ta_func/scratch_election.rs  <- the gate, copied
```

`git status --porcelain` after `generate` on the committed tree is empty — the
`regen-check` gate stays green. `mavp.rs`, `stoch.rs` and `stochf.rs` are
byte-identical to their parent.

Other backends, zero changed files each: `src/ta_func/`, `src/ta_abstract/`,
`src/ta_common/`, `ta_codegen/output/java/`, `ta_codegen/output/dotnet/`, `include/`,
`website/`, `ta_func_api.xml`, `CMakeLists.txt`.

The general MA path and both stream paths keep their real allocations — four
surviving `tempBuffer1`/`tempBuffer2` pairs in `bbands.rs` (guarded batch, unguarded
batch, and one per stream variant), pinned by a generator shape test. No `.to_vec()`
remains anywhere in the file.

## The gate is resident, not a one-off probe

Your 4800 comparisons were a throwaway probe; this one runs in CI on every push.

`templates/rust/scratch_election.rs` is hand-written, copied verbatim into the crate
by `generate` (held by the Rust backend's `clean_keep`), and declared `#[cfg(test)]`
in the generated `mod.rs`, so nothing ships in a release build.

**It is a `#[cfg(test)]` module rather than `output/rust/library/tests/*.rs`
deliberately.** An integration test there survives `generate`, but no CI job executes
it — `dev-nightly-tests.yml` runs `cargo test --lib` and `--doc` only. It would have
been a gate that never runs. `templates/rust/types.rs` is the established precedent
for hand-written source shipping inside the generated crate, so this is a second
template alongside it (wired via `RUST_TEMPLATE_MODULES` / `RUST_TEST_ONLY_MODULES`
in `main.rs` and `clean_keep` in `backends/mod.rs` — adding another means touching all
three, which is now written down in `generator/CLAUDE.md`).

Three properties, 5752 bit-exact comparisons, over periods 2/3/5/20/33/100 ×
`nbDev` (2,2)/(0,3)/(-1,2)/(1.5,2.5) × MAType 0/1/2/3/8 × n from 1 to 5000:

| property | comparisons | what a mis-election breaks |
|---|---|---|
| `BBANDS` == `MA` + `STDDEV` recomposed through the public API | 3264 | a genuinely separate code path; covers the electing SMA path *and* the untouched general path |
| independent of the prior contents of the output slices | 2032 | electing an output means reading a buffer the caller owned |
| independent of the output slices' capacity | 456 | the pre-#146 shape sized scratch from the caller's slice |

**All 5752 pass with the transform reverted.** That is the point — they pin numeric
invariance, not the absence of an allocation.

Discrimination, since a gate that cannot fail is not a gate. Four probes, each run
against this tree:

| probe | result |
|---|---|
| standard deviation written into the middle band instead of the upper | **caught** — 2 of 3 legs fail |
| band loop reordered so the scratch is clobbered before it is read | **caught** — composition leg fails |
| matcher widened by dropping the `then`-arm requirement (my v1 rule) | **caught** — the whole-tree non-firing test fails on `MAVP` |
| pass disabled entirely | gate still green, `bbands.rs` byte-identical to parent, 16 `.to_vec()` back |

Standard deviation into the *lower* band is **not** caught, correctly — that is an
equally valid election.

## Verification

Every one actually run, on the committed tree.

| check | result |
|---|---|
| `build.py generate` then `git status --porcelain` | empty |
| `git diff` over C / Java / .NET / include / website | empty |
| `build.py test` | `* All tests succeeded. *` |
| `build.py clippy` | clean, both crates |
| generator `cargo test` | 620 passed |
| crate `cargo test --lib` / `--doc` | 26 / 340 passed |
| `ta_regtest --codegen-only --language=c,rust` | C 161/0, Rust 161/0 |
| `ta_regtest --xlang-hash --language=rust` over BBANDS/MAVP/STOCH/STOCHF + MA family | 93 288 cases, **0 mismatches** — bit-identical to the in-process C library |
| `build.py format-check`, `check-source-lists` | clean |

## Performance

Throwaway interleaved A/B harness outside the tree, per your note — no second
benchmark tool in the released tree. It links the generated library before and after
as two crates in one process, alternates which variant runs first, and checks every
timed shape bit-for-bit before timing it. `SMA` — identical code in both crates — is
the control, so the control delta bounds harness bias.

### x86_64 — i7-10700K, macOS 26.5, rustc 1.97.0, `lto = "thin"`, `codegen-units = 1`, min of 25 rounds

**Control: within 0.13%.**

Exactly-sized output slices, ns/call, period 20:

| bars | before | after | gain |
|---|---|---|---|
| 100 | 508.3 | 296.8 | **+71.3%** |
| 500 | 1924.6 | 1618.2 | **+18.9%** |
| 5000 | 22864.7 | 19977.3 | **+14.5%** |

Flat in the period, as you predicted: at 500 bars +17.7/18.5/18.9/19.8% for periods
5/14/20/50.

Capacity group — 500 bars of data, output slices allocated once at capacity, ns/bar,
median of 8 processes:

| capacity | before (min..max) | after |
|---|---|---|
| 500 | 3.82 (3.77..3.83) | 3.23 |
| 5 000 | 6.90 (6.55..86.89) | 3.23 |
| 50 000 | 98.92 (59.48..153.60) | 3.20 |

The `before` spread is allocator-state dependent — the libmalloc analogue of the
glibc effect you described — and is itself the point; `after` does not move.

### aarch64 — Apple M5 Max, macOS 26.5.2, rustc 1.97.0, median of 11 processes

**Control: within 0.06%.**

| bars | before | after | gain |
|---|---|---|---|
| 100 | 177.3 | 128.4 | **+38.1%** |
| 500 | 815.1 | 693.8 | **+17.2%** |
| 5000 | 9791.7 | 7881.8 | **+24% to +35%** |

The 5000-bar row is reported as a range because it has a period sensitivity I cannot
explain. `after` reads 8185/7589/7882/7493 ns for periods 5/14/20/50 while `before`
stays flat near 10 000 — a 9% spread in `after` alone. It reproduces (under 1% within
each cell) and the output length varies by only 1% across those periods, so it is
neither noise nor work volume. Most likely loop alignment at the 40 KB buffer size.
It does not change the direction or the order of magnitude. Every other row is flat
in the period: at 500 bars +16.1/16.3/17.2/17.4%.

Capacity group — 500 bars of data, ns/bar, 24 processes:

| capacity | before | after |
|---|---|---|
| 500 | **bimodal: 1.62–1.66 (14/24) or 3.85–3.98 (10/24)** | 1.39 (1.38..1.39) |
| 5 000 | 3.62 (3.34..3.69) | 1.39 (1.39..1.40) |
| 50 000 | 24.66 (23.25..24.78) | 1.39 |

No single median is quoted for cap=500 `before` because it is genuinely bimodal
across processes, and collapsing it to one number would misrepresent it.

`after` is **1.38–1.40 ns/bar in all 72 readings** (24 processes × 3 capacities). The
extended sweep takes it further: `before` is linear in the caller's capacity across
four orders of magnitude while `after` stays 1.39, so at capacity 1 000 000 against
500 bars of data `before` reads 397.6–401.6 ns/bar against 1.39 — **289×**. That is
the argument you made in the issue, and it is the one that matters to us.

### Honest comparison to your prototype

These gains run higher than your +9.1% / +9.4% / +8.7–12%. **That is platform and
harness difference, not a claim that this implementation is better than yours** —
different CPUs, macOS libmalloc rather than glibc (so no `mmap`-threshold
transition to fall off), and a min-of-rounds interleaved harness rather than a single
sweep. The generated code is the same shape you described.

## Not in scope

- `STOCH`/`STOCHF`/`MAVP`, per your scope note — reaching them needs a matcher that
  tolerates one allocating arm, which is a widening of the rule and a separate change.
  Their non-firing is what lets me assert the other three backends were untouched.
- The Rust enum-optional-param residual (`Core::ma(.., i32::MIN)` not selecting SMA),
  which you flagged on #149 — happy to take that next if you want it.
