### PR TITLE
fix(website): bump postcss to 8.5.23+, closes an unflagged incomplete-fix advisory

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   undici: ^7.29.0
+  postcss: ^8.5.23
 
 importers:
 
@@ -1206,7 +1207,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: ^8.5.23
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1822,7 +1823,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: ^8.5.23
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1838,8 +1839,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-information@7.2.0:
@@ -3119,7 +3120,7 @@ snapshots:
       '@vue/shared': 3.5.39
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.22
+      postcss: 8.5.25
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.39':
@@ -3172,10 +3173,10 @@ snapshots:
       '@vuepress/core': 2.0.0-rc.30(@vue/compiler-sfc@3.5.39)(esbuild@0.28.1)(rolldown@1.1.5)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0))
       '@vuepress/shared': 2.0.0-rc.30
       '@vuepress/utils': 2.0.0-rc.30
-      autoprefixer: 10.5.2(postcss@8.5.22)
+      autoprefixer: 10.5.2(postcss@8.5.25)
       connect-history-api-fallback: 2.0.0
-      postcss: 8.5.22
-      postcss-load-config: 6.0.1(postcss@8.5.22)(yaml@2.9.0)
+      postcss: 8.5.25
+      postcss-load-config: 6.0.1(postcss@8.5.25)(yaml@2.9.0)
       rolldown: 1.1.5
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(sass-embedded@1.100.0)(sass@1.100.0)(yaml@2.9.0)
       vue: 3.5.39
@@ -3786,13 +3787,13 @@ snapshots:
       '@babel/types': 7.29.7
       ast-kit: 2.2.0
 
-  autoprefixer@10.5.2(postcss@8.5.22):
+  autoprefixer@10.5.2(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.6
       caniuse-lite: 1.0.30001805
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.22
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
   bail@2.0.2: {}
@@ -4401,16 +4402,16 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.22)(yaml@2.9.0):
+  postcss-load-config@6.0.1(postcss@8.5.25)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.22
+      postcss: 8.5.25
       yaml: 2.9.0
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.22:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4772,7 +4773,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.22
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ allowBuilds:
 
 overrides:
   undici: ^7.29.0
+  postcss: ^8.5.23


### PR DESCRIPTION
## Summary
- Follow-up to #167. \`pnpm audit\` (not yet a GitHub Dependabot alert on this repo) flags GHSA-fxqj-rqcc-2cmp: an incomplete fix of an earlier postcss \`sourceMappingURL\` path-traversal CVE, reached transitively through the vite/vue toolchain (100 dependency paths, all dev tooling). Patched in postcss \`>=8.5.23\`.
- Real exposure here is minimal regardless — exploitation requires running externally-supplied/untrusted CSS through postcss, and this site's build only ever processes its own authored source. Fixing anyway since the override is free (same \`pnpm-workspace.yaml\` mechanism as #167), resolves cleanly to 8.5.25, no version conflicts.

## Test plan
- [x] \`pnpm install\` resolves \`postcss@8.5.25\` (single resolved version)
- [x] \`pnpm audit\` now reports **zero** known vulnerabilities (was 1 moderate after #167)
- [x] \`pnpm run docs:build\` renders all 185 pages with no errors