### PR TITLE
perf(ultosc): evaluate each bar's true range once, not four times

### DIFF
--- a/src/ta_func/ta_ULTOSC.c
+++ b/src/ta_func/ta_ULTOSC.c
@@ -55,6 +55,9 @@
  *  -------------------------------------------------------------------
  *  281206 DM   Initial Implementation
  *  010606 MF   Abstract local arrays. Detect divide by zero.
+ *  073126 DX   Evaluate each bar's true range and close-minus-true-low once
+ *              instead of four times, keeping them in a CIRCBUF sized to the
+ *              longest period. Same values, same summation order, bit-exact.
  */
 
 TA_LIB_API int TA_ULTOSC_Lookback( int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3 )
@@ -112,12 +115,17 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
    int j;
    int today;
    int outIdx;
-   int trailingIdx1;
-   int trailingIdx2;
-   int trailingIdx3;
+   int trailingPos1;
+   int trailingPos2;
    int usedFlag[3];
    int periods[3];
    int sortedPeriods[3];
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
 
    if( startIdx < 0 )
       return TA_OUT_OF_RANGE_START_INDEX;
@@ -145,6 +153,14 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
    if( !outReal )
       return TA_BAD_PARAM;
 
+   /* The two per-bar terms the three moving sums are built from. Both are a
+    * pure function of the bar, so each bar is evaluated once on entry and read
+    * back when it leaves each of the three windows.
+    */
+   /* One entry per bar of the longest window. Stays on the stack for every
+    * period up to 32, which covers the 7/14/28 default.
+    */
+   /* Id, Type, Static Size */
    *outBegIdx= 0;
    *outNBElement= 0;
    /* Ensure that the time periods are ordered from shortest to longest.
@@ -185,53 +201,39 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
    {
       return TA_SUCCESS;
    }
-   /* Prime running totals used in moving averages */
+   if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+   if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+   {
+      term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_closeMinusTrueLow )
+      {
+         return TA_ALLOC_ERR;
+      }
+      term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_trueRange )
+      {
+         TA_Free( term_closeMinusTrueLow );
+         return TA_ALLOC_ERR;
+      }
+   }
+   else
+   {
+      term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+      term_trueRange = &local_term_trueRange[0];
+   }
+   maxIdx_term = (optInTimePeriod3-1);
+   term_Idx = 0;
+   /* Prime running totals used in moving averages.
+    *
+    * One pass over the longest warm-up window replaces three overlapping
+    * passes. A bar inside the shorter windows is added to those totals as it
+    * is reached, so every total still accumulates exactly the same bars in
+    * exactly the same ascending order as three separate loops did.
+    */
    a1Total = 0;
    b1Total = 0;
-   for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a1Total += closeMinusTrueLow;
-      b1Total += trueRange;
-   }
    a2Total = 0;
    b2Total = 0;
-   for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total += closeMinusTrueLow;
-      b2Total += trueRange;
-   }
    a3Total = 0;
    b3Total = 0;
    for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -252,15 +254,40 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      if( i >= startIdx - optInTimePeriod1 + 1 )
+      {
+         a1Total += closeMinusTrueLow;
+         b1Total += trueRange;
+      }
+      if( i >= startIdx - optInTimePeriod2 + 1 )
+      {
+         a2Total += closeMinusTrueLow;
+         b2Total += trueRange;
+      }
       a3Total += closeMinusTrueLow;
       b3Total += trueRange;
    }
    /* Calculate oscillator */
    today = startIdx;
    outIdx = 0;
-   trailingIdx1 = today - optInTimePeriod1 + 1;
-   trailingIdx2 = today - optInTimePeriod2 + 1;
-   trailingIdx3 = today - optInTimePeriod3 + 1;
+   /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+    * `today` and, once advanced past it, the slot of the bar leaving the
+    * longest window. The two shorter windows trail it by a fixed offset.
+    */
+   trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+   if( trailingPos1 >= optInTimePeriod3 )
+   {
+      trailingPos1 -= optInTimePeriod3;
+   }
+   trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+   if( trailingPos2 >= optInTimePeriod3 )
+   {
+      trailingPos2 -= optInTimePeriod3;
+   }
    while( today <= endIdx )
    {
       /* Add on today's terms */
@@ -280,6 +307,8 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
       a1Total += closeMinusTrueLow;
       a2Total += closeMinusTrueLow;
       a3Total += closeMinusTrueLow;
@@ -300,61 +329,27 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
       {
          output += a3Total / b3Total;
       }
-      /* Remove the trailing terms to prepare for next day */
-      tempLT = inLow[trailingIdx1];
-      tempHT = inHigh[trailingIdx1];
-      tempCY = inClose[trailingIdx1 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
+      /* Remove the trailing terms to prepare for next day. Each was evaluated
+       * once, when its bar entered the ring.
+       */
+      a1Total -= term_closeMinusTrueLow[trailingPos1];
+      b1Total -= term_trueRange[trailingPos1];
+      trailingPos1 += 1;
+      if( trailingPos1 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos1 = 0;
       }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
+      a2Total -= term_closeMinusTrueLow[trailingPos2];
+      b2Total -= term_trueRange[trailingPos2];
+      trailingPos2 += 1;
+      if( trailingPos2 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos2 = 0;
       }
-      a1Total -= closeMinusTrueLow;
-      b1Total -= trueRange;
-      tempLT = inLow[trailingIdx2];
-      tempHT = inHigh[trailingIdx2];
-      tempCY = inClose[trailingIdx2 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total -= closeMinusTrueLow;
-      b2Total -= trueRange;
-      tempLT = inLow[trailingIdx3];
-      tempHT = inHigh[trailingIdx3];
-      tempCY = inClose[trailingIdx3 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a3Total -= closeMinusTrueLow;
-      b3Total -= trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      a3Total -= term_closeMinusTrueLow[term_Idx];
+      b3Total -= term_trueRange[term_Idx];
       /* Last operation is to write the output. Must
        * be done after the trailing index have all been
        * taken care of because the caller is allowed
@@ -365,13 +360,12 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
       /* Increment indexes */
       outIdx += 1;
       today += 1;
-      trailingIdx1 += 1;
-      trailingIdx2 += 1;
-      trailingIdx3 += 1;
    }
    /* All done. Indicate the output limits and return. */
    *outNBElement= outIdx;
    *outBegIdx= startIdx;
+   if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow );
+   if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange );
    return TA_SUCCESS;
 }
 
@@ -408,12 +402,17 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Unguarded( int    startIdx,
    int j;
    int today;
    int outIdx;
-   int trailingIdx1;
-   int trailingIdx2;
-   int trailingIdx3;
+   int trailingPos1;
+   int trailingPos2;
    int usedFlag[3];
    int periods[3];
    int sortedPeriods[3];
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
 
    *outBegIdx= 0;
    *outNBElement= 0;
@@ -450,52 +449,32 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Unguarded( int    startIdx,
    {
       return TA_SUCCESS;
    }
+   if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+   if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+   {
+      term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_closeMinusTrueLow )
+      {
+         return TA_ALLOC_ERR;
+      }
+      term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_trueRange )
+      {
+         TA_Free( term_closeMinusTrueLow );
+         return TA_ALLOC_ERR;
+      }
+   }
+   else
+   {
+      term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+      term_trueRange = &local_term_trueRange[0];
+   }
+   maxIdx_term = (optInTimePeriod3-1);
+   term_Idx = 0;
    a1Total = 0;
    b1Total = 0;
-   for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a1Total += closeMinusTrueLow;
-      b1Total += trueRange;
-   }
    a2Total = 0;
    b2Total = 0;
-   for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total += closeMinusTrueLow;
-      b2Total += trueRange;
-   }
    a3Total = 0;
    b3Total = 0;
    for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -516,14 +495,35 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Unguarded( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      if( i >= startIdx - optInTimePeriod1 + 1 )
+      {
+         a1Total += closeMinusTrueLow;
+         b1Total += trueRange;
+      }
+      if( i >= startIdx - optInTimePeriod2 + 1 )
+      {
+         a2Total += closeMinusTrueLow;
+         b2Total += trueRange;
+      }
       a3Total += closeMinusTrueLow;
       b3Total += trueRange;
    }
    today = startIdx;
    outIdx = 0;
-   trailingIdx1 = today - optInTimePeriod1 + 1;
-   trailingIdx2 = today - optInTimePeriod2 + 1;
-   trailingIdx3 = today - optInTimePeriod3 + 1;
+   trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+   if( trailingPos1 >= optInTimePeriod3 )
+   {
+      trailingPos1 -= optInTimePeriod3;
+   }
+   trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+   if( trailingPos2 >= optInTimePeriod3 )
+   {
+      trailingPos2 -= optInTimePeriod3;
+   }
    while( today <= endIdx )
    {
       tempLT = inLow[today];
@@ -542,6 +542,8 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Unguarded( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
       a1Total += closeMinusTrueLow;
       a2Total += closeMinusTrueLow;
       a3Total += closeMinusTrueLow;
@@ -561,69 +563,32 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Unguarded( int    startIdx,
       {
          output += a3Total / b3Total;
       }
-      tempLT = inLow[trailingIdx1];
-      tempHT = inHigh[trailingIdx1];
-      tempCY = inClose[trailingIdx1 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
+      a1Total -= term_closeMinusTrueLow[trailingPos1];
+      b1Total -= term_trueRange[trailingPos1];
+      trailingPos1 += 1;
+      if( trailingPos1 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos1 = 0;
       }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
+      a2Total -= term_closeMinusTrueLow[trailingPos2];
+      b2Total -= term_trueRange[trailingPos2];
+      trailingPos2 += 1;
+      if( trailingPos2 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos2 = 0;
       }
-      a1Total -= closeMinusTrueLow;
-      b1Total -= trueRange;
-      tempLT = inLow[trailingIdx2];
-      tempHT = inHigh[trailingIdx2];
-      tempCY = inClose[trailingIdx2 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total -= closeMinusTrueLow;
-      b2Total -= trueRange;
-      tempLT = inLow[trailingIdx3];
-      tempHT = inHigh[trailingIdx3];
-      tempCY = inClose[trailingIdx3 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a3Total -= closeMinusTrueLow;
-      b3Total -= trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      a3Total -= term_closeMinusTrueLow[term_Idx];
+      b3Total -= term_trueRange[term_Idx];
       outReal[outIdx] = 100.0 * (output / 7.0);
       outIdx += 1;
       today += 1;
-      trailingIdx1 += 1;
-      trailingIdx2 += 1;
-      trailingIdx3 += 1;
    }
    *outNBElement= outIdx;
    *outBegIdx= startIdx;
+   if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow );
+   if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange );
    return TA_SUCCESS;
 }
 
@@ -660,12 +625,17 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
    int j;
    int today;
    int outIdx;
-   int trailingIdx1;
-   int trailingIdx2;
-   int trailingIdx3;
+   int trailingPos1;
+   int trailingPos2;
    int usedFlag[3];
    int periods[3];
    int sortedPeriods[3];
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
 
    if( startIdx < 0 )
       return TA_OUT_OF_RANGE_START_INDEX;
@@ -728,52 +698,32 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
    {
       return TA_SUCCESS;
    }
+   if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+   if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+   {
+      term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_closeMinusTrueLow )
+      {
+         return TA_ALLOC_ERR;
+      }
+      term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_trueRange )
+      {
+         TA_Free( term_closeMinusTrueLow );
+         return TA_ALLOC_ERR;
+      }
+   }
+   else
+   {
+      term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+      term_trueRange = &local_term_trueRange[0];
+   }
+   maxIdx_term = (optInTimePeriod3-1);
+   term_Idx = 0;
    a1Total = 0;
    b1Total = 0;
-   for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = (double)inLow[i];
-      tempHT = (double)inHigh[i];
-      tempCY = (double)inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a1Total += closeMinusTrueLow;
-      b1Total += trueRange;
-   }
    a2Total = 0;
    b2Total = 0;
-   for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = (double)inLow[i];
-      tempHT = (double)inHigh[i];
-      tempCY = (double)inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total += closeMinusTrueLow;
-      b2Total += trueRange;
-   }
    a3Total = 0;
    b3Total = 0;
    for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -794,14 +744,35 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      if( i >= startIdx - optInTimePeriod1 + 1 )
+      {
+         a1Total += closeMinusTrueLow;
+         b1Total += trueRange;
+      }
+      if( i >= startIdx - optInTimePeriod2 + 1 )
+      {
+         a2Total += closeMinusTrueLow;
+         b2Total += trueRange;
+      }
       a3Total += closeMinusTrueLow;
       b3Total += trueRange;
    }
    today = startIdx;
    outIdx = 0;
-   trailingIdx1 = today - optInTimePeriod1 + 1;
-   trailingIdx2 = today - optInTimePeriod2 + 1;
-   trailingIdx3 = today - optInTimePeriod3 + 1;
+   trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+   if( trailingPos1 >= optInTimePeriod3 )
+   {
+      trailingPos1 -= optInTimePeriod3;
+   }
+   trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+   if( trailingPos2 >= optInTimePeriod3 )
+   {
+      trailingPos2 -= optInTimePeriod3;
+   }
    while( today <= endIdx )
    {
       tempLT = (double)inLow[today];
@@ -820,6 +791,8 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
       a1Total += closeMinusTrueLow;
       a2Total += closeMinusTrueLow;
       a3Total += closeMinusTrueLow;
@@ -839,69 +812,32 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
       {
          output += a3Total / b3Total;
       }
-      tempLT = (double)inLow[trailingIdx1];
-      tempHT = (double)inHigh[trailingIdx1];
-      tempCY = (double)inClose[trailingIdx1 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
+      a1Total -= term_closeMinusTrueLow[trailingPos1];
+      b1Total -= term_trueRange[trailingPos1];
+      trailingPos1 += 1;
+      if( trailingPos1 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos1 = 0;
       }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
+      a2Total -= term_closeMinusTrueLow[trailingPos2];
+      b2Total -= term_trueRange[trailingPos2];
+      trailingPos2 += 1;
+      if( trailingPos2 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos2 = 0;
       }
-      a1Total -= closeMinusTrueLow;
-      b1Total -= trueRange;
-      tempLT = (double)inLow[trailingIdx2];
-      tempHT = (double)inHigh[trailingIdx2];
-      tempCY = (double)inClose[trailingIdx2 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total -= closeMinusTrueLow;
-      b2Total -= trueRange;
-      tempLT = (double)inLow[trailingIdx3];
-      tempHT = (double)inHigh[trailingIdx3];
-      tempCY = (double)inClose[trailingIdx3 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a3Total -= closeMinusTrueLow;
-      b3Total -= trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      a3Total -= term_closeMinusTrueLow[term_Idx];
+      b3Total -= term_trueRange[term_Idx];
       outReal[outIdx] = 100.0 * (output / 7.0);
       outIdx += 1;
       today += 1;
-      trailingIdx1 += 1;
-      trailingIdx2 += 1;
-      trailingIdx3 += 1;
    }
    *outNBElement= outIdx;
    *outBegIdx= startIdx;
+   if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow );
+   if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange );
    return TA_SUCCESS;
 }
 
@@ -938,12 +874,17 @@ TA_RetCode TA_S_ULTOSC_Unguarded( int    startIdx,
    int j;
    int today;
    int outIdx;
-   int trailingIdx1;
-   int trailingIdx2;
-   int trailingIdx3;
+   int trailingPos1;
+   int trailingPos2;
    int usedFlag[3];
    int periods[3];
    int sortedPeriods[3];
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
 
    *outBegIdx= 0;
    *outNBElement= 0;
@@ -980,52 +921,32 @@ TA_RetCode TA_S_ULTOSC_Unguarded( int    startIdx,
    {
       return TA_SUCCESS;
    }
+   if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+   if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+   {
+      term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_closeMinusTrueLow )
+      {
+         return TA_ALLOC_ERR;
+      }
+      term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+      if( !term_trueRange )
+      {
+         TA_Free( term_closeMinusTrueLow );
+         return TA_ALLOC_ERR;
+      }
+   }
+   else
+   {
+      term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+      term_trueRange = &local_term_trueRange[0];
+   }
+   maxIdx_term = (optInTimePeriod3-1);
+   term_Idx = 0;
    a1Total = 0;
    b1Total = 0;
-   for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = (double)inLow[i];
-      tempHT = (double)inHigh[i];
-      tempCY = (double)inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a1Total += closeMinusTrueLow;
-      b1Total += trueRange;
-   }
    a2Total = 0;
    b2Total = 0;
