### PR TITLE
perf(rust): render batch CIRCBUF with C's hybrid storage

### DIFF
--- a/ta_codegen/generator/src/backends/rust_lang.rs
+++ b/ta_codegen/generator/src/backends/rust_lang.rs
@@ -59,6 +59,12 @@ pub struct RustRenderCtx {
     /// empty. Empty ⇒ the constant renders literally (unresolved), which a
     /// build catches immediately.
     pub matype_map: std::collections::HashMap<String, String>,
+    /// CIRCBUF ids rendered with the C-style hybrid storage (stack array up to
+    /// the PROLOG static size, heap `Vec` above it), mapped to that static
+    /// size. Populated for batch bodies only; stream bodies leave it empty and
+    /// keep pure-`Vec` storage, whose ownership the open path moves into the
+    /// stream state struct.
+    pub circbuf_hybrid_static: std::collections::HashMap<String, i64>,
 }
 
 /// Build the `TA_MAType_*` → value-string map the [`ExprEmitter::var`] hook uses
@@ -110,6 +116,7 @@ impl RustRenderCtx {
             sentinel_vars: std::collections::HashSet::new(),
             result_error_returns: false,
             matype_map: std::collections::HashMap::new(),
+            circbuf_hybrid_static: std::collections::HashMap::new(),
         }
     }
 
@@ -471,6 +478,7 @@ fn gen_impl_block(func: &FuncDef, enums: &HashMap<String, EnumDef>, registry: &R
         sentinel_vars,
         result_error_returns: false,
         matype_map: build_matype_map(enums),
+        circbuf_hybrid_static: collect_circbuf_static(&func.body),
     };
 
     // `_private` holds the algorithm for the functions that declare one (Rust has
@@ -648,6 +656,7 @@ fn gen_guarded_func(
             sentinel_vars: g_sentinel_vars,
             result_error_returns: false,
             matype_map: build_matype_map(enums),
+            circbuf_hybrid_static: collect_circbuf_static(&func.body),
         };
         let g_for_loop_vars = collect_for_loop_vars(&func.body);
         let g_var_inits: std::collections::HashMap<String, &Expr> = func
@@ -675,7 +684,7 @@ fn gen_guarded_func(
                 static_size,
             }) = stmt
             {
-                out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size));
+                out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size, Some(circbuf_has_runtime_init(&func.body, id))));
                 continue;
             }
             if let Statement::VarDecl { var_type, name, init } = stmt {
@@ -743,6 +752,7 @@ fn gen_guarded_func(
             sentinel_vars: g_sentinel_vars,
             result_error_returns: false,
             matype_map: build_matype_map(enums),
+            circbuf_hybrid_static: collect_circbuf_static(&func.body),
         };
 
         // Use the same full rendering as the `_private` body
@@ -773,7 +783,7 @@ fn gen_guarded_func(
                 static_size,
             }) = stmt
             {
-                out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size));
+                out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size, Some(circbuf_has_runtime_init(&func.body, id))));
                 continue;
             }
             if let Statement::VarDecl { var_type, name, .. } = stmt {
@@ -1029,7 +1039,7 @@ fn gen_private_func_inner(
             static_size,
         }) = stmt
         {
-            out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size));
+            out.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size, Some(circbuf_has_runtime_init(&func.body, id))));
             continue;
         }
         if let Statement::VarDecl { var_type, name, .. } = stmt {
@@ -1305,21 +1315,50 @@ fn circbuf_storage(id: &str, layout: &CircBufLayout) -> Vec<(String, VarType)> {
     }
 }
 
