### PR TITLE
fix(website): bump undici to 7.29.0, closes 5 open Dependabot alerts

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^7.29.0
+
 importers:
 
   .:
@@ -2129,8 +2132,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -3846,7 +3849,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@5.0.0:
@@ -4686,7 +4689,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ allowBuilds:
   '@parcel/watcher': true
   esbuild: true
   vue-demi: true
+
+overrides:
+  undici: ^7.29.0


### PR DESCRIPTION
## Summary
- `undici` was pinned at 7.28.0 as a transitive dev dependency (`cheerio` → `undici`, `website/pnpm-lock.yaml`), vulnerable to 5 currently-open Dependabot alerts: 1 high (CVE-2026-13697, shared-cache disclosure) and 4 moderate (CRLF injection, cache-control whitespace bypass, cookie attribute injection, retry-interceptor desync).
- All five are fixed upstream in undici 7.29.0. Pinned via a `pnpm-workspace.yaml` override rather than bumping `cheerio` itself, to keep the change minimal (pnpm 10+ no longer reads `overrides` from `package.json`'s `pnpm` field — moved to `pnpm-workspace.yaml`).

## Separate finding, not included here
`pnpm audit` also surfaces a moderate `postcss` advisory (GHSA-fxqj-rqcc-2cmp, "incomplete fix" of an earlier postcss CVE) via the vite/vue toolchain — this is **not** one of the 5 Dependabot alerts (no repo alert exists for it yet) and is left out of this PR on purpose. Happy to file/fix separately if wanted.

## Test plan
- [x] `pnpm install --force` resolves `undici@7.29.0` (single resolved version, no duplicates)
- [x] `pnpm audit` no longer reports undici
- [x] `pnpm run docs:build` renders all 185 pages with no errors