-   for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-   {
-      tempLT = (double)inLow[i];
-      tempHT = (double)inHigh[i];
-      tempCY = (double)inClose[i - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total += closeMinusTrueLow;
-      b2Total += trueRange;
-   }
    a3Total = 0;
    b3Total = 0;
    for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -1046,14 +967,35 @@ TA_RetCode TA_S_ULTOSC_Unguarded( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      if( i >= startIdx - optInTimePeriod1 + 1 )
+      {
+         a1Total += closeMinusTrueLow;
+         b1Total += trueRange;
+      }
+      if( i >= startIdx - optInTimePeriod2 + 1 )
+      {
+         a2Total += closeMinusTrueLow;
+         b2Total += trueRange;
+      }
       a3Total += closeMinusTrueLow;
       b3Total += trueRange;
    }
    today = startIdx;
    outIdx = 0;
-   trailingIdx1 = today - optInTimePeriod1 + 1;
-   trailingIdx2 = today - optInTimePeriod2 + 1;
-   trailingIdx3 = today - optInTimePeriod3 + 1;
+   trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+   if( trailingPos1 >= optInTimePeriod3 )
+   {
+      trailingPos1 -= optInTimePeriod3;
+   }
+   trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+   if( trailingPos2 >= optInTimePeriod3 )
+   {
+      trailingPos2 -= optInTimePeriod3;
+   }
    while( today <= endIdx )
    {
       tempLT = (double)inLow[today];
@@ -1072,6 +1014,8 @@ TA_RetCode TA_S_ULTOSC_Unguarded( int    startIdx,
       {
          trueRange = tempDouble;
       }
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
       a1Total += closeMinusTrueLow;
       a2Total += closeMinusTrueLow;
       a3Total += closeMinusTrueLow;
@@ -1091,69 +1035,32 @@ TA_RetCode TA_S_ULTOSC_Unguarded( int    startIdx,
       {
          output += a3Total / b3Total;
       }
-      tempLT = (double)inLow[trailingIdx1];
-      tempHT = (double)inHigh[trailingIdx1];
-      tempCY = (double)inClose[trailingIdx1 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
+      a1Total -= term_closeMinusTrueLow[trailingPos1];
+      b1Total -= term_trueRange[trailingPos1];
+      trailingPos1 += 1;
+      if( trailingPos1 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos1 = 0;
       }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
+      a2Total -= term_closeMinusTrueLow[trailingPos2];
+      b2Total -= term_trueRange[trailingPos2];
+      trailingPos2 += 1;
+      if( trailingPos2 >= optInTimePeriod3 )
       {
-         trueRange = tempDouble;
+         trailingPos2 = 0;
       }
-      a1Total -= closeMinusTrueLow;
-      b1Total -= trueRange;
-      tempLT = (double)inLow[trailingIdx2];
-      tempHT = (double)inHigh[trailingIdx2];
-      tempCY = (double)inClose[trailingIdx2 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a2Total -= closeMinusTrueLow;
-      b2Total -= trueRange;
-      tempLT = (double)inLow[trailingIdx3];
-      tempHT = (double)inHigh[trailingIdx3];
-      tempCY = (double)inClose[trailingIdx3 - 1];
-      trueLow = min(tempLT,tempCY);
-      closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs(tempCY - tempHT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      tempDouble = fabs(tempCY - tempLT);
-      if( tempDouble > trueRange )
-      {
-         trueRange = tempDouble;
-      }
-      a3Total -= closeMinusTrueLow;
-      b3Total -= trueRange;
+      term_Idx++;
+      if( term_Idx > maxIdx_term ) term_Idx = 0;
+      a3Total -= term_closeMinusTrueLow[term_Idx];
+      b3Total -= term_trueRange[term_Idx];
       outReal[outIdx] = 100.0 * (output / 7.0);
       outIdx += 1;
       today += 1;
-      trailingIdx1 += 1;
-      trailingIdx2 += 1;
-      trailingIdx3 += 1;
    }
    *outNBElement= outIdx;
    *outBegIdx= startIdx;
+   if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow );
+   if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange );
    return TA_SUCCESS;
 }
 
@@ -1170,58 +1077,26 @@ struct TA_ULTOSC_Stream {
    double b2Total;
    double b3Total;
    double output;
+   int trailingPos1;
+   int trailingPos2;
+   int term_Idx;
+   int maxIdx_term;
    double lag1_inClose;
-   int ringPos_trailingIdx1;
-   int ringCap_trailingIdx1;
-   int ringLag_trailingIdx1;
-   double *ring_trailingIdx1_inHigh;
-   double *ringMirror_trailingIdx1_inHigh;
-   double *ring_trailingIdx1_inLow;
-   double *ringMirror_trailingIdx1_inLow;
-   double *ring_trailingIdx1_inClose;
-   double *ringMirror_trailingIdx1_inClose;
-   int ringPos_trailingIdx2;
-   int ringCap_trailingIdx2;
-   int ringLag_trailingIdx2;
-   double *ring_trailingIdx2_inHigh;
-   double *ringMirror_trailingIdx2_inHigh;
-   double *ring_trailingIdx2_inLow;
-   double *ringMirror_trailingIdx2_inLow;
-   double *ring_trailingIdx2_inClose;
-   double *ringMirror_trailingIdx2_inClose;
-   int ringPos_trailingIdx3;
-   int ringCap_trailingIdx3;
-   int ringLag_trailingIdx3;
-   double *ring_trailingIdx3_inHigh;
-   double *ringMirror_trailingIdx3_inHigh;
-   double *ring_trailingIdx3_inLow;
-   double *ringMirror_trailingIdx3_inLow;
-   double *ring_trailingIdx3_inClose;
-   double *ringMirror_trailingIdx3_inClose;
+   int cbSize_term;
+   double *cb_term_closeMinusTrueLow;
+   double *cbMirror_term_closeMinusTrueLow;
+   double *cb_term_trueRange;
+   double *cbMirror_term_trueRange;
 };
 
 /* Private function, not in public API. */
 static void TA_ULTOSC_ReleaseInternal( struct TA_ULTOSC_Stream *sp )
 {
    if( !sp ) return;
-   if( sp->ring_trailingIdx1_inHigh ) TA_Free( sp->ring_trailingIdx1_inHigh );
-   if( sp->ringMirror_trailingIdx1_inHigh ) TA_Free( sp->ringMirror_trailingIdx1_inHigh );
-   if( sp->ring_trailingIdx1_inLow ) TA_Free( sp->ring_trailingIdx1_inLow );
-   if( sp->ringMirror_trailingIdx1_inLow ) TA_Free( sp->ringMirror_trailingIdx1_inLow );
-   if( sp->ring_trailingIdx1_inClose ) TA_Free( sp->ring_trailingIdx1_inClose );
-   if( sp->ringMirror_trailingIdx1_inClose ) TA_Free( sp->ringMirror_trailingIdx1_inClose );
-   if( sp->ring_trailingIdx2_inHigh ) TA_Free( sp->ring_trailingIdx2_inHigh );
-   if( sp->ringMirror_trailingIdx2_inHigh ) TA_Free( sp->ringMirror_trailingIdx2_inHigh );
-   if( sp->ring_trailingIdx2_inLow ) TA_Free( sp->ring_trailingIdx2_inLow );
-   if( sp->ringMirror_trailingIdx2_inLow ) TA_Free( sp->ringMirror_trailingIdx2_inLow );
-   if( sp->ring_trailingIdx2_inClose ) TA_Free( sp->ring_trailingIdx2_inClose );
-   if( sp->ringMirror_trailingIdx2_inClose ) TA_Free( sp->ringMirror_trailingIdx2_inClose );
-   if( sp->ring_trailingIdx3_inHigh ) TA_Free( sp->ring_trailingIdx3_inHigh );
-   if( sp->ringMirror_trailingIdx3_inHigh ) TA_Free( sp->ringMirror_trailingIdx3_inHigh );
-   if( sp->ring_trailingIdx3_inLow ) TA_Free( sp->ring_trailingIdx3_inLow );
-   if( sp->ringMirror_trailingIdx3_inLow ) TA_Free( sp->ringMirror_trailingIdx3_inLow );
-   if( sp->ring_trailingIdx3_inClose ) TA_Free( sp->ring_trailingIdx3_inClose );
-   if( sp->ringMirror_trailingIdx3_inClose ) TA_Free( sp->ringMirror_trailingIdx3_inClose );
+   if( sp->cb_term_closeMinusTrueLow ) TA_Free( sp->cb_term_closeMinusTrueLow );
+   if( sp->cbMirror_term_closeMinusTrueLow ) TA_Free( sp->cbMirror_term_closeMinusTrueLow );
+   if( sp->cb_term_trueRange ) TA_Free( sp->cb_term_trueRange );
+   if( sp->cbMirror_term_trueRange ) TA_Free( sp->cbMirror_term_trueRange );
    TA_Free( sp );
 }
 
@@ -1236,15 +1111,6 @@ static void TA_ULTOSC_StepInternal( struct TA_ULTOSC_Stream *sp, double inHigh, 
    double tempLT;
    double tempCY;
 
-   sp->ring_trailingIdx1_inHigh[sp->ringPos_trailingIdx1] = inHigh;
-   sp->ring_trailingIdx1_inLow[sp->ringPos_trailingIdx1] = inLow;
-   sp->ring_trailingIdx1_inClose[sp->ringPos_trailingIdx1] = inClose;
-   sp->ring_trailingIdx2_inHigh[sp->ringPos_trailingIdx2] = inHigh;
-   sp->ring_trailingIdx2_inLow[sp->ringPos_trailingIdx2] = inLow;
-   sp->ring_trailingIdx2_inClose[sp->ringPos_trailingIdx2] = inClose;
-   sp->ring_trailingIdx3_inHigh[sp->ringPos_trailingIdx3] = inHigh;
-   sp->ring_trailingIdx3_inLow[sp->ringPos_trailingIdx3] = inLow;
-   sp->ring_trailingIdx3_inClose[sp->ringPos_trailingIdx3] = inClose;
    /* Add on today's terms */
    tempLT = inLow;
    tempHT = inHigh;
@@ -1262,6 +1128,8 @@ static void TA_ULTOSC_StepInternal( struct TA_ULTOSC_Stream *sp, double inHigh, 
    {
       trueRange = tempDouble;
    }
+   sp->cb_term_closeMinusTrueLow[sp->term_Idx] = closeMinusTrueLow;
+   sp->cb_term_trueRange[sp->term_Idx] = trueRange;
    sp->a1Total += closeMinusTrueLow;
    sp->a2Total += closeMinusTrueLow;
    sp->a3Total += closeMinusTrueLow;
@@ -1282,61 +1150,30 @@ static void TA_ULTOSC_StepInternal( struct TA_ULTOSC_Stream *sp, double inHigh, 
    {
       sp->output += sp->a3Total / sp->b3Total;
    }
-   /* Remove the trailing terms to prepare for next day */
-   tempLT = sp->ring_trailingIdx1_inLow[(sp->ringPos_trailingIdx1 + sp->ringCap_trailingIdx1 - sp->ringLag_trailingIdx1) % sp->ringCap_trailingIdx1];
-   tempHT = sp->ring_trailingIdx1_inHigh[(sp->ringPos_trailingIdx1 + sp->ringCap_trailingIdx1 - sp->ringLag_trailingIdx1) % sp->ringCap_trailingIdx1];
-   tempCY = sp->ring_trailingIdx1_inClose[(sp->ringPos_trailingIdx1 + sp->ringCap_trailingIdx1 - sp->ringLag_trailingIdx1 - 1) % sp->ringCap_trailingIdx1];
-   trueLow = min(tempLT,tempCY);
-   closeMinusTrueLow = sp->ring_trailingIdx1_inClose[(sp->ringPos_trailingIdx1 + sp->ringCap_trailingIdx1 - sp->ringLag_trailingIdx1) % sp->ringCap_trailingIdx1] - trueLow;
-   trueRange = tempHT - tempLT;
-   tempDouble = fabs(tempCY - tempHT);
-   if( tempDouble > trueRange )
+   /* Remove the trailing terms to prepare for next day. Each was evaluated
+    * once, when its bar entered the ring.
+    */
+   sp->a1Total -= sp->cb_term_closeMinusTrueLow[sp->trailingPos1];
+   sp->b1Total -= sp->cb_term_trueRange[sp->trailingPos1];
+   sp->trailingPos1 += 1;
+   if( sp->trailingPos1 >= sp->optInTimePeriod3 )
    {
-      trueRange = tempDouble;
+      sp->trailingPos1 = 0;
    }
-   tempDouble = fabs(tempCY - tempLT);
-   if( tempDouble > trueRange )
+   sp->a2Total -= sp->cb_term_closeMinusTrueLow[sp->trailingPos2];
+   sp->b2Total -= sp->cb_term_trueRange[sp->trailingPos2];
+   sp->trailingPos2 += 1;
+   if( sp->trailingPos2 >= sp->optInTimePeriod3 )
    {
-      trueRange = tempDouble;
+      sp->trailingPos2 = 0;
    }
-   sp->a1Total -= closeMinusTrueLow;
-   sp->b1Total -= trueRange;
-   tempLT = sp->ring_trailingIdx2_inLow[(sp->ringPos_trailingIdx2 + sp->ringCap_trailingIdx2 - sp->ringLag_trailingIdx2) % sp->ringCap_trailingIdx2];
-   tempHT = sp->ring_trailingIdx2_inHigh[(sp->ringPos_trailingIdx2 + sp->ringCap_trailingIdx2 - sp->ringLag_trailingIdx2) % sp->ringCap_trailingIdx2];
-   tempCY = sp->ring_trailingIdx2_inClose[(sp->ringPos_trailingIdx2 + sp->ringCap_trailingIdx2 - sp->ringLag_trailingIdx2 - 1) % sp->ringCap_trailingIdx2];
-   trueLow = min(tempLT,tempCY);
-   closeMinusTrueLow = sp->ring_trailingIdx2_inClose[(sp->ringPos_trailingIdx2 + sp->ringCap_trailingIdx2 - sp->ringLag_trailingIdx2) % sp->ringCap_trailingIdx2] - trueLow;
-   trueRange = tempHT - tempLT;
-   tempDouble = fabs(tempCY - tempHT);
-   if( tempDouble > trueRange )
+   sp->term_Idx = sp->term_Idx + 1;
+   if( sp->term_Idx > sp->maxIdx_term )
    {
-      trueRange = tempDouble;
+      sp->term_Idx = 0;
    }
-   tempDouble = fabs(tempCY - tempLT);
-   if( tempDouble > trueRange )
-   {
-      trueRange = tempDouble;
-   }
-   sp->a2Total -= closeMinusTrueLow;
-   sp->b2Total -= trueRange;
-   tempLT = sp->ring_trailingIdx3_inLow[(sp->ringPos_trailingIdx3 + sp->ringCap_trailingIdx3 - sp->ringLag_trailingIdx3) % sp->ringCap_trailingIdx3];
-   tempHT = sp->ring_trailingIdx3_inHigh[(sp->ringPos_trailingIdx3 + sp->ringCap_trailingIdx3 - sp->ringLag_trailingIdx3) % sp->ringCap_trailingIdx3];
-   tempCY = sp->ring_trailingIdx3_inClose[(sp->ringPos_trailingIdx3 + sp->ringCap_trailingIdx3 - sp->ringLag_trailingIdx3 - 1) % sp->ringCap_trailingIdx3];
-   trueLow = min(tempLT,tempCY);
-   closeMinusTrueLow = sp->ring_trailingIdx3_inClose[(sp->ringPos_trailingIdx3 + sp->ringCap_trailingIdx3 - sp->ringLag_trailingIdx3) % sp->ringCap_trailingIdx3] - trueLow;
-   trueRange = tempHT - tempLT;
-   tempDouble = fabs(tempCY - tempHT);
-   if( tempDouble > trueRange )
-   {
-      trueRange = tempDouble;
-   }
-   tempDouble = fabs(tempCY - tempLT);
-   if( tempDouble > trueRange )
-   {
-      trueRange = tempDouble;
-   }
-   sp->a3Total -= closeMinusTrueLow;
-   sp->b3Total -= trueRange;
+   sp->a3Total -= sp->cb_term_closeMinusTrueLow[sp->term_Idx];
+   sp->b3Total -= sp->cb_term_trueRange[sp->term_Idx];
    /* Last operation is to write the output. Must
     * be done after the trailing index have all been
     * taken care of because the caller is allowed
@@ -1346,36 +1183,18 @@ static void TA_ULTOSC_StepInternal( struct TA_ULTOSC_Stream *sp, double inHigh, 
    *outReal= 100.0 * (sp->output / 7.0);
    /* Increment indexes */
    sp->lag1_inClose = inClose;
-   sp->ring_trailingIdx1_inHigh[sp->ringPos_trailingIdx1] = inHigh;
-   sp->ring_trailingIdx1_inLow[sp->ringPos_trailingIdx1] = inLow;
-   sp->ring_trailingIdx1_inClose[sp->ringPos_trailingIdx1] = inClose;
-   sp->ringPos_trailingIdx1 = sp->ringPos_trailingIdx1 + 1;
-   if( sp->ringPos_trailingIdx1 >= sp->ringCap_trailingIdx1 )
-   {
-      sp->ringPos_trailingIdx1 = 0;
-   }
-   sp->ring_trailingIdx2_inHigh[sp->ringPos_trailingIdx2] = inHigh;
-   sp->ring_trailingIdx2_inLow[sp->ringPos_trailingIdx2] = inLow;
-   sp->ring_trailingIdx2_inClose[sp->ringPos_trailingIdx2] = inClose;
-   sp->ringPos_trailingIdx2 = sp->ringPos_trailingIdx2 + 1;
-   if( sp->ringPos_trailingIdx2 >= sp->ringCap_trailingIdx2 )
-   {
-      sp->ringPos_trailingIdx2 = 0;
-   }
-   sp->ring_trailingIdx3_inHigh[sp->ringPos_trailingIdx3] = inHigh;
-   sp->ring_trailingIdx3_inLow[sp->ringPos_trailingIdx3] = inLow;
-   sp->ring_trailingIdx3_inClose[sp->ringPos_trailingIdx3] = inClose;
-   sp->ringPos_trailingIdx3 = sp->ringPos_trailingIdx3 + 1;
-   if( sp->ringPos_trailingIdx3 >= sp->ringCap_trailingIdx3 )
-   {
-      sp->ringPos_trailingIdx3 = 0;
-   }
 }
 
 /* Private function, not in public API. */
 TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const double inHigh[], const double inLow[], const double inClose[], int startIdx, int historyLen, int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3, double *outReal )
 {
    struct TA_ULTOSC_Stream *sp;
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
    int endIdx;
    int dummyBegIdx;
    int dummyNBElement;
@@ -1405,6 +1224,10 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
    (void)startIdx; (void)dummyBegIdx; (void)dummyNBElement;
 
    {
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
       double a1Total = 0.0;
       double a2Total = 0.0;
       double a3Total = 0.0;
@@ -1426,12 +1249,15 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
       int j;
       int today;
       int outIdx;
-      int trailingIdx1;
-      int trailingIdx2;
-      int trailingIdx3;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int usedFlag[3];
       int periods[3];
       int sortedPeriods[3];
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       dummyBegIdx = 0;
       dummyNBElement = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -1472,53 +1298,39 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
       {
          return TA_BAD_PARAM;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+      {
+         term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+         if( !term_closeMinusTrueLow )
+         {
+            return TA_ALLOC_ERR;
+         }
+         term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+         if( !term_trueRange )
+         {
+            TA_Free( term_closeMinusTrueLow );
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+         term_trueRange = &local_term_trueRange[0];
+      }
+      maxIdx_term = (optInTimePeriod3-1);
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-      {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-      {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -1539,15 +1351,40 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
          {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) term_Idx = 0;
+         if( i >= startIdx - optInTimePeriod1 + 1 )
+         {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 )
+         {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 )
+      {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 )
+      {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx )
       {
          /* Add on today's terms */
@@ -1567,6 +1404,8 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
          {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -1587,61 +1426,27 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
          {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 )
          {
-            trueRange = tempDouble;
+            trailingPos1 = 0;
          }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 )
          {
-            trueRange = tempDouble;
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) term_Idx = 0;
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -1652,9 +1457,6 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       dummyNBElement = outIdx;
@@ -1662,7 +1464,7 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
 
       /* Capture the live batch state into the handle. */
       sp = (struct TA_ULTOSC_Stream *)TA_Malloc( sizeof(*sp) );
-      if( !sp ) { return TA_ALLOC_ERR; }
+      if( !sp ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); return TA_ALLOC_ERR; }
       memset( sp, 0, sizeof(*sp) );
       sp->optInTimePeriod1 = optInTimePeriod1;
       sp->optInTimePeriod2 = optInTimePeriod2;
@@ -1674,97 +1476,24 @@ TA_RetCode TA_ULTOSC_OpenInternal( struct TA_ULTOSC_Stream **stream, const doubl
       sp->b2Total = b2Total;
       sp->b3Total = b3Total;
       sp->output = output;
-      sp->ringLag_trailingIdx1 = (int)(today - trailingIdx1);
-      sp->ringCap_trailingIdx1 = sp->ringLag_trailingIdx1 + 2;
-      if( sp->ringLag_trailingIdx1 < 0 || sp->ringCap_trailingIdx1 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx1 > 0 ? sp->ringCap_trailingIdx1 : 1);
-        sp->ring_trailingIdx1_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inHigh[fillJ % sp->ringCap_trailingIdx1] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx1_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inLow[fillJ % sp->ringCap_trailingIdx1] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx1_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inClose[fillJ % sp->ringCap_trailingIdx1] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx1 = historyLen % sp->ringCap_trailingIdx1;
-      sp->ringLag_trailingIdx2 = (int)(today - trailingIdx2);
-      sp->ringCap_trailingIdx2 = sp->ringLag_trailingIdx2 + 2;
-      if( sp->ringLag_trailingIdx2 < 0 || sp->ringCap_trailingIdx2 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx2 > 0 ? sp->ringCap_trailingIdx2 : 1);
-        sp->ring_trailingIdx2_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inHigh[fillJ % sp->ringCap_trailingIdx2] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx2_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inLow[fillJ % sp->ringCap_trailingIdx2] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx2_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inClose[fillJ % sp->ringCap_trailingIdx2] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx2 = historyLen % sp->ringCap_trailingIdx2;
-      sp->ringLag_trailingIdx3 = (int)(today - trailingIdx3);
-      sp->ringCap_trailingIdx3 = sp->ringLag_trailingIdx3 + 2;
-      if( sp->ringLag_trailingIdx3 < 0 || sp->ringCap_trailingIdx3 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx3 > 0 ? sp->ringCap_trailingIdx3 : 1);
-        sp->ring_trailingIdx3_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inHigh[fillJ % sp->ringCap_trailingIdx3] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx3_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inLow[fillJ % sp->ringCap_trailingIdx3] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx3_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inClose[fillJ % sp->ringCap_trailingIdx3] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx3 = historyLen % sp->ringCap_trailingIdx3;
+      sp->trailingPos1 = trailingPos1;
+      sp->trailingPos2 = trailingPos2;
+      sp->term_Idx = term_Idx;
+      sp->maxIdx_term = maxIdx_term;
       sp->lag1_inClose = inClose[historyLen - 1];
+      sp->cbSize_term = maxIdx_term + 1;
+      if( sp->cbSize_term < 1 || sp->cbSize_term > historyLen + 1 ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
+      sp->cb_term_closeMinusTrueLow = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cb_term_closeMinusTrueLow ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      sp->cbMirror_term_closeMinusTrueLow = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cbMirror_term_closeMinusTrueLow ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      memcpy( sp->cb_term_closeMinusTrueLow, term_closeMinusTrueLow, sizeof(double) * (size_t)sp->cbSize_term );
+      sp->cb_term_trueRange = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cb_term_trueRange ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      sp->cbMirror_term_trueRange = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cbMirror_term_trueRange ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      memcpy( sp->cb_term_trueRange, term_trueRange, sizeof(double) * (size_t)sp->cbSize_term );
+      if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); 
       *outReal = lastValue_outReal;
       *stream = sp;
       return TA_SUCCESS;
@@ -1779,6 +1508,12 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Open( TA_ULTOSC_Stream **stream, const double in
 TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const double inHigh[], const double inLow[], const double inClose[], int historyLen, int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3, int *outBegIdx, int *outNBElement, double outReal[] )
 {
    struct TA_ULTOSC_Stream *sp;
+   double local_term_closeMinusTrueLow[32];
+   double *term_closeMinusTrueLow;
+   double local_term_trueRange[32];
+   double *term_trueRange;
+   int term_Idx;
+   int maxIdx_term;
    int endIdx;
    int startIdx;
    int dummyBegIdx;
@@ -1809,6 +1544,10 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
    (void)startIdx; (void)dummyBegIdx; (void)dummyNBElement;
 
    {
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
       double a1Total = 0.0;
       double a2Total = 0.0;
       double a3Total = 0.0;
@@ -1830,12 +1569,15 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
       int j;
       int today;
       int outIdx;
-      int trailingIdx1;
-      int trailingIdx2;
-      int trailingIdx3;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int usedFlag[3];
       int periods[3];
       int sortedPeriods[3];
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       *outBegIdx= 0;
       *outNBElement= 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -1876,53 +1618,39 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
       {
          return TA_BAD_PARAM;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod3 > (int)(sizeof(local_term_closeMinusTrueLow)/sizeof(double)) )
+      {
+         term_closeMinusTrueLow = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+         if( !term_closeMinusTrueLow )
+         {
+            return TA_ALLOC_ERR;
+         }
+         term_trueRange = TA_Malloc( sizeof(double)*optInTimePeriod3 );
+         if( !term_trueRange )
+         {
+            TA_Free( term_closeMinusTrueLow );
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         term_closeMinusTrueLow = &local_term_closeMinusTrueLow[0];
+         term_trueRange = &local_term_trueRange[0];
+      }
+      maxIdx_term = (optInTimePeriod3-1);
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 )
-      {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 )
-      {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 )
@@ -1943,15 +1671,40 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
          {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) term_Idx = 0;
+         if( i >= startIdx - optInTimePeriod1 + 1 )
+         {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 )
+         {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 )
+      {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 )
+      {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx )
       {
          /* Add on today's terms */
@@ -1971,6 +1724,8 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
          {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -1991,61 +1746,27 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
          {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 )
          {
-            trueRange = tempDouble;
+            trailingPos1 = 0;
          }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 )
          {
-            trueRange = tempDouble;
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = min(tempLT,tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = fabs(tempCY - tempHT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         tempDouble = fabs(tempCY - tempLT);
-         if( tempDouble > trueRange )
-         {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) term_Idx = 0;
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -2056,9 +1777,6 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       *outNBElement= outIdx;
@@ -2066,7 +1784,7 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
 
       /* Capture the live batch state into the handle. */
       sp = (struct TA_ULTOSC_Stream *)TA_Malloc( sizeof(*sp) );
-      if( !sp ) { return TA_ALLOC_ERR; }
+      if( !sp ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); return TA_ALLOC_ERR; }
       memset( sp, 0, sizeof(*sp) );
       sp->optInTimePeriod1 = optInTimePeriod1;
       sp->optInTimePeriod2 = optInTimePeriod2;
@@ -2078,97 +1796,24 @@ TA_LIB_API TA_RetCode TA_ULTOSC_OpenAndFill( TA_ULTOSC_Stream **stream, const do
       sp->b2Total = b2Total;
       sp->b3Total = b3Total;
       sp->output = output;
-      sp->ringLag_trailingIdx1 = (int)(today - trailingIdx1);
-      sp->ringCap_trailingIdx1 = sp->ringLag_trailingIdx1 + 2;
-      if( sp->ringLag_trailingIdx1 < 0 || sp->ringCap_trailingIdx1 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx1 > 0 ? sp->ringCap_trailingIdx1 : 1);
-        sp->ring_trailingIdx1_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inHigh[fillJ % sp->ringCap_trailingIdx1] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx1_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inLow[fillJ % sp->ringCap_trailingIdx1] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx1_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx1_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx1_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx1_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx1; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx1_inClose[fillJ % sp->ringCap_trailingIdx1] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx1 = historyLen % sp->ringCap_trailingIdx1;
-      sp->ringLag_trailingIdx2 = (int)(today - trailingIdx2);
-      sp->ringCap_trailingIdx2 = sp->ringLag_trailingIdx2 + 2;
-      if( sp->ringLag_trailingIdx2 < 0 || sp->ringCap_trailingIdx2 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx2 > 0 ? sp->ringCap_trailingIdx2 : 1);
-        sp->ring_trailingIdx2_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inHigh[fillJ % sp->ringCap_trailingIdx2] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx2_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inLow[fillJ % sp->ringCap_trailingIdx2] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx2_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx2_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx2_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx2_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx2; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx2_inClose[fillJ % sp->ringCap_trailingIdx2] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx2 = historyLen % sp->ringCap_trailingIdx2;
-      sp->ringLag_trailingIdx3 = (int)(today - trailingIdx3);
-      sp->ringCap_trailingIdx3 = sp->ringLag_trailingIdx3 + 2;
-      if( sp->ringLag_trailingIdx3 < 0 || sp->ringCap_trailingIdx3 > historyLen ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
-      { size_t allocN = (size_t)(sp->ringCap_trailingIdx3 > 0 ? sp->ringCap_trailingIdx3 : 1);
-        sp->ring_trailingIdx3_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inHigh ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inHigh[fillJ % sp->ringCap_trailingIdx3] = inHigh[fillJ];
-        }
-        sp->ring_trailingIdx3_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inLow ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inLow[fillJ % sp->ringCap_trailingIdx3] = inLow[fillJ];
-        }
-        sp->ring_trailingIdx3_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx3_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx3_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx3_inClose ) { TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        { int fillJ;
-          for( fillJ = historyLen - sp->ringCap_trailingIdx3; fillJ < historyLen; fillJ++ )
-             sp->ring_trailingIdx3_inClose[fillJ % sp->ringCap_trailingIdx3] = inClose[fillJ];
-        }
-      }
-      sp->ringPos_trailingIdx3 = historyLen % sp->ringCap_trailingIdx3;
+      sp->trailingPos1 = trailingPos1;
+      sp->trailingPos2 = trailingPos2;
+      sp->term_Idx = term_Idx;
+      sp->maxIdx_term = maxIdx_term;
       sp->lag1_inClose = inClose[historyLen - 1];
+      sp->cbSize_term = maxIdx_term + 1;
+      if( sp->cbSize_term < 1 || sp->cbSize_term > historyLen + 1 ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
+      sp->cb_term_closeMinusTrueLow = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cb_term_closeMinusTrueLow ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      sp->cbMirror_term_closeMinusTrueLow = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cbMirror_term_closeMinusTrueLow ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      memcpy( sp->cb_term_closeMinusTrueLow, term_closeMinusTrueLow, sizeof(double) * (size_t)sp->cbSize_term );
+      sp->cb_term_trueRange = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cb_term_trueRange ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      sp->cbMirror_term_trueRange = (double *)TA_Malloc( sizeof(double) * (size_t)sp->cbSize_term );
+      if( !sp->cbMirror_term_trueRange ) { if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); TA_ULTOSC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+      memcpy( sp->cb_term_trueRange, term_trueRange, sizeof(double) * (size_t)sp->cbSize_term );
+      if( term_closeMinusTrueLow != &local_term_closeMinusTrueLow[0] ) TA_Free( term_closeMinusTrueLow ); if( term_trueRange != &local_term_trueRange[0] ) TA_Free( term_trueRange ); 
       *stream = sp;
       return TA_SUCCESS;
    }
@@ -2187,24 +1832,10 @@ TA_LIB_API TA_RetCode TA_ULTOSC_Peek( const TA_ULTOSC_Stream *stream, double inH
 
    if( !stream || !outReal ) return TA_BAD_PARAM;
    scratch = *stream;
-   scratch.ring_trailingIdx1_inHigh = stream->ringMirror_trailingIdx1_inHigh;
-   memcpy( scratch.ring_trailingIdx1_inHigh, stream->ring_trailingIdx1_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingIdx1 > 0 ? stream->ringCap_trailingIdx1 : 1) );
-   scratch.ring_trailingIdx1_inLow = stream->ringMirror_trailingIdx1_inLow;
-   memcpy( scratch.ring_trailingIdx1_inLow, stream->ring_trailingIdx1_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingIdx1 > 0 ? stream->ringCap_trailingIdx1 : 1) );
-   scratch.ring_trailingIdx1_inClose = stream->ringMirror_trailingIdx1_inClose;
-   memcpy( scratch.ring_trailingIdx1_inClose, stream->ring_trailingIdx1_inClose, sizeof(double) * (size_t)(stream->ringCap_trailingIdx1 > 0 ? stream->ringCap_trailingIdx1 : 1) );
-   scratch.ring_trailingIdx2_inHigh = stream->ringMirror_trailingIdx2_inHigh;
-   memcpy( scratch.ring_trailingIdx2_inHigh, stream->ring_trailingIdx2_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingIdx2 > 0 ? stream->ringCap_trailingIdx2 : 1) );
-   scratch.ring_trailingIdx2_inLow = stream->ringMirror_trailingIdx2_inLow;
-   memcpy( scratch.ring_trailingIdx2_inLow, stream->ring_trailingIdx2_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingIdx2 > 0 ? stream->ringCap_trailingIdx2 : 1) );
-   scratch.ring_trailingIdx2_inClose = stream->ringMirror_trailingIdx2_inClose;
-   memcpy( scratch.ring_trailingIdx2_inClose, stream->ring_trailingIdx2_inClose, sizeof(double) * (size_t)(stream->ringCap_trailingIdx2 > 0 ? stream->ringCap_trailingIdx2 : 1) );
-   scratch.ring_trailingIdx3_inHigh = stream->ringMirror_trailingIdx3_inHigh;
-   memcpy( scratch.ring_trailingIdx3_inHigh, stream->ring_trailingIdx3_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingIdx3 > 0 ? stream->ringCap_trailingIdx3 : 1) );
-   scratch.ring_trailingIdx3_inLow = stream->ringMirror_trailingIdx3_inLow;
-   memcpy( scratch.ring_trailingIdx3_inLow, stream->ring_trailingIdx3_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingIdx3 > 0 ? stream->ringCap_trailingIdx3 : 1) );
-   scratch.ring_trailingIdx3_inClose = stream->ringMirror_trailingIdx3_inClose;
-   memcpy( scratch.ring_trailingIdx3_inClose, stream->ring_trailingIdx3_inClose, sizeof(double) * (size_t)(stream->ringCap_trailingIdx3 > 0 ? stream->ringCap_trailingIdx3 : 1) );
+   scratch.cb_term_closeMinusTrueLow = stream->cbMirror_term_closeMinusTrueLow;
+   memcpy( scratch.cb_term_closeMinusTrueLow, stream->cb_term_closeMinusTrueLow, sizeof(double) * (size_t)stream->cbSize_term );
+   scratch.cb_term_trueRange = stream->cbMirror_term_trueRange;
+   memcpy( scratch.cb_term_trueRange, stream->cb_term_trueRange, sizeof(double) * (size_t)stream->cbSize_term );
    TA_ULTOSC_StepInternal( &scratch, inHigh, inLow, inClose, outReal );
    return TA_SUCCESS;
 }

--- a/ta_codegen/input/ultosc/ultosc.c
+++ b/ta_codegen/input/ultosc/ultosc.c
@@ -11,6 +11,9 @@
  *  -------------------------------------------------------------------
  *  281206 DM   Initial Implementation
  *  010606 MF   Abstract local arrays. Detect divide by zero.
+ *  073126 DX   Evaluate each bar's true range and close-minus-true-low once
+ *              instead of four times, keeping them in a CIRCBUF sized to the
+ *              longest period. Same values, same summation order, bit-exact.
  */
 
 int ultosc_lookback(int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3)
@@ -34,6 +37,12 @@ TA_RetCode ultosc(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   /* The two per-bar terms the three moving sums are built from. Both are a
+    * pure function of the bar, so each bar is evaluated once on entry and read
+    * back when it leaves each of the three windows.
+    */
+   typedef struct { double closeMinusTrueLow; double trueRange; } UltOscTerm;
+
    double a1Total, a2Total, a3Total;
    double b1Total, b2Total, b3Total;
    double trueLow, trueRange, closeMinusTrueLow;
@@ -41,11 +50,16 @@ TA_RetCode ultosc(int startIdx, int endIdx,
    int lookbackTotal;
    int longestPeriod, longestIndex;
    int i,j,today,outIdx;
-   int trailingIdx1, trailingIdx2, trailingIdx3;
+   int trailingPos1, trailingPos2;
 
    int usedFlag[3];
    int periods[3];
    int sortedPeriods[3];
+
+   /* One entry per bar of the longest window. Stays on the stack for every
+    * period up to 32, which covers the 7/14/28 default.
+    */
+   CIRCBUF_PROLOG_CLASS( term, UltOscTerm, 32 ); /* Id, Type, Static Size */
 
    *outBegIdx = 0;
    *outNBElement = 0;
@@ -84,49 +98,22 @@ TA_RetCode ultosc(int startIdx, int endIdx,
    /* Make sure there is still something to evaluate. */
    if( startIdx > endIdx ) return TA_SUCCESS;
 
-   /* Prime running totals used in moving averages */
+   CIRCBUF_INIT_CLASS( term, UltOscTerm, optInTimePeriod3 );
+
+   /* Prime running totals used in moving averages.
+    *
+    * One pass over the longest warm-up window replaces three overlapping
+    * passes. A bar inside the shorter windows is added to those totals as it
+    * is reached, so every total still accumulates exactly the same bars in
+    * exactly the same ascending order as three separate loops did.
+    */
    a1Total = 0;
    b1Total = 0;
-   for ( i = startIdx-optInTimePeriod1+1; i < startIdx; ++i )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i-1];
-      trueLow = min( tempLT, tempCY );
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs( tempCY - tempHT );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      tempDouble = fabs( tempCY - tempLT  );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      a1Total += closeMinusTrueLow;
-      b1Total += trueRange;
-   }
-
    a2Total = 0;
    b2Total = 0;
-   for ( i = startIdx-optInTimePeriod2+1; i < startIdx; ++i )
-   {
-      tempLT = inLow[i];
-      tempHT = inHigh[i];
-      tempCY = inClose[i-1];
-      trueLow = min( tempLT, tempCY );
-      closeMinusTrueLow = inClose[i] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs( tempCY - tempHT );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      tempDouble = fabs( tempCY - tempLT  );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      a2Total += closeMinusTrueLow;
-      b2Total += trueRange;
-   }
-
    a3Total = 0;
    b3Total = 0;
+
    for ( i = startIdx-optInTimePeriod3+1; i < startIdx; ++i )
    {
       tempLT = inLow[i];
@@ -141,6 +128,21 @@ TA_RetCode ultosc(int startIdx, int endIdx,
       tempDouble = fabs( tempCY - tempLT  );
       if( tempDouble > trueRange )
          trueRange = tempDouble;
+
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+      CIRCBUF_NEXT(term);
+
+      if( i >= startIdx-optInTimePeriod1+1 )
+      {
+         a1Total += closeMinusTrueLow;
+         b1Total += trueRange;
+      }
+      if( i >= startIdx-optInTimePeriod2+1 )
+      {
+         a2Total += closeMinusTrueLow;
+         b2Total += trueRange;
+      }
       a3Total += closeMinusTrueLow;
       b3Total += trueRange;
    }
@@ -148,9 +150,16 @@ TA_RetCode ultosc(int startIdx, int endIdx,
    /* Calculate oscillator */
    today = startIdx;
    outIdx = 0;
-   trailingIdx1 = today - optInTimePeriod1 + 1;
-   trailingIdx2 = today - optInTimePeriod2 + 1;
-   trailingIdx3 = today - optInTimePeriod3 + 1;
+
+   /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+    * `today` and, once advanced past it, the slot of the bar leaving the
+    * longest window. The two shorter windows trail it by a fixed offset.
+    */
+   trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+   if( trailingPos1 >= optInTimePeriod3 ) trailingPos1 -= optInTimePeriod3;
+   trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+   if( trailingPos2 >= optInTimePeriod3 ) trailingPos2 -= optInTimePeriod3;
+
    while( today <= endIdx )
    {
       /* Add on today's terms */
@@ -166,6 +175,10 @@ TA_RetCode ultosc(int startIdx, int endIdx,
       tempDouble = fabs( tempCY - tempLT  );
       if( tempDouble > trueRange )
          trueRange = tempDouble;
+
+      term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+      term_trueRange[term_Idx] = trueRange;
+
       a1Total += closeMinusTrueLow;
       a2Total += closeMinusTrueLow;
       a3Total += closeMinusTrueLow;
@@ -180,51 +193,22 @@ TA_RetCode ultosc(int startIdx, int endIdx,
       if( !TA_IS_ZERO(b2Total) ) output += 2.0*(a2Total/b2Total);
       if( !TA_IS_ZERO(b3Total) ) output += a3Total/b3Total;
 
-      /* Remove the trailing terms to prepare for next day */
-      tempLT = inLow[trailingIdx1];
-      tempHT = inHigh[trailingIdx1];
-      tempCY = inClose[trailingIdx1-1];
-      trueLow = min( tempLT, tempCY );
-      closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs( tempCY - tempHT );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      tempDouble = fabs( tempCY - tempLT  );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      a1Total -= closeMinusTrueLow;
-      b1Total -= trueRange;
+      /* Remove the trailing terms to prepare for next day. Each was evaluated
+       * once, when its bar entered the ring.
+       */
+      a1Total -= term_closeMinusTrueLow[trailingPos1];
+      b1Total -= term_trueRange[trailingPos1];
+      trailingPos1++;
+      if( trailingPos1 >= optInTimePeriod3 ) trailingPos1 = 0;
 
-      tempLT = inLow[trailingIdx2];
-      tempHT = inHigh[trailingIdx2];
-      tempCY = inClose[trailingIdx2-1];
-      trueLow = min( tempLT, tempCY );
-      closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs( tempCY - tempHT );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      tempDouble = fabs( tempCY - tempLT  );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      a2Total -= closeMinusTrueLow;
-      b2Total -= trueRange;
+      a2Total -= term_closeMinusTrueLow[trailingPos2];
+      b2Total -= term_trueRange[trailingPos2];
+      trailingPos2++;
+      if( trailingPos2 >= optInTimePeriod3 ) trailingPos2 = 0;
 
-      tempLT = inLow[trailingIdx3];
-      tempHT = inHigh[trailingIdx3];
-      tempCY = inClose[trailingIdx3-1];
-      trueLow = min( tempLT, tempCY );
-      closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = fabs( tempCY - tempHT );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      tempDouble = fabs( tempCY - tempLT  );
-      if( tempDouble > trueRange )
-         trueRange = tempDouble;
-      a3Total -= closeMinusTrueLow;
-      b3Total -= trueRange;
+      CIRCBUF_NEXT(term);
+      a3Total -= term_closeMinusTrueLow[term_Idx];
+      b3Total -= term_trueRange[term_Idx];
 
       /* Last operation is to write the output. Must
        * be done after the trailing index have all been
@@ -237,14 +221,13 @@ TA_RetCode ultosc(int startIdx, int endIdx,
       /* Increment indexes */
       outIdx++;
       today++;
-      trailingIdx1++;
-      trailingIdx2++;
-      trailingIdx3++;
    }
 
    /* All done. Indicate the output limits and return. */
    *outNBElement = outIdx;
    *outBegIdx    = startIdx;
+
+   CIRCBUF_DESTROY(term);
 
    return TA_SUCCESS;
 }

--- a/ta_codegen/output/java/library/fragments/Core_ULTOSC.java
+++ b/ta_codegen/output/java/library/fragments/Core_ULTOSC.java
@@ -11,6 +11,9 @@
  *  -------------------------------------------------------------------
  *  281206 DM   Initial Implementation
  *  010606 MF   Abstract local arrays. Detect divide by zero.
+ *  073126 DX   Evaluate each bar's true range and close-minus-true-low once
+ *              instead of four times, keeping them in a CIRCBUF sized to the
+ *              longest period. Same values, same summation order, bit-exact.
  */
 
    /**
@@ -86,12 +89,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       if( startIdx < 0 ) {
          return RetCode.OutOfRangeStartIndex ;
       }
@@ -113,6 +119,14 @@
       } else if( optInTimePeriod3 < 1 || optInTimePeriod3 > 100000 ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -148,47 +162,22 @@
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -206,15 +195,36 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -231,6 +241,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -248,55 +260,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -307,9 +289,6 @@
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
@@ -349,12 +328,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       outBegIdx.value = 0;
       outNBElement.value = 0;
       periods[0] = optInTimePeriod1;
@@ -385,46 +367,15 @@
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -442,14 +393,31 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = inLow[today];
          tempHT = inHigh[today];
@@ -465,6 +433,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -481,60 +451,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -573,12 +508,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       if( startIdx < 0 ) {
          return RetCode.OutOfRangeStartIndex ;
       }
@@ -630,46 +568,15 @@
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -687,14 +594,31 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = (double)inLow[today];
          tempHT = (double)inHigh[today];
@@ -710,6 +634,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -726,60 +652,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = (double)inLow[trailingIdx1];
-         tempHT = (double)inHigh[trailingIdx1];
-         tempCY = (double)inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx2];
-         tempHT = (double)inHigh[trailingIdx2];
-         tempCY = (double)inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx3];
-         tempHT = (double)inHigh[trailingIdx3];
-         tempCY = (double)inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -818,12 +709,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       outBegIdx.value = 0;
       outNBElement.value = 0;
       periods[0] = optInTimePeriod1;
@@ -854,46 +748,15 @@
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -911,14 +774,31 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = (double)inLow[today];
          tempHT = (double)inHigh[today];
@@ -934,6 +814,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -950,60 +832,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = (double)inLow[trailingIdx1];
-         tempHT = (double)inHigh[trailingIdx1];
-         tempCY = (double)inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx2];
-         tempHT = (double)inHigh[trailingIdx2];
-         tempCY = (double)inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx3];
-         tempHT = (double)inHigh[trailingIdx3];
-         tempCY = (double)inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -1240,25 +1087,14 @@
       double b2Total;
       double b3Total;
       double output;
+      int trailingPos1;
+      int trailingPos2;
+      int term_Idx;
+      int maxIdx_term;
       double lag1_inClose;
-      int ringPos_trailingIdx1;
-      int ringCap_trailingIdx1;
-      int ringLag_trailingIdx1;
-      double[] ring_trailingIdx1_inHigh;
-      double[] ring_trailingIdx1_inLow;
-      double[] ring_trailingIdx1_inClose;
-      int ringPos_trailingIdx2;
-      int ringCap_trailingIdx2;
-      int ringLag_trailingIdx2;
-      double[] ring_trailingIdx2_inHigh;
-      double[] ring_trailingIdx2_inLow;
-      double[] ring_trailingIdx2_inClose;
-      int ringPos_trailingIdx3;
-      int ringCap_trailingIdx3;
-      int ringLag_trailingIdx3;
-      double[] ring_trailingIdx3_inHigh;
-      double[] ring_trailingIdx3_inLow;
-      double[] ring_trailingIdx3_inClose;
+      int cbSize_term;
+      double[] cb_term_closeMinusTrueLow;
+      double[] cb_term_trueRange;
       double cur_outReal;
       OutRange fillRange;
 
@@ -1282,25 +1118,14 @@
          this.b2Total = other.b2Total;
          this.b3Total = other.b3Total;
          this.output = other.output;
+         this.trailingPos1 = other.trailingPos1;
+         this.trailingPos2 = other.trailingPos2;
+         this.term_Idx = other.term_Idx;
+         this.maxIdx_term = other.maxIdx_term;
          this.lag1_inClose = other.lag1_inClose;
-         this.ringPos_trailingIdx1 = other.ringPos_trailingIdx1;
-         this.ringCap_trailingIdx1 = other.ringCap_trailingIdx1;
-         this.ringLag_trailingIdx1 = other.ringLag_trailingIdx1;
-         this.ring_trailingIdx1_inHigh = other.ring_trailingIdx1_inHigh.clone();
-         this.ring_trailingIdx1_inLow = other.ring_trailingIdx1_inLow.clone();
-         this.ring_trailingIdx1_inClose = other.ring_trailingIdx1_inClose.clone();
-         this.ringPos_trailingIdx2 = other.ringPos_trailingIdx2;
-         this.ringCap_trailingIdx2 = other.ringCap_trailingIdx2;
-         this.ringLag_trailingIdx2 = other.ringLag_trailingIdx2;
-         this.ring_trailingIdx2_inHigh = other.ring_trailingIdx2_inHigh.clone();
-         this.ring_trailingIdx2_inLow = other.ring_trailingIdx2_inLow.clone();
-         this.ring_trailingIdx2_inClose = other.ring_trailingIdx2_inClose.clone();
-         this.ringPos_trailingIdx3 = other.ringPos_trailingIdx3;
-         this.ringCap_trailingIdx3 = other.ringCap_trailingIdx3;
-         this.ringLag_trailingIdx3 = other.ringLag_trailingIdx3;
-         this.ring_trailingIdx3_inHigh = other.ring_trailingIdx3_inHigh.clone();
-         this.ring_trailingIdx3_inLow = other.ring_trailingIdx3_inLow.clone();
-         this.ring_trailingIdx3_inClose = other.ring_trailingIdx3_inClose.clone();
+         this.cbSize_term = other.cbSize_term;
+         this.cb_term_closeMinusTrueLow = other.cb_term_closeMinusTrueLow.clone();
+         this.cb_term_trueRange = other.cb_term_trueRange.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -1353,15 +1178,6 @@
       double tempHT = 0.0;
       double tempLT = 0.0;
       double tempCY = 0.0;
-      sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-      sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-      sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-      sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-      sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-      sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-      sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-      sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-      sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
       /* Add on today's terms */
       tempLT = inLow;
       tempHT = inHigh;
@@ -1377,6 +1193,8 @@
       if( tempDouble > trueRange ) {
          trueRange = tempDouble;
       }
+      sp.cb_term_closeMinusTrueLow[sp.term_Idx] = closeMinusTrueLow;
+      sp.cb_term_trueRange[sp.term_Idx] = trueRange;
       sp.a1Total += closeMinusTrueLow;
       sp.a2Total += closeMinusTrueLow;
       sp.a3Total += closeMinusTrueLow;
@@ -1394,55 +1212,27 @@
       if( !((-0.00000000000001 < sp.b3Total) && (sp.b3Total < 0.00000000000001)) ) {
          sp.output += sp.a3Total / sp.b3Total;
       }
-      /* Remove the trailing terms to prepare for next day */
-      tempLT = sp.ring_trailingIdx1_inLow[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1];
-      tempHT = sp.ring_trailingIdx1_inHigh[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1];
-      tempCY = sp.ring_trailingIdx1_inClose[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1 - 1) % sp.ringCap_trailingIdx1];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx1_inClose[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      /* Remove the trailing terms to prepare for next day. Each was evaluated
+       * once, when its bar entered the ring.
+       */
+      sp.a1Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos1];
+      sp.b1Total -= sp.cb_term_trueRange[sp.trailingPos1];
+      sp.trailingPos1 += 1;
+      if( sp.trailingPos1 >= sp.optInTimePeriod3 ) {
+         sp.trailingPos1 = 0;
       }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      sp.a2Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos2];
+      sp.b2Total -= sp.cb_term_trueRange[sp.trailingPos2];
+      sp.trailingPos2 += 1;
+      if( sp.trailingPos2 >= sp.optInTimePeriod3 ) {
+         sp.trailingPos2 = 0;
       }
-      sp.a1Total -= closeMinusTrueLow;
-      sp.b1Total -= trueRange;
-      tempLT = sp.ring_trailingIdx2_inLow[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2];
-      tempHT = sp.ring_trailingIdx2_inHigh[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2];
-      tempCY = sp.ring_trailingIdx2_inClose[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2 - 1) % sp.ringCap_trailingIdx2];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx2_inClose[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      sp.term_Idx = sp.term_Idx + 1;
+      if( sp.term_Idx > sp.maxIdx_term ) {
+         sp.term_Idx = 0;
       }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      sp.a2Total -= closeMinusTrueLow;
-      sp.b2Total -= trueRange;
-      tempLT = sp.ring_trailingIdx3_inLow[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3];
-      tempHT = sp.ring_trailingIdx3_inHigh[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3];
-      tempCY = sp.ring_trailingIdx3_inClose[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3 - 1) % sp.ringCap_trailingIdx3];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx3_inClose[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      sp.a3Total -= closeMinusTrueLow;
-      sp.b3Total -= trueRange;
+      sp.a3Total -= sp.cb_term_closeMinusTrueLow[sp.term_Idx];
+      sp.b3Total -= sp.cb_term_trueRange[sp.term_Idx];
       /* Last operation is to write the output. Must
        * be done after the trailing index have all been
        * taken care of because the caller is allowed
@@ -1452,27 +1242,6 @@
       sp.cur_outReal = 100.0 * (sp.output / 7.0);
       /* Increment indexes */
       sp.lag1_inClose = inClose;
-      sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-      sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-      sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-      sp.ringPos_trailingIdx1 = sp.ringPos_trailingIdx1 + 1;
-      if( sp.ringPos_trailingIdx1 >= sp.ringCap_trailingIdx1 ) {
-         sp.ringPos_trailingIdx1 = 0;
-      }
-      sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-      sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-      sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-      sp.ringPos_trailingIdx2 = sp.ringPos_trailingIdx2 + 1;
-      if( sp.ringPos_trailingIdx2 >= sp.ringCap_trailingIdx2 ) {
-         sp.ringPos_trailingIdx2 = 0;
-      }
-      sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-      sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-      sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
-      sp.ringPos_trailingIdx3 = sp.ringPos_trailingIdx3 + 1;
-      if( sp.ringPos_trailingIdx3 >= sp.ringCap_trailingIdx3 ) {
-         sp.ringPos_trailingIdx3 = 0;
-      }
    }
    private RetCode ultOscOpenBody( UltOscStream sp, double inHigh[], double inLow[], double inClose[], int startIdx, int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3 )
    {
@@ -1497,12 +1266,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       MInteger outBegIdx = new MInteger();
       MInteger outNBElement = new MInteger();
       double lastValue_outReal = 0.0;
@@ -1526,6 +1298,14 @@
       } else if( optInTimePeriod3 < 1 || optInTimePeriod3 > 100000 ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -1561,47 +1341,22 @@
       if( startIdx > endIdx ) {
          return RetCode.OutOfRangeEndIndex ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -1619,15 +1374,36 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -1644,6 +1420,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -1661,55 +1439,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -1720,67 +1468,14 @@
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
       /* Capture the live batch state into the handle. */
-      int capLag_trailingIdx1 = today - trailingIdx1;
-      int cap_trailingIdx1 = capLag_trailingIdx1 + 2;
-      if( capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen ) {
+      int capCb_term = maxIdx_term + 1;
+      if( capCb_term > historyLen + 1 ) {
          return RetCode.InternalError;
-      }
-      int allocN_trailingIdx1 = (cap_trailingIdx1 > 0)? cap_trailingIdx1 : 1;
-      double[] capRing_trailingIdx1_inHigh = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inHigh[fillJ % cap_trailingIdx1] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx1_inLow = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inLow[fillJ % cap_trailingIdx1] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx1_inClose = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inClose[fillJ % cap_trailingIdx1] = inClose[fillJ];
-      }
-      int capLag_trailingIdx2 = today - trailingIdx2;
-      int cap_trailingIdx2 = capLag_trailingIdx2 + 2;
-      if( capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx2 = (cap_trailingIdx2 > 0)? cap_trailingIdx2 : 1;
-      double[] capRing_trailingIdx2_inHigh = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inHigh[fillJ % cap_trailingIdx2] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx2_inLow = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inLow[fillJ % cap_trailingIdx2] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx2_inClose = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inClose[fillJ % cap_trailingIdx2] = inClose[fillJ];
-      }
-      int capLag_trailingIdx3 = today - trailingIdx3;
-      int cap_trailingIdx3 = capLag_trailingIdx3 + 2;
-      if( capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx3 = (cap_trailingIdx3 > 0)? cap_trailingIdx3 : 1;
-      double[] capRing_trailingIdx3_inHigh = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inHigh[fillJ % cap_trailingIdx3] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx3_inLow = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inLow[fillJ % cap_trailingIdx3] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx3_inClose = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inClose[fillJ % cap_trailingIdx3] = inClose[fillJ];
       }
       sp.optInTimePeriod1 = optInTimePeriod1;
       sp.optInTimePeriod2 = optInTimePeriod2;
@@ -1792,25 +1487,14 @@
       sp.b2Total = b2Total;
       sp.b3Total = b3Total;
       sp.output = output;
+      sp.trailingPos1 = trailingPos1;
+      sp.trailingPos2 = trailingPos2;
+      sp.term_Idx = term_Idx;
+      sp.maxIdx_term = maxIdx_term;
       sp.lag1_inClose = inClose[historyLen - 1];
-      sp.ringPos_trailingIdx1 = historyLen % cap_trailingIdx1;
-      sp.ringCap_trailingIdx1 = cap_trailingIdx1;
-      sp.ringLag_trailingIdx1 = capLag_trailingIdx1;
-      sp.ring_trailingIdx1_inHigh = capRing_trailingIdx1_inHigh;
-      sp.ring_trailingIdx1_inLow = capRing_trailingIdx1_inLow;
-      sp.ring_trailingIdx1_inClose = capRing_trailingIdx1_inClose;
-      sp.ringPos_trailingIdx2 = historyLen % cap_trailingIdx2;
-      sp.ringCap_trailingIdx2 = cap_trailingIdx2;
-      sp.ringLag_trailingIdx2 = capLag_trailingIdx2;
-      sp.ring_trailingIdx2_inHigh = capRing_trailingIdx2_inHigh;
-      sp.ring_trailingIdx2_inLow = capRing_trailingIdx2_inLow;
-      sp.ring_trailingIdx2_inClose = capRing_trailingIdx2_inClose;
-      sp.ringPos_trailingIdx3 = historyLen % cap_trailingIdx3;
-      sp.ringCap_trailingIdx3 = cap_trailingIdx3;
-      sp.ringLag_trailingIdx3 = capLag_trailingIdx3;
-      sp.ring_trailingIdx3_inHigh = capRing_trailingIdx3_inHigh;
-      sp.ring_trailingIdx3_inLow = capRing_trailingIdx3_inLow;
-      sp.ring_trailingIdx3_inClose = capRing_trailingIdx3_inClose;
+      sp.cbSize_term = capCb_term;
+      sp.cb_term_closeMinusTrueLow = term_closeMinusTrueLow;
+      sp.cb_term_trueRange = term_trueRange;
       sp.cur_outReal = lastValue_outReal;
       return RetCode.Success;
    }
@@ -1837,12 +1521,15 @@
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       int historyLen = inHigh.length;
       int endIdx = historyLen - 1;
       int startIdx = 0;
@@ -1867,6 +1554,14 @@
       if( (Object)outReal == (Object)inHigh || (Object)outReal == (Object)inLow || (Object)outReal == (Object)inClose ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -1902,47 +1597,22 @@
       if( startIdx > endIdx ) {
          return RetCode.OutOfRangeEndIndex ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -1960,15 +1630,36 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -1985,6 +1676,8 @@
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -2002,55 +1695,25 @@
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -2061,67 +1724,14 @@
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
       /* Capture the live batch state into the handle. */
-      int capLag_trailingIdx1 = today - trailingIdx1;
-      int cap_trailingIdx1 = capLag_trailingIdx1 + 2;
-      if( capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen ) {
+      int capCb_term = maxIdx_term + 1;
+      if( capCb_term > historyLen + 1 ) {
          return RetCode.InternalError;
-      }
-      int allocN_trailingIdx1 = (cap_trailingIdx1 > 0)? cap_trailingIdx1 : 1;
-      double[] capRing_trailingIdx1_inHigh = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inHigh[fillJ % cap_trailingIdx1] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx1_inLow = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inLow[fillJ % cap_trailingIdx1] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx1_inClose = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inClose[fillJ % cap_trailingIdx1] = inClose[fillJ];
-      }
-      int capLag_trailingIdx2 = today - trailingIdx2;
-      int cap_trailingIdx2 = capLag_trailingIdx2 + 2;
-      if( capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx2 = (cap_trailingIdx2 > 0)? cap_trailingIdx2 : 1;
-      double[] capRing_trailingIdx2_inHigh = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inHigh[fillJ % cap_trailingIdx2] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx2_inLow = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inLow[fillJ % cap_trailingIdx2] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx2_inClose = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inClose[fillJ % cap_trailingIdx2] = inClose[fillJ];
-      }
-      int capLag_trailingIdx3 = today - trailingIdx3;
-      int cap_trailingIdx3 = capLag_trailingIdx3 + 2;
-      if( capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx3 = (cap_trailingIdx3 > 0)? cap_trailingIdx3 : 1;
-      double[] capRing_trailingIdx3_inHigh = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inHigh[fillJ % cap_trailingIdx3] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx3_inLow = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inLow[fillJ % cap_trailingIdx3] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx3_inClose = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inClose[fillJ % cap_trailingIdx3] = inClose[fillJ];
       }
       sp.optInTimePeriod1 = optInTimePeriod1;
       sp.optInTimePeriod2 = optInTimePeriod2;
@@ -2133,25 +1743,14 @@
       sp.b2Total = b2Total;
       sp.b3Total = b3Total;
       sp.output = output;
+      sp.trailingPos1 = trailingPos1;
+      sp.trailingPos2 = trailingPos2;
+      sp.term_Idx = term_Idx;
+      sp.maxIdx_term = maxIdx_term;
       sp.lag1_inClose = inClose[historyLen - 1];
-      sp.ringPos_trailingIdx1 = historyLen % cap_trailingIdx1;
-      sp.ringCap_trailingIdx1 = cap_trailingIdx1;
-      sp.ringLag_trailingIdx1 = capLag_trailingIdx1;
-      sp.ring_trailingIdx1_inHigh = capRing_trailingIdx1_inHigh;
-      sp.ring_trailingIdx1_inLow = capRing_trailingIdx1_inLow;
-      sp.ring_trailingIdx1_inClose = capRing_trailingIdx1_inClose;
-      sp.ringPos_trailingIdx2 = historyLen % cap_trailingIdx2;
-      sp.ringCap_trailingIdx2 = cap_trailingIdx2;
-      sp.ringLag_trailingIdx2 = capLag_trailingIdx2;
-      sp.ring_trailingIdx2_inHigh = capRing_trailingIdx2_inHigh;
-      sp.ring_trailingIdx2_inLow = capRing_trailingIdx2_inLow;
-      sp.ring_trailingIdx2_inClose = capRing_trailingIdx2_inClose;
-      sp.ringPos_trailingIdx3 = historyLen % cap_trailingIdx3;
-      sp.ringCap_trailingIdx3 = cap_trailingIdx3;
-      sp.ringLag_trailingIdx3 = capLag_trailingIdx3;
-      sp.ring_trailingIdx3_inHigh = capRing_trailingIdx3_inHigh;
-      sp.ring_trailingIdx3_inLow = capRing_trailingIdx3_inLow;
-      sp.ring_trailingIdx3_inClose = capRing_trailingIdx3_inClose;
+      sp.cbSize_term = capCb_term;
+      sp.cb_term_closeMinusTrueLow = term_closeMinusTrueLow;
+      sp.cb_term_trueRange = term_trueRange;
       sp.cur_outReal = outReal[outNBElement.value - 1];
       return RetCode.Success;
    }

--- a/ta_codegen/output/java/library/src/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/io/github/talib/Core.java
@@ -177932,6 +177932,9 @@ public class Core {
  *  -------------------------------------------------------------------
  *  281206 DM   Initial Implementation
  *  010606 MF   Abstract local arrays. Detect divide by zero.
+ *  073126 DX   Evaluate each bar's true range and close-minus-true-low once
+ *              instead of four times, keeping them in a CIRCBUF sized to the
+ *              longest period. Same values, same summation order, bit-exact.
  */
 
    /**
@@ -178007,12 +178010,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       if( startIdx < 0 ) {
          return RetCode.OutOfRangeStartIndex ;
       }
@@ -178034,6 +178040,14 @@ public class Core {
       } else if( optInTimePeriod3 < 1 || optInTimePeriod3 > 100000 ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -178069,47 +178083,22 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -178127,15 +178116,36 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -178152,6 +178162,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -178169,55 +178181,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -178228,9 +178210,6 @@ public class Core {
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
@@ -178270,12 +178249,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       outBegIdx.value = 0;
       outNBElement.value = 0;
       periods[0] = optInTimePeriod1;
@@ -178306,46 +178288,15 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -178363,14 +178314,31 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = inLow[today];
          tempHT = inHigh[today];
@@ -178386,6 +178354,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -178402,60 +178372,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -178494,12 +178429,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       if( startIdx < 0 ) {
          return RetCode.OutOfRangeStartIndex ;
       }
@@ -178551,46 +178489,15 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -178608,14 +178515,31 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = (double)inLow[today];
          tempHT = (double)inHigh[today];
@@ -178631,6 +178555,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -178647,60 +178573,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = (double)inLow[trailingIdx1];
-         tempHT = (double)inHigh[trailingIdx1];
-         tempCY = (double)inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx2];
-         tempHT = (double)inHigh[trailingIdx2];
-         tempCY = (double)inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx3];
-         tempHT = (double)inHigh[trailingIdx3];
-         tempCY = (double)inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -178739,12 +178630,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       outBegIdx.value = 0;
       outNBElement.value = 0;
       periods[0] = optInTimePeriod1;
@@ -178775,46 +178669,15 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.Success ;
       }
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = (double)inLow[i];
-         tempHT = (double)inHigh[i];
-         tempCY = (double)inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -178832,14 +178695,31 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          tempLT = (double)inLow[today];
          tempHT = (double)inHigh[today];
@@ -178855,6 +178735,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -178871,60 +178753,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         tempLT = (double)inLow[trailingIdx1];
-         tempHT = (double)inHigh[trailingIdx1];
-         tempCY = (double)inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx2];
-         tempHT = (double)inHigh[trailingIdx2];
-         tempCY = (double)inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = (double)inLow[trailingIdx3];
-         tempHT = (double)inHigh[trailingIdx3];
-         tempCY = (double)inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = (double)inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          outReal[outIdx] = 100.0 * (output / 7.0);
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
@@ -179161,25 +179008,14 @@ public class Core {
       double b2Total;
       double b3Total;
       double output;
+      int trailingPos1;
+      int trailingPos2;
+      int term_Idx;
+      int maxIdx_term;
       double lag1_inClose;
-      int ringPos_trailingIdx1;
-      int ringCap_trailingIdx1;
-      int ringLag_trailingIdx1;
-      double[] ring_trailingIdx1_inHigh;
-      double[] ring_trailingIdx1_inLow;
-      double[] ring_trailingIdx1_inClose;
-      int ringPos_trailingIdx2;
-      int ringCap_trailingIdx2;
-      int ringLag_trailingIdx2;
-      double[] ring_trailingIdx2_inHigh;
-      double[] ring_trailingIdx2_inLow;
-      double[] ring_trailingIdx2_inClose;
-      int ringPos_trailingIdx3;
-      int ringCap_trailingIdx3;
-      int ringLag_trailingIdx3;
-      double[] ring_trailingIdx3_inHigh;
-      double[] ring_trailingIdx3_inLow;
-      double[] ring_trailingIdx3_inClose;
+      int cbSize_term;
+      double[] cb_term_closeMinusTrueLow;
+      double[] cb_term_trueRange;
       double cur_outReal;
       OutRange fillRange;
 
@@ -179203,25 +179039,14 @@ public class Core {
          this.b2Total = other.b2Total;
          this.b3Total = other.b3Total;
          this.output = other.output;
+         this.trailingPos1 = other.trailingPos1;
+         this.trailingPos2 = other.trailingPos2;
+         this.term_Idx = other.term_Idx;
+         this.maxIdx_term = other.maxIdx_term;
          this.lag1_inClose = other.lag1_inClose;
-         this.ringPos_trailingIdx1 = other.ringPos_trailingIdx1;
-         this.ringCap_trailingIdx1 = other.ringCap_trailingIdx1;
-         this.ringLag_trailingIdx1 = other.ringLag_trailingIdx1;
-         this.ring_trailingIdx1_inHigh = other.ring_trailingIdx1_inHigh.clone();
-         this.ring_trailingIdx1_inLow = other.ring_trailingIdx1_inLow.clone();
-         this.ring_trailingIdx1_inClose = other.ring_trailingIdx1_inClose.clone();
-         this.ringPos_trailingIdx2 = other.ringPos_trailingIdx2;
-         this.ringCap_trailingIdx2 = other.ringCap_trailingIdx2;
-         this.ringLag_trailingIdx2 = other.ringLag_trailingIdx2;
-         this.ring_trailingIdx2_inHigh = other.ring_trailingIdx2_inHigh.clone();
-         this.ring_trailingIdx2_inLow = other.ring_trailingIdx2_inLow.clone();
-         this.ring_trailingIdx2_inClose = other.ring_trailingIdx2_inClose.clone();
-         this.ringPos_trailingIdx3 = other.ringPos_trailingIdx3;
-         this.ringCap_trailingIdx3 = other.ringCap_trailingIdx3;
-         this.ringLag_trailingIdx3 = other.ringLag_trailingIdx3;
-         this.ring_trailingIdx3_inHigh = other.ring_trailingIdx3_inHigh.clone();
-         this.ring_trailingIdx3_inLow = other.ring_trailingIdx3_inLow.clone();
-         this.ring_trailingIdx3_inClose = other.ring_trailingIdx3_inClose.clone();
+         this.cbSize_term = other.cbSize_term;
+         this.cb_term_closeMinusTrueLow = other.cb_term_closeMinusTrueLow.clone();
+         this.cb_term_trueRange = other.cb_term_trueRange.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -179274,15 +179099,6 @@ public class Core {
       double tempHT = 0.0;
       double tempLT = 0.0;
       double tempCY = 0.0;
-      sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-      sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-      sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-      sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-      sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-      sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-      sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-      sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-      sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
       /* Add on today's terms */
       tempLT = inLow;
       tempHT = inHigh;
@@ -179298,6 +179114,8 @@ public class Core {
       if( tempDouble > trueRange ) {
          trueRange = tempDouble;
       }
+      sp.cb_term_closeMinusTrueLow[sp.term_Idx] = closeMinusTrueLow;
+      sp.cb_term_trueRange[sp.term_Idx] = trueRange;
       sp.a1Total += closeMinusTrueLow;
       sp.a2Total += closeMinusTrueLow;
       sp.a3Total += closeMinusTrueLow;
@@ -179315,55 +179133,27 @@ public class Core {
       if( !((-0.00000000000001 < sp.b3Total) && (sp.b3Total < 0.00000000000001)) ) {
          sp.output += sp.a3Total / sp.b3Total;
       }
-      /* Remove the trailing terms to prepare for next day */
-      tempLT = sp.ring_trailingIdx1_inLow[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1];
-      tempHT = sp.ring_trailingIdx1_inHigh[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1];
-      tempCY = sp.ring_trailingIdx1_inClose[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1 - 1) % sp.ringCap_trailingIdx1];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx1_inClose[(sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      /* Remove the trailing terms to prepare for next day. Each was evaluated
+       * once, when its bar entered the ring.
+       */
+      sp.a1Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos1];
+      sp.b1Total -= sp.cb_term_trueRange[sp.trailingPos1];
+      sp.trailingPos1 += 1;
+      if( sp.trailingPos1 >= sp.optInTimePeriod3 ) {
+         sp.trailingPos1 = 0;
       }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      sp.a2Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos2];
+      sp.b2Total -= sp.cb_term_trueRange[sp.trailingPos2];
+      sp.trailingPos2 += 1;
+      if( sp.trailingPos2 >= sp.optInTimePeriod3 ) {
+         sp.trailingPos2 = 0;
       }
-      sp.a1Total -= closeMinusTrueLow;
-      sp.b1Total -= trueRange;
-      tempLT = sp.ring_trailingIdx2_inLow[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2];
-      tempHT = sp.ring_trailingIdx2_inHigh[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2];
-      tempCY = sp.ring_trailingIdx2_inClose[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2 - 1) % sp.ringCap_trailingIdx2];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx2_inClose[(sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
+      sp.term_Idx = sp.term_Idx + 1;
+      if( sp.term_Idx > sp.maxIdx_term ) {
+         sp.term_Idx = 0;
       }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      sp.a2Total -= closeMinusTrueLow;
-      sp.b2Total -= trueRange;
-      tempLT = sp.ring_trailingIdx3_inLow[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3];
-      tempHT = sp.ring_trailingIdx3_inHigh[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3];
-      tempCY = sp.ring_trailingIdx3_inClose[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3 - 1) % sp.ringCap_trailingIdx3];
-      trueLow = Math.min(tempLT, tempCY);
-      closeMinusTrueLow = sp.ring_trailingIdx3_inClose[(sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3] - trueLow;
-      trueRange = tempHT - tempLT;
-      tempDouble = Math.abs(tempCY - tempHT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      tempDouble = Math.abs(tempCY - tempLT);
-      if( tempDouble > trueRange ) {
-         trueRange = tempDouble;
-      }
-      sp.a3Total -= closeMinusTrueLow;
-      sp.b3Total -= trueRange;
+      sp.a3Total -= sp.cb_term_closeMinusTrueLow[sp.term_Idx];
+      sp.b3Total -= sp.cb_term_trueRange[sp.term_Idx];
       /* Last operation is to write the output. Must
        * be done after the trailing index have all been
        * taken care of because the caller is allowed
@@ -179373,27 +179163,6 @@ public class Core {
       sp.cur_outReal = 100.0 * (sp.output / 7.0);
       /* Increment indexes */
       sp.lag1_inClose = inClose;
-      sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-      sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-      sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-      sp.ringPos_trailingIdx1 = sp.ringPos_trailingIdx1 + 1;
-      if( sp.ringPos_trailingIdx1 >= sp.ringCap_trailingIdx1 ) {
-         sp.ringPos_trailingIdx1 = 0;
-      }
-      sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-      sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-      sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-      sp.ringPos_trailingIdx2 = sp.ringPos_trailingIdx2 + 1;
-      if( sp.ringPos_trailingIdx2 >= sp.ringCap_trailingIdx2 ) {
-         sp.ringPos_trailingIdx2 = 0;
-      }
-      sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-      sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-      sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
-      sp.ringPos_trailingIdx3 = sp.ringPos_trailingIdx3 + 1;
-      if( sp.ringPos_trailingIdx3 >= sp.ringCap_trailingIdx3 ) {
-         sp.ringPos_trailingIdx3 = 0;
-      }
    }
    private RetCode ultOscOpenBody( UltOscStream sp, double inHigh[], double inLow[], double inClose[], int startIdx, int optInTimePeriod1, int optInTimePeriod2, int optInTimePeriod3 )
    {
@@ -179418,12 +179187,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       MInteger outBegIdx = new MInteger();
       MInteger outNBElement = new MInteger();
       double lastValue_outReal = 0.0;
@@ -179447,6 +179219,14 @@ public class Core {
       } else if( optInTimePeriod3 < 1 || optInTimePeriod3 > 100000 ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -179482,47 +179262,22 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.OutOfRangeEndIndex ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -179540,15 +179295,36 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -179565,6 +179341,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -179582,55 +179360,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -179641,67 +179389,14 @@ public class Core {
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
       /* Capture the live batch state into the handle. */
-      int capLag_trailingIdx1 = today - trailingIdx1;
-      int cap_trailingIdx1 = capLag_trailingIdx1 + 2;
-      if( capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen ) {
+      int capCb_term = maxIdx_term + 1;
+      if( capCb_term > historyLen + 1 ) {
          return RetCode.InternalError;
-      }
-      int allocN_trailingIdx1 = (cap_trailingIdx1 > 0)? cap_trailingIdx1 : 1;
-      double[] capRing_trailingIdx1_inHigh = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inHigh[fillJ % cap_trailingIdx1] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx1_inLow = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inLow[fillJ % cap_trailingIdx1] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx1_inClose = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inClose[fillJ % cap_trailingIdx1] = inClose[fillJ];
-      }
-      int capLag_trailingIdx2 = today - trailingIdx2;
-      int cap_trailingIdx2 = capLag_trailingIdx2 + 2;
-      if( capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx2 = (cap_trailingIdx2 > 0)? cap_trailingIdx2 : 1;
-      double[] capRing_trailingIdx2_inHigh = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inHigh[fillJ % cap_trailingIdx2] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx2_inLow = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inLow[fillJ % cap_trailingIdx2] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx2_inClose = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inClose[fillJ % cap_trailingIdx2] = inClose[fillJ];
-      }
-      int capLag_trailingIdx3 = today - trailingIdx3;
-      int cap_trailingIdx3 = capLag_trailingIdx3 + 2;
-      if( capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx3 = (cap_trailingIdx3 > 0)? cap_trailingIdx3 : 1;
-      double[] capRing_trailingIdx3_inHigh = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inHigh[fillJ % cap_trailingIdx3] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx3_inLow = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inLow[fillJ % cap_trailingIdx3] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx3_inClose = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inClose[fillJ % cap_trailingIdx3] = inClose[fillJ];
       }
       sp.optInTimePeriod1 = optInTimePeriod1;
       sp.optInTimePeriod2 = optInTimePeriod2;
@@ -179713,25 +179408,14 @@ public class Core {
       sp.b2Total = b2Total;
       sp.b3Total = b3Total;
       sp.output = output;
+      sp.trailingPos1 = trailingPos1;
+      sp.trailingPos2 = trailingPos2;
+      sp.term_Idx = term_Idx;
+      sp.maxIdx_term = maxIdx_term;
       sp.lag1_inClose = inClose[historyLen - 1];
-      sp.ringPos_trailingIdx1 = historyLen % cap_trailingIdx1;
-      sp.ringCap_trailingIdx1 = cap_trailingIdx1;
-      sp.ringLag_trailingIdx1 = capLag_trailingIdx1;
-      sp.ring_trailingIdx1_inHigh = capRing_trailingIdx1_inHigh;
-      sp.ring_trailingIdx1_inLow = capRing_trailingIdx1_inLow;
-      sp.ring_trailingIdx1_inClose = capRing_trailingIdx1_inClose;
-      sp.ringPos_trailingIdx2 = historyLen % cap_trailingIdx2;
-      sp.ringCap_trailingIdx2 = cap_trailingIdx2;
-      sp.ringLag_trailingIdx2 = capLag_trailingIdx2;
-      sp.ring_trailingIdx2_inHigh = capRing_trailingIdx2_inHigh;
-      sp.ring_trailingIdx2_inLow = capRing_trailingIdx2_inLow;
-      sp.ring_trailingIdx2_inClose = capRing_trailingIdx2_inClose;
-      sp.ringPos_trailingIdx3 = historyLen % cap_trailingIdx3;
-      sp.ringCap_trailingIdx3 = cap_trailingIdx3;
-      sp.ringLag_trailingIdx3 = capLag_trailingIdx3;
-      sp.ring_trailingIdx3_inHigh = capRing_trailingIdx3_inHigh;
-      sp.ring_trailingIdx3_inLow = capRing_trailingIdx3_inLow;
-      sp.ring_trailingIdx3_inClose = capRing_trailingIdx3_inClose;
+      sp.cbSize_term = capCb_term;
+      sp.cb_term_closeMinusTrueLow = term_closeMinusTrueLow;
+      sp.cb_term_trueRange = term_trueRange;
       sp.cur_outReal = lastValue_outReal;
       return RetCode.Success;
    }
@@ -179758,12 +179442,15 @@ public class Core {
       int j = 0;
       int today = 0;
       int outIdx = 0;
-      int trailingIdx1 = 0;
-      int trailingIdx2 = 0;
-      int trailingIdx3 = 0;
+      int trailingPos1 = 0;
+      int trailingPos2 = 0;
       int[] usedFlag = new int[3];
       int[] periods = new int[3];
       int[] sortedPeriods = new int[3];
+      double[] term_closeMinusTrueLow;
+      double[] term_trueRange;
+      int term_Idx = 0;
+      int maxIdx_term = (32)-1;
       int historyLen = inHigh.length;
       int endIdx = historyLen - 1;
       int startIdx = 0;
@@ -179788,6 +179475,14 @@ public class Core {
       if( (Object)outReal == (Object)inHigh || (Object)outReal == (Object)inLow || (Object)outReal == (Object)inClose ) {
          return RetCode.BadParam;
       }
+      /* The two per-bar terms the three moving sums are built from. Both are a
+       * pure function of the bar, so each bar is evaluated once on entry and read
+       * back when it leaves each of the three windows.
+       */
+      /* One entry per bar of the longest window. Stays on the stack for every
+       * period up to 32, which covers the 7/14/28 default.
+       */
+      /* Id, Type, Static Size */
       outBegIdx.value = 0;
       outNBElement.value = 0;
       /* Ensure that the time periods are ordered from shortest to longest.
@@ -179823,47 +179518,22 @@ public class Core {
       if( startIdx > endIdx ) {
          return RetCode.OutOfRangeEndIndex ;
       }
-      /* Prime running totals used in moving averages */
+      if( optInTimePeriod3 < 1 ) return RetCode.AllocErr;
+      term_closeMinusTrueLow = new double[optInTimePeriod3];
+      term_trueRange = new double[optInTimePeriod3];
+      maxIdx_term = (optInTimePeriod3)-1;
+      term_Idx = 0;
+      /* Prime running totals used in moving averages.
+       *
+       * One pass over the longest warm-up window replaces three overlapping
+       * passes. A bar inside the shorter windows is added to those totals as it
+       * is reached, so every total still accumulates exactly the same bars in
+       * exactly the same ascending order as three separate loops did.
+       */
       a1Total = 0;
       b1Total = 0;
-      for( i = startIdx - optInTimePeriod1 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a1Total += closeMinusTrueLow;
-         b1Total += trueRange;
-      }
       a2Total = 0;
       b2Total = 0;
-      for( i = startIdx - optInTimePeriod2 + 1; i < startIdx; i += 1 ) {
-         tempLT = inLow[i];
-         tempHT = inHigh[i];
-         tempCY = inClose[i - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[i] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total += closeMinusTrueLow;
-         b2Total += trueRange;
-      }
       a3Total = 0;
       b3Total = 0;
       for( i = startIdx - optInTimePeriod3 + 1; i < startIdx; i += 1 ) {
@@ -179881,15 +179551,36 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         if( i >= startIdx - optInTimePeriod1 + 1 ) {
+            a1Total += closeMinusTrueLow;
+            b1Total += trueRange;
+         }
+         if( i >= startIdx - optInTimePeriod2 + 1 ) {
+            a2Total += closeMinusTrueLow;
+            b2Total += trueRange;
+         }
          a3Total += closeMinusTrueLow;
          b3Total += trueRange;
       }
       /* Calculate oscillator */
       today = startIdx;
       outIdx = 0;
-      trailingIdx1 = today - optInTimePeriod1 + 1;
-      trailingIdx2 = today - optInTimePeriod2 + 1;
-      trailingIdx3 = today - optInTimePeriod3 + 1;
+      /* The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+       * `today` and, once advanced past it, the slot of the bar leaving the
+       * longest window. The two shorter windows trail it by a fixed offset.
+       */
+      trailingPos1 = term_Idx + optInTimePeriod3 - optInTimePeriod1 + 1;
+      if( trailingPos1 >= optInTimePeriod3 ) {
+         trailingPos1 -= optInTimePeriod3;
+      }
+      trailingPos2 = term_Idx + optInTimePeriod3 - optInTimePeriod2 + 1;
+      if( trailingPos2 >= optInTimePeriod3 ) {
+         trailingPos2 -= optInTimePeriod3;
+      }
       while( today <= endIdx ) {
          /* Add on today's terms */
          tempLT = inLow[today];
@@ -179906,6 +179597,8 @@ public class Core {
          if( tempDouble > trueRange ) {
             trueRange = tempDouble;
          }
+         term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+         term_trueRange[term_Idx] = trueRange;
          a1Total += closeMinusTrueLow;
          a2Total += closeMinusTrueLow;
          a3Total += closeMinusTrueLow;
@@ -179923,55 +179616,25 @@ public class Core {
          if( !((-0.00000000000001 < b3Total) && (b3Total < 0.00000000000001)) ) {
             output += a3Total / b3Total;
          }
-         /* Remove the trailing terms to prepare for next day */
-         tempLT = inLow[trailingIdx1];
-         tempHT = inHigh[trailingIdx1];
-         tempCY = inClose[trailingIdx1 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         /* Remove the trailing terms to prepare for next day. Each was evaluated
+          * once, when its bar entered the ring.
+          */
+         a1Total -= term_closeMinusTrueLow[trailingPos1];
+         b1Total -= term_trueRange[trailingPos1];
+         trailingPos1 += 1;
+         if( trailingPos1 >= optInTimePeriod3 ) {
+            trailingPos1 = 0;
          }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
+         a2Total -= term_closeMinusTrueLow[trailingPos2];
+         b2Total -= term_trueRange[trailingPos2];
+         trailingPos2 += 1;
+         if( trailingPos2 >= optInTimePeriod3 ) {
+            trailingPos2 = 0;
          }
-         a1Total -= closeMinusTrueLow;
-         b1Total -= trueRange;
-         tempLT = inLow[trailingIdx2];
-         tempHT = inHigh[trailingIdx2];
-         tempCY = inClose[trailingIdx2 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a2Total -= closeMinusTrueLow;
-         b2Total -= trueRange;
-         tempLT = inLow[trailingIdx3];
-         tempHT = inHigh[trailingIdx3];
-         tempCY = inClose[trailingIdx3 - 1];
-         trueLow = Math.min(tempLT, tempCY);
-         closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-         trueRange = tempHT - tempLT;
-         tempDouble = Math.abs(tempCY - tempHT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         tempDouble = Math.abs(tempCY - tempLT);
-         if( tempDouble > trueRange ) {
-            trueRange = tempDouble;
-         }
-         a3Total -= closeMinusTrueLow;
-         b3Total -= trueRange;
+         term_Idx++;
+         if( term_Idx > maxIdx_term ) { term_Idx = 0; }
+         a3Total -= term_closeMinusTrueLow[term_Idx];
+         b3Total -= term_trueRange[term_Idx];
          /* Last operation is to write the output. Must
           * be done after the trailing index have all been
           * taken care of because the caller is allowed
@@ -179982,67 +179645,14 @@ public class Core {
          /* Increment indexes */
          outIdx += 1;
          today += 1;
-         trailingIdx1 += 1;
-         trailingIdx2 += 1;
-         trailingIdx3 += 1;
       }
       /* All done. Indicate the output limits and return. */
       outNBElement.value = outIdx;
       outBegIdx.value = startIdx;
       /* Capture the live batch state into the handle. */
-      int capLag_trailingIdx1 = today - trailingIdx1;
-      int cap_trailingIdx1 = capLag_trailingIdx1 + 2;
-      if( capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen ) {
+      int capCb_term = maxIdx_term + 1;
+      if( capCb_term > historyLen + 1 ) {
          return RetCode.InternalError;
-      }
-      int allocN_trailingIdx1 = (cap_trailingIdx1 > 0)? cap_trailingIdx1 : 1;
-      double[] capRing_trailingIdx1_inHigh = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inHigh[fillJ % cap_trailingIdx1] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx1_inLow = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inLow[fillJ % cap_trailingIdx1] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx1_inClose = new double[allocN_trailingIdx1];
-      for( int fillJ = historyLen - cap_trailingIdx1; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx1_inClose[fillJ % cap_trailingIdx1] = inClose[fillJ];
-      }
-      int capLag_trailingIdx2 = today - trailingIdx2;
-      int cap_trailingIdx2 = capLag_trailingIdx2 + 2;
-      if( capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx2 = (cap_trailingIdx2 > 0)? cap_trailingIdx2 : 1;
-      double[] capRing_trailingIdx2_inHigh = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inHigh[fillJ % cap_trailingIdx2] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx2_inLow = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inLow[fillJ % cap_trailingIdx2] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx2_inClose = new double[allocN_trailingIdx2];
-      for( int fillJ = historyLen - cap_trailingIdx2; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx2_inClose[fillJ % cap_trailingIdx2] = inClose[fillJ];
-      }
-      int capLag_trailingIdx3 = today - trailingIdx3;
-      int cap_trailingIdx3 = capLag_trailingIdx3 + 2;
-      if( capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen ) {
-         return RetCode.InternalError;
-      }
-      int allocN_trailingIdx3 = (cap_trailingIdx3 > 0)? cap_trailingIdx3 : 1;
-      double[] capRing_trailingIdx3_inHigh = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inHigh[fillJ % cap_trailingIdx3] = inHigh[fillJ];
-      }
-      double[] capRing_trailingIdx3_inLow = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inLow[fillJ % cap_trailingIdx3] = inLow[fillJ];
-      }
-      double[] capRing_trailingIdx3_inClose = new double[allocN_trailingIdx3];
-      for( int fillJ = historyLen - cap_trailingIdx3; fillJ < historyLen; fillJ++ ) {
-         capRing_trailingIdx3_inClose[fillJ % cap_trailingIdx3] = inClose[fillJ];
       }
       sp.optInTimePeriod1 = optInTimePeriod1;
       sp.optInTimePeriod2 = optInTimePeriod2;
@@ -180054,25 +179664,14 @@ public class Core {
       sp.b2Total = b2Total;
       sp.b3Total = b3Total;
       sp.output = output;
+      sp.trailingPos1 = trailingPos1;
+      sp.trailingPos2 = trailingPos2;
+      sp.term_Idx = term_Idx;
+      sp.maxIdx_term = maxIdx_term;
       sp.lag1_inClose = inClose[historyLen - 1];
-      sp.ringPos_trailingIdx1 = historyLen % cap_trailingIdx1;
-      sp.ringCap_trailingIdx1 = cap_trailingIdx1;
-      sp.ringLag_trailingIdx1 = capLag_trailingIdx1;
-      sp.ring_trailingIdx1_inHigh = capRing_trailingIdx1_inHigh;
-      sp.ring_trailingIdx1_inLow = capRing_trailingIdx1_inLow;
-      sp.ring_trailingIdx1_inClose = capRing_trailingIdx1_inClose;
-      sp.ringPos_trailingIdx2 = historyLen % cap_trailingIdx2;
-      sp.ringCap_trailingIdx2 = cap_trailingIdx2;
-      sp.ringLag_trailingIdx2 = capLag_trailingIdx2;
-      sp.ring_trailingIdx2_inHigh = capRing_trailingIdx2_inHigh;
-      sp.ring_trailingIdx2_inLow = capRing_trailingIdx2_inLow;
-      sp.ring_trailingIdx2_inClose = capRing_trailingIdx2_inClose;
-      sp.ringPos_trailingIdx3 = historyLen % cap_trailingIdx3;
-      sp.ringCap_trailingIdx3 = cap_trailingIdx3;
-      sp.ringLag_trailingIdx3 = capLag_trailingIdx3;
-      sp.ring_trailingIdx3_inHigh = capRing_trailingIdx3_inHigh;
-      sp.ring_trailingIdx3_inLow = capRing_trailingIdx3_inLow;
-      sp.ring_trailingIdx3_inClose = capRing_trailingIdx3_inClose;
+      sp.cbSize_term = capCb_term;
+      sp.cb_term_closeMinusTrueLow = term_closeMinusTrueLow;
+      sp.cb_term_trueRange = term_trueRange;
       sp.cur_outReal = outReal[outNBElement.value - 1];
       return RetCode.Success;
    }

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -52,6 +52,9 @@
  *  -------------------------------------------------------------------
  *  281206 DM   Initial Implementation
  *  010606 MF   Abstract local arrays. Detect divide by zero.
+ *  073126 DX   Evaluate each bar's true range and close-minus-true-low once
+ *              instead of four times, keeping them in a CIRCBUF sized to the
+ *              longest period. Same values, same summation order, bit-exact.
  */
 
 // Import types from parent module
@@ -235,12 +238,21 @@ impl Core {
         let mut j: usize = 0_usize;
         let mut today: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
-        let mut trailingIdx1: usize = 0_usize;
-        let mut trailingIdx2: usize = 0_usize;
-        let mut trailingIdx3: usize = 0_usize;
+        let mut trailingPos1: usize = 0_usize;
+        let mut trailingPos2: usize = 0_usize;
         let mut usedFlag: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut periods: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut sortedPeriods: [i32; 3 as usize] = [0i32; 3 as usize];
+        let mut term_closeMinusTrueLow: Vec<f64> = Vec::new();
+        let mut term_trueRange: Vec<f64> = Vec::new();
+        let mut term_Idx: usize = 0;
+        let mut maxIdx_term: usize = 31;
+        // The two per-bar terms the three moving sums are built from. Both are a
+        // pure function of the bar, so each bar is evaluated once on entry and read
+        // back when it leaves each of the three windows.
+        // One entry per bar of the longest window. Stays on the stack for every
+        // period up to 32, which covers the 7/14/28 default.
+        // Id, Type, Static Size
         (*outBegIdx) = 0;
         (*outNBElement) = 0;
         // Ensure that the time periods are ordered from shortest to longest.
@@ -281,53 +293,21 @@ impl Core {
         if startIdx > endIdx {
             return RetCode::Success;
         }
-        // Prime running totals used in moving averages
+        if optInTimePeriod3 < 1 { return RetCode::AllocErr; }
+        term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
+        term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+        maxIdx_term = ((optInTimePeriod3) as usize) - 1;
+        term_Idx = 0;
+        // Prime running totals used in moving averages.
+        //
+        // One pass over the longest warm-up window replaces three overlapping
+        // passes. A bar inside the shorter windows is added to those totals as it
+        // is reached, so every total still accumulates exactly the same bars in
+        // exactly the same ascending order as three separate loops did.
         a1Total = 0.0;
         b1Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod1) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod1) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a1Total += closeMinusTrueLow;
-            b1Total += trueRange;
-            i += 1;
-        }
         a2Total = 0.0;
         b2Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod2) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod2) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total += closeMinusTrueLow;
-            b2Total += trueRange;
-            i += 1;
-        }
         a3Total = 0.0;
         b3Total = 0.0;
         // for( i = startIdx - (optInTimePeriod3) as usize + 1; i < startIdx; i += 1 )
@@ -347,6 +327,18 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            if i >= startIdx - (optInTimePeriod1) as usize + 1 {
+                a1Total += closeMinusTrueLow;
+                b1Total += trueRange;
+            }
+            if i >= startIdx - (optInTimePeriod2) as usize + 1 {
+                a2Total += closeMinusTrueLow;
+                b2Total += trueRange;
+            }
             a3Total += closeMinusTrueLow;
             b3Total += trueRange;
             i += 1;
@@ -354,9 +346,17 @@ impl Core {
         // Calculate oscillator
         today = startIdx;
         outIdx = 0;
-        trailingIdx1 = today - (optInTimePeriod1) as usize + 1;
-        trailingIdx2 = today - (optInTimePeriod2) as usize + 1;
-        trailingIdx3 = today - (optInTimePeriod3) as usize + 1;
+        // The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+        // `today` and, once advanced past it, the slot of the bar leaving the
+        // longest window. The two shorter windows trail it by a fixed offset.
+        trailingPos1 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod1) as usize + 1;
+        if trailingPos1 >= (optInTimePeriod3) as usize {
+            trailingPos1 -= optInTimePeriod3;
+        }
+        trailingPos2 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod2) as usize + 1;
+        if trailingPos2 >= (optInTimePeriod3) as usize {
+            trailingPos2 -= optInTimePeriod3;
+        }
         while today <= endIdx {
             // Add on today's terms
             tempLT = inLow[today];
@@ -373,6 +373,8 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
             a1Total += closeMinusTrueLow;
             a2Total += closeMinusTrueLow;
             a3Total += closeMinusTrueLow;
@@ -390,55 +392,24 @@ impl Core {
             if !((b3Total).abs() < 1e-14) {
                 output += a3Total / b3Total;
             }
-            // Remove the trailing terms to prepare for next day
-            tempLT = inLow[trailingIdx1];
-            tempHT = inHigh[trailingIdx1];
-            tempCY = inClose[trailingIdx1 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            // Remove the trailing terms to prepare for next day. Each was evaluated
+            // once, when its bar entered the ring.
+            a1Total -= term_closeMinusTrueLow[trailingPos1];
+            b1Total -= term_trueRange[trailingPos1];
+            trailingPos1 += 1;
+            if trailingPos1 >= (optInTimePeriod3) as usize {
+                trailingPos1 = 0;
             }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            a2Total -= term_closeMinusTrueLow[trailingPos2];
+            b2Total -= term_trueRange[trailingPos2];
+            trailingPos2 += 1;
+            if trailingPos2 >= (optInTimePeriod3) as usize {
+                trailingPos2 = 0;
             }
-            a1Total -= closeMinusTrueLow;
-            b1Total -= trueRange;
-            tempLT = inLow[trailingIdx2];
-            tempHT = inHigh[trailingIdx2];
-            tempCY = inClose[trailingIdx2 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total -= closeMinusTrueLow;
-            b2Total -= trueRange;
-            tempLT = inLow[trailingIdx3];
-            tempHT = inHigh[trailingIdx3];
-            tempCY = inClose[trailingIdx3 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a3Total -= closeMinusTrueLow;
-            b3Total -= trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            a3Total -= term_closeMinusTrueLow[term_Idx];
+            b3Total -= term_trueRange[term_Idx];
             // Last operation is to write the output. Must
             // be done after the trailing index have all been
             // taken care of because the caller is allowed
@@ -448,9 +419,6 @@ impl Core {
             // Increment indexes
             outIdx += 1;
             today += 1;
-            trailingIdx1 += 1;
-            trailingIdx2 += 1;
-            trailingIdx3 += 1;
         }
         // All done. Indicate the output limits and return.
         (*outNBElement) = outIdx;
@@ -499,12 +467,15 @@ impl Core {
         let mut j: usize = 0_usize;
         let mut today: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
-        let mut trailingIdx1: usize = 0_usize;
-        let mut trailingIdx2: usize = 0_usize;
-        let mut trailingIdx3: usize = 0_usize;
+        let mut trailingPos1: usize = 0_usize;
+        let mut trailingPos2: usize = 0_usize;
         let mut usedFlag: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut periods: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut sortedPeriods: [i32; 3 as usize] = [0i32; 3 as usize];
+        let mut term_closeMinusTrueLow: Vec<f64> = Vec::new();
+        let mut term_trueRange: Vec<f64> = Vec::new();
+        let mut term_Idx: usize = 0;
+        let mut maxIdx_term: usize = 31;
         assert!(endIdx < inHigh.len());
         assert!(endIdx < inLow.len());
         assert!(endIdx < inClose.len());
@@ -547,52 +518,15 @@ impl Core {
         if startIdx > endIdx {
             return RetCode::Success;
         }
+        if optInTimePeriod3 < 1 { return RetCode::AllocErr; }
+        term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
+        term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+        maxIdx_term = ((optInTimePeriod3) as usize) - 1;
+        term_Idx = 0;
         a1Total = 0.0;
         b1Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod1) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod1) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a1Total += closeMinusTrueLow;
-            b1Total += trueRange;
-            i += 1;
-        }
         a2Total = 0.0;
         b2Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod2) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod2) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total += closeMinusTrueLow;
-            b2Total += trueRange;
-            i += 1;
-        }
         a3Total = 0.0;
         b3Total = 0.0;
         // for( i = startIdx - (optInTimePeriod3) as usize + 1; i < startIdx; i += 1 )
@@ -612,15 +546,32 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            if i >= startIdx - (optInTimePeriod1) as usize + 1 {
+                a1Total += closeMinusTrueLow;
+                b1Total += trueRange;
+            }
+            if i >= startIdx - (optInTimePeriod2) as usize + 1 {
+                a2Total += closeMinusTrueLow;
+                b2Total += trueRange;
+            }
             a3Total += closeMinusTrueLow;
             b3Total += trueRange;
             i += 1;
         }
         today = startIdx;
         outIdx = 0;
-        trailingIdx1 = today - (optInTimePeriod1) as usize + 1;
-        trailingIdx2 = today - (optInTimePeriod2) as usize + 1;
-        trailingIdx3 = today - (optInTimePeriod3) as usize + 1;
+        trailingPos1 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod1) as usize + 1;
+        if trailingPos1 >= (optInTimePeriod3) as usize {
+            trailingPos1 -= optInTimePeriod3;
+        }
+        trailingPos2 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod2) as usize + 1;
+        if trailingPos2 >= (optInTimePeriod3) as usize {
+            trailingPos2 -= optInTimePeriod3;
+        }
         while today <= endIdx {
             tempLT = inLow[today];
             tempHT = inHigh[today];
@@ -636,6 +587,8 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
             a1Total += closeMinusTrueLow;
             a2Total += closeMinusTrueLow;
             a3Total += closeMinusTrueLow;
@@ -652,60 +605,25 @@ impl Core {
             if !((b3Total).abs() < 1e-14) {
                 output += a3Total / b3Total;
             }
-            tempLT = inLow[trailingIdx1];
-            tempHT = inHigh[trailingIdx1];
-            tempCY = inClose[trailingIdx1 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            a1Total -= term_closeMinusTrueLow[trailingPos1];
+            b1Total -= term_trueRange[trailingPos1];
+            trailingPos1 += 1;
+            if trailingPos1 >= (optInTimePeriod3) as usize {
+                trailingPos1 = 0;
             }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            a2Total -= term_closeMinusTrueLow[trailingPos2];
+            b2Total -= term_trueRange[trailingPos2];
+            trailingPos2 += 1;
+            if trailingPos2 >= (optInTimePeriod3) as usize {
+                trailingPos2 = 0;
             }
-            a1Total -= closeMinusTrueLow;
-            b1Total -= trueRange;
-            tempLT = inLow[trailingIdx2];
-            tempHT = inHigh[trailingIdx2];
-            tempCY = inClose[trailingIdx2 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total -= closeMinusTrueLow;
-            b2Total -= trueRange;
-            tempLT = inLow[trailingIdx3];
-            tempHT = inHigh[trailingIdx3];
-            tempCY = inClose[trailingIdx3 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a3Total -= closeMinusTrueLow;
-            b3Total -= trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            a3Total -= term_closeMinusTrueLow[term_Idx];
+            b3Total -= term_trueRange[term_Idx];
             outReal[outIdx] = 100.0 * (output / 7.0);
             outIdx += 1;
             today += 1;
-            trailingIdx1 += 1;
-            trailingIdx2 += 1;
-            trailingIdx3 += 1;
         }
         (*outNBElement) = outIdx;
         (*outBegIdx) = startIdx;
@@ -738,25 +656,14 @@ struct UltoscStreamState {
     b2Total: f64,
     b3Total: f64,
     output: f64,
+    trailingPos1: usize,
+    trailingPos2: usize,
+    term_Idx: usize,
+    maxIdx_term: usize,
     lag1_inClose: f64,
-    ringPos_trailingIdx1: usize,
-    ringCap_trailingIdx1: usize,
-    ringLag_trailingIdx1: usize,
-    ring_trailingIdx1_inHigh: Vec<f64>,
-    ring_trailingIdx1_inLow: Vec<f64>,
-    ring_trailingIdx1_inClose: Vec<f64>,
-    ringPos_trailingIdx2: usize,
-    ringCap_trailingIdx2: usize,
-    ringLag_trailingIdx2: usize,
-    ring_trailingIdx2_inHigh: Vec<f64>,
-    ring_trailingIdx2_inLow: Vec<f64>,
-    ring_trailingIdx2_inClose: Vec<f64>,
-    ringPos_trailingIdx3: usize,
-    ringCap_trailingIdx3: usize,
-    ringLag_trailingIdx3: usize,
-    ring_trailingIdx3_inHigh: Vec<f64>,
-    ring_trailingIdx3_inLow: Vec<f64>,
-    ring_trailingIdx3_inClose: Vec<f64>,
+    cbSize_term: usize,
+    cb_term_closeMinusTrueLow: Vec<f64>,
+    cb_term_trueRange: Vec<f64>,
 }
 
 #[allow(non_snake_case)]
@@ -774,15 +681,6 @@ impl Core {
         let mut tempHT: f64 = 0.0_f64;
         let mut tempLT: f64 = 0.0_f64;
         let mut tempCY: f64 = 0.0_f64;
-        sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-        sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-        sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-        sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-        sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-        sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-        sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-        sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-        sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
         // Add on today's terms
         tempLT = inLow;
         tempHT = inHigh;
@@ -798,6 +696,8 @@ impl Core {
         if tempDouble > trueRange {
             trueRange = tempDouble;
         }
+        sp.cb_term_closeMinusTrueLow[sp.term_Idx] = closeMinusTrueLow;
+        sp.cb_term_trueRange[sp.term_Idx] = trueRange;
         sp.a1Total += closeMinusTrueLow;
         sp.a2Total += closeMinusTrueLow;
         sp.a3Total += closeMinusTrueLow;
@@ -815,55 +715,26 @@ impl Core {
         if !((sp.b3Total).abs() < 1e-14) {
             sp.output += sp.a3Total / sp.b3Total;
         }
-        // Remove the trailing terms to prepare for next day
-        tempLT = sp.ring_trailingIdx1_inLow[((sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1) as usize];
-        tempHT = sp.ring_trailingIdx1_inHigh[((sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1) as usize];
-        tempCY = sp.ring_trailingIdx1_inClose[((sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1 - 1) % sp.ringCap_trailingIdx1) as usize];
-        trueLow = (tempLT).min(tempCY);
-        closeMinusTrueLow = sp.ring_trailingIdx1_inClose[((sp.ringPos_trailingIdx1 + sp.ringCap_trailingIdx1 - sp.ringLag_trailingIdx1) % sp.ringCap_trailingIdx1) as usize] - trueLow;
-        trueRange = tempHT - tempLT;
-        tempDouble = (tempCY - tempHT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
+        // Remove the trailing terms to prepare for next day. Each was evaluated
+        // once, when its bar entered the ring.
+        sp.a1Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos1];
+        sp.b1Total -= sp.cb_term_trueRange[sp.trailingPos1];
+        sp.trailingPos1 += 1;
+        if sp.trailingPos1 >= (sp.optInTimePeriod3) as usize {
+            sp.trailingPos1 = 0;
         }
-        tempDouble = (tempCY - tempLT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
+        sp.a2Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos2];
+        sp.b2Total -= sp.cb_term_trueRange[sp.trailingPos2];
+        sp.trailingPos2 += 1;
+        if sp.trailingPos2 >= (sp.optInTimePeriod3) as usize {
+            sp.trailingPos2 = 0;
         }
-        sp.a1Total -= closeMinusTrueLow;
-        sp.b1Total -= trueRange;
-        tempLT = sp.ring_trailingIdx2_inLow[((sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2) as usize];
-        tempHT = sp.ring_trailingIdx2_inHigh[((sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2) as usize];
-        tempCY = sp.ring_trailingIdx2_inClose[((sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2 - 1) % sp.ringCap_trailingIdx2) as usize];
-        trueLow = (tempLT).min(tempCY);
-        closeMinusTrueLow = sp.ring_trailingIdx2_inClose[((sp.ringPos_trailingIdx2 + sp.ringCap_trailingIdx2 - sp.ringLag_trailingIdx2) % sp.ringCap_trailingIdx2) as usize] - trueLow;
-        trueRange = tempHT - tempLT;
-        tempDouble = (tempCY - tempHT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
+        sp.term_Idx = sp.term_Idx + 1;
+        if sp.term_Idx > sp.maxIdx_term {
+            sp.term_Idx = 0;
         }
-        tempDouble = (tempCY - tempLT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
-        }
-        sp.a2Total -= closeMinusTrueLow;
-        sp.b2Total -= trueRange;
-        tempLT = sp.ring_trailingIdx3_inLow[((sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3) as usize];
-        tempHT = sp.ring_trailingIdx3_inHigh[((sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3) as usize];
-        tempCY = sp.ring_trailingIdx3_inClose[((sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3 - 1) % sp.ringCap_trailingIdx3) as usize];
-        trueLow = (tempLT).min(tempCY);
-        closeMinusTrueLow = sp.ring_trailingIdx3_inClose[((sp.ringPos_trailingIdx3 + sp.ringCap_trailingIdx3 - sp.ringLag_trailingIdx3) % sp.ringCap_trailingIdx3) as usize] - trueLow;
-        trueRange = tempHT - tempLT;
-        tempDouble = (tempCY - tempHT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
-        }
-        tempDouble = (tempCY - tempLT).abs();
-        if tempDouble > trueRange {
-            trueRange = tempDouble;
-        }
-        sp.a3Total -= closeMinusTrueLow;
-        sp.b3Total -= trueRange;
+        sp.a3Total -= sp.cb_term_closeMinusTrueLow[sp.term_Idx];
+        sp.b3Total -= sp.cb_term_trueRange[sp.term_Idx];
         // Last operation is to write the output. Must
         // be done after the trailing index have all been
         // taken care of because the caller is allowed
@@ -872,27 +743,6 @@ impl Core {
         (*outReal) = 100.0 * (sp.output / 7.0);
         // Increment indexes
         sp.lag1_inClose = inClose;
-        sp.ring_trailingIdx1_inHigh[sp.ringPos_trailingIdx1] = inHigh;
-        sp.ring_trailingIdx1_inLow[sp.ringPos_trailingIdx1] = inLow;
-        sp.ring_trailingIdx1_inClose[sp.ringPos_trailingIdx1] = inClose;
-        sp.ringPos_trailingIdx1 = sp.ringPos_trailingIdx1 + 1;
-        if sp.ringPos_trailingIdx1 >= sp.ringCap_trailingIdx1 {
-            sp.ringPos_trailingIdx1 = 0;
-        }
-        sp.ring_trailingIdx2_inHigh[sp.ringPos_trailingIdx2] = inHigh;
-        sp.ring_trailingIdx2_inLow[sp.ringPos_trailingIdx2] = inLow;
-        sp.ring_trailingIdx2_inClose[sp.ringPos_trailingIdx2] = inClose;
-        sp.ringPos_trailingIdx2 = sp.ringPos_trailingIdx2 + 1;
-        if sp.ringPos_trailingIdx2 >= sp.ringCap_trailingIdx2 {
-            sp.ringPos_trailingIdx2 = 0;
-        }
-        sp.ring_trailingIdx3_inHigh[sp.ringPos_trailingIdx3] = inHigh;
-        sp.ring_trailingIdx3_inLow[sp.ringPos_trailingIdx3] = inLow;
-        sp.ring_trailingIdx3_inClose[sp.ringPos_trailingIdx3] = inClose;
-        sp.ringPos_trailingIdx3 = sp.ringPos_trailingIdx3 + 1;
-        if sp.ringPos_trailingIdx3 >= sp.ringCap_trailingIdx3 {
-            sp.ringPos_trailingIdx3 = 0;
-        }
     }
 
     /// Internal startIdx-anchored open behind [`Core::ultosc_open`] (composition seam).
@@ -947,12 +797,21 @@ impl Core {
         let mut j: usize = 0_usize;
         let mut today: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
-        let mut trailingIdx1: usize = 0_usize;
-        let mut trailingIdx2: usize = 0_usize;
-        let mut trailingIdx3: usize = 0_usize;
+        let mut trailingPos1: usize = 0_usize;
+        let mut trailingPos2: usize = 0_usize;
         let mut usedFlag: [i32; 3 as usize] = [0_i32; 3 as usize];
         let mut periods: [i32; 3 as usize] = [0_i32; 3 as usize];
         let mut sortedPeriods: [i32; 3 as usize] = [0_i32; 3 as usize];
+        let mut term_closeMinusTrueLow: Vec<f64> = Vec::new();
+        let mut term_trueRange: Vec<f64> = Vec::new();
+        let mut term_Idx: usize = 0;
+        let mut maxIdx_term: usize = 31;
+        // The two per-bar terms the three moving sums are built from. Both are a
+        // pure function of the bar, so each bar is evaluated once on entry and read
+        // back when it leaves each of the three windows.
+        // One entry per bar of the longest window. Stays on the stack for every
+        // period up to 32, which covers the 7/14/28 default.
+        // Id, Type, Static Size
         dummyBegIdx = 0;
         dummyNBElement = 0;
         // Ensure that the time periods are ordered from shortest to longest.
@@ -993,53 +852,21 @@ impl Core {
         if startIdx > endIdx {
             return Err(RetCode::BadParam);
         }
-        // Prime running totals used in moving averages
+        if optInTimePeriod3 < 1 { return Err(RetCode::AllocErr); }
+        term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
+        term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+        maxIdx_term = ((optInTimePeriod3) as usize) - 1;
+        term_Idx = 0;
+        // Prime running totals used in moving averages.
+        //
+        // One pass over the longest warm-up window replaces three overlapping
+        // passes. A bar inside the shorter windows is added to those totals as it
+        // is reached, so every total still accumulates exactly the same bars in
+        // exactly the same ascending order as three separate loops did.
         a1Total = 0.0;
         b1Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod1) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod1) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a1Total += closeMinusTrueLow;
-            b1Total += trueRange;
-            i += 1;
-        }
         a2Total = 0.0;
         b2Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod2) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod2) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total += closeMinusTrueLow;
-            b2Total += trueRange;
-            i += 1;
-        }
         a3Total = 0.0;
         b3Total = 0.0;
         // for( i = startIdx - (optInTimePeriod3) as usize + 1; i < startIdx; i += 1 )
@@ -1059,6 +886,18 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            if i >= startIdx - (optInTimePeriod1) as usize + 1 {
+                a1Total += closeMinusTrueLow;
+                b1Total += trueRange;
+            }
+            if i >= startIdx - (optInTimePeriod2) as usize + 1 {
+                a2Total += closeMinusTrueLow;
+                b2Total += trueRange;
+            }
             a3Total += closeMinusTrueLow;
             b3Total += trueRange;
             i += 1;
@@ -1066,9 +905,17 @@ impl Core {
         // Calculate oscillator
         today = startIdx;
         outIdx = 0;
-        trailingIdx1 = today - (optInTimePeriod1) as usize + 1;
-        trailingIdx2 = today - (optInTimePeriod2) as usize + 1;
-        trailingIdx3 = today - (optInTimePeriod3) as usize + 1;
+        // The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+        // `today` and, once advanced past it, the slot of the bar leaving the
+        // longest window. The two shorter windows trail it by a fixed offset.
+        trailingPos1 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod1) as usize + 1;
+        if trailingPos1 >= (optInTimePeriod3) as usize {
+            trailingPos1 -= optInTimePeriod3;
+        }
+        trailingPos2 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod2) as usize + 1;
+        if trailingPos2 >= (optInTimePeriod3) as usize {
+            trailingPos2 -= optInTimePeriod3;
+        }
         while today <= endIdx {
             // Add on today's terms
             tempLT = inLow[today];
@@ -1085,6 +932,8 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
             a1Total += closeMinusTrueLow;
             a2Total += closeMinusTrueLow;
             a3Total += closeMinusTrueLow;
@@ -1102,55 +951,24 @@ impl Core {
             if !((b3Total).abs() < 1e-14) {
                 output += a3Total / b3Total;
             }
-            // Remove the trailing terms to prepare for next day
-            tempLT = inLow[trailingIdx1];
-            tempHT = inHigh[trailingIdx1];
-            tempCY = inClose[trailingIdx1 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            // Remove the trailing terms to prepare for next day. Each was evaluated
+            // once, when its bar entered the ring.
+            a1Total -= term_closeMinusTrueLow[trailingPos1];
+            b1Total -= term_trueRange[trailingPos1];
+            trailingPos1 += 1;
+            if trailingPos1 >= (optInTimePeriod3) as usize {
+                trailingPos1 = 0;
             }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            a2Total -= term_closeMinusTrueLow[trailingPos2];
+            b2Total -= term_trueRange[trailingPos2];
+            trailingPos2 += 1;
+            if trailingPos2 >= (optInTimePeriod3) as usize {
+                trailingPos2 = 0;
             }
-            a1Total -= closeMinusTrueLow;
-            b1Total -= trueRange;
-            tempLT = inLow[trailingIdx2];
-            tempHT = inHigh[trailingIdx2];
-            tempCY = inClose[trailingIdx2 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total -= closeMinusTrueLow;
-            b2Total -= trueRange;
-            tempLT = inLow[trailingIdx3];
-            tempHT = inHigh[trailingIdx3];
-            tempCY = inClose[trailingIdx3 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a3Total -= closeMinusTrueLow;
-            b3Total -= trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            a3Total -= term_closeMinusTrueLow[term_Idx];
+            b3Total -= term_trueRange[term_Idx];
             // Last operation is to write the output. Must
             // be done after the trailing index have all been
             // taken care of because the caller is allowed
@@ -1160,104 +978,15 @@ impl Core {
             // Increment indexes
             outIdx += 1;
             today += 1;
-            trailingIdx1 += 1;
-            trailingIdx2 += 1;
-            trailingIdx3 += 1;
         }
         // All done. Indicate the output limits and return.
         dummyNBElement = outIdx;
         dummyBegIdx = startIdx;
 
         // Capture the live batch state into the handle.
-        let capLag_trailingIdx1: i64 = (today as i64) - (trailingIdx1 as i64);
-        let cap_trailingIdx1: i64 = capLag_trailingIdx1 + 2;
-        if capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen as i64 {
+        let cbSize_term: usize = maxIdx_term + 1;
+        if cbSize_term > historyLen + 1 {
             return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx1: usize = if cap_trailingIdx1 > 0 { cap_trailingIdx1 as usize } else { 1 };
-        let mut ring_trailingIdx1_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inHigh[fillJ % cap_trailingIdx1 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx1_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inLow[fillJ % cap_trailingIdx1 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx1_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inClose[fillJ % cap_trailingIdx1 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
-        }
-        let capLag_trailingIdx2: i64 = (today as i64) - (trailingIdx2 as i64);
-        let cap_trailingIdx2: i64 = capLag_trailingIdx2 + 2;
-        if capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen as i64 {
-            return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx2: usize = if cap_trailingIdx2 > 0 { cap_trailingIdx2 as usize } else { 1 };
-        let mut ring_trailingIdx2_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inHigh[fillJ % cap_trailingIdx2 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx2_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inLow[fillJ % cap_trailingIdx2 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx2_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inClose[fillJ % cap_trailingIdx2 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
-        }
-        let capLag_trailingIdx3: i64 = (today as i64) - (trailingIdx3 as i64);
-        let cap_trailingIdx3: i64 = capLag_trailingIdx3 + 2;
-        if capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen as i64 {
-            return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx3: usize = if cap_trailingIdx3 > 0 { cap_trailingIdx3 as usize } else { 1 };
-        let mut ring_trailingIdx3_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inHigh[fillJ % cap_trailingIdx3 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx3_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inLow[fillJ % cap_trailingIdx3 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx3_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inClose[fillJ % cap_trailingIdx3 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
         }
         let state = UltoscStreamState {
             optInTimePeriod1,
@@ -1270,25 +999,14 @@ impl Core {
             b2Total,
             b3Total,
             output,
+            trailingPos1,
+            trailingPos2,
+            term_Idx,
+            maxIdx_term,
             lag1_inClose: inClose[historyLen - 1],
-            ringPos_trailingIdx1: historyLen % cap_trailingIdx1 as usize,
-            ringCap_trailingIdx1: cap_trailingIdx1 as usize,
-            ringLag_trailingIdx1: capLag_trailingIdx1 as usize,
-            ring_trailingIdx1_inHigh,
-            ring_trailingIdx1_inLow,
-            ring_trailingIdx1_inClose,
-            ringPos_trailingIdx2: historyLen % cap_trailingIdx2 as usize,
-            ringCap_trailingIdx2: cap_trailingIdx2 as usize,
-            ringLag_trailingIdx2: capLag_trailingIdx2 as usize,
-            ring_trailingIdx2_inHigh,
-            ring_trailingIdx2_inLow,
-            ring_trailingIdx2_inClose,
-            ringPos_trailingIdx3: historyLen % cap_trailingIdx3 as usize,
-            ringCap_trailingIdx3: cap_trailingIdx3 as usize,
-            ringLag_trailingIdx3: capLag_trailingIdx3 as usize,
-            ring_trailingIdx3_inHigh,
-            ring_trailingIdx3_inLow,
-            ring_trailingIdx3_inClose,
+            cbSize_term: cbSize_term,
+            cb_term_closeMinusTrueLow: term_closeMinusTrueLow,
+            cb_term_trueRange: term_trueRange,
         };
         Ok((UltoscStream { core: self.clone(), state }, lastValue_outReal))
     }
@@ -1374,12 +1092,21 @@ impl Core {
         let mut j: usize = 0_usize;
         let mut today: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
-        let mut trailingIdx1: usize = 0_usize;
-        let mut trailingIdx2: usize = 0_usize;
-        let mut trailingIdx3: usize = 0_usize;
+        let mut trailingPos1: usize = 0_usize;
+        let mut trailingPos2: usize = 0_usize;
         let mut usedFlag: [i32; 3 as usize] = [0_i32; 3 as usize];
         let mut periods: [i32; 3 as usize] = [0_i32; 3 as usize];
         let mut sortedPeriods: [i32; 3 as usize] = [0_i32; 3 as usize];
+        let mut term_closeMinusTrueLow: Vec<f64> = Vec::new();
+        let mut term_trueRange: Vec<f64> = Vec::new();
+        let mut term_Idx: usize = 0;
+        let mut maxIdx_term: usize = 31;
+        // The two per-bar terms the three moving sums are built from. Both are a
+        // pure function of the bar, so each bar is evaluated once on entry and read
+        // back when it leaves each of the three windows.
+        // One entry per bar of the longest window. Stays on the stack for every
+        // period up to 32, which covers the 7/14/28 default.
+        // Id, Type, Static Size
         (*outBegIdx) = 0;
         (*outNBElement) = 0;
         // Ensure that the time periods are ordered from shortest to longest.
@@ -1420,53 +1147,21 @@ impl Core {
         if startIdx > endIdx {
             return Err(RetCode::BadParam);
         }
-        // Prime running totals used in moving averages
+        if optInTimePeriod3 < 1 { return Err(RetCode::AllocErr); }
+        term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
+        term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+        maxIdx_term = ((optInTimePeriod3) as usize) - 1;
+        term_Idx = 0;
+        // Prime running totals used in moving averages.
+        //
+        // One pass over the longest warm-up window replaces three overlapping
+        // passes. A bar inside the shorter windows is added to those totals as it
+        // is reached, so every total still accumulates exactly the same bars in
+        // exactly the same ascending order as three separate loops did.
         a1Total = 0.0;
         b1Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod1) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod1) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a1Total += closeMinusTrueLow;
-            b1Total += trueRange;
-            i += 1;
-        }
         a2Total = 0.0;
         b2Total = 0.0;
-        // for( i = startIdx - (optInTimePeriod2) as usize + 1; i < startIdx; i += 1 )
-        i = startIdx - (optInTimePeriod2) as usize + 1;
-        while i < startIdx {
-            tempLT = inLow[i];
-            tempHT = inHigh[i];
-            tempCY = inClose[i - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[i] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total += closeMinusTrueLow;
-            b2Total += trueRange;
-            i += 1;
-        }
         a3Total = 0.0;
         b3Total = 0.0;
         // for( i = startIdx - (optInTimePeriod3) as usize + 1; i < startIdx; i += 1 )
@@ -1486,6 +1181,18 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            if i >= startIdx - (optInTimePeriod1) as usize + 1 {
+                a1Total += closeMinusTrueLow;
+                b1Total += trueRange;
+            }
+            if i >= startIdx - (optInTimePeriod2) as usize + 1 {
+                a2Total += closeMinusTrueLow;
+                b2Total += trueRange;
+            }
             a3Total += closeMinusTrueLow;
             b3Total += trueRange;
             i += 1;
@@ -1493,9 +1200,17 @@ impl Core {
         // Calculate oscillator
         today = startIdx;
         outIdx = 0;
-        trailingIdx1 = today - (optInTimePeriod1) as usize + 1;
-        trailingIdx2 = today - (optInTimePeriod2) as usize + 1;
-        trailingIdx3 = today - (optInTimePeriod3) as usize + 1;
+        // The warm-up wrote optInTimePeriod3-1 bars, so term_Idx is the slot for
+        // `today` and, once advanced past it, the slot of the bar leaving the
+        // longest window. The two shorter windows trail it by a fixed offset.
+        trailingPos1 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod1) as usize + 1;
+        if trailingPos1 >= (optInTimePeriod3) as usize {
+            trailingPos1 -= optInTimePeriod3;
+        }
+        trailingPos2 = term_Idx + (optInTimePeriod3) as usize - (optInTimePeriod2) as usize + 1;
+        if trailingPos2 >= (optInTimePeriod3) as usize {
+            trailingPos2 -= optInTimePeriod3;
+        }
         while today <= endIdx {
             // Add on today's terms
             tempLT = inLow[today];
@@ -1512,6 +1227,8 @@ impl Core {
             if tempDouble > trueRange {
                 trueRange = tempDouble;
             }
+            term_closeMinusTrueLow[term_Idx] = closeMinusTrueLow;
+            term_trueRange[term_Idx] = trueRange;
             a1Total += closeMinusTrueLow;
             a2Total += closeMinusTrueLow;
             a3Total += closeMinusTrueLow;
@@ -1529,55 +1246,24 @@ impl Core {
             if !((b3Total).abs() < 1e-14) {
                 output += a3Total / b3Total;
             }
-            // Remove the trailing terms to prepare for next day
-            tempLT = inLow[trailingIdx1];
-            tempHT = inHigh[trailingIdx1];
-            tempCY = inClose[trailingIdx1 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx1] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            // Remove the trailing terms to prepare for next day. Each was evaluated
+            // once, when its bar entered the ring.
+            a1Total -= term_closeMinusTrueLow[trailingPos1];
+            b1Total -= term_trueRange[trailingPos1];
+            trailingPos1 += 1;
+            if trailingPos1 >= (optInTimePeriod3) as usize {
+                trailingPos1 = 0;
             }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
+            a2Total -= term_closeMinusTrueLow[trailingPos2];
+            b2Total -= term_trueRange[trailingPos2];
+            trailingPos2 += 1;
+            if trailingPos2 >= (optInTimePeriod3) as usize {
+                trailingPos2 = 0;
             }
-            a1Total -= closeMinusTrueLow;
-            b1Total -= trueRange;
-            tempLT = inLow[trailingIdx2];
-            tempHT = inHigh[trailingIdx2];
-            tempCY = inClose[trailingIdx2 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx2] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a2Total -= closeMinusTrueLow;
-            b2Total -= trueRange;
-            tempLT = inLow[trailingIdx3];
-            tempHT = inHigh[trailingIdx3];
-            tempCY = inClose[trailingIdx3 - 1];
-            trueLow = (tempLT).min(tempCY);
-            closeMinusTrueLow = inClose[trailingIdx3] - trueLow;
-            trueRange = tempHT - tempLT;
-            tempDouble = (tempCY - tempHT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            tempDouble = (tempCY - tempLT).abs();
-            if tempDouble > trueRange {
-                trueRange = tempDouble;
-            }
-            a3Total -= closeMinusTrueLow;
-            b3Total -= trueRange;
+            term_Idx += 1;
+            if term_Idx > maxIdx_term { term_Idx = 0; }
+            a3Total -= term_closeMinusTrueLow[term_Idx];
+            b3Total -= term_trueRange[term_Idx];
             // Last operation is to write the output. Must
             // be done after the trailing index have all been
             // taken care of because the caller is allowed
@@ -1587,104 +1273,15 @@ impl Core {
             // Increment indexes
             outIdx += 1;
             today += 1;
-            trailingIdx1 += 1;
-            trailingIdx2 += 1;
-            trailingIdx3 += 1;
         }
         // All done. Indicate the output limits and return.
         (*outNBElement) = outIdx;
         (*outBegIdx) = startIdx;
 
         // Capture the live batch state into the handle.
-        let capLag_trailingIdx1: i64 = (today as i64) - (trailingIdx1 as i64);
-        let cap_trailingIdx1: i64 = capLag_trailingIdx1 + 2;
-        if capLag_trailingIdx1 < 0 || cap_trailingIdx1 > historyLen as i64 {
+        let cbSize_term: usize = maxIdx_term + 1;
+        if cbSize_term > historyLen + 1 {
             return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx1: usize = if cap_trailingIdx1 > 0 { cap_trailingIdx1 as usize } else { 1 };
-        let mut ring_trailingIdx1_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inHigh[fillJ % cap_trailingIdx1 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx1_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inLow[fillJ % cap_trailingIdx1 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx1_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx1];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx1 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx1_inClose[fillJ % cap_trailingIdx1 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
-        }
-        let capLag_trailingIdx2: i64 = (today as i64) - (trailingIdx2 as i64);
-        let cap_trailingIdx2: i64 = capLag_trailingIdx2 + 2;
-        if capLag_trailingIdx2 < 0 || cap_trailingIdx2 > historyLen as i64 {
-            return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx2: usize = if cap_trailingIdx2 > 0 { cap_trailingIdx2 as usize } else { 1 };
-        let mut ring_trailingIdx2_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inHigh[fillJ % cap_trailingIdx2 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx2_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inLow[fillJ % cap_trailingIdx2 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx2_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx2];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx2 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx2_inClose[fillJ % cap_trailingIdx2 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
-        }
-        let capLag_trailingIdx3: i64 = (today as i64) - (trailingIdx3 as i64);
-        let cap_trailingIdx3: i64 = capLag_trailingIdx3 + 2;
-        if capLag_trailingIdx3 < 0 || cap_trailingIdx3 > historyLen as i64 {
-            return Err(RetCode::InternalError);
-        }
-        let allocN_trailingIdx3: usize = if cap_trailingIdx3 > 0 { cap_trailingIdx3 as usize } else { 1 };
-        let mut ring_trailingIdx3_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inHigh[fillJ % cap_trailingIdx3 as usize] = inHigh[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx3_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inLow[fillJ % cap_trailingIdx3 as usize] = inLow[fillJ];
-                fillJ += 1;
-            }
-        }
-        let mut ring_trailingIdx3_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx3];
-        {
-            let mut fillJ: usize = historyLen - cap_trailingIdx3 as usize;
-            while fillJ < historyLen {
-                ring_trailingIdx3_inClose[fillJ % cap_trailingIdx3 as usize] = inClose[fillJ];
-                fillJ += 1;
-            }
         }
         let state = UltoscStreamState {
             optInTimePeriod1,
@@ -1697,25 +1294,14 @@ impl Core {
             b2Total,
             b3Total,
             output,
+            trailingPos1,
+            trailingPos2,
+            term_Idx,
+            maxIdx_term,
             lag1_inClose: inClose[historyLen - 1],
-            ringPos_trailingIdx1: historyLen % cap_trailingIdx1 as usize,
-            ringCap_trailingIdx1: cap_trailingIdx1 as usize,
-            ringLag_trailingIdx1: capLag_trailingIdx1 as usize,
-            ring_trailingIdx1_inHigh,
-            ring_trailingIdx1_inLow,
-            ring_trailingIdx1_inClose,
-            ringPos_trailingIdx2: historyLen % cap_trailingIdx2 as usize,
-            ringCap_trailingIdx2: cap_trailingIdx2 as usize,
-            ringLag_trailingIdx2: capLag_trailingIdx2 as usize,
-            ring_trailingIdx2_inHigh,
-            ring_trailingIdx2_inLow,
-            ring_trailingIdx2_inClose,
-            ringPos_trailingIdx3: historyLen % cap_trailingIdx3 as usize,
-            ringCap_trailingIdx3: cap_trailingIdx3 as usize,
-            ringLag_trailingIdx3: capLag_trailingIdx3 as usize,
-            ring_trailingIdx3_inHigh,
-            ring_trailingIdx3_inLow,
-            ring_trailingIdx3_inClose,
+            cbSize_term: cbSize_term,
+            cb_term_closeMinusTrueLow: term_closeMinusTrueLow,
+            cb_term_trueRange: term_trueRange,
         };
         Ok(UltoscStream { core: self.clone(), state })
     }


### PR DESCRIPTION
## What this changes

`ultosc.c`'s steady-state loop computes the per-bar true range and
close-minus-true-low pair **four times for every output bar**: once for the
entering bar, and once each for the three trailing bars leaving the 7/14/28
windows.

```c
while( today <= endIdx )
{
   /* bar `today`        */ trueLow = min(tempLT,tempCY); ... a1Total += ...; b1Total += ...;
   /* bar trailingIdx1   */ trueLow = min(tempLT,tempCY); ... a1Total -= ...; b1Total -= ...;
   /* bar trailingIdx2   */ trueLow = min(tempLT,tempCY); ... a2Total -= ...; b2Total -= ...;
   /* bar trailingIdx3   */ trueLow = min(tempLT,tempCY); ... a3Total -= ...; b3Total -= ...;
}
```

Both quantities depend only on `(inHigh[i], inLow[i], inClose[i],
inClose[i-1])`, so three of those four evaluations reproduce a value the loop
already produced a few hundred iterations earlier. The warm-up has the same
shape: three overlapping priming loops re-evaluate the bars inside the shorter
windows two and three times over.

This patch computes each bar once on entry, keeps the pair in a `CIRCBUF` sized
to the longest period, and has the three trailing subtractions read it back. The
warm-up becomes a single pass over the longest window that adds each bar to the
shorter windows' totals as it reaches them.

## Measurements, absolute and wall-clock

`ta_bench_direct --function=ULTOSC --points=100000 --iters=200`, GCC 13.3
x86-64. I rebuilt each arm from source and measured both in the same session.

| | ns per call (100,000 bars) | ns per bar |
|---|--:|--:|
| `dev` @ `cae5c3d` | 962,141 | 9.62 |
| this branch | 586,417 | 5.86 |
| | **−375,724 ns (−39.1%)** | **−3.76** |

A second harness agrees. It sweeps six `.text` layouts (nop padding ahead of the
archive plus varying `-falign-functions`), draws a fresh random-walk fixture for
every repetition, and times both arms in the same window. Its layout-swept
median ratio is **0.6166 and 0.6134** across two independent measurement blocks,
so both methods land near −38%.

This is a wall-clock number, not an instruction count. Your note on #147 says
Callgrind Ir moved a flat −8% on the last change in this family while wall time
ranged from −27% to +2%, so I measured accordingly. It is also one toolchain on
one machine, GCC x86-64. I have not measured MSVC or Apple clang and would not
want the number read as transferable.

`--points` sweep on the same box, rebuilding each arm and alternating, ns per
call (`dev` → branch): 20,000 → 191,594 → 119,872 (−37.4%); 100,000 → 962,141 →
586,417 (−39.1%); 200,000 → 1,920,054 → 1,199,955 (−37.5%). A repeat of the
branch arm gave 120,678 / 601,996 / 1,195,507. The ratio holds flat in `n`,
which is what a per-bar constant-factor change should do.

## Correctness

**Bit-identical by construction, not by tolerance.** The same expression
produces every value from the same operands, and every total accumulates the
same bars in the same ascending order. I reassociated nothing, carried no
running total across the series, and left the output expression alone. The
change is *when* a value gets computed, never *how*.

What I checked:

* `ta_regtest` passes in full.
* A differential harness compares raw IEEE bytes against a `dev` build over 10
  period vectors (including `1/1/1`, `28/14/7` reversed, `14/14/14`, `5/100/20`)
  × 7 price regimes (random walk, monotone up, monotone down, flat, alternating
  trend/chop, near-epsilon magnitudes, large magnitudes) × the guarded,
  unguarded and `TA_S_` float entry points, full range, two subranges, the
  single-bar `startIdx==endIdx` shape, the first computable bar, the empty
  range, in-place aliasing with `outReal == inClose` (#130), the streaming
  `Open`/`Peek`/`Update`/`Close` trajectory and `OpenAndFill`. Byte-identical
  throughout.
* Every timed repetition also compares a per-call output digest at the measured
  size (100,000 bars) against a `dev` build, so the timed path gets checked on
  exactly the data it is timed on.

Two scope notes, since both are easy to get wrong here:

* The ring is `CIRCBUF_PROLOG_CLASS(term, UltOscTerm, 32)`, so at the default
  7/14/28 it lives entirely on the stack and **adds no allocation**. It reaches
  the heap only when the longest period exceeds 32, `CIRCBUF_INIT_CLASS` already
  returns `TA_ALLOC_ERR` on failure, and `CIRCBUF_DESTROY` runs on the one path
  that can reach it.
* `ULTOSC` is `flags: [stream]` and the streaming tier derives from this same
  body. Generation still derives it, and the stream trajectory is part of the
  bit-exactness check above.

I left three further changes out on purpose. Rewriting the true range as
`max(high, prevClose) - min(low, prevClose)`, hoisting `prevClose` across the
loop, and inferring the two longer windows' zero-checks from the shortest one
each measured faster, and together they reach about −45% rather than −38%. But
each one rests on an argument I could not discharge for every input the API
accepts: that `high >= low` always holds, that the in-place aliasing read order
does not matter, and that a running sum carrying subtractions cannot round to
zero while a shorter one has not. This diff is the part that needs no such
argument. Happy to send any of them separately if you want them measured on
their own.

## Generated files

`ta_codegen/input/ultosc/ultosc.c` is the only file I edited by hand; the rest
is `cd ta_codegen/generator && cargo run -- generate`. The generated surfaces
lose 1,602 lines net, because each backend had unrolled the four true-range
blocks into every variant.

## Provenance

The `CIRCBUF` formulation came out of an automated optimization search over this
one file, run against a harness that gated on the bit-exactness matrix above.
The trajectory is public as a record of that search:
https://dashboard.weco.ai/share/x-g7CdO52PGLAE_gLtyWrCxmRE1w-p9H

The diff here is not the search's best-scoring step. It is a deliberately
narrower version of it, for the reason given above. I have read and measured the
change myself and take responsibility for it.

