### PR TITLE
fix(ta_codegen): stop emitting the duplicated NULL-check blocks

### DIFF
--- a/src/ta_func/ta_ADXR.c
+++ b/src/ta_func/ta_ADXR.c
@@ -342,11 +342,6 @@ TA_RetCode TA_ADXR_OpenInternal( struct TA_ADXR_Stream **stream, const double in
          TA_ADX_Close( sub0 ); TA_Free( sc_outReal );
          return TA_ALLOC_ERR;
       }
-      if( !adx )
-      {
-         TA_ADX_Close( sub0 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       /* Compute ADX over a range that starts (period-1) bars earlier, so each
        * ADXR bar can pair the current ADX with the ADX from (period-1) bars ago.
        */
@@ -480,11 +475,6 @@ TA_LIB_API TA_RetCode TA_ADXR_OpenAndFill( TA_ADXR_Stream **stream, const double
          return TA_BAD_PARAM;
       }
       adx = malloc((endIdx - startIdx + optInTimePeriod) * sizeof(double));
-      if( !adx )
-      {
-         TA_ADX_Close( sub0 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       if( !adx )
       {
          TA_ADX_Close( sub0 ); TA_Free( sc_outReal );

--- a/src/ta_func/ta_APO.c
+++ b/src/ta_func/ta_APO.c
@@ -320,11 +320,6 @@ TA_RetCode TA_APO_OpenInternal( struct TA_APO_Stream **stream, const double inRe
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
          return TA_ALLOC_ERR;
       }
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       /* Make sure slow is really slower than
        * the fast period! if not, swap...
        */
@@ -458,11 +453,6 @@ TA_LIB_API TA_RetCode TA_APO_OpenAndFill( TA_APO_Stream **stream, const double i
       int i;
       /* Allocate an intermediate buffer. */
       tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       if( !tempBuffer )
       {
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );

--- a/src/ta_func/ta_BBANDS.c
+++ b/src/ta_func/ta_BBANDS.c
@@ -786,21 +786,10 @@ TA_RetCode TA_BBANDS_OpenInternal( struct TA_BBANDS_Stream **stream, const doubl
          TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
          return TA_ALLOC_ERR;
       }
-      if( !tempBuffer1 )
-      {
-         TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
-         return TA_ALLOC_ERR;
-      }
       tempBuffer2 = malloc((endIdx - startIdx + 1) * sizeof(double));
       if( !tempBuffer2 )
       {
          free( tempBuffer1 ); TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
-         return TA_ALLOC_ERR;
-      }
-      if( !tempBuffer2 )
-      {
-         free(tempBuffer1);
-         TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
          return TA_ALLOC_ERR;
       }
       /* Calculate the middle band moving average. */
@@ -986,21 +975,10 @@ TA_LIB_API TA_RetCode TA_BBANDS_OpenAndFill( TA_BBANDS_Stream **stream, const do
          TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
          return TA_ALLOC_ERR;
       }
-      if( !tempBuffer1 )
-      {
-         TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
-         return TA_ALLOC_ERR;
-      }
       tempBuffer2 = malloc((endIdx - startIdx + 1) * sizeof(double));
       if( !tempBuffer2 )
       {
          free( tempBuffer1 ); TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
-         return TA_ALLOC_ERR;
-      }
-      if( !tempBuffer2 )
-      {
-         free(tempBuffer1);
-         TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 ); TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
          return TA_ALLOC_ERR;
       }
       /* Calculate the middle band moving average. */

--- a/src/ta_func/ta_MACDEXT.c
+++ b/src/ta_func/ta_MACDEXT.c
@@ -616,25 +616,10 @@ TA_RetCode TA_MACDEXT_OpenInternal( struct TA_MACDEXT_Stream **stream, const dou
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
          return TA_ALLOC_ERR;
       }
-      if( !fastMABuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
-         return TA_ALLOC_ERR;
-      }
       slowMABuffer = malloc(tempInteger * sizeof(double));
       if( !slowMABuffer )
       {
          free( fastMABuffer ); TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
-         return TA_ALLOC_ERR;
-      }
-      if( !slowMABuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
-         free(fastMABuffer);
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
          return TA_ALLOC_ERR;
       }
       /* Calculate the slow MA.
@@ -895,25 +880,10 @@ TA_LIB_API TA_RetCode TA_MACDEXT_OpenAndFill( TA_MACDEXT_Stream **stream, const 
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
          return TA_ALLOC_ERR;
       }
-      if( !fastMABuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
-         return TA_ALLOC_ERR;
-      }
       slowMABuffer = malloc(tempInteger * sizeof(double));
       if( !slowMABuffer )
       {
          free( fastMABuffer ); TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
-         return TA_ALLOC_ERR;
-      }
-      if( !slowMABuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
-         free(fastMABuffer);
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_MA_Close( sub2 ); TA_Free( sc_outMACD ); TA_Free( sc_outMACDSignal ); TA_Free( sc_outMACDHist );
          return TA_ALLOC_ERR;
       }
       /* Calculate the slow MA.

--- a/src/ta_func/ta_PPO.c
+++ b/src/ta_func/ta_PPO.c
@@ -344,11 +344,6 @@ TA_RetCode TA_PPO_OpenInternal( struct TA_PPO_Stream **stream, const double inRe
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
          return TA_ALLOC_ERR;
       }
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       /* Make sure slow is really slower than
        * the fast period! if not, swap...
        */
@@ -490,11 +485,6 @@ TA_LIB_API TA_RetCode TA_PPO_OpenAndFill( TA_PPO_Stream **stream, const double i
       int i;
       /* Allocate an intermediate buffer. */
       tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       if( !tempBuffer )
       {
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );

--- a/src/ta_func/ta_PVO.c
+++ b/src/ta_func/ta_PVO.c
@@ -338,11 +338,6 @@ TA_RetCode TA_PVO_OpenInternal( struct TA_PVO_Stream **stream, const double inVo
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
          return TA_ALLOC_ERR;
       }
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       /* Make sure slow is really slower than
        * the fast period! if not, swap...
        */
@@ -484,11 +479,6 @@ TA_LIB_API TA_RetCode TA_PVO_OpenAndFill( TA_PVO_Stream **stream, const double i
       int i;
       /* Allocate an intermediate buffer. */
       tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
-      if( !tempBuffer )
-      {
-         TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );
-         return TA_ALLOC_ERR;
-      }
       if( !tempBuffer )
       {
          TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outReal );

--- a/src/ta_func/ta_STOCH.c
+++ b/src/ta_func/ta_STOCH.c
@@ -851,11 +851,6 @@ TA_RetCode TA_STOCH_OpenInternal( struct TA_STOCH_Stream **stream, const double 
             TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outSlowK ); TA_Free( sc_outSlowD );
             return TA_ALLOC_ERR;
          }
-         if( !tempBuffer )
-         {
-            TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outSlowK ); TA_Free( sc_outSlowD );
-            return TA_ALLOC_ERR;
-         }
       }
       /* Do the K calculation */
       while( today <= endIdx )
@@ -1214,11 +1209,6 @@ TA_LIB_API TA_RetCode TA_STOCH_OpenAndFill( TA_STOCH_Stream **stream, const doub
       {
          bufferIsAllocated = 1;
          tempBuffer = malloc((endIdx - today + 1) * sizeof(double));
-         if( !tempBuffer )
-         {
-            TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outSlowK ); TA_Free( sc_outSlowD );
-            return TA_ALLOC_ERR;
-         }
          if( !tempBuffer )
          {
             TA_MA_Close( sub0 ); TA_MA_Close( sub1 ); TA_Free( sc_outSlowK ); TA_Free( sc_outSlowD );

--- a/src/ta_func/ta_STOCHF.c
+++ b/src/ta_func/ta_STOCHF.c
@@ -801,11 +801,6 @@ TA_RetCode TA_STOCHF_OpenInternal( struct TA_STOCHF_Stream **stream, const doubl
             TA_MA_Close( sub0 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
             return TA_ALLOC_ERR;
          }
-         if( !tempBuffer )
-         {
-            TA_MA_Close( sub0 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
-            return TA_ALLOC_ERR;
-         }
       }
       /* Do the K calculation */
       while( today <= endIdx )
@@ -1131,11 +1126,6 @@ TA_LIB_API TA_RetCode TA_STOCHF_OpenAndFill( TA_STOCHF_Stream **stream, const do
       {
          bufferIsAllocated = 1;
          tempBuffer = malloc((endIdx - today + 1) * sizeof(double));
-         if( !tempBuffer )
-         {
-            TA_MA_Close( sub0 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
-            return TA_ALLOC_ERR;
-         }
          if( !tempBuffer )
          {
             TA_MA_Close( sub0 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );

--- a/src/ta_func/ta_STOCHRSI.c
+++ b/src/ta_func/ta_STOCHRSI.c
@@ -429,13 +429,6 @@ TA_RetCode TA_STOCHRSI_OpenInternal( struct TA_STOCHRSI_Stream **stream, const d
          TA_RSI_Close( sub0 ); TA_STOCHF_Close( sub1 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
          return TA_ALLOC_ERR;
       }
-      if( !tempRSIBuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
-         TA_RSI_Close( sub0 ); TA_STOCHF_Close( sub1 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
-         return TA_ALLOC_ERR;
-      }
       /* Sub-stream 0: rsi over `inReal`, warmed from bar 0 up to the
        * sub-call's own startIdx (the seeding point). */
       {
@@ -605,13 +598,6 @@ TA_LIB_API TA_RetCode TA_STOCHRSI_OpenAndFill( TA_STOCHRSI_Stream **stream, cons
       tempRSIBuffer = malloc(tempArraySize * sizeof(double));
       if( !tempRSIBuffer )
       {
-         TA_RSI_Close( sub0 ); TA_STOCHF_Close( sub1 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
-         return TA_ALLOC_ERR;
-      }
-      if( !tempRSIBuffer )
-      {
-         dummyBegIdx = 0;
-         dummyNBElement = 0;
          TA_RSI_Close( sub0 ); TA_STOCHF_Close( sub1 ); TA_Free( sc_outFastK ); TA_Free( sc_outFastD );
          return TA_ALLOC_ERR;
       }

--- a/ta_codegen/generator/src/backends/c_stream.rs
+++ b/ta_codegen/generator/src/backends/c_stream.rs
@@ -1253,6 +1253,113 @@ fn composed_open_expr_fn(outputs: &[String]) -> impl Fn(Expr) -> Expr + '_ {
     }
 }
 
+/// Drop a source NULL check that the injected one already covers.
+///
+/// [`malloc_null_check_block`] emits `alloc; if(!x){ cleanup; return ALLOC_ERR; }`
+/// for every allocating intermediate. When the input `.c` checked the same
+/// allocation itself — STOCH, ADXR, BBANDS and six more do — that check is
+/// transcribed right after the injected block and the pair renders identically,
+/// the second one unreachable.
+///
+/// It has to be dropped here rather than in the statement map: the map is 1:1
+/// and cannot see that the `If` it is looking at follows an injection for the
+/// same variable. Suppressing the INJECTED block instead would be wrong — it
+/// carries a cascading `free()` of every intermediate allocated before it
+/// (`ta_BBANDS.c` frees `tempBuffer1` when `tempBuffer2` fails) that the source
+/// check does not have.
+fn drop_duplicate_null_checks(stmts: Vec<Statement>) -> Vec<Statement> {
+    /// `if( !x ) { ... }` -> `x`
+    fn null_check_var(s: &Statement) -> Option<&str> {
+        let Statement::If {
+            condition: Expr::Not(inner),
+            ..
+        } = s
+        else {
+            return None;
+        };
+        match inner.as_ref() {
+            Expr::Var(v) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+    /// The variable an injected block checks, taken from its trailing `If`.
+    fn injected_block_var(s: &Statement) -> Option<&str> {
+        let Statement::Block { body } = s else {
+            return None;
+        };
+        null_check_var(body.last()?)
+    }
+
+    let mut out: Vec<Statement> = Vec::with_capacity(stmts.len());
+    for s in stmts {
+        let s = recurse(s);
+        if let (Some(prev), Some(cur)) = (out.last().and_then(injected_block_var), null_check_var(&s))
+        {
+            if prev == cur {
+                continue;
+            }
+        }
+        out.push(s);
+    }
+    return out;
+
+    fn recurse(s: Statement) -> Statement {
+        match s {
+            Statement::Block { body } => Statement::Block {
+                body: drop_duplicate_null_checks(body),
+            },
+            Statement::If {
+                condition,
+                then_body,
+                else_body,
+                cond_comments,
+            } => Statement::If {
+                condition,
+                then_body: drop_duplicate_null_checks(then_body),
+                else_body: drop_duplicate_null_checks(else_body),
+                cond_comments,
+            },
+            Statement::While { condition, body } => Statement::While {
+                condition,
+                body: drop_duplicate_null_checks(body),
+            },
+            Statement::DoWhile { condition, body } => Statement::DoWhile {
+                condition,
+                body: drop_duplicate_null_checks(body),
+            },
+            Statement::For { var, count, body } => Statement::For {
+                var,
+                count,
+                body: drop_duplicate_null_checks(body),
+            },
+            Statement::ForC {
+                init,
+                condition,
+                update,
+                body,
+            } => Statement::ForC {
+                init,
+                condition,
+                update,
+                body: drop_duplicate_null_checks(body),
+            },
+            Statement::Switch {
+                expr,
+                cases,
+                default,
+            } => Statement::Switch {
+                expr,
+                cases: cases
+                    .into_iter()
+                    .map(|(k, v)| (k, drop_duplicate_null_checks(v)))
+                    .collect(),
+                default: drop_duplicate_null_checks(default),
+            },
+            other => other,
+        }
+    }
+}
+
 /// `name = malloc(...); if (!name) { cleanup; return ALLOC_ERR; }` — the batch
 /// bodies malloc intermediate series without a NULL check (a pre-existing batch
 /// defect that surfaces as UB on this NEW API surface). The `= malloc` is
@@ -1365,8 +1472,8 @@ fn build_composed_open_bodies(
         tail.pop();
     }
     (
-        streaming::rewrite_stmts(&region, &fe, &fs),
-        streaming::rewrite_stmts(&tail, &fe, &fs),
+        drop_duplicate_null_checks(streaming::rewrite_stmts(&region, &fe, &fs)),
+        drop_duplicate_null_checks(streaming::rewrite_stmts(&tail, &fe, &fs)),
     )
 }
 


### PR DESCRIPTION
Closes #169.

## Why the two obvious fixes both fail

You recorded both in the issue, and they hold up:

1. **Skip the injection when the source already checks** — loses the cascading `free()`. The injected block frees every intermediate allocated before it; the source check does not. `test_c_bbands_open_frees_prior_intermediate_on_oom` catches it.
2. **Drop the transcribed source check** — changes nothing, 22 before and 22 after.

The reason (2) does nothing is structural rather than a matter of matching the right shape: `fs` is a **1:1 statement map**. It is handed one `Statement` at a time and returns one back. When it is holding the source's `if( !tempBuffer )`, it has no way to know whether the statement *before* it was an injection for that same variable — that context does not exist at that point in the fold.

## The fix

Reconcile one level up instead. After `rewrite_stmts` has produced the statement list, a peephole walks it: an `if( !x )` whose **immediately preceding sibling** is an injected block ending in `if( !x )` is dropped. What survives is the injected block, with the stronger cleanup — so the OOM semantics that (1) would have destroyed are preserved by construction, not by care.

It recurses through nested bodies (`If` / `While` / `DoWhile` / `For` / `ForC` / `Switch` / `Block`) since the composed region can be arbitrarily nested.

`ta_BBANDS.c`, before and after — the block that survives is the one that was already there:

```c
  if( !tempBuffer2 )
  {
     free( tempBuffer1 ); TA_MA_Close( sub0 ); TA_STDDEV_Close( sub1 );
     TA_Free( sc_outRealUpperBand ); TA_Free( sc_outRealMiddleBand ); TA_Free( sc_outRealLowerBand );
     return TA_ALLOC_ERR;
  }
- if( !tempBuffer2 )          /* the weaker copy, unreachable */
- {
-    free(tempBuffer1);
-    return TA_ALLOC_ERR;
- }
```

## Effect

22 duplicate pairs across 9 functions → 0: `ADXR`, `APO`, `BBANDS`, `MACDEXT`, `PPO`, `PVO`, `STOCH`, `STOCHF`, `STOCHRSI`.

Your idempotence point holds after this too — the peephole keys off the pairing, not off a fixed list, so a NULL check added to a new input `.c` for a stream intermediate collapses the same way instead of doubling.

## Verification

```
test_c_bbands_open_frees_prior_intermediate_on_oom   ok    (the gate that caught attempt 1)
generator suite      322 + 255 + 14 + 11 + 10 + 2 passed, 0 failed
ta_regtest           all green
variant parity       168 functions x 37,248 vectors, bit-identical
C library            0 errors
```

Duplicate count measured directly on the generated sources with a regex over consecutive identical `if( !x ){...}` pairs: 22 on `dev`, 0 here.
