### PR TITLE
docs(midpoint,midprice): correct the amortized O(1) claim (#147)

### DIFF
--- a/src/ta_func/ta_MIDPOINT.c
+++ b/src/ta_func/ta_MIDPOINT.c
@@ -134,9 +134,20 @@ TA_LIB_API TA_RetCode TA_MIDPOINT( int    startIdx,
     * output to be the same buffer.
     *
     * The highest/lowest of the window is cached with its
-    * index; a rescan of the window is needed only when the
-    * cached extremum drops out of the window (amortized O(1)
-    * per bar instead of O(period)).
+    * index; the window is rescanned only when the cached
+    * extremum drops out of the window. That is O(1) per bar
+    * while the extremum sits away from the trailing edge, but
+    * it is not amortized O(1): an extremum on the oldest
+    * in-window bar drops out on the very next bar, so the
+    * rescan repeats and the cost stays O(period) per bar for
+    * as long as that persists.
+    *
+    * Tracking both extrema keeps that state going through a
+    * trend: while the high is refreshed by each new bar, the
+    * low stays pinned at the oldest bar for the whole leg
+    * (and the reverse on the way down). A flat stretch pins
+    * both. Random-walk input is the favourable case, where
+    * rescans are rare. See issue #147.
     */
    outIdx = 0;
    today = startIdx;
@@ -642,9 +653,20 @@ TA_RetCode TA_MIDPOINT_OpenInternal( struct TA_MIDPOINT_Stream **stream, const d
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -811,9 +833,20 @@ TA_LIB_API TA_RetCode TA_MIDPOINT_OpenAndFill( TA_MIDPOINT_Stream **stream, cons
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/src/ta_func/ta_MIDPRICE.c
+++ b/src/ta_func/ta_MIDPRICE.c
@@ -147,9 +147,19 @@ TA_LIB_API TA_RetCode TA_MIDPRICE( int    startIdx,
     *   (~period 19-20 with gcc/clang -O3 on x86-64).
     *
     * - Larger periods: cache the highest high/lowest low with its
-    *   index; a rescan of the window is needed only when the cached
-    *   extremum drops out of the window (amortized O(1) per bar
-    *   instead of O(period)).
+    *   index; the window is rescanned only when the cached extremum
+    *   drops out of the window. That is O(1) per bar while the
+    *   extremum sits away from the trailing edge, but it is not
+    *   amortized O(1): an extremum on the oldest in-window bar drops
+    *   out on the very next bar, so the rescan repeats and the cost
+    *   stays O(period) per bar for as long as that persists.
+    *
+    *   Tracking both extrema keeps that state going through a trend:
+    *   while the highest high is refreshed by each new bar, the
+    *   lowest low stays pinned at the oldest bar for the whole leg
+    *   (and the reverse on the way down). A flat stretch pins both.
+    *   Random-walk input is the favourable case, where rescans are
+    *   rare. See issue #147.
     */
    outIdx = 0;
    today = startIdx;
@@ -777,9 +787,19 @@ TA_RetCode TA_MIDPRICE_OpenInternal( struct TA_MIDPRICE_Stream **stream, const d
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -956,9 +976,19 @@ TA_LIB_API TA_RetCode TA_MIDPRICE_OpenAndFill( TA_MIDPRICE_Stream **stream, cons
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/input/midpoint/midpoint.c
+++ b/ta_codegen/input/midpoint/midpoint.c
@@ -65,9 +65,20 @@ TA_RetCode midpoint(int startIdx, int endIdx,
     * output to be the same buffer.
     *
     * The highest/lowest of the window is cached with its
-    * index; a rescan of the window is needed only when the
-    * cached extremum drops out of the window (amortized O(1)
-    * per bar instead of O(period)).
+    * index; the window is rescanned only when the cached
+    * extremum drops out of the window. That is O(1) per bar
+    * while the extremum sits away from the trailing edge, but
+    * it is not amortized O(1): an extremum on the oldest
+    * in-window bar drops out on the very next bar, so the
+    * rescan repeats and the cost stays O(period) per bar for
+    * as long as that persists.
+    *
+    * Tracking both extrema keeps that state going through a
+    * trend: while the high is refreshed by each new bar, the
+    * low stays pinned at the oldest bar for the whole leg
+    * (and the reverse on the way down). A flat stretch pins
+    * both. Random-walk input is the favourable case, where
+    * rescans are rare. See issue #147.
     */
    outIdx = 0;
    today       = startIdx;

--- a/ta_codegen/input/midprice/midprice.c
+++ b/ta_codegen/input/midprice/midprice.c
@@ -76,9 +76,19 @@ TA_RetCode midprice(int startIdx, int endIdx,
     *   (~period 19-20 with gcc/clang -O3 on x86-64).
     *
     * - Larger periods: cache the highest high/lowest low with its
-    *   index; a rescan of the window is needed only when the cached
-    *   extremum drops out of the window (amortized O(1) per bar
-    *   instead of O(period)).
+    *   index; the window is rescanned only when the cached extremum
+    *   drops out of the window. That is O(1) per bar while the
+    *   extremum sits away from the trailing edge, but it is not
+    *   amortized O(1): an extremum on the oldest in-window bar drops
+    *   out on the very next bar, so the rescan repeats and the cost
+    *   stays O(period) per bar for as long as that persists.
+    *
+    *   Tracking both extrema keeps that state going through a trend:
+    *   while the highest high is refreshed by each new bar, the
+    *   lowest low stays pinned at the oldest bar for the whole leg
+    *   (and the reverse on the way down). A flat stretch pins both.
+    *   Random-walk input is the favourable case, where rescans are
+    *   rare. See issue #147.
     */
    outIdx = 0;
    today       = startIdx;

--- a/ta_codegen/output/java/library/fragments/Core_MIDPOINT.java
+++ b/ta_codegen/output/java/library/fragments/Core_MIDPOINT.java
@@ -96,9 +96,20 @@
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -745,9 +756,20 @@
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -878,9 +900,20 @@
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/library/fragments/Core_MIDPRICE.java
+++ b/ta_codegen/output/java/library/fragments/Core_MIDPRICE.java
@@ -108,9 +108,19 @@
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -854,9 +864,19 @@
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -995,9 +1015,19 @@
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/library/src/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/io/github/talib/Core.java
@@ -133721,9 +133721,20 @@ public class Core {
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -134370,9 +134381,20 @@ public class Core {
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -134503,9 +134525,20 @@ public class Core {
        * output to be the same buffer.
        *
        * The highest/lowest of the window is cached with its
-       * index; a rescan of the window is needed only when the
-       * cached extremum drops out of the window (amortized O(1)
-       * per bar instead of O(period)).
+       * index; the window is rescanned only when the cached
+       * extremum drops out of the window. That is O(1) per bar
+       * while the extremum sits away from the trailing edge, but
+       * it is not amortized O(1): an extremum on the oldest
+       * in-window bar drops out on the very next bar, so the
+       * rescan repeats and the cost stays O(period) per bar for
+       * as long as that persists.
+       *
+       * Tracking both extrema keeps that state going through a
+       * trend: while the high is refreshed by each new bar, the
+       * low stays pinned at the oldest bar for the whole leg
+       * (and the reverse on the way down). A flat stretch pins
+       * both. Random-walk input is the favourable case, where
+       * rescans are rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -134747,9 +134780,19 @@ public class Core {
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -135493,9 +135536,19 @@ public class Core {
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
@@ -135634,9 +135687,19 @@ public class Core {
        *   (~period 19-20 with gcc/clang -O3 on x86-64).
        *
        * - Larger periods: cache the highest high/lowest low with its
-       *   index; a rescan of the window is needed only when the cached
-       *   extremum drops out of the window (amortized O(1) per bar
-       *   instead of O(period)).
+       *   index; the window is rescanned only when the cached extremum
+       *   drops out of the window. That is O(1) per bar while the
+       *   extremum sits away from the trailing edge, but it is not
+       *   amortized O(1): an extremum on the oldest in-window bar drops
+       *   out on the very next bar, so the rescan repeats and the cost
+       *   stays O(period) per bar for as long as that persists.
+       *
+       *   Tracking both extrema keeps that state going through a trend:
+       *   while the highest high is refreshed by each new bar, the
+       *   lowest low stays pinned at the oldest bar for the whole leg
+       *   (and the reverse on the way down). A flat stretch pins both.
+       *   Random-walk input is the favourable case, where rescans are
+       *   rare. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -133556,9 +133556,20 @@ class Core {
            * output to be the same buffer.
            *
            * The highest/lowest of the window is cached with its
-           * index; a rescan of the window is needed only when the
-           * cached extremum drops out of the window (amortized O(1)
-           * per bar instead of O(period)).
+           * index; the window is rescanned only when the cached
+           * extremum drops out of the window. That is O(1) per bar
+           * while the extremum sits away from the trailing edge, but
+           * it is not amortized O(1): an extremum on the oldest
+           * in-window bar drops out on the very next bar, so the
+           * rescan repeats and the cost stays O(period) per bar for
+           * as long as that persists.
+           *
+           * Tracking both extrema keeps that state going through a
+           * trend: while the high is refreshed by each new bar, the
+           * low stays pinned at the oldest bar for the whole leg
+           * (and the reverse on the way down). A flat stretch pins
+           * both. Random-walk input is the favourable case, where
+           * rescans are rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
@@ -134205,9 +134216,20 @@ class Core {
            * output to be the same buffer.
            *
            * The highest/lowest of the window is cached with its
-           * index; a rescan of the window is needed only when the
-           * cached extremum drops out of the window (amortized O(1)
-           * per bar instead of O(period)).
+           * index; the window is rescanned only when the cached
+           * extremum drops out of the window. That is O(1) per bar
+           * while the extremum sits away from the trailing edge, but
+           * it is not amortized O(1): an extremum on the oldest
+           * in-window bar drops out on the very next bar, so the
+           * rescan repeats and the cost stays O(period) per bar for
+           * as long as that persists.
+           *
+           * Tracking both extrema keeps that state going through a
+           * trend: while the high is refreshed by each new bar, the
+           * low stays pinned at the oldest bar for the whole leg
+           * (and the reverse on the way down). A flat stretch pins
+           * both. Random-walk input is the favourable case, where
+           * rescans are rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
@@ -134338,9 +134360,20 @@ class Core {
            * output to be the same buffer.
            *
            * The highest/lowest of the window is cached with its
-           * index; a rescan of the window is needed only when the
-           * cached extremum drops out of the window (amortized O(1)
-           * per bar instead of O(period)).
+           * index; the window is rescanned only when the cached
+           * extremum drops out of the window. That is O(1) per bar
+           * while the extremum sits away from the trailing edge, but
+           * it is not amortized O(1): an extremum on the oldest
+           * in-window bar drops out on the very next bar, so the
+           * rescan repeats and the cost stays O(period) per bar for
+           * as long as that persists.
+           *
+           * Tracking both extrema keeps that state going through a
+           * trend: while the high is refreshed by each new bar, the
+           * low stays pinned at the oldest bar for the whole leg
+           * (and the reverse on the way down). A flat stretch pins
+           * both. Random-walk input is the favourable case, where
+           * rescans are rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
@@ -134582,9 +134615,19 @@ class Core {
            *   (~period 19-20 with gcc/clang -O3 on x86-64).
            *
            * - Larger periods: cache the highest high/lowest low with its
-           *   index; a rescan of the window is needed only when the cached
-           *   extremum drops out of the window (amortized O(1) per bar
-           *   instead of O(period)).
+           *   index; the window is rescanned only when the cached extremum
+           *   drops out of the window. That is O(1) per bar while the
+           *   extremum sits away from the trailing edge, but it is not
+           *   amortized O(1): an extremum on the oldest in-window bar drops
+           *   out on the very next bar, so the rescan repeats and the cost
+           *   stays O(period) per bar for as long as that persists.
+           *
+           *   Tracking both extrema keeps that state going through a trend:
+           *   while the highest high is refreshed by each new bar, the
+           *   lowest low stays pinned at the oldest bar for the whole leg
+           *   (and the reverse on the way down). A flat stretch pins both.
+           *   Random-walk input is the favourable case, where rescans are
+           *   rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
@@ -135328,9 +135371,19 @@ class Core {
            *   (~period 19-20 with gcc/clang -O3 on x86-64).
            *
            * - Larger periods: cache the highest high/lowest low with its
-           *   index; a rescan of the window is needed only when the cached
-           *   extremum drops out of the window (amortized O(1) per bar
-           *   instead of O(period)).
+           *   index; the window is rescanned only when the cached extremum
+           *   drops out of the window. That is O(1) per bar while the
+           *   extremum sits away from the trailing edge, but it is not
+           *   amortized O(1): an extremum on the oldest in-window bar drops
+           *   out on the very next bar, so the rescan repeats and the cost
+           *   stays O(period) per bar for as long as that persists.
+           *
+           *   Tracking both extrema keeps that state going through a trend:
+           *   while the highest high is refreshed by each new bar, the
+           *   lowest low stays pinned at the oldest bar for the whole leg
+           *   (and the reverse on the way down). A flat stretch pins both.
+           *   Random-walk input is the favourable case, where rescans are
+           *   rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
@@ -135469,9 +135522,19 @@ class Core {
            *   (~period 19-20 with gcc/clang -O3 on x86-64).
            *
            * - Larger periods: cache the highest high/lowest low with its
-           *   index; a rescan of the window is needed only when the cached
-           *   extremum drops out of the window (amortized O(1) per bar
-           *   instead of O(period)).
+           *   index; the window is rescanned only when the cached extremum
+           *   drops out of the window. That is O(1) per bar while the
+           *   extremum sits away from the trailing edge, but it is not
+           *   amortized O(1): an extremum on the oldest in-window bar drops
+           *   out on the very next bar, so the rescan repeats and the cost
+           *   stays O(period) per bar for as long as that persists.
+           *
+           *   Tracking both extrema keeps that state going through a trend:
+           *   while the highest high is refreshed by each new bar, the
+           *   lowest low stays pinned at the oldest bar for the whole leg
+           *   (and the reverse on the way down). A flat stretch pins both.
+           *   Random-walk input is the favourable case, where rescans are
+           *   rare. See issue #147.
            */
           outIdx = 0;
           today = startIdx;

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -197,9 +197,20 @@ impl Core {
         // output to be the same buffer.
         //
         // The highest/lowest of the window is cached with its
-        // index; a rescan of the window is needed only when the
-        // cached extremum drops out of the window (amortized O(1)
-        // per bar instead of O(period)).
+        // index; the window is rescanned only when the cached
+        // extremum drops out of the window. That is O(1) per bar
+        // while the extremum sits away from the trailing edge, but
+        // it is not amortized O(1): an extremum on the oldest
+        // in-window bar drops out on the very next bar, so the
+        // rescan repeats and the cost stays O(period) per bar for
+        // as long as that persists.
+        //
+        // Tracking both extrema keeps that state going through a
+        // trend: while the high is refreshed by each new bar, the
+        // low stays pinned at the oldest bar for the whole leg
+        // (and the reverse on the way down). A flat stretch pins
+        // both. Random-walk input is the favourable case, where
+        // rescans are rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
@@ -484,9 +495,20 @@ impl Core {
         // output to be the same buffer.
         //
         // The highest/lowest of the window is cached with its
-        // index; a rescan of the window is needed only when the
-        // cached extremum drops out of the window (amortized O(1)
-        // per bar instead of O(period)).
+        // index; the window is rescanned only when the cached
+        // extremum drops out of the window. That is O(1) per bar
+        // while the extremum sits away from the trailing edge, but
+        // it is not amortized O(1): an extremum on the oldest
+        // in-window bar drops out on the very next bar, so the
+        // rescan repeats and the cost stays O(period) per bar for
+        // as long as that persists.
+        //
+        // Tracking both extrema keeps that state going through a
+        // trend: while the high is refreshed by each new bar, the
+        // low stays pinned at the oldest bar for the whole leg
+        // (and the reverse on the way down). A flat stretch pins
+        // both. Random-walk input is the favourable case, where
+        // rescans are rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
@@ -649,9 +671,20 @@ impl Core {
         // output to be the same buffer.
         //
         // The highest/lowest of the window is cached with its
-        // index; a rescan of the window is needed only when the
-        // cached extremum drops out of the window (amortized O(1)
-        // per bar instead of O(period)).
+        // index; the window is rescanned only when the cached
+        // extremum drops out of the window. That is O(1) per bar
+        // while the extremum sits away from the trailing edge, but
+        // it is not amortized O(1): an extremum on the oldest
+        // in-window bar drops out on the very next bar, so the
+        // rescan repeats and the cost stays O(period) per bar for
+        // as long as that persists.
+        //
+        // Tracking both extrema keeps that state going through a
+        // trend: while the high is refreshed by each new bar, the
+        // low stays pinned at the oldest bar for the whole leg
+        // (and the reverse on the way down). A flat stretch pins
+        // both. Random-walk input is the favourable case, where
+        // rescans are rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -215,9 +215,19 @@ impl Core {
         //   (~period 19-20 with gcc/clang -O3 on x86-64).
         //
         // - Larger periods: cache the highest high/lowest low with its
-        //   index; a rescan of the window is needed only when the cached
-        //   extremum drops out of the window (amortized O(1) per bar
-        //   instead of O(period)).
+        //   index; the window is rescanned only when the cached extremum
+        //   drops out of the window. That is O(1) per bar while the
+        //   extremum sits away from the trailing edge, but it is not
+        //   amortized O(1): an extremum on the oldest in-window bar drops
+        //   out on the very next bar, so the rescan repeats and the cost
+        //   stays O(period) per bar for as long as that persists.
+        //
+        //   Tracking both extrema keeps that state going through a trend:
+        //   while the highest high is refreshed by each new bar, the
+        //   lowest low stays pinned at the oldest bar for the whole leg
+        //   (and the reverse on the way down). A flat stretch pins both.
+        //   Random-walk input is the favourable case, where rescans are
+        //   rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
@@ -557,9 +567,19 @@ impl Core {
         //   (~period 19-20 with gcc/clang -O3 on x86-64).
         //
         // - Larger periods: cache the highest high/lowest low with its
-        //   index; a rescan of the window is needed only when the cached
-        //   extremum drops out of the window (amortized O(1) per bar
-        //   instead of O(period)).
+        //   index; the window is rescanned only when the cached extremum
+        //   drops out of the window. That is O(1) per bar while the
+        //   extremum sits away from the trailing edge, but it is not
+        //   amortized O(1): an extremum on the oldest in-window bar drops
+        //   out on the very next bar, so the rescan repeats and the cost
+        //   stays O(period) per bar for as long as that persists.
+        //
+        //   Tracking both extrema keeps that state going through a trend:
+        //   while the highest high is refreshed by each new bar, the
+        //   lowest low stays pinned at the oldest bar for the whole leg
+        //   (and the reverse on the way down). A flat stretch pins both.
+        //   Random-walk input is the favourable case, where rescans are
+        //   rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
@@ -731,9 +751,19 @@ impl Core {
         //   (~period 19-20 with gcc/clang -O3 on x86-64).
         //
         // - Larger periods: cache the highest high/lowest low with its
-        //   index; a rescan of the window is needed only when the cached
-        //   extremum drops out of the window (amortized O(1) per bar
-        //   instead of O(period)).
+        //   index; the window is rescanned only when the cached extremum
+        //   drops out of the window. That is O(1) per bar while the
+        //   extremum sits away from the trailing edge, but it is not
+        //   amortized O(1): an extremum on the oldest in-window bar drops
+        //   out on the very next bar, so the rescan repeats and the cost
+        //   stays O(period) per bar for as long as that persists.
+        //
+        //   Tracking both extrema keeps that state going through a trend:
+        //   while the highest high is refreshed by each new bar, the
+        //   lowest low stays pinned at the oldest bar for the whole leg
+        //   (and the reverse on the way down). A flat stretch pins both.
+        //   Random-walk input is the favourable case, where rescans are
+        //   rare. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;


### PR DESCRIPTION
Comment-only fix for the part of #147 you accepted. **No algorithm change** — that
discussion stays in #147.

## What the comment claimed

Both functions documented the cached-extremum rolling min/max as:

> a rescan of the window is needed only when the cached extremum drops out of the
> window (amortized O(1) per bar instead of O(period))

## What the code does

The rescan is gated on `highestIdx < trailingIdx` / `lowestIdx < trailingIdx`, and
`trailingIdx` advances one bar per iteration. So an extremum sitting on the **oldest
in-window bar** drops out on the very next bar, the rescan fires again, and per-bar
cost stays O(period) for as long as that condition holds. That is not amortized
O(1) — it is O(1) in the common case with an O(period) worst case that can persist.

These two track *both* extrema, which is what makes the condition self-sustaining
rather than incidental: through a trend leg the high is refreshed by each new bar
while the low stays pinned at the oldest bar for the entire leg (and the reverse on
the way down). A flat stretch pins both. Random-walk input is the favourable case,
where rescans are rare.

Counting the inner-loop comparisons actually executed by the `midpoint` loop
(20k bars, comparisons per bar):

| input | period 14 | period 30 | period 200 |
|---|---|---|---|
| random walk | 3.99 | 5.99 | 13.42 |
| alternating trend/chop (200-bar legs) | 8.40 | 17.17 | 103.50 |
| monotone up or down | 13.00 | 29.00 | 199.01 |

The monotone rows are `period - 1` per bar, i.e. every bar rescans. They are the
clean limit, not the interesting case — the middle row is the ordinary one, and it
tracks period rather than staying flat.

## What this PR changes

The comments now describe that behaviour instead of asserting a bound the code does
not reach: O(1) in the common case, O(period) per bar while an extremum sits at the
trailing edge, and the trending input class where that keeps happening. Wording
follows the surrounding comment style; `midprice`'s existing `<= 20` naive-rescan
bullet was already accurate and is left alone.

Edited only the two source-of-truth inputs:

- `ta_codegen/input/midpoint/midpoint.c`
- `ta_codegen/input/midprice/midprice.c`

then regenerated (`cd ta_codegen/generator && cargo run -- generate`, plus
`generate-servers` for the tracked Java server source, which embeds `Core` and
therefore carries the comment too). The remaining 8 files in the diff are that
generated output — C, Rust and Java all pick up the new wording. The .NET backend
has no per-function generated source, so nothing there changes.

**Zero numerics change.** Every changed line is inside a comment:

```
git show -U0 HEAD | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-][[:space:]]*(\*|//|/\*)'      # -> no output
```

## Verification (all run locally, macOS arm64, Apple clang 21)

| check | result |
|---|---|
| `cargo run -- generate` then `git status --porcelain` | clean (also clean after re-running `generate-servers`) |
| `scripts/build.py format-check` | all 171 input files already formatted |
| `scripts/build.py test` | `* All tests succeeded. Enjoy the library. *` |
| `scripts/build.py clippy` | Clippy clean (generator + generated crate) |
| `ta_codegen/generator` `cargo test` | 70 passed, 0 failed |
| generated crate `cargo test` | 366 passed, 0 failed |
| `scripts/regtest.py --language=c,rust --codegen-only` | all functions PASS vs the reference oracle, incl. MIDPOINT / MIDPRICE |
| `ta_regtest --xlang-hash --language=rust` | `Rust: 211162 cases, 0 mismatch(es)` — PASS, bit-identical |

`--xlang-hash` for Java/.NET was not run here: this box has JDK 11 (the build wants
`--release 17`) and .NET SDK 7 (the server targets net10), so those servers do not
build locally. Pre-existing environment limitation, unrelated to this change — and
since the diff is comments only, CI covers it.

## Notes for review

- I did **not** add a `Change history` entry or contributor initials to either file
  header, to keep the diff to the two comment blocks you pointed at. Happy to add
  them in the repo's format if you'd prefer the correction logged there.
- The comments reference `issue #147`, matching the inline-issue-reference style
  used elsewhere in `ta_codegen/input` (e.g. `cmf.c`, `imi.c`).
- Framing deliberately leads with the trending case and treats monotone/flat as the
  limit, per your note about not optimizing for — or advertising — synthetic input.

Algorithm evaluation (deque vs Van Herk/Gil-Werman vs attacking the rescan), the
benchmark corpus, and the index-returning tie-break question are all out of scope
here and continue in #147.
