### PR TITLE
fix(ta_codegen): make the C bench tools build under MSVC

### DIFF
--- a/ta_codegen/generator/src/bench_gen.rs
+++ b/ta_codegen/generator/src/bench_gen.rs
@@ -22,8 +22,8 @@ pub fn generate_c_bench(funcs: &[FuncDef]) -> String {
     s.push_str(" * Output: FUNCNAME timing_ns (one per line)\n");
     s.push_str(" */\n");
     s.push_str("#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n");
-    s.push_str("#include <math.h>\n#include <time.h>\n");
-    s.push_str("#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
+    s.push_str("#include <math.h>\n#include <time.h>\n#include <ctype.h>\n");
+    s.push_str("#ifdef _WIN32\n#include <windows.h>\n#endif\n#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
     // The shared benchmark input corpus (src/tools/ta_bench is on the include
     // path — see the ta_bench_cg / ta_bench_stream gcc invocations in main.rs).
     s.push_str("#include \"bench_corpus.h\"\n\n");
@@ -556,8 +556,8 @@ pub fn generate_c_stream_bench(funcs: &[FuncDef]) -> String {
     s.push_str(" * Output: `NAME batch_last update peek lookback handle_bytes` per line.\n");
     s.push_str(" */\n");
     s.push_str("#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n");
-    s.push_str("#include <math.h>\n#include <time.h>\n");
-    s.push_str("#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
+    s.push_str("#include <math.h>\n#include <time.h>\n#include <ctype.h>\n");
+    s.push_str("#ifdef _WIN32\n#include <windows.h>\n#endif\n#ifdef __APPLE__\n#include <mach/mach_time.h>\n#endif\n\n");
     // The shared benchmark input corpus (src/tools/ta_bench is on the include
     // path — see the ta_bench_cg / ta_bench_stream gcc invocations in main.rs).
     s.push_str("#include \"bench_corpus.h\"\n\n");
@@ -703,7 +703,21 @@ __CORPUS_ARGS__    }
 
 const TIMING_HELPER: &str = r"
 static long long get_nanotime(void) {
-#ifdef __APPLE__
+#if defined(_WIN32)
+    /* No clock_gettime in the MSVC CRT. QueryPerformanceCounter is the
+     * monotonic counter here; its frequency is fixed for the lifetime of the
+     * process, so one query is enough. Scaling ticks->ns as (t/f)*1e9 would
+     * truncate to whole seconds, and t*1e9 overflows a signed 64-bit at
+     * ~9.2e9 ticks (roughly an hour at a 10 MHz QPC), so split the tick count
+     * into whole seconds plus a remainder before scaling.
+     */
+    static LARGE_INTEGER freq = {0};
+    LARGE_INTEGER now;
+    if( freq.QuadPart == 0 ) QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&now);
+    return (long long)((now.QuadPart / freq.QuadPart) * 1000000000LL
+         + ((now.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
+#elif defined(__APPLE__)
     static mach_timebase_info_data_t info = {0, 0};
     if( info.denom == 0 ) mach_timebase_info(&info);
     uint64_t t = mach_absolute_time();
@@ -770,12 +784,37 @@ const CORPUS_ARGS: &str = r#"        else if( strncmp(argv[i], "--shape=", 8) ==
 "#;
 
 const FUNC_MATCHES: &str = r#"
+/* strtok_r and strcasestr are POSIX; the MSVC CRT has neither. strtok_s is the
+ * same call with the same reentrancy contract, and the case-insensitive search
+ * is short enough to spell out rather than reach for a platform extension.
+ */
+#if defined(_WIN32)
+#define bench_strtok_r(str, delim, save) strtok_s((str), (delim), (save))
+#else
+#define bench_strtok_r(str, delim, save) strtok_r((str), (delim), (save))
+#endif
+
+static const char *bench_strcasestr(const char *hay, const char *needle) {
+    if( !*needle ) return hay;
+    for( ; *hay; hay++ )
+    {
+        const char *h = hay, *n = needle;
+        while( *h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n) )
+        {
+            h++;
+            n++;
+        }
+        if( !*n ) return hay;
+    }
+    return NULL;
+}
+
 static int func_matches(const char *filter, const char *name) {
     if( !filter || !*filter ) return 1;
     char buf[512]; strncpy(buf, filter, sizeof(buf)-1); buf[sizeof(buf)-1]='\0';
     char *saveptr = NULL;
-    for( char *tok = strtok_r(buf, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr) )
-        if( strcasestr(name, tok) ) return 1;
+    for( char *tok = bench_strtok_r(buf, ",", &saveptr); tok; tok = bench_strtok_r(NULL, ",", &saveptr) )
+        if( bench_strcasestr(name, tok) ) return 1;
     return 0;
 }
 

--- a/ta_codegen/output/c/tools/ta_bench_cg.c
+++ b/ta_codegen/output/c/tools/ta_bench_cg.c
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include <ctype.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #ifdef __APPLE__
 #include <mach/mach_time.h>
 #endif
@@ -191,7 +195,21 @@
 
 
 static long long get_nanotime(void) {
-#ifdef __APPLE__
+#if defined(_WIN32)
+    /* No clock_gettime in the MSVC CRT. QueryPerformanceCounter is the
+     * monotonic counter here; its frequency is fixed for the lifetime of the
+     * process, so one query is enough. Scaling ticks->ns as (t/f)*1e9 would
+     * truncate to whole seconds, and t*1e9 overflows a signed 64-bit at
+     * ~9.2e9 ticks (roughly an hour at a 10 MHz QPC), so split the tick count
+     * into whole seconds plus a remainder before scaling.
+     */
+    static LARGE_INTEGER freq = {0};
+    LARGE_INTEGER now;
+    if( freq.QuadPart == 0 ) QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&now);
+    return (long long)((now.QuadPart / freq.QuadPart) * 1000000000LL
+         + ((now.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
+#elif defined(__APPLE__)
     static mach_timebase_info_data_t info = {0, 0};
     if( info.denom == 0 ) mach_timebase_info(&info);
     uint64_t t = mach_absolute_time();
@@ -235,12 +253,37 @@ static int g_outIntBuf0[MAX_POINTS];
 static int g_outIntBuf1[MAX_POINTS];
 
 
+/* strtok_r and strcasestr are POSIX; the MSVC CRT has neither. strtok_s is the
+ * same call with the same reentrancy contract, and the case-insensitive search
+ * is short enough to spell out rather than reach for a platform extension.
+ */
+#if defined(_WIN32)
+#define bench_strtok_r(str, delim, save) strtok_s((str), (delim), (save))
+#else
+#define bench_strtok_r(str, delim, save) strtok_r((str), (delim), (save))
+#endif
+
+static const char *bench_strcasestr(const char *hay, const char *needle) {
+    if( !*needle ) return hay;
+    for( ; *hay; hay++ )
+    {
+        const char *h = hay, *n = needle;
+        while( *h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n) )
+        {
+            h++;
+            n++;
+        }
+        if( !*n ) return hay;
+    }
+    return NULL;
+}
+
 static int func_matches(const char *filter, const char *name) {
     if( !filter || !*filter ) return 1;
     char buf[512]; strncpy(buf, filter, sizeof(buf)-1); buf[sizeof(buf)-1]='\0';
     char *saveptr = NULL;
-    for( char *tok = strtok_r(buf, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr) )
-        if( strcasestr(name, tok) ) return 1;
+    for( char *tok = bench_strtok_r(buf, ",", &saveptr); tok; tok = bench_strtok_r(NULL, ",", &saveptr) )
+        if( bench_strcasestr(name, tok) ) return 1;
     return 0;
 }
 

--- a/ta_codegen/output/c/tools/ta_bench_stream.c
+++ b/ta_codegen/output/c/tools/ta_bench_stream.c
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include <ctype.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #ifdef __APPLE__
 #include <mach/mach_time.h>
 #endif
@@ -226,7 +230,21 @@ static void bench_tracked_free(void *p) {
 
 
 static long long get_nanotime(void) {
-#ifdef __APPLE__
+#if defined(_WIN32)
+    /* No clock_gettime in the MSVC CRT. QueryPerformanceCounter is the
+     * monotonic counter here; its frequency is fixed for the lifetime of the
+     * process, so one query is enough. Scaling ticks->ns as (t/f)*1e9 would
+     * truncate to whole seconds, and t*1e9 overflows a signed 64-bit at
+     * ~9.2e9 ticks (roughly an hour at a 10 MHz QPC), so split the tick count
+     * into whole seconds plus a remainder before scaling.
+     */
+    static LARGE_INTEGER freq = {0};
+    LARGE_INTEGER now;
+    if( freq.QuadPart == 0 ) QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&now);
+    return (long long)((now.QuadPart / freq.QuadPart) * 1000000000LL
+         + ((now.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
+#elif defined(__APPLE__)
     static mach_timebase_info_data_t info = {0, 0};
     if( info.denom == 0 ) mach_timebase_info(&info);
     uint64_t t = mach_absolute_time();
@@ -273,12 +291,37 @@ static double *g_rt_open, *g_rt_high, *g_rt_low, *g_rt_close, *g_rt_volume, *g_r
 static int g_rtCap;
 
 
+/* strtok_r and strcasestr are POSIX; the MSVC CRT has neither. strtok_s is the
+ * same call with the same reentrancy contract, and the case-insensitive search
+ * is short enough to spell out rather than reach for a platform extension.
+ */
+#if defined(_WIN32)
+#define bench_strtok_r(str, delim, save) strtok_s((str), (delim), (save))
+#else
+#define bench_strtok_r(str, delim, save) strtok_r((str), (delim), (save))
+#endif
+
+static const char *bench_strcasestr(const char *hay, const char *needle) {
+    if( !*needle ) return hay;
+    for( ; *hay; hay++ )
+    {
+        const char *h = hay, *n = needle;
+        while( *h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n) )
+        {
+            h++;
+            n++;
+        }
+        if( !*n ) return hay;
+    }
+    return NULL;
+}
+
 static int func_matches(const char *filter, const char *name) {
     if( !filter || !*filter ) return 1;
     char buf[512]; strncpy(buf, filter, sizeof(buf)-1); buf[sizeof(buf)-1]='\0';
     char *saveptr = NULL;
-    for( char *tok = strtok_r(buf, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr) )
-        if( strcasestr(name, tok) ) return 1;
+    for( char *tok = bench_strtok_r(buf, ",", &saveptr); tok; tok = bench_strtok_r(NULL, ",", &saveptr) )
+        if( bench_strcasestr(name, tok) ) return 1;
     return 0;
 }
 


### PR DESCRIPTION
`ta_bench_cg` and `ta_bench_stream` have never compiled on MSVC. I hit this while producing the MSVC column for #147 and fixed it in the generator; the numbers in that issue exist because of this patch.

## What breaks

Three POSIX-only dependencies, none present in the MSVC CRT:

| | symptom |
|---|---|
| `clock_gettime` / `CLOCK_MONOTONIC` | `error C2065` — `get_nanotime()` has `__APPLE__` and POSIX branches, no `_WIN32` |
| `strtok_r` | `LNK2019` |
| `strcasestr` | `LNK2019` |

The first one is a hard parse error, so nothing downstream even gets a chance.

This leaves MSVC with no way to run the in-tree benchmarks — the toolchain where a plain-C codegen change is least likely to be caught by anything else.

## The fix

All three in `bench_gen.rs`, so both generated tools inherit it.

**Timing.** A `_WIN32` branch on `QueryPerformanceCounter`. The frequency is fixed for the process lifetime, so it is queried once. Ticks are converted by splitting into whole seconds plus a remainder:

```c
return (long long)((now.QuadPart / freq.QuadPart) * 1000000000LL
     + ((now.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
```

`(t / f) * 1e9` on its own truncates to whole seconds; `t * 1e9` overflows a signed 64-bit at ~9.2e9 ticks, which is about an hour of uptime at a 10 MHz QPC. The split avoids both.

**`strtok_r`** → `strtok_s` behind a `bench_strtok_r` macro. Same reentrancy contract, same argument order.

**`strcasestr`** → a local `bench_strcasestr`. It is a short loop and every alternative is another platform extension.

## Verification

- **MSVC Build Tools 2022 x64, pristine `dev` clone at `755800275`**: patch applies clean, both binaries compile, both run. `ta_bench_cg --points=2000 --iters=5 --function=MAX` returns sane timings.
- **macOS clang regression**: both still compile with no new warnings and produce unchanged output.
- Generated sources are committed alongside the generator change, so `generate-bench --backend=c` is a no-op on this branch.

## One measurement note

Worth knowing before anyone quotes Windows numbers: QPC is typically 10 MHz, so `ta_bench_stream`'s `batch_last_ns` at `--iters=50` quantizes to 2 ns steps — 3–10 ticks per measurement. In my first MSVC run that read as one function *improving* 0.70x and another regressing 2.50x, both pure artefacts; at `--iters=5000` the same comparison moved to 0.33x and the baseline itself went from 20.000 to 45.000 ns. A low-iteration Windows run measures the timer, not the code.