-/// Emit the function-top declarations for a CIRCBUF prolog: an empty `Vec` per
-/// field-split storage, the `usize` rotation index, and the `usize` bound. The bound
-/// is seeded to `static_size - 1` (NOT 0) so the `INIT_LOCAL_ONLY` path (HT functions)
-/// sizes its buffer correctly before any `INIT` runs. Indent is the 8-space body level.
-pub(crate) fn emit_circbuf_prolog_rust(id: &str, layout: &CircBufLayout, static_size: i64) -> String {
+/// Emit the function-top declarations for a CIRCBUF prolog, plus the `usize`
+/// rotation index and bound. The bound is seeded to `static_size - 1` (NOT 0)
+/// so the `INIT_LOCAL_ONLY` path (HT functions) sizes its buffer correctly
+/// before any `INIT` runs. Indent is the 8-space body level.
+///
+/// `hybrid_runtime_init` selects the storage shape:
+/// - `None` (stream tier): an empty `Vec` per field-split storage — the open
+///   path moves these into the stream state struct, so they must own heap.
+/// - `Some(has_init)` (batch tier): the C-style hybrid — a zeroed stack array
+///   of the static size, a deferred heap `Vec` (only when a runtime `INIT`
+///   exists to reach it), and a `&mut` slice the body indexes through.
+pub(crate) fn emit_circbuf_prolog_rust(
+    id: &str,
+    layout: &CircBufLayout,
+    static_size: i64,
+    hybrid_runtime_init: Option<bool>,
+) -> String {
     let mut s = String::new();
     for (storage, t) in circbuf_storage(id, layout) {
-        let vt = if matches!(t, VarType::Integer) {
-            "i32"
+        let (vt, zero) = if matches!(t, VarType::Integer) {
+            ("i32", "0i32")
         } else {
-            "f64"
+            ("f64", "0.0_f64")
         };
-        s.push_str(&format!(
-            "        let mut {storage}: Vec<{vt}> = Vec::new();\n"
-        ));
+        match hybrid_runtime_init {
+            None => {
+                s.push_str(&format!(
+                    "        let mut {storage}: Vec<{vt}> = Vec::new();\n"
+                ));
+            }
+            Some(has_runtime_init) => {
+                s.push_str(&format!(
+                    "        let mut local_{storage}: [{vt}; {static_size}] = [{zero}; {static_size}];\n"
+                ));
+                if has_runtime_init {
+                    s.push_str(&format!(
+                        "        let mut heap_{storage}: Vec<{vt}> = Vec::new();\n"
+                    ));
+                }
+                s.push_str(&format!(
+                    "        let mut {storage}: &mut [{vt}] = &mut [];\n"
+                ));
+            }
+        }
     }
     s.push_str(&format!("        let mut {id}_Idx: usize = 0;\n"));
     s.push_str(&format!(
@@ -1327,6 +1366,43 @@ pub(crate) fn emit_circbuf_prolog_rust(id: &str, layout: &CircBufLayout, static_
         static_size - 1
     ));
     s
+}
+
+/// CIRCBUF prologs in `body` as `id → static size` — the batch tier's
+/// hybrid-storage map ([`RustRenderCtx::circbuf_hybrid_static`]). Prologs are
+/// declarations, so only the top level of `body` is scanned.
+pub(crate) fn collect_circbuf_static(body: &[Statement]) -> std::collections::HashMap<String, i64> {
+    body.iter()
+        .filter_map(|s| match s {
+            Statement::CircBuf(CircBuf::Prolog { id, static_size, .. }) => {
+                Some((id.clone(), *static_size))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Whether a runtime-sized `CIRCBUF_INIT` for `id` appears anywhere in `body`
+/// (as opposed to `INIT_LOCAL_ONLY`, which never needs the heap fallback).
+pub(crate) fn circbuf_has_runtime_init(body: &[Statement], id: &str) -> bool {
+    body.iter().any(|stmt| match stmt {
+        Statement::CircBuf(CircBuf::Init { id: init_id, .. }) => init_id == id,
+        Statement::If { then_body, else_body, .. } => {
+            circbuf_has_runtime_init(then_body, id) || circbuf_has_runtime_init(else_body, id)
+        }
+        Statement::While { body: b, .. } | Statement::DoWhile { body: b, .. } => {
+            circbuf_has_runtime_init(b, id)
+        }
+        Statement::For { body: b, .. } | Statement::ForC { body: b, .. } => {
+            circbuf_has_runtime_init(b, id)
+        }
+        Statement::Block { body: b } => circbuf_has_runtime_init(b, id),
+        Statement::Switch { cases, default, .. } => {
+            cases.iter().any(|(_, cb)| circbuf_has_runtime_init(cb, id))
+                || circbuf_has_runtime_init(default, id)
+        }
+        _ => false,
+    })
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2139,7 +2215,11 @@ impl StatementEmitter for RustStmt<'_, '_> {
             CircBuf::Next { id } => {
                 format!("{pad}{id}_Idx += 1;\n{pad}if {id}_Idx > maxIdx_{id} {{ {id}_Idx = 0; }}\n")
             }
-            // Runtime-sized: (re)allocate each storage Vec to `size` (always heap).
+            // Runtime-sized. Batch tier (id present in circbuf_hybrid_static):
+            // C-style hybrid — bind the slices to the prolog's stack arrays when
+            // the runtime size fits the static capacity, heap-allocate otherwise.
+            // Stream tier: (re)allocate each storage Vec to `size` (always heap;
+            // the open path moves the Vecs into the stream state struct).
             CircBuf::Init { id, layout, size } => {
                 let sz = render_expr(
                     size,
@@ -2159,32 +2239,67 @@ impl StatementEmitter for RustStmt<'_, '_> {
                 s.push_str(&format!(
                     "{pad}if {sz} < 1 {{ {alloc_fail} }}\n"
                 ));
-                for (storage, t) in circbuf_storage(id, layout) {
-                    let zero = if matches!(t, VarType::Integer) {
-                        "0i32"
-                    } else {
-                        "0.0_f64"
-                    };
+                if let Some(static_size) = self.ctx.circbuf_hybrid_static.get(id) {
                     s.push_str(&format!(
-                        "{pad}{storage} = vec![{zero}; ({sz}) as usize];\n"
+                        "{pad}if ({sz}) as usize <= {static_size}usize {{\n"
                     ));
+                    for (storage, _) in circbuf_storage(id, layout) {
+                        s.push_str(&format!(
+                            "{pad}    {storage} = &mut local_{storage};\n"
+                        ));
+                    }
+                    s.push_str(&format!("{pad}}} else {{\n"));
+                    for (storage, t) in circbuf_storage(id, layout) {
+                        let zero = if matches!(t, VarType::Integer) {
+                            "0i32"
+                        } else {
+                            "0.0_f64"
+                        };
+                        s.push_str(&format!(
+                            "{pad}    heap_{storage} = vec![{zero}; ({sz}) as usize];\n"
+                        ));
+                        s.push_str(&format!(
+                            "{pad}    {storage} = &mut heap_{storage};\n"
+                        ));
+                    }
+                    s.push_str(&format!("{pad}}}\n"));
+                } else {
+                    for (storage, t) in circbuf_storage(id, layout) {
+                        let zero = if matches!(t, VarType::Integer) {
+                            "0i32"
+                        } else {
+                            "0.0_f64"
+                        };
+                        s.push_str(&format!(
+                            "{pad}{storage} = vec![{zero}; ({sz}) as usize];\n"
+                        ));
+                    }
                 }
                 s.push_str(&format!("{pad}maxIdx_{id} = (({sz}) as usize) - 1;\n"));
                 s.push_str(&format!("{pad}{id}_Idx = 0;\n"));
                 s
             }
             // Always the static capacity; bound was seeded in the prolog (maxIdx + 1).
+            // Batch tier: bind to the prolog's zeroed stack arrays — no allocation.
             CircBuf::InitLocalOnly { id, layout } => {
                 let mut s = String::new();
-                for (storage, t) in circbuf_storage(id, layout) {
-                    let zero = if matches!(t, VarType::Integer) {
-                        "0i32"
-                    } else {
-                        "0.0_f64"
-                    };
-                    s.push_str(&format!(
-                        "{pad}{storage} = vec![{zero}; maxIdx_{id} + 1];\n"
-                    ));
+                if self.ctx.circbuf_hybrid_static.contains_key(id) {
+                    for (storage, _) in circbuf_storage(id, layout) {
+                        s.push_str(&format!(
+                            "{pad}{storage} = &mut local_{storage};\n"
+                        ));
+                    }
+                } else {
+                    for (storage, t) in circbuf_storage(id, layout) {
+                        let zero = if matches!(t, VarType::Integer) {
+                            "0i32"
+                        } else {
+                            "0.0_f64"
+                        };
+                        s.push_str(&format!(
+                            "{pad}{storage} = vec![{zero}; maxIdx_{id} + 1];\n"
+                        ));
+                    }
                 }
                 s.push_str(&format!("{pad}{id}_Idx = 0;\n"));
                 s

--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -245,6 +245,7 @@ fn build_typing_from(func: &FuncDef, body: &[Statement], models: &[&StreamModel]
             // Stream bodies dispatch MA-type structurally (case labels /
             // sub-opens), never via `== TA_MAType_*`, so no map is needed.
             matype_map: HashMap::new(),
+            circbuf_hybrid_static: HashMap::new(),
         },
         extrema_i32,
     }
@@ -1141,7 +1142,7 @@ fn emit_open_region(
     // Declarations (hoisted; always `mut` — the crate allows unused_mut).
     for stmt in body {
         if let Statement::CircBuf(CircBuf::Prolog { id, layout, static_size }) = stmt {
-            o.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size));
+            o.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size, None));
             continue;
         }
         if let Statement::VarDecl { var_type, name, .. } = stmt {
@@ -2038,6 +2039,7 @@ fn plan_ctx(func: &FuncDef, enums: &HashMap<String, EnumDef>) -> RustRenderCtx {
         // The dispatch identity guard can compare `optInMAType == TA_MAType_*`
         // (TA_MAType_DISABLED, #93); resolve those to their ordinal like batch.
         matype_map: build_matype_map(enums),
+        circbuf_hybrid_static: HashMap::new(),
     }
 }
 
@@ -3170,7 +3172,7 @@ fn emit_composed_region(
 
     for stmt in body {
         if let Statement::CircBuf(CircBuf::Prolog { id, layout, static_size }) = stmt {
-            o.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size));
+            o.push_str(&emit_circbuf_prolog_rust(id, layout, *static_size, None));
             continue;
         }
         if let Statement::VarDecl { var_type, name, .. } = stmt {

--- a/ta_codegen/output/rust/library/src/ta_func/cci.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cci.rs
@@ -201,7 +201,9 @@ impl Core {
         let mut j: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
         let mut lookbackTotal: usize = 0_usize;
-        let mut circBuffer: Vec<f64> = Vec::new();
+        let mut local_circBuffer: [f64; 30] = [0.0_f64; 30];
+        let mut heap_circBuffer: Vec<f64> = Vec::new();
+        let mut circBuffer: &mut [f64] = &mut [];
         let mut circBuffer_Idx: usize = 0;
         let mut maxIdx_circBuffer: usize = 29;
         // This ptr will points on a circular buffer of
@@ -223,7 +225,12 @@ impl Core {
         // Allocate a circular buffer equal to the requested
         // period.
         if optInTimePeriod < 1 { return RetCode::AllocErr; }
-        circBuffer = vec![0.0_f64; (optInTimePeriod) as usize];
+        if (optInTimePeriod) as usize <= 30usize {
+            circBuffer = &mut local_circBuffer;
+        } else {
+            heap_circBuffer = vec![0.0_f64; (optInTimePeriod) as usize];
+            circBuffer = &mut heap_circBuffer;
+        }
         maxIdx_circBuffer = ((optInTimePeriod) as usize) - 1;
         circBuffer_Idx = 0;
         // Do the MA calculation using tight loops.

--- a/ta_codegen/output/rust/library/src/ta_func/cmf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmf.rs
@@ -234,8 +234,12 @@ impl Core {
         let mut outIdx: usize = 0_usize;
         let mut i: usize = 0_usize;
         let mut today: usize = 0_usize;
-        let mut mfv_flow: Vec<f64> = Vec::new();
-        let mut mfv_volume: Vec<f64> = Vec::new();
+        let mut local_mfv_flow: [f64; 50] = [0.0_f64; 50];
+        let mut heap_mfv_flow: Vec<f64> = Vec::new();
+        let mut mfv_flow: &mut [f64] = &mut [];
+        let mut local_mfv_volume: [f64; 50] = [0.0_f64; 50];
+        let mut heap_mfv_volume: Vec<f64> = Vec::new();
+        let mut mfv_volume: &mut [f64] = &mut [];
         let mut mfv_Idx: usize = 0;
         let mut maxIdx_mfv: usize = 49;
         // Both the per-bar money flow volume and the volume that produced it are
@@ -258,8 +262,15 @@ impl Core {
             return RetCode::Success;
         }
         if optInTimePeriod < 1 { return RetCode::AllocErr; }
-        mfv_flow = vec![0.0_f64; (optInTimePeriod) as usize];
-        mfv_volume = vec![0.0_f64; (optInTimePeriod) as usize];
+        if (optInTimePeriod) as usize <= 50usize {
+            mfv_flow = &mut local_mfv_flow;
+            mfv_volume = &mut local_mfv_volume;
+        } else {
+            heap_mfv_flow = vec![0.0_f64; (optInTimePeriod) as usize];
+            mfv_flow = &mut heap_mfv_flow;
+            heap_mfv_volume = vec![0.0_f64; (optInTimePeriod) as usize];
+            mfv_volume = &mut heap_mfv_volume;
+        }
         maxIdx_mfv = ((optInTimePeriod) as usize) - 1;
         mfv_Idx = 0;
         outIdx = 0;

--- a/ta_codegen/output/rust/library/src/ta_func/hma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/hma.rs
@@ -226,7 +226,9 @@ impl Core {
         let mut fullOut: f64 = 0.0_f64;
         let mut halfOut: f64 = 0.0_f64;
         let mut diffReal: f64 = 0.0_f64;
-        let mut dRing: Vec<f64> = Vec::new();
+        let mut local_dRing: [f64; 50] = [0.0_f64; 50];
+        let mut heap_dRing: Vec<f64> = Vec::new();
+        let mut dRing: &mut [f64] = &mut [];
         let mut dRing_Idx: usize = 0;
         let mut maxIdx_dRing: usize = 49;
         // The de-lagged series needs only its last sqrt(n) values, so the whole
@@ -327,7 +329,12 @@ impl Core {
             // slot with the current one, advance.
             ringSize = sqrtPeriod - 1;
             if ringSize < 1 { return RetCode::AllocErr; }
-            dRing = vec![0.0_f64; (ringSize) as usize];
+            if (ringSize) as usize <= 50usize {
+                dRing = &mut local_dRing;
+            } else {
+                heap_dRing = vec![0.0_f64; (ringSize) as usize];
+                dRing = &mut heap_dRing;
+            }
             maxIdx_dRing = ((ringSize) as usize) - 1;
             dRing_Idx = 0;
             // Warm-up: the sqrtPeriod-1 de-lagged values before the first output

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
@@ -234,7 +234,8 @@ impl Core {
         let mut constDeg2RadBy360: f64 = 0.0_f64;
         let mut todayValue: f64 = 0.0_f64;
         let mut smoothPeriod: f64 = 0.0_f64;
-        let mut smoothPrice: Vec<f64> = Vec::new();
+        let mut local_smoothPrice: [f64; 50] = [0.0_f64; 50];
+        let mut smoothPrice: &mut [f64] = &mut [];
         let mut smoothPrice_Idx: usize = 0;
         let mut maxIdx_smoothPrice: usize = 49;
         let mut idx: usize = 0_usize;
@@ -250,7 +251,7 @@ impl Core {
         // Varaible used to keep track of the previous
         // smooth price. In the case of this algorithm,
         // we will never need more than 50 values.
-        smoothPrice = vec![0.0_f64; maxIdx_smoothPrice + 1];
+        smoothPrice = &mut local_smoothPrice;
         smoothPrice_Idx = 0;
         // Variable used to calculate the dominant cycle phase
         // circular buffer already declared

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -248,7 +248,8 @@ impl Core {
         let mut constDeg2RadBy360: f64 = 0.0_f64;
         let mut todayValue: f64 = 0.0_f64;
         let mut smoothPeriod: f64 = 0.0_f64;
-        let mut smoothPrice: Vec<f64> = Vec::new();
+        let mut local_smoothPrice: [f64; 50] = [0.0_f64; 50];
+        let mut smoothPrice: &mut [f64] = &mut [];
         let mut smoothPrice_Idx: usize = 0;
         let mut maxIdx_smoothPrice: usize = 49;
         let mut idx: usize = 0_usize;
@@ -264,7 +265,7 @@ impl Core {
         // Varaible used to keep track of the previous
         // smooth price. In the case of this algorithm,
         // we will never need more than 50 values.
-        smoothPrice = vec![0.0_f64; maxIdx_smoothPrice + 1];
+        smoothPrice = &mut local_smoothPrice;
         smoothPrice_Idx = 0;
         // Variable used to calculate the dominant cycle phase
         // circular buffer already declared

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -247,7 +247,8 @@ impl Core {
         let mut constDeg2RadBy360: f64 = 0.0_f64;
         let mut todayValue: f64 = 0.0_f64;
         let mut smoothPeriod: f64 = 0.0_f64;
-        let mut smoothPrice: Vec<f64> = Vec::new();
+        let mut local_smoothPrice: [f64; 50] = [0.0_f64; 50];
+        let mut smoothPrice: &mut [f64] = &mut [];
         let mut smoothPrice_Idx: usize = 0;
         let mut maxIdx_smoothPrice: usize = 49;
         let mut idx: usize = 0_usize;
@@ -272,7 +273,7 @@ impl Core {
         // Variable used to keep track of the previous
         // smooth price. In the case of this algorithm,
         // we will never need more than 50 values.
-        smoothPrice = vec![0.0_f64; maxIdx_smoothPrice + 1];
+        smoothPrice = &mut local_smoothPrice;
         smoothPrice_Idx = 0;
         // Variable used to calculate the dominant cycle phase
         // Variable used to calculate the trend mode

--- a/ta_codegen/output/rust/library/src/ta_func/mfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mfi.rs
@@ -214,14 +214,25 @@ impl Core {
         let mut outIdx: usize = 0_usize;
         let mut i: usize = 0_usize;
         let mut today: usize = 0_usize;
-        let mut mflow_positive: Vec<f64> = Vec::new();
-        let mut mflow_negative: Vec<f64> = Vec::new();
+        let mut local_mflow_positive: [f64; 50] = [0.0_f64; 50];
+        let mut heap_mflow_positive: Vec<f64> = Vec::new();
+        let mut mflow_positive: &mut [f64] = &mut [];
+        let mut local_mflow_negative: [f64; 50] = [0.0_f64; 50];
+        let mut heap_mflow_negative: Vec<f64> = Vec::new();
+        let mut mflow_negative: &mut [f64] = &mut [];
         let mut mflow_Idx: usize = 0;
         let mut maxIdx_mflow: usize = 49;
         // Id, Type, Static Size
         if optInTimePeriod < 1 { return RetCode::AllocErr; }
-        mflow_positive = vec![0.0_f64; (optInTimePeriod) as usize];
-        mflow_negative = vec![0.0_f64; (optInTimePeriod) as usize];
+        if (optInTimePeriod) as usize <= 50usize {
+            mflow_positive = &mut local_mflow_positive;
+            mflow_negative = &mut local_mflow_negative;
+        } else {
+            heap_mflow_positive = vec![0.0_f64; (optInTimePeriod) as usize];
+            mflow_positive = &mut heap_mflow_positive;
+            heap_mflow_negative = vec![0.0_f64; (optInTimePeriod) as usize];
+            mflow_negative = &mut heap_mflow_negative;
+        }
         maxIdx_mflow = ((optInTimePeriod) as usize) - 1;
         mflow_Idx = 0;
         (*outBegIdx) = 0;

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -248,8 +248,12 @@ impl Core {
         let mut usedFlag: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut periods: [i32; 3 as usize] = [0i32; 3 as usize];
         let mut sortedPeriods: [i32; 3 as usize] = [0i32; 3 as usize];
-        let mut term_closeMinusTrueLow: Vec<f64> = Vec::new();
-        let mut term_trueRange: Vec<f64> = Vec::new();
+        let mut local_term_closeMinusTrueLow: [f64; 32] = [0.0_f64; 32];
+        let mut heap_term_closeMinusTrueLow: Vec<f64> = Vec::new();
+        let mut term_closeMinusTrueLow: &mut [f64] = &mut [];
+        let mut local_term_trueRange: [f64; 32] = [0.0_f64; 32];
+        let mut heap_term_trueRange: Vec<f64> = Vec::new();
+        let mut term_trueRange: &mut [f64] = &mut [];
         let mut term_Idx: usize = 0;
         let mut maxIdx_term: usize = 31;
         // The two per-bar terms the three moving sums are built from. Both are a
@@ -299,8 +303,15 @@ impl Core {
             return RetCode::Success;
         }
         if optInTimePeriod3 < 1 { return RetCode::AllocErr; }
-        term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
-        term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+        if (optInTimePeriod3) as usize <= 32usize {
+            term_closeMinusTrueLow = &mut local_term_closeMinusTrueLow;
+            term_trueRange = &mut local_term_trueRange;
+        } else {
+            heap_term_closeMinusTrueLow = vec![0.0_f64; (optInTimePeriod3) as usize];
+            term_closeMinusTrueLow = &mut heap_term_closeMinusTrueLow;
+            heap_term_trueRange = vec![0.0_f64; (optInTimePeriod3) as usize];
+            term_trueRange = &mut heap_term_trueRange;
+        }
         maxIdx_term = ((optInTimePeriod3) as usize) - 1;
         term_Idx = 0;
         // Prime running totals used in moving averages.


### PR DESCRIPTION
Closes #155. This is your prototype from the issue, forwarded to the post-#166 tree and regenerated — the credit is yours, I carried it across and verified it.

## Porting note

The patch applied to `rust_lang.rs` and `rust_stream.rs` with a three-way merge and no conflicts. I had expected the Unguarded removal to have moved the ground under it (`gen_unguarded_or_private_func` is in the hunk headers), but it does not touch the surface the patch keys off.

`#154` is merged, so the ordering constraint you noted is satisfied.

## What lands

Batch bodies mirror C's macro: a stack array at the `CIRCBUF_PROLOG` static size, heap only when the runtime period exceeds it. The stream tier is untouched and keeps pure-`Vec` storage — its open path moves the `Vec`s into the stream state struct, which is already one allocation per `Open` and none per `Update`.

Generated `cci.rs`:

```rust
let mut local_circBuffer: [f64; 30] = [0.0_f64; 30];
let mut heap_circBuffer: Vec<f64> = Vec::new();
let mut circBuffer: &mut [f64] = &mut [];
...
if (optInTimePeriod) as usize <= 30usize {
    circBuffer = &mut local_circBuffer;
} else {
    heap_circBuffer = vec![0.0_f64; (optInTimePeriod) as usize];
    circBuffer = &mut heap_circBuffer;
}
```

| | after |
|---|---|
| `CCI`, `CMF`, `MFI`, `ULTOSC` | allocation-free at any period up to the static size — covers every default |
| `HT_DCPHASE`, `HT_SINE`, `HT_TRENDMODE` | allocation-free outright (`INIT_LOCAL_ONLY`) |
| `HMA` | unchanged, no runtime-sized `INIT` |

## Why it is worth more now than when you filed it

You measured it as an allocation-property win plus a small-input win, and rated it not urgent against eight functions. The rolling-extrema work in #147 adds six more `CIRCBUF` carriers — `MIN` and `MAX` take two each, `MINMAX` / `MIDPOINT` / `MIDPRICE` / `WILLR` four each — so on that branch Rust would allocate 20 times per call where C allocates nothing. The runtime-sized population goes from 5 functions to 11.

## Verification

```
ta_regtest       all green; variant parity 168 x 37,248 vectors, bit-identical
--xlang-hash     Rust  212,228 cases,  0 mismatches
                 C#    212,174 cases,  0 mismatches
                 Java  211,108 cases, 14 mismatches -- the pre-existing
                                       TA_HT_TRENDMODE 14, unchanged from dev
cargo check      clean, no warnings
C library        0 errors
```

Java and C# were built with JDK 17 and .NET 10 so the tolerance-lane servers are real rather than skipped.
