### PR TITLE
feat(ta_bench): #147 — trending/chop input classes for the benchmark corpus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,53 @@ changes or benchmarks are invalid. `regtest.py` handles this automatically.
 Full-suite benchmark runs have 10–20% variance from icache pressure;
 use `--function=NAME --iters=500` for ground truth.
 
+### Benchmark input corpus
+
+Some indicators have input-dependent cost, so which series you measure on is
+part of the measurement. `src/tools/ta_bench/bench_corpus.h` holds the corpus —
+one deterministic generator, shared by `ta_bench`, `ta_bench_direct` and the
+generated `ta_bench_cg` / `ta_bench_stream`. Select a class with `--shape=`:
+
+```bash
+cd bin && ./ta_bench --list-shapes            # the input classes and what each reaches
+
+# random walk (default: the historical seed-42 series) and GBM — the acceptance gate
+./ta_bench --language=cref,c --function=WILLR --shape=randwalk --iters=500
+./ta_bench --language=cref,c --function=WILLR --shape=gbm      --iters=500
+
+# alternating trend/chop legs — the class rolling min/max degrades on
+for s in trend-chop-0.5p trend-chop-1p trend-chop-2p trend-chop-4p; do
+  ./ta_bench --language=cref,c --function=WILLR --shape=$s --period=30 --iters=500
+done
+```
+
+The rolling min/max behind MIN, MAX, MINMAX, MIDPOINT, MIDPRICE, WILLR, STOCH
+and STOCHF caches the window extremum and rescans the window when that extremum
+is the bar dropping out of it, so its cost depends on how often that happens. On
+a zero-drift walk the rate decays as ~1/sqrt(period); on a trending leg it is
+set by the drift/noise ratio instead and barely moves with the period, so the
+two separate further the longer the window (1.1x the rescan rate at period 14,
+3x at period 200). `randwalk` alone cannot see that — issue #147.
+
+The tail shapes are not peers: `constant` is the worst case at `2*(period-1)`
+comparisons per bar, exactly twice `mono-up`/`mono-down`. Flat input pins both
+extrema because the rescan compares with strict `>`/`<` and leaves the cached
+index on `trailingIdx`, so the `>=`/`<=` fast-path arms never run; a monotone
+ramp pins only one of the two.
+
+`--shape` is opt-in and `randwalk` reproduces the pre-corpus series bit for bit,
+so a default run costs and measures exactly what it did before. `--seed` picks
+the stream; `--regime-period` the window the trend/chop regime length is relative
+to (defaults to `--period` when given, else 14); `--trend-strength` the trend-leg
+drift in per-bar standard deviations (default 0.5 — sweep it to see how the cost
+responds to trend/noise). `--verify-corpus` checks every shape is reproducible
+and produces valid OHLC.
+
+The corpus is timing-only — it is never hashed and is unrelated to
+`fuzz_data.h`, whose `FUZZ_*` shape list is iterated by `--fuzz-064` /
+`--xlang-hash`. Keep it that way: adding a shape there changes what those gates
+compare (see the note at `test_variants.c:148`).
+
 ## Project Structure
 
 ```

--- a/scripts/regtest.py
+++ b/scripts/regtest.py
@@ -22,6 +22,11 @@ Filters (applied to generate AND test):
 Perftest options:
   --points=5000              Data points (default 5000)
   --iters=20                 Iterations (default 20)
+  --shape=trend-chop-1p      Benchmark input class (default randwalk;
+                             ta_bench --list-shapes prints them)
+  --seed=42                  Corpus seed (default 42)
+  --regime-period=30         Reference window for the trend/chop regime length
+  --trend-strength=0.5       Trend-leg drift, in per-bar standard deviations
 
 Examples:
   scripts/regtest.py                                             # full pipeline
@@ -30,6 +35,8 @@ Examples:
                                                                  # regen SMA indicator + test
   scripts/regtest.py --no-regtest --language=c --function=STOCH  # build + perftest only
   scripts/regtest.py --test-only --no-regtest --function=STOCH   # just perftest, no build
+  scripts/regtest.py --test-only --no-regtest --function=WILLR --shape=trend-chop-1p
+                                                                 # perftest on trending input
 """
 
 import os
@@ -435,7 +442,11 @@ def main():
             direct_args = [a for a in passthrough
                            if a.startswith("--function=")
                            or a.startswith("--iters=")
-                           or a.startswith("--points=")]
+                           or a.startswith("--points=")
+                           or a.startswith("--shape=")
+                           or a.startswith("--seed=")
+                           or a.startswith("--regime-period=")
+                           or a.startswith("--trend-strength=")]
             direct_rc = subprocess.run(
                 [bench_direct] + direct_args, cwd=bin_dir,
             ).returncode

--- a/src/tools/ta_bench/bench_corpus.h
+++ b/src/tools/ta_bench/bench_corpus.h
@@ -1,0 +1,486 @@
+#ifndef BENCH_CORPUS_H
+#define BENCH_CORPUS_H
+
+/* bench_corpus.h — the benchmark input corpus: the synthetic price series the
+ * ta_bench binaries measure on.
+ *
+ * One shared header so ta_bench, ta_bench_direct and the two generated benches
+ * (ta_bench_cg, ta_bench_stream) measure the SAME series; before this each
+ * carried its own copy of the same seed-42 walk.
+ *
+ * Every series is a pure function of its BenchCorpusCfg and n — no time(), no
+ * rand(), no locale, no platform state — so the same selection reproduces byte
+ * for byte on re-run (`--verify-corpus` checks exactly that). Unlike
+ * fuzz_data.h these arrays are never hashed or compared against an oracle, only
+ * timed, so no cross-toolchain bit-identity is required and the
+ * -ffp-contract=off constraint of fuzz_data.h (#150) does not apply here.
+ *
+ * WHY MORE THAN ONE SHAPE — the rolling min/max shared by MIN, MAX, MINMAX,
+ * MIDPOINT, MIDPRICE, WILLR, STOCH and STOCHF caches the window extremum with
+ * its index and rescans the whole window whenever that extremum falls out of
+ * it, so its cost is input-dependent. What a corpus has to vary is how often
+ * that rescan fires, i.e. how often the window extremum is its OLDEST bar:
+ *
+ *   - on a driftless walk the rate decays as ~1/sqrt(period), because the
+ *     extremum of a long driftless window is seldom at its start: measured
+ *     33%/23%/9% of bars (either extremum) at period 14/30/200;
+ *   - on a trending leg the rate is set by the per-bar drift/noise ratio and is
+ *     nearly independent of the period: 36%/30%/27% for trend-chop-1p at the
+ *     default --trend-strength (~43% of the bars inside a trend leg itself).
+ *
+ * So the two classes separate further the longer the window — 1.1x the rescan
+ * rate at period 14, 3x at period 200 — and a lone zero-drift walk cannot see
+ * it. Note the trend case is a MAJORITY-quiet one, not a pathological one: it
+ * is the minority of bars that rescan, just far more of them than on the walk.
+ * Within an uptrend it is the low that is pinned near the oldest bar while the
+ * high refreshes almost every bar, so the dual-extremum functions degrade on
+ * either trend direction and the single-extremum ones on one direction each.
+ * Real markets alternate trending and range-bound legs, which is why
+ * `trend-chop-*` is the input class this corpus was missing (issue #147).
+ *
+ * THE TAIL SHAPES ARE NOT PEERS — `constant` is the worst case in the family,
+ * at 2*(period-1) inner comparisons per bar, exactly TWICE `mono-up`/`mono-down`
+ * (period-1). The reason is a tie-break, not the trend mechanism above: the
+ * rescan loop compares with strict `>` / `<`, so on equal values it leaves
+ * highestIdx/lowestIdx parked on trailingIdx, the `< trailingIdx` guard refires
+ * on the very next bar, and the `>= highest` / `<= lowest` fast-path arms — the
+ * ones that would otherwise move the cached index onto the newest bar and end
+ * the rescans — never execute at all. Flat input does this to BOTH extrema
+ * indefinitely; a monotone ramp pins only one of the two (in an up-ramp the high
+ * is always the newest bar), which is precisely why it costs half as much.
+ *
+ * `randwalk` stays the default and reproduces the pre-existing seed-42 series
+ * bit for bit, so numbers taken before this corpus existed remain comparable.
+ * Shapes are opt-in via --shape=NAME: a benchmark run costs the same as before
+ * unless you ask for another class.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Historical benchmark seed. Kept as the default so --shape=randwalk with no
+ * --seed reproduces the series every earlier measurement used. */
+#define BENCH_CORPUS_SEED 42
+
+/* Default reference period for the regime-length of the trend/chop shapes:
+ * the default optInTimePeriod of the dual-extremum functions in #147
+ * (MIDPOINT, MIDPRICE, WILLR). See the regime-ratio note below. */
+#define BENCH_CORPUS_PERIOD 14
+
+/* Default trend-leg drift, in units of the per-bar standard deviation.
+ *
+ * This is the corpus knob that decides how trending a trend leg is, so it is
+ * worth being explicit about. At 0.5 a bar's expected move is half its noise:
+ * 31% of the bars in an "uptrend" still close lower, and at the 1%/bar
+ * volatility these legs use (~16%/yr) a 63-bar leg gains ~37% — an ordinary
+ * strong leg in a real name, not a monotone series in disguise. It also
+ * matters mechanically: the window low sits on the
+ * oldest bar exactly when the leg has not traded back below where the window
+ * opened, and that probability is set by this ratio — measured inside an
+ * uptrend leg, 25% at 0.25, 43% at 0.5, 64% at 1.0 — NOT by the period, and
+ * NOT by how long the leg runs. Sweep it with --trend-strength to
+ * see how the rolling min/max cost responds; 0 degenerates to a chop-only
+ * series and large values approach the monotone tail shapes. */
+#define BENCH_CORPUS_TREND 0.5
+
+/* Input classes. Keep BENCH_NSHAPES last; the names below are the --shape=
+ * tokens, lowercase-hyphen as in fuzz_data.h's shape list. */
+enum {
+    BENCH_RANDWALK = 0,     /* seed-42 additive walk around 100 — the historical
+                               default; zero drift, so the rescan rate decays as
+                               ~1/sqrt(period) and is lowest where it matters most */
+    BENCH_RANDWALK_LO,      /* same walk, 1/4 the step size                      */
+    BENCH_RANDWALK_HI,      /* same walk, 4x the step size                       */
+    BENCH_GBM,              /* geometric Brownian motion, 20%/yr vol on daily
+                               bars — the realistic-input acceptance gate        */
+    BENCH_TREND_CHOP_HALF,  /* alternating trend/chop, regime = period/2         */
+    BENCH_TREND_CHOP_1,     /* alternating trend/chop, regime = period           */
+    BENCH_TREND_CHOP_2,     /* alternating trend/chop, regime = 2 x period       */
+    BENCH_TREND_CHOP_4,     /* alternating trend/chop, regime = 4 x period       */
+    BENCH_MONO_UP,          /* strictly increasing — degenerate tail case        */
+    BENCH_MONO_DOWN,        /* strictly decreasing — degenerate tail case        */
+    BENCH_CONSTANT,         /* flat O=H=L=C — plateau, pins BOTH extrema         */
+    BENCH_NSHAPES
+};
+
+/* Generator family behind each shape. */
+enum {
+    BENCH_GEN_WALK = 0,     /* legacy LCG additive walk, param = step scale      */
+    BENCH_GEN_GBM,          /* lognormal, param = annualized volatility          */
+    BENCH_GEN_TRENDCHOP,    /* alternating regimes, param = regime/period ratio  */
+    BENCH_GEN_RAMP,         /* linear, param = +1 up / -1 down                   */
+    BENCH_GEN_FLAT          /* constant                                          */
+};
+
+typedef struct {
+    const char *name;       /* --shape= token                                   */
+    int         gen;        /* BENCH_GEN_*                                      */
+    double      param;      /* meaning depends on gen (see above)               */
+    const char *note;       /* one line for --list-shapes                       */
+} BenchShape;
+
+/* Regime ratios: the trend/chop regime length N is set relative to the rolling
+ * window P (--regime-period, default 14) because the degradation is a function
+ * of N/P, not of N. N < P means every window straddles a regime boundary, so
+ * the pinned extremum is repeatedly displaced by the chop and the cache still
+ * helps; N >= P means a window sits inside one leg for most of its life and the
+ * rescan rate saturates — measured at P=200, 0.5p rescans on 17% of bars while
+ * 1p/2p/4p all land within a point of 27%. 0.5/1/2/4 brackets that transition,
+ * and shows where it flattens. With the default P=14 the regimes are 7/14/28/56,
+ * which against MIN/MAX/MINMAX's own default window of 30 are 0.23/0.47/0.93/
+ * 1.87 x — so one sweep covers roughly 0.25p..4p across both default periods in
+ * the family. */
+static const BenchShape BENCH_SHAPES[BENCH_NSHAPES] = {
+    { "randwalk",         BENCH_GEN_WALK,      1.00,
+      "zero-drift additive walk, seed 42 (historical default)" },
+    { "randwalk-lo",      BENCH_GEN_WALK,      0.25,
+      "same walk, 1/4 step size (low volatility)" },
+    { "randwalk-hi",      BENCH_GEN_WALK,      4.00,
+      "same walk, 4x step size (high volatility)" },
+    { "gbm",              BENCH_GEN_GBM,       0.20,
+      "geometric Brownian motion, 20%/yr vol on daily bars" },
+    { "trend-chop-0.5p",  BENCH_GEN_TRENDCHOP, 0.50,
+      "alternating trend/chop legs, regime = period/2" },
+    { "trend-chop-1p",    BENCH_GEN_TRENDCHOP, 1.00,
+      "alternating trend/chop legs, regime = period" },
+    { "trend-chop-2p",    BENCH_GEN_TRENDCHOP, 2.00,
+      "alternating trend/chop legs, regime = 2x period" },
+    { "trend-chop-4p",    BENCH_GEN_TRENDCHOP, 4.00,
+      "alternating trend/chop legs, regime = 4x period" },
+    { "mono-up",          BENCH_GEN_RAMP,      1.00,
+      "strictly increasing ramp: pins the low only, period-1 per bar" },
+    { "mono-down",        BENCH_GEN_RAMP,     -1.00,
+      "strictly decreasing ramp: pins the high only, period-1 per bar" },
+    { "constant",         BENCH_GEN_FLAT,      0.00,
+      "flat O=H=L=C: WORST case, pins both, 2*(period-1) per bar" }
+};
+
+/* ---- PRNGs ---------------------------------------------------------------
+ * Two, deliberately. The `randwalk*` family keeps the original glibc-style LCG
+ * so `randwalk` stays bit-identical to the pre-corpus series (and so the low/hi
+ * variants are the same process at a different step scale, not a different
+ * process). Everything added here uses splitmix64, the same generator
+ * fuzz_data.h uses. */
+
+static unsigned long long bench_sm_next(unsigned long long *s)
+{
+    unsigned long long z = (*s += 0x9E3779B97F4A7C15ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+/* Uniform in [0,1) from the top 53 bits. */
+static double bench_sm_unit(unsigned long long *s)
+{
+    return (double)(bench_sm_next(s) >> 11) * (1.0 / 9007199254740992.0);
+}
+
+/* Standard normal, Box-Muller. Cached second deviate, so the stream advances
+ * two uniforms per pair and stays reproducible for a given (shape,seed,n). */
+typedef struct {
+    unsigned long long s;
+    double spare;
+    int    hasSpare;
+} BenchRng;
+
+static void bench_rng_init(BenchRng *r, int shape, int seed)
+{
+    r->s = 0x243F6A8885A308D3ULL
+         ^ ((unsigned long long)(unsigned int)seed * 0xD1B54A32D192ED03ULL)
+         ^ ((unsigned long long)(unsigned int)shape << 32);
+    r->spare = 0.0;
+    r->hasSpare = 0;
+}
+
+static double bench_rng_normal(BenchRng *r)
+{
+    double u1, u2, mag;
+    if( r->hasSpare ) { r->hasSpare = 0; return r->spare; }
+    /* Guard the log against an exact 0 from the uniform. */
+    do { u1 = bench_sm_unit(&r->s); } while( u1 <= 1.0e-300 );
+    u2 = bench_sm_unit(&r->s);
+    mag = sqrt(-2.0 * log(u1));
+    r->spare = mag * sin(6.283185307179586476925286766559 * u2);
+    r->hasSpare = 1;
+    return mag * cos(6.283185307179586476925286766559 * u2);
+}
+
+/* ---- Corpus selection --------------------------------------------------- */
+
+typedef struct {
+    int    shape;          /* BENCH_* input class                              */
+    int    seed;           /* PRNG stream                                      */
+    int    refPeriod;      /* rolling window the regime length is relative to  */
+    double trendStrength;  /* trend-leg drift, in per-bar standard deviations  */
+} BenchCorpusCfg;
+
+static void bench_corpus_defaults(BenchCorpusCfg *cfg)
+{
+    cfg->shape         = BENCH_RANDWALK;
+    cfg->seed          = BENCH_CORPUS_SEED;
+    cfg->refPeriod     = BENCH_CORPUS_PERIOD;
+    cfg->trendStrength = BENCH_CORPUS_TREND;
+}
+
+/* ---- Shape lookup ------------------------------------------------------- */
+
+/* Shape id for a --shape= token, or -1 when unknown. */
+static int bench_shape_id(const char *name)
+{
+    int i;
+    if( !name || !*name ) return BENCH_RANDWALK;
+    for( i = 0; i < BENCH_NSHAPES; i++ )
+        if( strcmp(BENCH_SHAPES[i].name, name) == 0 ) return i;
+    return -1;
+}
+
+static const char *bench_shape_name(int shape)
+{
+    if( shape < 0 || shape >= BENCH_NSHAPES ) return "?";
+    return BENCH_SHAPES[shape].name;
+}
+
+/* One line per input class, for --list-shapes. */
+static void bench_shape_list(void)
+{
+    int i;
+    printf("Benchmark input corpus (--shape=NAME, default %s):\n",
+           BENCH_SHAPES[BENCH_RANDWALK].name);
+    for( i = 0; i < BENCH_NSHAPES; i++ )
+        printf("  %-16s %s\n", BENCH_SHAPES[i].name, BENCH_SHAPES[i].note);
+    printf("\nTrend/chop regime length is --regime-period (default %d) times the ratio\n"
+           "in the shape name; --trend-strength (default %.2f) is the trend-leg drift in\n"
+           "per-bar standard deviations; --seed (default %d) picks the stream.\n",
+           BENCH_CORPUS_PERIOD, BENCH_CORPUS_TREND, BENCH_CORPUS_SEED);
+}
+
+/* ---- Corpus generator ---------------------------------------------------
+ * Fills OHLCV+OI (length n) for one input class. Invariants held by every
+ * shape: all values finite, high >= max(open,close), low <= min(open,close),
+ * low > 0. The output is a pure function of (cfg, n).
+ *
+ * periods may be NULL — when given it receives MAVP's per-bar period series in
+ * its default [2..30] range.
+ */
+static void bench_corpus_gen(const BenchCorpusCfg *cfg, int n,
+                             double *o, double *h, double *l, double *c,
+                             double *v, double *oi, double *periods)
+{
+    const BenchShape *sh;
+    BenchRng rng;
+    double param;
+    int i, period = 16;
+    int shape = cfg->shape;
+    int seed = cfg->seed;
+    int refPeriod = cfg->refPeriod;
+
+    if( shape < 0 || shape >= BENCH_NSHAPES ) shape = BENCH_RANDWALK;
+    if( refPeriod < 2 ) refPeriod = BENCH_CORPUS_PERIOD;
+    sh = &BENCH_SHAPES[shape];
+    param = sh->param;
+    bench_rng_init(&rng, shape, seed);
+
+    if( sh->gen == BENCH_GEN_WALK )
+    {
+        /* The pre-corpus generator, with the step size factored out. At
+         * param 1.0 amp/hw are exactly 2.0/0.5 and every bar is bit-identical
+         * to the series ta_bench measured before this header existed. */
+        unsigned int lcg = (unsigned int)seed;
+        double price = 100.0;
+        double amp = 2.0 * param, hw = 0.5 * param;
+        for( i = 0; i < n; i++ ) {
+            double r, oo, cc;
+            lcg = lcg * 1103515245 + 12345;
+            r = ((double)(lcg >> 16) / 32768.0) - 1.0;
+            oo = price; cc = price + r * amp;
+            o[i] = oo; c[i] = cc;
+            h[i] = fmax(oo, cc) + fabs(r) * hw;
+            l[i] = fmin(oo, cc) - fabs(r) * hw;
+            if( l[i] < 1.0 ) l[i] = 1.0;
+            v[i] = 1000000.0 + r * 500000.0;
+            oi[i] = 0.0;
+            price = cc; if( price < 1.0 ) price = 1.0;
+            if( periods ) {
+                /* Wandering period series in MAVP's default [2..30] range:
+                 * exercises the multi-period grouping, not just the
+                 * single-period fast path. */
+                period += (int)((lcg >> 8) % 7) - 3;
+                if( period < 2 ) period = 2;
+                if( period > 30 ) period = 30;
+                periods[i] = (double)period;
+            }
+        }
+        return;
+    }
+
+    if( sh->gen == BENCH_GEN_FLAT )
+    {
+        for( i = 0; i < n; i++ ) {
+            o[i] = h[i] = l[i] = c[i] = 100.0;
+            v[i] = 1000000.0;
+            oi[i] = 0.0;
+            if( periods ) periods[i] = 14.0;
+        }
+        return;
+    }
+
+    if( sh->gen == BENCH_GEN_RAMP )
+    {
+        /* 100..1000 (or the reverse) over the whole series, so the ramp is
+         * strictly monotone in open/high/low/close at any n without running
+         * into non-positive prices. */
+        double span = (n > 1) ? 900.0 / (double)(n - 1) : 0.0;
+        for( i = 0; i < n; i++ ) {
+            double t = (param > 0.0) ? (double)i : (double)(n - 1 - i);
+            double cc = 100.0 + span * t;
+            double oo = cc - 0.5 * span * ((param > 0.0) ? 1.0 : -1.0);
+            o[i] = oo; c[i] = cc;
+            h[i] = fmax(oo, cc) + 0.25 * span + 1.0e-6;
+            l[i] = fmin(oo, cc) - 0.25 * span - 1.0e-6;
+            if( l[i] < 1.0 ) l[i] = 1.0;
+            v[i] = 1000000.0;
+            oi[i] = 0.0;
+            if( periods ) periods[i] = 14.0;
+        }
+        return;
+    }
+
+    /* ---- Stochastic shapes: build a close series, then an intrabar envelope. */
+    {
+        /* Per-bar log-return sd. GBM: annualized vol over 252 daily bars.
+         * Trend/chop: 1%/bar, ordinary daily equity volatility. */
+        double sigma = (sh->gen == BENCH_GEN_GBM)
+                     ? param / sqrt(252.0)
+                     : 0.01;
+        /* Ito-corrected 5%/yr drift for GBM; the trend/chop legs carry their
+         * own drift below. */
+        double mu = (sh->gen == BENCH_GEN_GBM)
+                  ? 0.05 / 252.0 - 0.5 * sigma * sigma
+                  : 0.0;
+        /* Trend legs: drift cfg->trendStrength standard deviations per bar (see
+         * BENCH_CORPUS_TREND for why the default is 0.5 and what it controls).
+         * Chop legs: no drift, pulled back toward the level the leg opened at
+         * (AR(1), phi = 0.10) so they are genuinely range-bound. */
+        double trendDrift = cfg->trendStrength * sigma;
+        double phi = 0.10;
+        /* Regime length in bars, and the 4-leg cycle up/chop/down/chop. The
+         * trend direction alternates so the level stays bounded and so the
+         * single-extremum functions see both their favourable and their
+         * degrading direction within one series. */
+        int regime = (sh->gen == BENCH_GEN_TRENDCHOP)
+                   ? (int)(param * (double)refPeriod + 0.5)
+                   : 0;
+        double logp = log(100.0), anchor = logp;
+        int leg = 0, legBar = 0;
+
+        if( sh->gen == BENCH_GEN_TRENDCHOP && regime < 2 ) regime = 2;
+
+        for( i = 0; i < n; i++ )
+        {
+            double z = bench_rng_normal(&rng);
+            double cc, oo, hi, lo, w;
+
+            if( sh->gen == BENCH_GEN_TRENDCHOP )
+            {
+                if( legBar >= regime ) { legBar = 0; leg = (leg + 1) & 3; anchor = logp; }
+                switch( leg ) {
+                case 0: logp += trendDrift + sigma * z; break;              /* up   */
+                case 2: logp += -trendDrift + sigma * z; break;             /* down */
+                default: logp += -phi * (logp - anchor) + sigma * z; break; /* chop */
+                }
+                legBar++;
+            }
+            else
+            {
+                logp += mu + sigma * z;
+            }
+
+            cc = exp(logp);
+            /* Intrabar: open a fraction of a bar's move away from the close,
+             * high/low a fraction of one sd outside the body. */
+            oo = cc * (1.0 + sigma * 0.5 * bench_sm_unit(&rng.s) - sigma * 0.25);
+            hi = fmax(oo, cc); lo = fmin(oo, cc);
+            w  = sigma * 0.5 * bench_sm_unit(&rng.s);
+            hi = hi * (1.0 + w);
+            w  = sigma * 0.5 * bench_sm_unit(&rng.s);
+            lo = lo * (1.0 - w);
+            o[i] = oo; c[i] = cc; h[i] = hi; l[i] = lo;
+            if( l[i] < 1.0e-6 ) l[i] = 1.0e-6;
+            v[i] = 1000000.0 + 500000.0 * (bench_sm_unit(&rng.s) - 0.5);
+            oi[i] = 0.0;
+            if( periods ) {
+                period += (int)(bench_sm_next(&rng.s) % 7) - 3;
+                if( period < 2 ) period = 2;
+                if( period > 30 ) period = 30;
+                periods[i] = (double)period;
+            }
+        }
+    }
+}
+
+/* ---- Self-check (--verify-corpus) ---------------------------------------
+ * Two properties, for every shape:
+ *   1. reproducible — two generations of the same (shape, seed, n) are
+ *      byte-identical, so a measurement can be repeated exactly;
+ *   2. valid OHLC   — all values finite, high >= max(open,close),
+ *      low <= min(open,close), low > 0, and the MAVP period series in [2,30].
+ * Returns the number of failing shapes; prints one line each. */
+static int bench_corpus_selfcheck(int n, const BenchCorpusCfg *base)
+{
+    BenchCorpusCfg cfg = *base;
+    double *a, *b;
+    int shape, failures = 0;
+    const int NARR = 7;
+
+    if( n < 64 ) n = 64;
+    a = (double *)malloc(sizeof(double) * (size_t)NARR * (size_t)n);
+    b = (double *)malloc(sizeof(double) * (size_t)NARR * (size_t)n);
+    if( !a || !b ) { printf("  corpus selfcheck: allocation failed\n"); free(a); free(b); return 1; }
+
+    printf("Corpus self-check (n=%d seed=%d regime-period=%d trend-strength=%.2f)\n",
+           n, base->seed, base->refPeriod, base->trendStrength);
+    for( shape = 0; shape < BENCH_NSHAPES; shape++ )
+    {
+        const char *why = NULL;
+        int i;
+        double *ao = a, *ah = a+n, *al = a+2*n, *ac = a+3*n,
+               *av = a+4*n, *ai = a+5*n, *ap = a+6*n;
+
+        memset(a, 0xA5, sizeof(double) * (size_t)NARR * (size_t)n);
+        memset(b, 0x5A, sizeof(double) * (size_t)NARR * (size_t)n);
+        cfg.shape = shape;
+        bench_corpus_gen(&cfg, n, ao, ah, al, ac, av, ai, ap);
+        bench_corpus_gen(&cfg, n, b, b+n, b+2*n, b+3*n, b+4*n, b+5*n, b+6*n);
+
+        if( memcmp(a, b, sizeof(double) * (size_t)NARR * (size_t)n) != 0 )
+            why = "not reproducible";
+
+        for( i = 0; i < n && !why; i++ )
+        {
+            double hi = (ao[i] > ac[i]) ? ao[i] : ac[i];
+            double lo = (ao[i] < ac[i]) ? ao[i] : ac[i];
+            if( !(ao[i] == ao[i]) || !(ah[i] == ah[i]) ||
+                !(al[i] == al[i]) || !(ac[i] == ac[i]) ||
+                !(av[i] == av[i]) || !(ai[i] == ai[i]) || !(ap[i] == ap[i]) )
+                why = "non-finite value";
+            else if( ah[i] < hi )            why = "high below body";
+            else if( al[i] > lo )            why = "low above body";
+            else if( !(al[i] > 0.0) )        why = "non-positive low";
+            else if( ap[i] < 2.0 || ap[i] > 30.0 ) why = "period out of [2,30]";
+        }
+
+        printf("  %-16s %s\n", BENCH_SHAPES[shape].name, why ? why : "ok");
+        if( why ) failures++;
+    }
+    printf("%s (%d shape%s, %d failure%s)\n",
+           failures ? "CORPUS SELF-CHECK FAILED" : "corpus self-check passed",
+           BENCH_NSHAPES, (BENCH_NSHAPES == 1) ? "" : "s",
+           failures, (failures == 1) ? "" : "s");
+    free(a); free(b);
+    return failures;
+}
+
+#endif /* BENCH_CORPUS_H */

--- a/src/tools/ta_bench/ta_bench.c
+++ b/src/tools/ta_bench/ta_bench.c
@@ -6,6 +6,11 @@
  *
  * Usage:
  *   ./ta_bench [--points=N] [--iters=N] [--language=c,rust] [--function=RSI,SMA]
+ *              [--shape=NAME] [--seed=N] [--regime-period=N] [--trend-strength=F]
+ *              [--list-shapes] [--verify-corpus]
+ *
+ * --shape picks the input class from the corpus in bench_corpus.h; the default
+ * reproduces the series this tool has always used. --list-shapes prints them.
  */
 
 #include <stdio.h>
@@ -39,6 +44,7 @@ static char *win_strcasestr(const char *haystack, const char *needle)
 
 #include "ta_libc.h"
 #include "codegen_pipe.h"
+#include "bench_corpus.h"
 
 /* ---- Configuration ---- */
 
@@ -71,12 +77,12 @@ static long long get_nanotime(void) {
 #endif
 }
 
-/* ---- Test data ---- */
+/* ---- Test data (corpus shapes live in bench_corpus.h) ---- */
 
 static TA_Real *g_open, *g_high, *g_low, *g_close, *g_volume, *g_oi;
 static int g_nPoints;
 
-static void generate_price_data(int n) {
+static void generate_price_data(int n, const BenchCorpusCfg *corpus) {
     g_nPoints = n;
     g_open   = calloc(n, sizeof(TA_Real));
     g_high   = calloc(n, sizeof(TA_Real));
@@ -84,19 +90,7 @@ static void generate_price_data(int n) {
     g_close  = calloc(n, sizeof(TA_Real));
     g_volume = calloc(n, sizeof(TA_Real));
     g_oi     = calloc(n, sizeof(TA_Real));
-    unsigned int seed = 42;
-    double price = 100.0;
-    for( int i = 0; i < n; i++ ) {
-        seed = seed * 1103515245 + 12345;
-        double r = ((double)(seed >> 16) / 32768.0) - 1.0;
-        double o = price, c = price + r * 2.0;
-        double h = fmax(o, c) + fabs(r) * 0.5;
-        double l = fmin(o, c) - fabs(r) * 0.5;
-        if( l < 1.0 ) l = 1.0;
-        g_open[i] = o; g_high[i] = h; g_low[i] = l; g_close[i] = c;
-        g_volume[i] = 1000000.0 + r * 500000.0;
-        price = c; if( price < 1.0 ) price = 1.0;
-    }
+    bench_corpus_gen(corpus, n, g_open, g_high, g_low, g_close, g_volume, g_oi, NULL);
 }
 
 /* ---- JSON helpers ---- */
@@ -349,6 +343,13 @@ int main(int argc, char *argv[]) {
     int n_iters  = DEFAULT_ITERS;
     const char *lang_filter = NULL;
     const char *func_filter = NULL;
+    const char *shape_name = NULL;
+    int verify_corpus = 0;
+    BenchCorpusCfg corpus;
+    int seed = BENCH_CORPUS_SEED;
+    double trend_strength = BENCH_CORPUS_TREND;
+    int regime_period = 0;   /* 0 = derive (see below) */
+    int shape;
 
     for( int i = 1; i < argc; i++ ) {
         if( strncmp(argv[i], "--points=", 9) == 0 )       n_points = atoi(argv[i]+9);
@@ -356,13 +357,42 @@ int main(int argc, char *argv[]) {
         else if( strncmp(argv[i], "--language=", 11) == 0 ) lang_filter = argv[i]+11;
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
         else if( strncmp(argv[i], "--period=", 9) == 0 )    g_period_override = atoi(argv[i]+9);
+        else if( strncmp(argv[i], "--shape=", 8) == 0 )     shape_name = argv[i]+8;
+        else if( strncmp(argv[i], "--seed=", 7) == 0 )      seed = atoi(argv[i]+7);
+        else if( strncmp(argv[i], "--regime-period=", 16) == 0 ) regime_period = atoi(argv[i]+16);
+        else if( strncmp(argv[i], "--trend-strength=", 17) == 0 ) trend_strength = atof(argv[i]+17);
+        else if( strcmp(argv[i], "--list-shapes") == 0 )  { bench_shape_list(); return 0; }
+        else if( strcmp(argv[i], "--verify-corpus") == 0 ) verify_corpus = 1;
     }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
 
-    TA_Initialize();
-    generate_price_data(n_points);
+    shape = bench_shape_id(shape_name);
+    if( shape < 0 ) {
+        printf("ta_bench: unknown --shape=%s\n\n", shape_name);
+        bench_shape_list();
+        return 1;
+    }
+    /* The regime length of the trend/chop shapes is relative to the rolling
+     * window under test, so when --period pins the window use that; otherwise
+     * fall back to the corpus default. */
+    if( regime_period <= 0 )
+        regime_period = (g_period_override > 0) ? g_period_override : BENCH_CORPUS_PERIOD;
 
-    printf("ta_bench: %d points, %d iters (server-side)\n\n", n_points, n_iters);
+    bench_corpus_defaults(&corpus);
+    corpus.shape         = shape;
+    corpus.seed          = seed;
+    corpus.refPeriod     = regime_period;
+    corpus.trendStrength = trend_strength;
+
+    if( verify_corpus )
+        return bench_corpus_selfcheck(4096, &corpus) ? 1 : 0;
+
+    TA_Initialize();
+    generate_price_data(n_points, &corpus);
+
+    printf("ta_bench: %d points, %d iters, shape=%s seed=%d regime-period=%d"
+           " trend-strength=%.2f (server-side)\n\n",
+           n_points, n_iters, bench_shape_name(shape), seed, regime_period, trend_strength);
 
     /* Start servers + load data */
     char *reqBuf  = malloc(JSON_BUF_SIZE);
@@ -432,7 +462,8 @@ int main(int argc, char *argv[]) {
     };
     TA_ForEachFunc(bench_one_function, &ctx);
 
-    printf("\n%d indicators benchmarked (%d points, %d iters)\n", ctx.count, n_points, n_iters);
+    printf("\n%d indicators benchmarked (%d points, %d iters, shape=%s)\n",
+           ctx.count, n_points, n_iters, bench_shape_name(shape));
     printf("(red >10%% slower, green >10%% faster than C-ref)\n");
 
     /* Cleanup */

--- a/src/tools/ta_bench/ta_bench_direct.c
+++ b/src/tools/ta_bench/ta_bench_direct.c
@@ -7,6 +7,11 @@
  *
  * Usage:
  *   ./ta_bench_direct [--points=N] [--iters=N] [--function=RSI,SMA]
+ *                     [--shape=NAME] [--seed=N] [--regime-period=N] [--trend-strength=F]
+ *                     [--list-shapes] [--verify-corpus]
+ *
+ * --shape picks the input class from the corpus in bench_corpus.h; the default
+ * reproduces the series this tool has always used. --list-shapes prints them.
  */
 
 #include <stdio.h>
@@ -39,6 +44,7 @@ static char *win_strcasestr(const char *haystack, const char *needle)
 #endif
 
 #include "ta_libc.h"
+#include "bench_corpus.h"
 
 /* ---- Configuration ---- */
 
@@ -71,12 +77,12 @@ static long long get_nanotime(void) {
 #endif
 }
 
-/* ---- Test data (same seed=42 as ta_bench / ta_bench_cg) ---- */
+/* ---- Test data (same corpus as ta_bench / ta_bench_cg — bench_corpus.h) ---- */
 
 static TA_Real *g_open, *g_high, *g_low, *g_close, *g_volume, *g_oi;
 static int g_nPoints;
 
-static void generate_price_data(int n) {
+static void generate_price_data(int n, const BenchCorpusCfg *corpus) {
     g_nPoints = n;
     g_open   = calloc(n, sizeof(TA_Real));
     g_high   = calloc(n, sizeof(TA_Real));
@@ -84,19 +90,7 @@ static void generate_price_data(int n) {
     g_close  = calloc(n, sizeof(TA_Real));
     g_volume = calloc(n, sizeof(TA_Real));
     g_oi     = calloc(n, sizeof(TA_Real));
-    unsigned int seed = 42;
-    double price = 100.0;
-    for( int i = 0; i < n; i++ ) {
-        seed = seed * 1103515245 + 12345;
-        double r = ((double)(seed >> 16) / 32768.0) - 1.0;
-        double o = price, c = price + r * 2.0;
-        double h = fmax(o, c) + fabs(r) * 0.5;
-        double l = fmin(o, c) - fabs(r) * 0.5;
-        if( l < 1.0 ) l = 1.0;
-        g_open[i] = o; g_high[i] = h; g_low[i] = l; g_close[i] = c;
-        g_volume[i] = 1000000.0 + r * 500000.0;
-        price = c; if( price < 1.0 ) price = 1.0;
-    }
+    bench_corpus_gen(corpus, n, g_open, g_high, g_low, g_close, g_volume, g_oi, NULL);
 }
 
 /* ---- Output buffers ---- */
@@ -199,18 +193,49 @@ int main(int argc, char *argv[]) {
     int n_points = DEFAULT_POINTS;
     int n_iters  = DEFAULT_ITERS;
     const char *func_filter = NULL;
+    const char *shape_name = NULL;
+    int verify_corpus = 0;
+    BenchCorpusCfg corpus;
+    int seed = BENCH_CORPUS_SEED;
+    double trend_strength = BENCH_CORPUS_TREND;
+    int regime_period = BENCH_CORPUS_PERIOD;
+    int shape;
 
     for( int i = 1; i < argc; i++ ) {
         if( strncmp(argv[i], "--points=", 9) == 0 )       n_points = atoi(argv[i]+9);
         else if( strncmp(argv[i], "--iters=", 8) == 0 )    n_iters = atoi(argv[i]+8);
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
+        else if( strncmp(argv[i], "--shape=", 8) == 0 )     shape_name = argv[i]+8;
+        else if( strncmp(argv[i], "--seed=", 7) == 0 )      seed = atoi(argv[i]+7);
+        else if( strncmp(argv[i], "--regime-period=", 16) == 0 ) regime_period = atoi(argv[i]+16);
+        else if( strncmp(argv[i], "--trend-strength=", 17) == 0 ) trend_strength = atof(argv[i]+17);
+        else if( strcmp(argv[i], "--list-shapes") == 0 )  { bench_shape_list(); return 0; }
+        else if( strcmp(argv[i], "--verify-corpus") == 0 ) verify_corpus = 1;
     }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
 
-    TA_Initialize();
-    generate_price_data(n_points);
+    shape = bench_shape_id(shape_name);
+    if( shape < 0 ) {
+        printf("ta_bench_direct: unknown --shape=%s\n\n", shape_name);
+        bench_shape_list();
+        return 1;
+    }
 
-    printf("ta_bench_direct: %d points, %d iters (direct calls)\n\n", n_points, n_iters);
+    bench_corpus_defaults(&corpus);
+    corpus.shape         = shape;
+    corpus.seed          = seed;
+    corpus.refPeriod     = regime_period;
+    corpus.trendStrength = trend_strength;
+
+    if( verify_corpus )
+        return bench_corpus_selfcheck(4096, &corpus) ? 1 : 0;
+
+    TA_Initialize();
+    generate_price_data(n_points, &corpus);
+
+    printf("ta_bench_direct: %d points, %d iters, shape=%s seed=%d regime-period=%d"
+           " trend-strength=%.2f (direct calls)\n\n",
+           n_points, n_iters, bench_shape_name(shape), seed, regime_period, trend_strength);
 
     /* Phase 1: Reference timing via TA_CallFunc */
     printf("  Running reference (libta-lib.a)...\n");
@@ -222,7 +247,10 @@ int main(int argc, char *argv[]) {
     /* Phase 2: Codegen timing via ta_bench_cg subprocess */
     printf("  Running codegen (ta_bench_cg)...\n");
     char cmd[1024];
-    snprintf(cmd, sizeof(cmd), "./ta_bench_cg --points=%d --iters=%d", n_points, n_iters);
+    snprintf(cmd, sizeof(cmd),
+             "./ta_bench_cg --points=%d --iters=%d --shape=%s --seed=%d"
+             " --regime-period=%d --trend-strength=%.6g",
+             n_points, n_iters, bench_shape_name(shape), seed, regime_period, trend_strength);
     if( func_filter )
         snprintf(cmd + strlen(cmd), sizeof(cmd) - strlen(cmd), " --function=%s", func_filter);
 
@@ -262,8 +290,8 @@ int main(int argc, char *argv[]) {
                clr, g_results[i].cg_ns, rst, ratio);
     }
 
-    printf("\n%d indicators benchmarked (%d points, %d iters, direct calls)\n",
-           g_nResults, n_points, n_iters);
+    printf("\n%d indicators benchmarked (%d points, %d iters, shape=%s, direct calls)\n",
+           g_nResults, n_points, n_iters, bench_shape_name(shape));
     printf("(red >10%% slower, green >10%% faster than C-ref)\n");
 
     free(g_open); free(g_high); free(g_low); free(g_close); free(g_volume); free(g_oi);

--- a/ta_codegen/generator/src/bench_gen.rs
+++ b/ta_codegen/generator/src/bench_gen.rs
@@ -1,8 +1,14 @@
 //! Generates a standalone direct-call benchmark binary for the C backend.
 //!
-//! Unlike the JSON-RPC server, this binary generates its own price data
-//! (deterministic, seed=42) and calls indicator functions directly.
-//! Output: one `FUNCNAME timing_ns` line per function on stdout.
+//! Unlike the JSON-RPC server, this binary generates its own price data and
+//! calls indicator functions directly. Output: one `FUNCNAME timing_ns` line
+//! per function on stdout.
+//!
+//! The price data comes from `src/tools/ta_bench/bench_corpus.h`, the same
+//! corpus header ta_bench and ta_bench_direct use, so all four benchmark
+//! binaries measure the same series for a given (shape, seed, n) — see
+//! `--shape` / `--list-shapes`. The default shape reproduces the seed-42 walk
+//! these binaries generated inline before the corpus header existed.
 
 use crate::ir::{FuncDef, ParamType};
 use crate::server_gen::expand_input_names;
@@ -18,6 +24,9 @@ pub fn generate_c_bench(funcs: &[FuncDef]) -> String {
     s.push_str("#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n");
     s.push_str("#include <math.h>\n#include <time.h>\n");
     s.push_str("#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
+    // The shared benchmark input corpus (src/tools/ta_bench is on the include
+    // path — see the ta_bench_cg / ta_bench_stream gcc invocations in main.rs).
+    s.push_str("#include \"bench_corpus.h\"\n\n");
 
     // Include headers for unguarded and private function declarations
     s.push_str("#include \"ta_func_unguarded.h\"\n");
@@ -50,7 +59,7 @@ pub fn generate_c_bench(funcs: &[FuncDef]) -> String {
 
     s.push_str(FUNC_MATCHES);
     generate_bench_func(&mut s, funcs);
-    s.push_str(MAIN_FUNC);
+    s.push_str(&MAIN_FUNC.replace("__CORPUS_ARGS__", CORPUS_ARGS));
 
     s
 }
@@ -502,6 +511,9 @@ pub fn generate_c_stream_bench(funcs: &[FuncDef]) -> String {
     s.push_str("#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n");
     s.push_str("#include <math.h>\n#include <time.h>\n");
     s.push_str("#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
+    // The shared benchmark input corpus (src/tools/ta_bench is on the include
+    // path — see the ta_bench_cg / ta_bench_stream gcc invocations in main.rs).
+    s.push_str("#include \"bench_corpus.h\"\n\n");
 
     s.push_str("#include \"ta_func_unguarded.h\"\n");
     s.push_str("#include \"ta_func/ta_func_private.h\"\n\n");
@@ -543,7 +555,7 @@ pub fn generate_c_stream_bench(funcs: &[FuncDef]) -> String {
 
     s.push_str(FUNC_MATCHES);
     generate_stream_bench_func(&mut s, funcs);
-    s.push_str(STREAM_MAIN_FUNC);
+    s.push_str(&STREAM_MAIN_FUNC.replace("__CORPUS_ARGS__", CORPUS_ARGS));
     s
 }
 
@@ -603,7 +615,7 @@ int main(int argc, char *argv[]) {
         if( strncmp(argv[i], "--points=", 9) == 0 )    n_points = atoi(argv[i]+9);
         else if( strncmp(argv[i], "--iters=", 8) == 0 ) n_iters = atoi(argv[i]+8);
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
-    }
+__CORPUS_ARGS__    }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
     if( n_points < BENCH_MASK + 1 ) n_points = BENCH_MASK + 1; /* the bar feed indexes it & BENCH_MASK */
     if( n_iters < 1 ) n_iters = 1;
@@ -656,6 +668,12 @@ const PRICE_DATA_GEN: &str = r"
 static double *g_open, *g_high, *g_low, *g_close, *g_volume, *g_oi, *g_periods;
 static int g_nPoints;
 
+/* Corpus selection (--shape / --seed / --regime-period / --trend-strength).
+ * The defaults reproduce the seed-42 walk this binary generated inline before
+ * bench_corpus.h existed. */
+static BenchCorpusCfg g_corpus = { BENCH_RANDWALK, BENCH_CORPUS_SEED,
+                                   BENCH_CORPUS_PERIOD, BENCH_CORPUS_TREND };
+
 static void generate_price_data(int n) {
     g_nPoints = n;
     g_open   = calloc(n, sizeof(double));
@@ -665,29 +683,29 @@ static void generate_price_data(int n) {
     g_volume = calloc(n, sizeof(double));
     g_oi     = calloc(n, sizeof(double));
     g_periods = calloc(n, sizeof(double));
-    unsigned int seed = 42;
-    double price = 100.0;
-    int period = 16;
-    for( int i = 0; i < n; i++ ) {
-        seed = seed * 1103515245 + 12345;
-        double r = ((double)(seed >> 16) / 32768.0) - 1.0;
-        double o = price, c = price + r * 2.0;
-        double h = fmax(o, c) + fabs(r) * 0.5;
-        double l = fmin(o, c) - fabs(r) * 0.5;
-        if( l < 1.0 ) l = 1.0;
-        g_open[i] = o; g_high[i] = h; g_low[i] = l; g_close[i] = c;
-        g_volume[i] = 1000000.0 + r * 500000.0;
-        price = c; if( price < 1.0 ) price = 1.0;
-        /* Wandering period series in MAVP's default [2..30] range: exercises
-         * the multi-period grouping, not just the single-period fast path. */
-        period += (int)((seed >> 8) % 7) - 3;
-        if( period < 2 ) period = 2;
-        if( period > 30 ) period = 30;
-        g_periods[i] = (double)period;
-    }
+    bench_corpus_gen(&g_corpus, n,
+                     g_open, g_high, g_low, g_close, g_volume, g_oi, g_periods);
 }
 
 ";
+
+/* Shared --shape / --seed / --regime-period / --list-shapes handling, spliced
+ * into both generated mains. Unknown shape names fail loudly rather than
+ * silently benchmarking the default. */
+const CORPUS_ARGS: &str = r#"        else if( strncmp(argv[i], "--shape=", 8) == 0 ) {
+            g_corpus.shape = bench_shape_id(argv[i]+8);
+            if( g_corpus.shape < 0 ) {
+                printf("unknown --shape=%s\n\n", argv[i]+8);
+                bench_shape_list();
+                return 1;
+            }
+        }
+        else if( strncmp(argv[i], "--seed=", 7) == 0 )   g_corpus.seed = atoi(argv[i]+7);
+        else if( strncmp(argv[i], "--regime-period=", 16) == 0 ) g_corpus.refPeriod = atoi(argv[i]+16);
+        else if( strncmp(argv[i], "--trend-strength=", 17) == 0 ) g_corpus.trendStrength = atof(argv[i]+17);
+        else if( strcmp(argv[i], "--list-shapes") == 0 ) { bench_shape_list(); return 0; }
+        else if( strcmp(argv[i], "--verify-corpus") == 0 ) return bench_corpus_selfcheck(4096, &g_corpus) ? 1 : 0;
+"#;
 
 const FUNC_MATCHES: &str = r#"
 static int func_matches(const char *filter, const char *name) {
@@ -711,7 +729,7 @@ int main(int argc, char *argv[]) {
         if( strncmp(argv[i], "--points=", 9) == 0 )    n_points = atoi(argv[i]+9);
         else if( strncmp(argv[i], "--iters=", 8) == 0 ) n_iters = atoi(argv[i]+8);
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
-    }
+__CORPUS_ARGS__    }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
     generate_price_data(n_points);
     bench_all(func_filter, n_iters);

--- a/ta_codegen/generator/src/main.rs
+++ b/ta_codegen/generator/src/main.rs
@@ -988,6 +988,9 @@ fn build_servers(backend_filter: Option<&str>) {
                 let ta_abstract_serve_dir = root.join("ta_codegen/generator/templates/c");
                 // fuzz_data.h (shared seed-generator/hasher) for stream_verify.
                 let ta_regtest_dir = src_dir.join("tools/ta_regtest");
+                // bench_corpus.h (shared benchmark input corpus) for the two
+                // generated benchmark binaries below.
+                let ta_bench_dir = src_dir.join("tools/ta_bench");
                 let src = c_dir.join("ta_codegen_serve.c");
                 let dst = bin_dir.join("ta_codegen_serve_c");
                 match std::process::Command::new("gcc")
@@ -1030,6 +1033,7 @@ fn build_servers(backend_filter: Option<&str>) {
                             bench_dst.to_str().unwrap(),
                             bench_src.to_str().unwrap(),
                             &format!("-I{}", bench_inc_c.to_str().unwrap()),
+                            &format!("-I{}", ta_bench_dir.to_str().unwrap()),
                             &format!("-I{}", include_dir.to_str().unwrap()),
                             &format!("-I{}", src_dir.to_str().unwrap()),
                             &format!("-I{}", ta_func_dir.to_str().unwrap()),
@@ -1061,6 +1065,7 @@ fn build_servers(backend_filter: Option<&str>) {
                             sbench_dst.to_str().unwrap(),
                             sbench_src.to_str().unwrap(),
                             &format!("-I{}", bench_inc_c.to_str().unwrap()),
+                            &format!("-I{}", ta_bench_dir.to_str().unwrap()),
                             &format!("-I{}", include_dir.to_str().unwrap()),
                             &format!("-I{}", src_dir.to_str().unwrap()),
                             &format!("-I{}", ta_func_dir.to_str().unwrap()),

--- a/ta_codegen/output/c/tools/ta_bench_cg.c
+++ b/ta_codegen/output/c/tools/ta_bench_cg.c
@@ -11,6 +11,8 @@
 #include <mach/mach_time.h>
 #endif
 
+#include "bench_corpus.h"
+
 #include "ta_func_unguarded.h"
 #include "ta_func/ta_func_private.h"
 
@@ -207,6 +209,12 @@ static long long get_nanotime(void) {
 static double *g_open, *g_high, *g_low, *g_close, *g_volume, *g_oi, *g_periods;
 static int g_nPoints;
 
+/* Corpus selection (--shape / --seed / --regime-period / --trend-strength).
+ * The defaults reproduce the seed-42 walk this binary generated inline before
+ * bench_corpus.h existed. */
+static BenchCorpusCfg g_corpus = { BENCH_RANDWALK, BENCH_CORPUS_SEED,
+                                   BENCH_CORPUS_PERIOD, BENCH_CORPUS_TREND };
+
 static void generate_price_data(int n) {
     g_nPoints = n;
     g_open   = calloc(n, sizeof(double));
@@ -216,26 +224,8 @@ static void generate_price_data(int n) {
     g_volume = calloc(n, sizeof(double));
     g_oi     = calloc(n, sizeof(double));
     g_periods = calloc(n, sizeof(double));
-    unsigned int seed = 42;
-    double price = 100.0;
-    int period = 16;
-    for( int i = 0; i < n; i++ ) {
-        seed = seed * 1103515245 + 12345;
-        double r = ((double)(seed >> 16) / 32768.0) - 1.0;
-        double o = price, c = price + r * 2.0;
-        double h = fmax(o, c) + fabs(r) * 0.5;
-        double l = fmin(o, c) - fabs(r) * 0.5;
-        if( l < 1.0 ) l = 1.0;
-        g_open[i] = o; g_high[i] = h; g_low[i] = l; g_close[i] = c;
-        g_volume[i] = 1000000.0 + r * 500000.0;
-        price = c; if( price < 1.0 ) price = 1.0;
-        /* Wandering period series in MAVP's default [2..30] range: exercises
-         * the multi-period grouping, not just the single-period fast path. */
-        period += (int)((seed >> 8) % 7) - 3;
-        if( period < 2 ) period = 2;
-        if( period > 30 ) period = 30;
-        g_periods[i] = (double)period;
-    }
+    bench_corpus_gen(&g_corpus, n,
+                     g_open, g_high, g_low, g_close, g_volume, g_oi, g_periods);
 }
 
 #define MAX_POINTS 200000
@@ -2977,6 +2967,19 @@ int main(int argc, char *argv[]) {
         if( strncmp(argv[i], "--points=", 9) == 0 )    n_points = atoi(argv[i]+9);
         else if( strncmp(argv[i], "--iters=", 8) == 0 ) n_iters = atoi(argv[i]+8);
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
+        else if( strncmp(argv[i], "--shape=", 8) == 0 ) {
+            g_corpus.shape = bench_shape_id(argv[i]+8);
+            if( g_corpus.shape < 0 ) {
+                printf("unknown --shape=%s\n\n", argv[i]+8);
+                bench_shape_list();
+                return 1;
+            }
+        }
+        else if( strncmp(argv[i], "--seed=", 7) == 0 )   g_corpus.seed = atoi(argv[i]+7);
+        else if( strncmp(argv[i], "--regime-period=", 16) == 0 ) g_corpus.refPeriod = atoi(argv[i]+16);
+        else if( strncmp(argv[i], "--trend-strength=", 17) == 0 ) g_corpus.trendStrength = atof(argv[i]+17);
+        else if( strcmp(argv[i], "--list-shapes") == 0 ) { bench_shape_list(); return 0; }
+        else if( strcmp(argv[i], "--verify-corpus") == 0 ) return bench_corpus_selfcheck(4096, &g_corpus) ? 1 : 0;
     }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
     generate_price_data(n_points);

--- a/ta_codegen/output/c/tools/ta_bench_stream.c
+++ b/ta_codegen/output/c/tools/ta_bench_stream.c
@@ -11,6 +11,8 @@
 #include <mach/mach_time.h>
 #endif
 
+#include "bench_corpus.h"
+
 #include "ta_func_unguarded.h"
 #include "ta_func/ta_func_private.h"
 
@@ -242,6 +244,12 @@ static long long get_nanotime(void) {
 static double *g_open, *g_high, *g_low, *g_close, *g_volume, *g_oi, *g_periods;
 static int g_nPoints;
 
+/* Corpus selection (--shape / --seed / --regime-period / --trend-strength).
+ * The defaults reproduce the seed-42 walk this binary generated inline before
+ * bench_corpus.h existed. */
+static BenchCorpusCfg g_corpus = { BENCH_RANDWALK, BENCH_CORPUS_SEED,
+                                   BENCH_CORPUS_PERIOD, BENCH_CORPUS_TREND };
+
 static void generate_price_data(int n) {
     g_nPoints = n;
     g_open   = calloc(n, sizeof(double));
@@ -251,26 +259,8 @@ static void generate_price_data(int n) {
     g_volume = calloc(n, sizeof(double));
     g_oi     = calloc(n, sizeof(double));
     g_periods = calloc(n, sizeof(double));
-    unsigned int seed = 42;
-    double price = 100.0;
-    int period = 16;
-    for( int i = 0; i < n; i++ ) {
-        seed = seed * 1103515245 + 12345;
-        double r = ((double)(seed >> 16) / 32768.0) - 1.0;
-        double o = price, c = price + r * 2.0;
-        double h = fmax(o, c) + fabs(r) * 0.5;
-        double l = fmin(o, c) - fabs(r) * 0.5;
-        if( l < 1.0 ) l = 1.0;
-        g_open[i] = o; g_high[i] = h; g_low[i] = l; g_close[i] = c;
-        g_volume[i] = 1000000.0 + r * 500000.0;
-        price = c; if( price < 1.0 ) price = 1.0;
-        /* Wandering period series in MAVP's default [2..30] range: exercises
-         * the multi-period grouping, not just the single-period fast path. */
-        period += (int)((seed >> 8) % 7) - 3;
-        if( period < 2 ) period = 2;
-        if( period > 30 ) period = 30;
-        g_periods[i] = (double)period;
-    }
+    bench_corpus_gen(&g_corpus, n,
+                     g_open, g_high, g_low, g_close, g_volume, g_oi, g_periods);
 }
 
 #define MAX_POINTS 200000
@@ -11412,6 +11402,19 @@ int main(int argc, char *argv[]) {
         if( strncmp(argv[i], "--points=", 9) == 0 )    n_points = atoi(argv[i]+9);
         else if( strncmp(argv[i], "--iters=", 8) == 0 ) n_iters = atoi(argv[i]+8);
         else if( strncmp(argv[i], "--function=", 11) == 0 ) func_filter = argv[i]+11;
+        else if( strncmp(argv[i], "--shape=", 8) == 0 ) {
+            g_corpus.shape = bench_shape_id(argv[i]+8);
+            if( g_corpus.shape < 0 ) {
+                printf("unknown --shape=%s\n\n", argv[i]+8);
+                bench_shape_list();
+                return 1;
+            }
+        }
+        else if( strncmp(argv[i], "--seed=", 7) == 0 )   g_corpus.seed = atoi(argv[i]+7);
+        else if( strncmp(argv[i], "--regime-period=", 16) == 0 ) g_corpus.refPeriod = atoi(argv[i]+16);
+        else if( strncmp(argv[i], "--trend-strength=", 17) == 0 ) g_corpus.trendStrength = atof(argv[i]+17);
+        else if( strcmp(argv[i], "--list-shapes") == 0 ) { bench_shape_list(); return 0; }
+        else if( strcmp(argv[i], "--verify-corpus") == 0 ) return bench_corpus_selfcheck(4096, &g_corpus) ? 1 : 0;
     }
     if( n_points > MAX_POINTS ) n_points = MAX_POINTS;
     if( n_points < BENCH_MASK + 1 ) n_points = BENCH_MASK + 1; /* the bar feed indexes it & BENCH_MASK */


### PR DESCRIPTION
Adds the trending/chop input class to the benchmark corpus, per your reply on #147
("The trending/chop cases would be a genuinely useful addition to the benchmark
corpus ... Send that as its own PR"). Plus the random-walk volatilities, GBM, and
the monotone/constant tail you asked the evaluation to be structured around.

**This PR contains no algorithm change.** `ta_codegen/input/*` is untouched; the
rolling min/max implementations, the `midpoint`/`midprice` comments and every
generated indicator are byte-for-byte unchanged. It only changes what data the
benchmark binaries measure on, and only when asked.

## Why this input class

The cached-extremum rolling min/max rescans the window whenever the cached
extremum is the bar dropping out of it, so its cost is input-dependent — and the
existing corpus had exactly one input: a single zero-drift random walk. There was
no way to see the behaviour you described:

> while the high keeps refreshing, the low sits pinned at the oldest in-window
> bar for the whole run

On a zero-drift walk the extremum is rarely the oldest bar; on a trending leg it
often is, and for the dual-extremum functions (MIDPOINT, MIDPRICE, WILLR, STOCH,
STOCHF, MINMAX) one of the two extrema is the pinned one in *either* trend
direction. `randwalk` alone cannot distinguish an implementation that handles that
from one that doesn't, which is what made it worth adding independently of any
algorithm work.

## Where it lives

Extended in place, not a second harness. `generate_price_data()` was copy-pasted
into four benchmark binaries; it is now one shared header,
`src/tools/ta_bench/bench_corpus.h`, included by all four:

| binary | before | after |
|---|---|---|
| `ta_bench` | inline seed-42 walk | `bench_corpus.h` |
| `ta_bench_direct` | inline seed-42 walk (same series, separate copy) | `bench_corpus.h` |
| `ta_bench_cg` (generated) | `PRICE_DATA_GEN` in `bench_gen.rs` | `bench_corpus.h` |
| `ta_bench_stream` (generated) | same `PRICE_DATA_GEN` | `bench_corpus.h` |

Sharing a `src/tools` header into generated code follows the existing precedent:
the C server already gets `-Isrc/tools/ta_regtest` so it can compile `fuzz_data.h`.
The two `-I` additions for the bench builds are the only change in `main.rs`.

`ta_codegen/output/c/tools/ta_bench_cg.c` and `ta_bench_stream.c` are regenerated
and committed; `git status --porcelain` is clean after
`cargo run -- generate` + `generate-bench --backend=c`.

## The input classes

`./ta_bench --list-shapes`

```
Benchmark input corpus (--shape=NAME, default randwalk):
  randwalk         zero-drift additive walk, seed 42 (historical default)
  randwalk-lo      same walk, 1/4 step size (low volatility)
  randwalk-hi      same walk, 4x step size (high volatility)
  gbm              geometric Brownian motion, 20%/yr vol on daily bars
  trend-chop-0.5p  alternating trend/chop legs, regime = period/2
  trend-chop-1p    alternating trend/chop legs, regime = period
  trend-chop-2p    alternating trend/chop legs, regime = 2x period
  trend-chop-4p    alternating trend/chop legs, regime = 4x period
  mono-up          strictly increasing ramp: pins the low only, period-1 per bar
  mono-down        strictly decreasing ramp: pins the high only, period-1 per bar
  constant         flat O=H=L=C: WORST case, pins both, 2*(period-1) per bar
```

New flags on all four binaries: `--shape=NAME`, `--seed=N`, `--regime-period=N`,
`--trend-strength=F`, `--list-shapes`, `--verify-corpus`. `--shape` is opt-in and
defaults to `randwalk`, so a benchmark run with no new flags costs and measures
exactly what it did before.

The trend/chop shapes run a 4-leg cycle — up-trend, chop, down-trend, chop — of
`N` bars each. The direction alternates so the level stays bounded and so the
single-extremum functions meet both their favourable and their degrading direction
in one series. Chop legs are mean-reverting (AR(1), phi 0.10) around the level the
leg opened at, so they are genuinely range-bound rather than a slower walk.

### Regime lengths

`N` is set relative to the rolling window `P` (`--regime-period`, default 14 — the
default `optInTimePeriod` of MIDPOINT/MIDPRICE/WILLR; in `ta_bench` it follows
`--period` when you pin one) because the degradation is a function of `N/P`, not
of `N`:

- `N < P` — every window straddles a regime boundary, so the pinned extremum is
  repeatedly displaced by the chop and the cache still earns its keep.
- `N ≈ P` — a window sits inside one leg for most of its life.
- `N > P` — whole windows fit inside a leg, so the rescan fires for runs of `P`
  consecutive bars.

0.5/1/2/4 brackets that transition from both sides. At the default `P=14` the four
regimes are 7/14/28/56 bars, which against MIN/MAX/MINMAX's own default window of
30 are 0.23/0.47/0.93/1.87× — so one sweep covers roughly 0.25p..4p across both
default periods in the family.

### Trend strength, and one correction to the mechanism

`--trend-strength` is the trend-leg drift in per-bar standard deviations
(default 0.5). It is exposed rather than buried because it is the one parameter
that decides whether a "trend leg" is an ordinary market or a monotone series in
disguise — and I'd rather you could audit that than take my word for it. At 0.5,
31% of the bars in an uptrend still close lower, and at the 1%/bar volatility
these legs use (~16%/yr) a 63-bar leg gains ~37%: a strong but entirely ordinary
run.

Counting the bars that force a rescan — the bars where the window extremum *is*
the oldest in-window bar — turned up a correction worth stating. Measured inside
an uptrend leg (`trend-chop-4p`, P=200):

| trend-strength (sd/bar) | low pinned at the oldest bar, inside an uptrend leg |
|---|---|
| 0.25 | 24.9% |
| 0.50 (default) | 42.6% |
| 1.00 | 63.8% |

The low is pinned at the oldest bar exactly when the leg has not traded back
below where the window opened, and that probability is governed by the per-bar
drift/noise ratio — **not** by the period, and **not** by how long the leg runs.
So "the low sits pinned at the oldest bar for the whole run" holds only in the
near-monotone limit; at the default strength it is a minority of bars, 43%. The
*high*, on the other hand, is pinned on ~0% of the bars inside an uptrend leg —
that part of your description is exact, and it is why a dual-extremum function
has precisely one degraded extremum per trend direction.

Your conclusion survives the correction, with a sharper mechanism behind it. What
makes the corpus discriminate *more at larger windows* is not the O(period) cost
of a rescan — that applies to `randwalk` equally — it is that the two rescan
**rates** diverge as the window grows. Either-extremum rescan rate, whole series,
n=200000:

| period | `randwalk` | `trend-chop-1p` | rate ratio |
|---|---|---|---|
| 14 | 33.2% | 36.2% | 1.09x |
| 30 | 22.6% | 30.4% | 1.35x |
| 200 | 8.9% | 26.7% | 3.00x |

`randwalk`'s rate follows ~1/sqrt(period) closely (taking the high alone:
16.5%·√14 = 61.7, 11.2%·√30 = 61.3, 4.3%·√200 = 60.8) — the extremum of a long
driftless window is seldom at its start. The trend rate decays far more slowly
(18.2/15.2/13.5% for the high: a 26% fall from period 14 to 200, against
`randwalk`'s 74%) because it is floored by the drift/noise ratio instead. So the
*ratio* grows roughly as √period.

That is a prediction rather than a story, and the wall-clock below confirms it:
1.09x predicted vs 1.06–1.12x measured at period 14, 1.35x vs 1.23–1.32x at 30,
3.00x vs 2.79–3.30x at 200. (The period-14 range excludes MIDPRICE, which is on
its unconditional `<= 20` path there and cannot respond to the input at all — see
the `midprice` section below. Periods 30 and 200 include it.)

### The flat case: your `2*(period - 1)` reproduces, and it re-labels the corpus

Thank you for the rescan counts on #152 — they changed how this corpus classifies
its own tail, so I have folded them in rather than just citing them.

I had `mono-up`, `mono-down` and `constant` all labelled "tail case", as if they
were peers. They are not: flat is the worst case in the family at `2*(period-1)`
comparisons per bar, exactly twice monotone's `period-1`. `--list-shapes` now says
so, and the notes name the mechanism you identified rather than the one I had
assumed:

```
  mono-up          strictly increasing ramp: pins the low only, period-1 per bar
  mono-down        strictly decreasing ramp: pins the high only, period-1 per bar
  constant         flat O=H=L=C: WORST case, pins both, 2*(period-1) per bar
```

Your tie-break explanation is visible in `midpoint.c` as you describe: the rescan
loop tests `tmpHigh > highest` / `tmpLow < lowest` strictly, so on flat input no
element beats the first, the scan leaves `highestIdx`/`lowestIdx` on
`trailingIdx`, and next bar `trailingIdx` has moved past it — so the
`highestIdx < trailingIdx` guard refires forever and the `else if( tmpHigh >=
highest )` / `else if( tmpLow <= lowest )` arms are unreachable on that input. I
had written "a plateau pins both extrema" and derived it from the trend mechanism;
that conclusion was right for the wrong reason, and the corpus header now
attributes it to the tie-break.

**Independent cross-validation.** Your numbers are comparison counts; mine are
wall-clock, so the 1:2 ratio is a falsifiable prediction across the two. MIDPOINT,
median of 3 sweeps:

| period | `randwalk` | monotone (mean of up/down) | flat | flat / monotone | your count ratio |
|---|---|---|---|---|---|
| 14 | 7.3 ns/bar | 7.4 | 13.4 | **1.80x** | 2.00x |
| 30 | 8.2 | 18.4 | 34.9 | **1.90x** | 2.00x |
| 200 | 15.9 | 163.2 | 325.2 | **1.99x** | 2.00x |

It converges to your 2.00x from below, hitting 1.99x at period 200. Fitting
`ns = a + b·comparisons` on (`randwalk`, monotone) only and then *predicting* flat
from your count of 398.00 gives 323.2 ns/bar against 325.2 measured — **0.6%
error**, with b = 0.80 ns per comparison and a = 3.2 ns of fixed per-bar cost.

One caveat in the other direction, which I would rather flag than smooth over: at
period 14 that same fit fails badly (predicts 7.7, measures 13.4, −43%). The
reason is that monotone's 13.00 comparisons/bar cost essentially the same as
`randwalk`'s 3.99 there (7.4 vs 7.3 ns) — a short, perfectly branch-predicted
rescan is nearly free, while `randwalk`'s rarer rescans are unpredictable and pay
mispredictions instead. So comparison counts and wall-clock are only proportional
once the window is long enough for the scan to dominate; at small periods the
counts overstate what any timing harness can resolve. Your counts are the cleaner
invariant, which is an argument for keeping both instruments.

### A side effect: the corpus measures `midprice`'s period-20 split

`midprice` already documents its own period split — `optInTimePeriod <= 20` takes
the unconditional auto-vectorizing full rescan, above 20 the cached-extremum path,
with the crossover noted as ~19–20 — and it is the only function in the tree with
one. What the corpus adds is that the split becomes *visible in a measurement*
rather than something you have to read the source to know: at period 14 MIDPRICE is
completely input-independent, and MIDPOINT, which has no such branch, is not:

| period | MIDPOINT flat/`randwalk` | MIDPRICE flat/`randwalk` |
|---|---|---|
| 14 | 1.84x | **1.00x** |
| 30 | 4.25x | 4.35x |
| 200 | 20.39x | 20.49x |

At period 14 MIDPRICE is flat to within 1% across all nine input classes, because
the `<= 20` branch does the same work regardless of the data; MIDPOINT, which has
no such branch, already pays 1.84x on flat input at the same window — and 14 is
MIDPOINT's own default period. Above the threshold the two converge, as they
should. I am reporting this only as something the corpus now makes measurable —
**no algorithm change is proposed here**, and whether MIDPOINT should acquire the
same small-period path is your call, not this PR's.

One related note, since it is now merged and I would rather point at it than leave
it: the batch comments from #152 say the low "stays pinned at the oldest bar for
the whole leg". Per the measurement above that holds in the near-monotone limit
rather than generally (43% of trend-leg bars at the default drift/noise ratio). It
is a wording refinement to a comment this PR deliberately does not touch — happy to
send it as a two-line follow-up to `ta_codegen/input/` if you want it.

## Does the corpus actually expose the degradation

Same binary, same functions, same period on every row — only the input class
changes. If the corpus had no discriminating power the rows would be flat.

**Method.** `ta_bench --language=c --function=MIDPOINT,MIDPRICE,WILLR,MINMAX,MIN,MAX
--points=100000 --iters=100 --period=P --shape=S`, i.e. the repo's own tool with
server-side iteration (no JSON on the hot path), its `BENCH_PASSES 3` min-of-3
per server and its SMA thermal canary. Wall-clock only, no instruction counts;
figures are ns per bar (call time / 100000 points). The whole 3-period × 9-shape
grid was then repeated **three times end to end** and the tables report the
per-cell **median of the three**. Intel i7-10700K @ 3.80GHz (iMac20,1, x86_64),
macOS 26.5.1, Apple clang 21.0.0, `-O3`, guarded path.

The box was not dedicated — 1-minute load average at each repetition's start was
4.2 / 9.6 / 2.5 from unrelated work — which is why three full repetitions and a
median rather than a single run. Resulting per-cell spread `(max-min)/median`
across the three: median 2% and worst 7% at period 14, median 1% and worst 13% at
period 30, median 0% and worst 2% at period 200. The period-200 rows that carry
the argument are the tightest. Treat anything under ~1.15x as unresolved.

**period 14** — ns/bar (median of 3), ratio vs `randwalk`

| shape | MIDPOINT | MIDPRICE | WILLR | MINMAX | MIN | MAX |
|---|---|---|---|---|---|---|
| `randwalk` | 7.3 | 5.7 | 7.7 | 7.2 | 3.8 | 3.8 |
| `gbm` | 7.3 (1.00x) | 5.8 (1.01x) | 7.6 (0.99x) | 7.2 (1.00x) | 3.8 (1.00x) | 3.8 (1.01x) |
| `trend-chop-0.5p` | 7.5 (1.03x) | 5.7 (1.00x) | 7.9 (1.02x) | 7.4 (1.03x) | 3.8 (1.00x) | 3.8 (1.02x) |
| `trend-chop-1p` | 7.7 (1.06x) | 5.7 (1.00x) | 8.2 (1.06x) | 7.6 (1.07x) | 4.0 (1.06x) | 4.1 (1.09x) |
| `trend-chop-2p` | 7.8 (1.08x) | 5.7 (1.00x) | 8.4 (1.08x) | 7.7 (1.08x) | 4.1 (1.09x) | 4.1 (1.10x) |
| `trend-chop-4p` | 7.9 (1.08x) | 5.7 (1.00x) | 8.4 (1.08x) | 7.7 (1.08x) | 4.1 (1.08x) | 4.2 (1.12x) |
| `mono-up` | 7.4 (1.02x) | 5.7 (1.00x) | 9.6 (1.24x) | 7.3 (1.02x) | 6.9 (1.81x) | 0.9 (0.23x) |
| `mono-down` | 7.4 (1.02x) | 5.7 (1.00x) | 9.5 (1.23x) | 7.4 (1.03x) | 0.8 (0.20x) | 7.1 (1.88x) |
| `constant` | 13.4 (1.84x) | 5.7 (1.00x) | 14.8 (1.92x) | 13.4 (1.87x) | 6.9 (1.81x) | 7.1 (1.88x) |

**period 30** — ns/bar (median of 3), ratio vs `randwalk`

| shape | MIDPOINT | MIDPRICE | WILLR | MINMAX | MIN | MAX |
|---|---|---|---|---|---|---|
| `randwalk` | 8.2 | 8.1 | 8.6 | 8.1 | 4.3 | 4.1 |
| `gbm` | 8.2 (0.99x) | 8.0 (0.99x) | 8.5 (0.99x) | 8.1 (1.00x) | 4.4 (1.01x) | 4.1 (0.98x) |
| `trend-chop-0.5p` | 9.2 (1.12x) | 9.0 (1.12x) | 9.6 (1.12x) | 9.0 (1.11x) | 4.7 (1.07x) | 4.7 (1.13x) |
| `trend-chop-1p` | 10.4 (1.26x) | 10.3 (1.27x) | 10.9 (1.26x) | 10.2 (1.26x) | 5.3 (1.23x) | 5.3 (1.28x) |
| `trend-chop-2p` | 10.6 (1.29x) | 10.5 (1.30x) | 11.1 (1.29x) | 10.5 (1.29x) | 5.5 (1.26x) | 5.4 (1.30x) |
| `trend-chop-4p` | 10.6 (1.29x) | 10.6 (1.30x) | 11.1 (1.29x) | 10.5 (1.29x) | 5.5 (1.26x) | 5.5 (1.32x) |
| `mono-up` | 18.5 (2.25x) | 18.7 (2.31x) | 20.9 (2.43x) | 18.5 (2.29x) | 17.6 (4.05x) | 0.9 (0.21x) |
| `mono-down` | 18.3 (2.22x) | 18.7 (2.30x) | 20.6 (2.40x) | 18.3 (2.26x) | 0.8 (0.17x) | 17.8 (4.29x) |
| `constant` | 34.9 (4.25x) | 35.3 (4.35x) | 36.4 (4.24x) | 34.9 (4.32x) | 17.6 (4.06x) | 17.8 (4.30x) |

**period 200** — ns/bar (median of 3), ratio vs `randwalk`

| shape | MIDPOINT | MIDPRICE | WILLR | MINMAX | MIN | MAX |
|---|---|---|---|---|---|---|
| `randwalk` | 15.9 | 15.9 | 16.3 | 15.9 | 8.6 | 7.4 |
| `gbm` | 15.6 (0.98x) | 15.5 (0.97x) | 15.9 (0.97x) | 15.6 (0.98x) | 8.9 (1.04x) | 6.7 (0.91x) |
| `trend-chop-0.5p` | 30.7 (1.92x) | 30.2 (1.90x) | 30.7 (1.88x) | 30.5 (1.92x) | 15.2 (1.78x) | 15.3 (2.08x) |
| `trend-chop-1p` | 48.2 (3.02x) | 47.8 (3.01x) | 48.1 (2.95x) | 48.0 (3.02x) | 23.9 (2.79x) | 24.2 (3.29x) |
| `trend-chop-2p` | 49.3 (3.09x) | 48.7 (3.07x) | 49.2 (3.02x) | 49.2 (3.10x) | 24.9 (2.91x) | 24.3 (3.30x) |
| `trend-chop-4p` | 48.8 (3.06x) | 48.4 (3.05x) | 48.9 (3.00x) | 48.7 (3.06x) | 25.0 (2.91x) | 23.9 (3.24x) |
| `mono-up` | 163.3 (10.24x) | 163.3 (10.29x) | 164.8 (10.11x) | 163.0 (10.25x) | 162.4 (18.94x) | 0.9 (0.12x) |
| `mono-down` | 163.1 (10.23x) | 163.8 (10.32x) | 164.8 (10.11x) | 163.0 (10.25x) | 0.8 (0.09x) | 162.9 (22.15x) |
| `constant` | 325.2 (20.39x) | 325.1 (20.49x) | 325.7 (19.98x) | 325.0 (20.44x) | 162.6 (18.97x) | 162.7 (22.12x) |

Reading it:

- **`gbm` is flat against `randwalk`** — 0.97–1.04x everywhere. The acceptance
  gate you named has no cost of its own to explain away.
- **`trend-chop-{1,2,4}p` costs ~2.8–3.3x more than `randwalk` at period 200**,
  ~1.23–1.32x at period 30, ~1.06–1.12x at period 14 (MIDPRICE excepted at 14, see
  below): inside the noise at the smallest window, resolved at 30, decisive at 200.
  That is the period-scaling the rescan-rate ratio predicts, matched at all three
  points.
- **`trend-chop-0.5p` is measurably milder** (1.78–2.08x vs 2.8–3.3x at period
  200) and 1p/2p/4p converge on each other. So the cost really is a function of
  regime/period, which is what the regime ratios were chosen to probe — the sweep
  is not redundant, and the short regime is the one where the cache still works.
- **The single-extremum asymmetry comes out exactly as described.** At period 200,
  `MIN` on `mono-up` is 18.94x but on `mono-down` 0.09x; `MAX` is the mirror,
  0.12x and 22.15x. The dual-extremum functions degrade on *both* monotone
  directions (10.1–10.3x) and their absolute cost on trend/chop is about twice the
  single-extremum functions' (≈48 vs ≈24 ns/bar). The dual *ratio* is not twice the
  single ratio, because numerator and denominator both roughly double.
- **`constant` is the worst case, and by the right factor** — 20.0–20.5x on the
  dual-extremum functions at period 200, ~1.99x of monotone, per the section above.

Monotone and flat are reported as the degenerate tail, not the case this corpus
exists for; the trending/chop rows are.
## Determinism

Every series is a pure function of `(shape, seed, refPeriod, trendStrength, n)` —
no `time()`, no `rand()`, no platform state. Verified:

- `--verify-corpus` (new, in-tree, on all four binaries) generates each shape
  twice into differently pre-poisoned buffers and requires byte-equality, plus
  finite values, `high >= max(open,close)`, `low <= min(open,close)`, `low > 0`
  and MAVP's period series inside [2,30]. 11/11 shapes ok.
- across separate processes: sha256 of the raw `double` arrays for all 11 shapes ×
  n ∈ {4096, 100000}, identical run to run.
- `randwalk` reproduces the pre-existing series **byte for byte** — both the
  6-array `ta_bench` form and the 7-array `ta_bench_cg` form including the MAVP
  period series — checked at n=100000 against the old generator lifted verbatim
  from `dev`. The step size is factored out as `amp = 2.0 * scale`, exactly 2.0 at
  `scale = 1.0`, so historical numbers stay comparable.

Unlike `fuzz_data.h` these arrays are never hashed or compared against an oracle,
only timed, so cross-toolchain bit-identity is not required and the
`-ffp-contract=off` constraint from #150 does not apply. The header says so
explicitly, so nobody later mistakes it for oracle input.

## Effect on the existing gates and comparisons: none

You flagged this risk in the tree yourselves, at
`src/tools/ta_regtest/ta_test_func/test_variants.c:148`:

> Adding zero volume as a tenth `FUZZ_*` shape was deliberately avoided: the fuzz
> shape list is iterated by `--fuzz-064`, whose oracle is a frozen v0.6.4 binary,
> so a new shape silently changes what that gate compares. This list is local.

This PR follows that precedent exactly — the benchmark shape list is local to
`ta_bench`. `fuzz_data.h` and its Rust/Java ports are untouched, so the
`--fuzz-064` and `--xlang-hash` comparison counts are structurally unchanged, not
merely observed to be unchanged: `git diff dev -- src/tools/ta_regtest
ta_codegen/generator/templates/rust/fuzz.rs
ta_codegen/generator/templates/java/FuzzData.java` is empty, and `bench_corpus.h`
is included by exactly the four benchmark binaries and nothing else.

Run anyway, on this branch:

| gate | result |
|---|---|
| `scripts/build.py test` | all tests succeeded |
| `scripts/regtest.py --no-generate --no-perftest --no-direct-bench --codegen-only --language=c,rust` | 161 indicators × C + Rust, **0 failures** |
| `ta_regtest --fuzz-064` | 171230 comparisons, **0 failures**, PASS |
| `ta_regtest --xlang-hash --language=c,rust` | 210008 golden cases, **0 mismatches**, PASS |
| `git status --porcelain` after `generate` + `generate-bench` | clean |

(Java and .NET servers do not build on this machine — JDK 17 and .NET 10 targets
are unavailable locally — so `--xlang-hash` was run for `c,rust`. That limitation
predates this branch and is unrelated to the corpus.)

`scripts/regtest.py` grew `--shape` / `--seed` / `--regime-period` /
`--trend-strength` in its passthrough list so the direct bench receives them (it
filters passthrough args by prefix), and `CLAUDE.md` documents the corpus under
Performance Testing.

## What I am not claiming

This is a measurement instrument, not a performance improvement — nothing here
makes any function faster. The table above is evidence that the corpus has
discriminating power on the input class that was missing, so that a future
algorithm comparison has something to be judged on.
