### PR TITLE
perf: block-scan the rolling extremum window (MIN, MAX, MINMAX, MIDPOINT, MIDPRICE, WILLR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ See [github commits](https://github.com/TA-Lib/ta-lib/commits) for complete list
 - ~40%: ULTOSC (#154). Thanks @dexhunter !
 - ~30%: MAVP (#143). Thanks @dexhunter !
 - ~27% Apple, ~8% GCC: MIN, MAX, MINMAX, MININDEX, MAXINDEX, MINMAXINDEX, MIDPOINT, MIDPRICE, AROON, AROONOSC and WILLR (#128). Thanks @dexhunter !
+- 2x to 15x on trending or flat data, 1.6x to 4x on random walks: MIN, MAX, MINMAX,
+  MIDPOINT, MIDPRICE and WILLR (#147). The rolling window no longer rescans when its
+  extremum leaves; cost per bar is now a fixed number of comparisons at any period.
+  Measured on Apple clang (arm64 and x86-64), gcc and MSVC. Single-extremum MIN and MAX
+  are slightly slower on strictly monotone input in their own direction (under 1 ns per
+  bar), and recomputing one bar through the batch call rather than the streaming API is
+  slower on clang and faster on MSVC.
 - ~20%: VAR, STDDEV, BBANDS
 - ~10%: ATR and NATR
 

--- a/src/ta_func/ta_MAX.c
+++ b/src/ta_func/ta_MAX.c
@@ -76,6 +76,14 @@ TA_LIB_API TA_RetCode TA_MAX( int    startIdx,
                               int          *outNBElement,
                               double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
    double highest;
    double tmp;
    int outIdx;
@@ -121,38 +129,172 @@ TA_LIB_API TA_RetCode TA_MAX( int    startIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. All three are straight-line loops with no
+    *   data-dependent branching, which is what lets a compiler vectorize
+    *   them, and the work is 3 comparisons per bar regardless of period.
+    *   Both scratch arrays hold COPIES, so input and output may alias.
+    *
+    * - Streaming: cache the highest value with its index; rescan only
+    *   when the cached extremum leaves the window. O(1) per bar while the
+    *   extremum sits away from the trailing edge, but not amortized O(1):
+    *   an extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar for
+    *   as long as that persists.
     */
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = inReal[today];
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = inReal[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            sufHighest[i - blockStart] = highest;
          }
-      } else if( tmp >= highest )
-      {
-         highestIdx = today;
-         highest = tmp;
+         highest = sufHighest[0];
+         outReal[outIdx++] = highest;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockStart + optInTimePeriod];
+            preHighest[0] = highest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inReal[blockStart + optInTimePeriod + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               preHighest[i] = highest;
+               i += 1;
+            }
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               outReal[outIdx++] = highest;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = highest;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      while( today <= endIdx )
+      {
+         tmp = inReal[today];
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = inReal[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+         } else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+         }
+         outReal[outIdx++] = highest;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    /* Keep the outBegIdx relative to the
     * caller input before returning.
@@ -170,6 +312,14 @@ TA_RetCode TA_S_MAX( int    startIdx,
                      int          *outNBElement,
                      double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
    double highest;
    double tmp;
    int outIdx;
@@ -207,34 +357,135 @@ TA_RetCode TA_S_MAX( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = (double)inReal[today];
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = (double)inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         i = blockStart + optInTimePeriod - 1;
+         highest = (double)inReal[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = (double)inReal[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            sufHighest[i - blockStart] = highest;
          }
-      } else if( tmp >= highest )
-      {
-         highestIdx = today;
-         highest = tmp;
+         highest = sufHighest[0];
+         outReal[outIdx++] = highest;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = (double)inReal[blockStart + optInTimePeriod];
+            preHighest[0] = highest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = (double)inReal[blockStart + optInTimePeriod + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               preHighest[i] = highest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               outReal[outIdx++] = highest;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = highest;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      while( today <= endIdx )
+      {
+         tmp = (double)inReal[today];
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = (double)inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = (double)inReal[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+         } else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+         }
+         outReal[outIdx++] = highest;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    *outBegIdx= startIdx;
    *outNBElement= outIdx;
@@ -357,6 +608,27 @@ static TA_RetCode TA_MAX_OpenCore( struct TA_MAX_Stream **stream, const double i
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;

--- a/src/ta_func/ta_MIDPOINT.c
+++ b/src/ta_func/ta_MIDPOINT.c
@@ -77,6 +77,22 @@ TA_LIB_API TA_RetCode TA_MIDPOINT( int    startIdx,
                                    int          *outNBElement,
                                    double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmpLow;
@@ -148,61 +164,239 @@ TA_LIB_API TA_RetCode TA_MIDPOINT( int    startIdx,
     * (and the reverse on the way down). A flat stretch pins
     * both. Random-walk input is the favourable case, where
     * rescans are rare. See issue #147.
+    *
+    * The batch tier does not use that automaton: it takes the first arm
+    * for every period in range (the threshold is the declared maximum),
+    * and the automaton above is what the streaming tier transitions on.
+    * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+    * form: the p outputs belonging to one block boundary are produced
+    * together, one backward pass for the older block's suffix extrema,
+    * one forward pass for the newer block's prefix extrema, and a third
+    * pass to combine. Both extrema travel in the same passes. All the
+    * loops are straight-line with no data-dependent branching, which is
+    * what lets a compiler vectorize them, and the work per bar is a
+    * fixed number of comparisons regardless of period. Every scratch
+    * array holds COPIES, so input and output may alias.
     */
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpHigh = inReal[today];
-      tmpLow = tmpHigh;
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmpHigh = inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
-         }
-      } else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
-      if( lowestIdx < trailingIdx )
-      {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
-         {
-            tmpLow = inReal[i];
-            if( tmpLow < lowest )
+            if( tmpHigh < lowest )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               lowest = tmpHigh;
             }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
+         outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest + lowest) / 2.0;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = (highest + lowest) / 2.0;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmpHigh = inReal[today];
+         tmpLow = tmpHigh;
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpHigh = inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
+            }
+         } else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpLow = inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         } else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+         outReal[outIdx++] = (highest + lowest) / 2.0;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    /* Keep the outBegIdx relative to the
     * caller input before returning.
@@ -220,6 +414,22 @@ TA_RetCode TA_S_MIDPOINT( int    startIdx,
                           int          *outNBElement,
                           double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmpLow;
@@ -260,57 +470,210 @@ TA_RetCode TA_S_MIDPOINT( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpHigh = (double)inReal[today];
-      tmpLow = tmpHigh;
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = (double)inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         i = blockStart + optInTimePeriod - 1;
+         highest = (double)inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmpHigh = (double)inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
-         }
-      } else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
-      if( lowestIdx < trailingIdx )
-      {
-         lowestIdx = trailingIdx;
-         lowest = (double)inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
-         {
-            tmpLow = (double)inReal[i];
-            if( tmpLow < lowest )
+            if( tmpHigh < lowest )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               lowest = tmpHigh;
             }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
+         outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = (double)inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = (double)inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest + lowest) / 2.0;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = (highest + lowest) / 2.0;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmpHigh = (double)inReal[today];
+         tmpLow = tmpHigh;
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = (double)inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpHigh = (double)inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
+            }
+         } else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = (double)inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpLow = (double)inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         } else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+         outReal[outIdx++] = (highest + lowest) / 2.0;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    *outBegIdx= startIdx;
    *outNBElement= outIdx;
@@ -483,6 +846,19 @@ static TA_RetCode TA_MIDPOINT_OpenCore( struct TA_MIDPOINT_Stream **stream, cons
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;

--- a/src/ta_func/ta_MIDPRICE.c
+++ b/src/ta_func/ta_MIDPRICE.c
@@ -81,6 +81,22 @@ TA_LIB_API TA_RetCode TA_MIDPRICE( int    startIdx,
                                    int          *outNBElement,
                                    double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmpLow;
@@ -137,16 +153,21 @@ TA_LIB_API TA_RetCode TA_MIDPRICE( int    startIdx,
     * Note that this algorithm allows the input and
     * output to be the same buffer.
     *
-    * Two equivalent algorithms, picked by period. Their outputs are
-    * bit-identical; only the scan strategy differs:
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), and
+    * the second arm is what the streaming tier transitions on:
     *
-    * - Small periods (<= 20): rescan the whole window on every bar.
-    *   The two independent comparison chains auto-vectorize on modern
-    *   compilers, which beats any per-bar bookkeeping while the window
-    *   is short. The threshold sits near the measured crossover
-    *   (~period 19-20 with gcc/clang -O3 on x86-64).
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass for the older block's suffix extrema, one
+    *   forward pass for the newer block's prefix extrema, and a third
+    *   pass to combine. High and low travel in the same passes. All the
+    *   loops are straight-line with no data-dependent branching, which
+    *   is what lets a compiler vectorize them, and the work per bar is a
+    *   fixed number of comparisons regardless of period. Every scratch
+    *   array holds COPIES, so input and output may alias.
     *
-    * - Larger periods: cache the highest high/lowest low with its
+    * - Streaming: cache the highest high/lowest low with its
     *   index; the window is rescanned only when the cached extremum
     *   drops out of the window. That is O(1) per bar while the
     *   extremum sits away from the trailing edge, but it is not
@@ -164,29 +185,170 @@ TA_LIB_API TA_RetCode TA_MIDPRICE( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   if( optInTimePeriod <= 20 )
+   if( optInTimePeriod <= 100000 )
    {
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
+      {
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
       while( today <= endIdx )
       {
-         lowest = inLow[trailingIdx];
-         highest = inHigh[trailingIdx];
-         trailingIdx += 1;
-         for( i = trailingIdx; i <= today; i += 1 )
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inHigh[i];
+         lowest = inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
          {
-            tmpLow = inLow[i];
-            if( tmpLow < lowest )
-            {
-               lowest = tmpLow;
-            }
+            i -= 1;
             tmpHigh = inHigh[i];
             if( tmpHigh > highest )
             {
                highest = tmpHigh;
             }
+            tmpLow = inLow[i];
+            if( tmpLow < lowest )
+            {
+               lowest = tmpLow;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
+         outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+         trailingIdx += 1;
          today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inHigh[blockNext];
+            lowest = inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inHigh[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               tmpLow = inLow[blockNext + i];
+               if( tmpLow < lowest )
+               {
+                  lowest = tmpLow;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest + lowest) / 2.0;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
    } else 
    {
       highestIdx = 0 - 1;
@@ -259,6 +421,22 @@ TA_RetCode TA_S_MIDPRICE( int    startIdx,
                           int          *outNBElement,
                           double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmpLow;
@@ -301,29 +479,158 @@ TA_RetCode TA_S_MIDPRICE( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   if( optInTimePeriod <= 20 )
+   if( optInTimePeriod <= 100000 )
    {
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
+      {
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
       while( today <= endIdx )
       {
-         lowest = (double)inLow[trailingIdx];
-         highest = (double)inHigh[trailingIdx];
-         trailingIdx += 1;
-         for( i = trailingIdx; i <= today; i += 1 )
+         i = blockStart + optInTimePeriod - 1;
+         highest = (double)inHigh[i];
+         lowest = (double)inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
          {
-            tmpLow = (double)inLow[i];
-            if( tmpLow < lowest )
-            {
-               lowest = tmpLow;
-            }
+            i -= 1;
             tmpHigh = (double)inHigh[i];
             if( tmpHigh > highest )
             {
                highest = tmpHigh;
             }
+            tmpLow = (double)inLow[i];
+            if( tmpLow < lowest )
+            {
+               lowest = tmpLow;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
+         outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+         trailingIdx += 1;
          today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = (double)inHigh[blockNext];
+            lowest = (double)inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = (double)inHigh[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               tmpLow = (double)inLow[blockNext + i];
+               if( tmpLow < lowest )
+               {
+                  lowest = tmpLow;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest + lowest) / 2.0;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
    } else 
    {
       highestIdx = 0 - 1;
@@ -539,16 +846,21 @@ static TA_RetCode TA_MIDPRICE_OpenCore( struct TA_MIDPRICE_Stream **stream, cons
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not

--- a/src/ta_func/ta_MIN.c
+++ b/src/ta_func/ta_MIN.c
@@ -76,6 +76,14 @@ TA_LIB_API TA_RetCode TA_MIN( int    startIdx,
                               int          *outNBElement,
                               double        outReal[] )
 {
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double tmp;
    int outIdx;
@@ -121,38 +129,172 @@ TA_LIB_API TA_RetCode TA_MIN( int    startIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. All three are straight-line loops with no
+    *   data-dependent branching, which is what lets a compiler vectorize
+    *   them, and the work is 3 comparisons per bar regardless of period.
+    *   Both scratch arrays hold COPIES, so input and output may alias.
+    *
+    * - Streaming: cache the lowest value with its index; rescan only
+    *   when the cached extremum leaves the window. O(1) per bar while the
+    *   extremum sits away from the trailing edge, but not amortized O(1):
+    *   an extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar for
+    *   as long as that persists.
     */
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = inReal[today];
-      if( lowestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
       {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         lowest = inReal[i];
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = inReal[i];
             if( tmp < lowest )
             {
-               lowestIdx = i;
                lowest = tmp;
             }
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
+         lowest = sufLowest[0];
+         outReal[outIdx++] = lowest;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            lowest = inReal[blockStart + optInTimePeriod];
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inReal[blockStart + optInTimePeriod + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = lowest;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = lowest;
-      trailingIdx += 1;
-      today += 1;
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmp = inReal[today];
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = inReal[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+         } else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+         }
+         outReal[outIdx++] = lowest;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    /* Keep the outBegIdx relative to the
     * caller input before returning.
@@ -170,6 +312,14 @@ TA_RetCode TA_S_MIN( int    startIdx,
                      int          *outNBElement,
                      double        outReal[] )
 {
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double tmp;
    int outIdx;
@@ -207,34 +357,135 @@ TA_RetCode TA_S_MIN( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = (double)inReal[today];
-      if( lowestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
       {
-         lowestIdx = trailingIdx;
-         lowest = (double)inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         i = blockStart + optInTimePeriod - 1;
+         lowest = (double)inReal[i];
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = (double)inReal[i];
             if( tmp < lowest )
             {
-               lowestIdx = i;
                lowest = tmp;
             }
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
+         lowest = sufLowest[0];
+         outReal[outIdx++] = lowest;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            lowest = (double)inReal[blockStart + optInTimePeriod];
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = (double)inReal[blockStart + optInTimePeriod + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = lowest;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outReal[outIdx++] = lowest;
-      trailingIdx += 1;
-      today += 1;
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmp = (double)inReal[today];
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = (double)inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = (double)inReal[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+         } else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+         }
+         outReal[outIdx++] = lowest;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    *outBegIdx= startIdx;
    *outNBElement= outIdx;
@@ -357,6 +608,27 @@ static TA_RetCode TA_MIN_OpenCore( struct TA_MIN_Stream **stream, const double i
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;

--- a/src/ta_func/ta_MINMAX.c
+++ b/src/ta_func/ta_MINMAX.c
@@ -73,6 +73,22 @@ TA_LIB_API TA_RetCode TA_MINMAX( int    startIdx,
                                  double        outMin[],
                                  double        outMax[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double highest;
    double lowest;
    double tmpHigh;
@@ -125,63 +141,258 @@ TA_LIB_API TA_RetCode TA_MINMAX( int    startIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. Both extrema travel in the same passes, so the
+    *   two outputs cost one traversal, not two. All the loops are
+    *   straight-line with no data-dependent branching, which is what lets
+    *   a compiler vectorize them, and the work is a fixed number of
+    *   comparisons per bar regardless of period. Every scratch array holds
+    *   COPIES, so input and output may alias.
+    *
+    * - Streaming: cache each extremum with its index; rescan only when
+    *   the cached one leaves the window. O(1) per bar while the extremum
+    *   sits away from the trailing edge, but not amortized O(1): an
+    *   extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar
+    *   for as long as that persists. Tracking both extrema keeps that
+    *   state going through a trend: while the highest is refreshed by
+    *   each new bar, the lowest stays pinned at the oldest bar for the
+    *   whole leg (and the reverse on the way down).
     */
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpHigh = inReal[today];
-      tmpLow = tmpHigh;
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmpHigh = inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
-         }
-      } else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
-      if( lowestIdx < trailingIdx )
-      {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
-         {
-            tmpLow = inReal[i];
-            if( tmpLow < lowest )
+            if( tmpHigh < lowest )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               lowest = tmpHigh;
             }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
+         outMax[outIdx] = sufHighest[0];
+         outMin[outIdx] = sufLowest[0];
+         outIdx += 1;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outMax[outIdx] = highest;
+               outMin[outIdx] = lowest;
+               outIdx += 1;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outMax[outIdx] = highest;
-      outMin[outIdx] = lowest;
-      outIdx += 1;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmpHigh = inReal[today];
+         tmpLow = tmpHigh;
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpHigh = inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
+            }
+         } else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpLow = inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         } else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+         outMax[outIdx] = highest;
+         outMin[outIdx] = lowest;
+         outIdx += 1;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    /* Keep the outBegIdx relative to the
     * caller input before returning.
@@ -200,6 +411,22 @@ TA_RetCode TA_S_MINMAX( int    startIdx,
                         double        outMin[],
                         double        outMax[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double highest;
    double lowest;
    double tmpHigh;
@@ -244,59 +471,216 @@ TA_RetCode TA_S_MINMAX( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   highest = 0.0;
-   lowestIdx = 0 - 1;
-   lowest = 0.0;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpHigh = (double)inReal[today];
-      tmpLow = tmpHigh;
-      if( highestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         highestIdx = trailingIdx;
-         highest = (double)inReal[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         i = blockStart + optInTimePeriod - 1;
+         highest = (double)inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmpHigh = (double)inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
-         }
-      } else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
-      if( lowestIdx < trailingIdx )
-      {
-         lowestIdx = trailingIdx;
-         lowest = (double)inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
-         {
-            tmpLow = (double)inReal[i];
-            if( tmpLow < lowest )
+            if( tmpHigh < lowest )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               lowest = tmpHigh;
             }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
-      } else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
+         outMax[outIdx] = sufHighest[0];
+         outMin[outIdx] = sufLowest[0];
+         outIdx += 1;
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = (double)inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = (double)inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outMax[outIdx] = highest;
+               outMin[outIdx] = lowest;
+               outIdx += 1;
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      outMax[outIdx] = highest;
-      outMin[outIdx] = lowest;
-      outIdx += 1;
-      trailingIdx += 1;
-      today += 1;
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      highest = 0.0;
+      lowestIdx = 0 - 1;
+      lowest = 0.0;
+      while( today <= endIdx )
+      {
+         tmpHigh = (double)inReal[today];
+         tmpLow = tmpHigh;
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = (double)inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpHigh = (double)inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
+            }
+         } else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = (double)inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmpLow = (double)inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         } else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+         outMax[outIdx] = highest;
+         outMin[outIdx] = lowest;
+         outIdx += 1;
+         trailingIdx += 1;
+         today += 1;
+      }
    }
    *outBegIdx= startIdx;
    *outNBElement= outIdx;
@@ -447,6 +831,32 @@ static TA_RetCode TA_MINMAX_OpenCore( struct TA_MINMAX_Stream **stream, const do
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;

--- a/src/ta_func/ta_WILLR.c
+++ b/src/ta_func/ta_WILLR.c
@@ -76,6 +76,22 @@ TA_LIB_API TA_RetCode TA_WILLR( int    startIdx,
                                 int          *outNBElement,
                                 double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmp;
@@ -130,74 +146,285 @@ TA_LIB_API TA_RetCode TA_WILLR( int    startIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), and
+    * the second arm is what the streaming tier transitions on:
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass for the older block's suffix extrema, one
+    *   forward pass for the newer block's prefix extrema, and a third
+    *   pass to combine and emit. High and low travel in the same passes.
+    *   All the loops are straight-line with no data-dependent branching,
+    *   which is what lets a compiler vectorize them, and the work per
+    *   bar is a fixed number of comparisons regardless of period. Every
+    *   scratch array holds COPIES, so input and output may alias.
+    *
+    *   'diff' is recomputed on every bar here rather than only when an
+    *   extremum moves. That is the same value: the streaming arm leaves
+    *   diff untouched exactly when neither extremum changed, in which
+    *   case (highest-lowest) is unchanged too.
+    *
+    * - Streaming: cache the highest high/lowest low with its index and
+    *   rescan only when the cached extremum leaves the window. O(1) per
+    *   bar while the extremum sits away from the trailing edge, but not
+    *   amortized O(1): an extremum on the oldest in-window bar drops out
+    *   on the very next bar, so the rescan repeats and the cost stays
+    *   O(period) per bar for as long as that persists. See issue #147.
     */
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   lowestIdx = highestIdx;
-   lowest = 0.0;
-   highest = lowest;
-   diff = highest;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      /* Set the lowest low */
-      tmp = inLow[today];
-      if( lowestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         lowestIdx = trailingIdx;
-         lowest = inLow[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
-            tmp = inLow[i];
-            if( tmp < lowest )
-            {
-               lowestIdx = i;
-               lowest = tmp;
-            }
+            return TA_ALLOC_ERR;
          }
-         diff = (highest - lowest) / (0 - 100.0);
-      } else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
-         diff = (highest - lowest) / (0 - 100.0);
       }
-      /* Set the highest high */
-      tmp = inHigh[today];
-      if( highestIdx < trailingIdx )
+      else
       {
-         highestIdx = trailingIdx;
-         highest = inHigh[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inHigh[i];
+         lowest = inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = inHigh[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            tmp = inLow[i];
+            if( tmp < lowest )
+            {
+               lowest = tmp;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
+         highest = sufHighest[0];
+         lowest = sufLowest[0];
          diff = (highest - lowest) / (0 - 100.0);
-      } else if( tmp >= highest )
-      {
-         highestIdx = today;
-         highest = tmp;
-         diff = (highest - lowest) / (0 - 100.0);
+         if( diff != 0.0 )
+         {
+            outReal[outIdx++] = (highest - inClose[today]) / diff;
+         } else 
+         {
+            outReal[outIdx++] = 0.0;
+         }
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inHigh[blockNext];
+            lowest = inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inHigh[blockNext + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               tmp = inLow[blockNext + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            /* Combine and emit. The suffix half is the older one, so
+             * preferring it on a tie keeps the earliest-wins rule. The
+             * bar being emitted for offset m is today+m-1: 'today' was
+             * advanced once above and is not touched inside this loop.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+               if( diff != 0.0 )
+               {
+                  outReal[outIdx++] = (highest - inClose[today + m - 1]) / diff;
+               } else 
+               {
+                  outReal[outIdx++] = 0.0;
+               }
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      if( diff != 0.0 )
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      lowestIdx = highestIdx;
+      lowest = 0.0;
+      highest = lowest;
+      diff = highest;
+      while( today <= endIdx )
       {
-         outReal[outIdx++] = (highest - inClose[today]) / diff;
-      } else 
-      {
-         outReal[outIdx++] = 0.0;
+         /* Set the lowest low */
+         tmp = inLow[today];
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inLow[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = inLow[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+            diff = (highest - lowest) / (0 - 100.0);
+         } else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+            diff = (highest - lowest) / (0 - 100.0);
+         }
+         /* Set the highest high */
+         tmp = inHigh[today];
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inHigh[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = inHigh[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+            diff = (highest - lowest) / (0 - 100.0);
+         } else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+            diff = (highest - lowest) / (0 - 100.0);
+         }
+         if( diff != 0.0 )
+         {
+            outReal[outIdx++] = (highest - inClose[today]) / diff;
+         } else 
+         {
+            outReal[outIdx++] = 0.0;
+         }
+         trailingIdx += 1;
+         today += 1;
       }
-      trailingIdx += 1;
-      today += 1;
    }
    /* Keep the outBegIdx relative to the
     * caller input before returning.
@@ -217,6 +444,22 @@ TA_RetCode TA_S_WILLR( int    startIdx,
                        int          *outNBElement,
                        double        outReal[] )
 {
+   double local_sufHighest[30];
+   double *sufHighest;
+   int sufHighest_Idx;
+   int maxIdx_sufHighest;
+   double local_preHighest[30];
+   double *preHighest;
+   int preHighest_Idx;
+   int maxIdx_preHighest;
+   double local_sufLowest[30];
+   double *sufLowest;
+   int sufLowest_Idx;
+   int maxIdx_sufLowest;
+   double local_preLowest[30];
+   double *preLowest;
+   int preLowest_Idx;
+   int maxIdx_preLowest;
    double lowest;
    double highest;
    double tmp;
@@ -262,68 +505,239 @@ TA_RetCode TA_S_WILLR( int    startIdx,
    outIdx = 0;
    today = startIdx;
    trailingIdx = startIdx - nbInitialElementNeeded;
-   highestIdx = 0 - 1;
-   lowestIdx = highestIdx;
-   lowest = 0.0;
-   highest = lowest;
-   diff = highest;
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = (double)inLow[today];
-      if( lowestIdx < trailingIdx )
+      int blockStart;
+      int nAvail;
+      int m;
+      int blockNext;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufHighest)/sizeof(double)) )
       {
-         lowestIdx = trailingIdx;
-         lowest = (double)inLow[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufHighest )
          {
-            tmp = (double)inLow[i];
-            if( tmp < lowest )
-            {
-               lowestIdx = i;
-               lowest = tmp;
-            }
+            return TA_ALLOC_ERR;
          }
-         diff = (highest - lowest) / (0 - 100.0);
-      } else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
-         diff = (highest - lowest) / (0 - 100.0);
       }
-      tmp = (double)inHigh[today];
-      if( highestIdx < trailingIdx )
+      else
       {
-         highestIdx = trailingIdx;
-         highest = (double)inHigh[highestIdx];
-         i = highestIdx;
-         TA_UNROLL(4)
-         while( ++i <= today )
+         sufHighest = &local_sufHighest[0];
+      }
+      maxIdx_sufHighest = (optInTimePeriod-1);
+      sufHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preHighest)/sizeof(double)) )
+      {
+         preHighest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preHighest )
          {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preHighest = &local_preHighest[0];
+      }
+      maxIdx_preHighest = (optInTimePeriod-1);
+      preHighest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_sufLowest)/sizeof(double)) )
+      {
+         sufLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !sufLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         sufLowest = &local_sufLowest[0];
+      }
+      maxIdx_sufLowest = (optInTimePeriod-1);
+      sufLowest_Idx = 0;
+      if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
+      if( (int)optInTimePeriod > (int)(sizeof(local_preLowest)/sizeof(double)) )
+      {
+         preLowest = TA_Malloc( sizeof(double)*optInTimePeriod );
+         if( !preLowest )
+         {
+            return TA_ALLOC_ERR;
+         }
+      }
+      else
+      {
+         preLowest = &local_preLowest[0];
+      }
+      maxIdx_preLowest = (optInTimePeriod-1);
+      preLowest_Idx = 0;
+      blockStart = trailingIdx;
+      while( today <= endIdx )
+      {
+         i = blockStart + optInTimePeriod - 1;
+         highest = (double)inHigh[i];
+         lowest = (double)inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
+         {
+            i -= 1;
             tmp = (double)inHigh[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            tmp = (double)inLow[i];
+            if( tmp < lowest )
+            {
+               lowest = tmp;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
+         highest = sufHighest[0];
+         lowest = sufLowest[0];
          diff = (highest - lowest) / (0 - 100.0);
-      } else if( tmp >= highest )
-      {
-         highestIdx = today;
-         highest = tmp;
-         diff = (highest - lowest) / (0 - 100.0);
+         if( diff != 0.0 )
+         {
+            outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+         } else 
+         {
+            outReal[outIdx++] = 0.0;
+         }
+         trailingIdx += 1;
+         today += 1;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         } else 
+         {
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = (double)inHigh[blockNext];
+            lowest = (double)inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = (double)inHigh[blockNext + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               tmp = (double)inLow[blockNext + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i += 1;
+            }
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+               if( diff != 0.0 )
+               {
+                  outReal[outIdx++] = (highest - (double)inClose[today + m - 1]) / diff;
+               } else 
+               {
+                  outReal[outIdx++] = 0.0;
+               }
+               m += 1;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      if( diff != 0.0 )
+      if( sufHighest != &local_sufHighest[0] ) TA_Free( sufHighest );
+      if( preHighest != &local_preHighest[0] ) TA_Free( preHighest );
+      if( sufLowest != &local_sufLowest[0] ) TA_Free( sufLowest );
+      if( preLowest != &local_preLowest[0] ) TA_Free( preLowest );
+   } else 
+   {
+      highestIdx = 0 - 1;
+      lowestIdx = highestIdx;
+      lowest = 0.0;
+      highest = lowest;
+      diff = highest;
+      while( today <= endIdx )
       {
-         outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
-      } else 
-      {
-         outReal[outIdx++] = 0.0;
+         tmp = (double)inLow[today];
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = (double)inLow[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = (double)inLow[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+            diff = (highest - lowest) / (0 - 100.0);
+         } else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+            diff = (highest - lowest) / (0 - 100.0);
+         }
+         tmp = (double)inHigh[today];
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = (double)inHigh[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i <= today )
+            {
+               tmp = (double)inHigh[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+            diff = (highest - lowest) / (0 - 100.0);
+         } else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+            diff = (highest - lowest) / (0 - 100.0);
+         }
+         if( diff != 0.0 )
+         {
+            outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+         } else 
+         {
+            outReal[outIdx++] = 0.0;
+         }
+         trailingIdx += 1;
+         today += 1;
       }
-      trailingIdx += 1;
-      today += 1;
    }
    *outBegIdx= startIdx;
    *outNBElement= outIdx;
@@ -498,6 +912,32 @@ static TA_RetCode TA_WILLR_OpenCore( struct TA_WILLR_Stream **stream, const doub
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/input/max/max.c
+++ b/ta_codegen/input/max/max.c
@@ -27,6 +27,8 @@ TA_RetCode max(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   CIRCBUF_PROLOG(sufHighest,double,30);
+   CIRCBUF_PROLOG(preHighest,double,30);
    double highest, tmp;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, today, i, highestIdx;
@@ -54,42 +56,155 @@ TA_RetCode max(int startIdx, int endIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. All three are straight-line loops with no
+    *   data-dependent branching, which is what lets a compiler vectorize
+    *   them, and the work is 3 comparisons per bar regardless of period.
+    *   Both scratch arrays hold COPIES, so input and output may alias.
+    *
+    * - Streaming: cache the highest value with its index; rescan only
+    *   when the cached extremum leaves the window. O(1) per bar while the
+    *   extremum sits away from the trailing edge, but not amortized O(1):
+    *   an extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar for
+    *   as long as that persists.
     */
    outIdx = 0;
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
-   highestIdx  = -1;
-   highest     = 0.0;
 
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = inReal[today];
+      int blockStart, nAvail, m;
 
-      if( highestIdx < trailingIdx )
+      CIRCBUF_INIT( sufHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( preHighest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
+      while( today <= endIdx )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         sufHighest[optInTimePeriod - 1] = highest;
          TA_UNROLL(4)
-         while( ++i<=today )
+         while( i > blockStart )
          {
+            i--;
             tmp = inReal[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            sufHighest[i - blockStart] = highest;
+         }
+
+         highest = sufHighest[0];
+         outReal[outIdx++] = highest;
+         trailingIdx++;
+         today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockStart + optInTimePeriod];
+            preHighest[0] = highest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inReal[blockStart + optInTimePeriod + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               preHighest[i] = highest;
+               i++;
+            }
+
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               outReal[outIdx++] = highest;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
          }
       }
-      else if( tmp >= highest )
-      {
-         highestIdx = today;
-         highest = tmp;
-      }
 
-      outReal[outIdx++] = highest;
-      trailingIdx++;
-      today++;
+      CIRCBUF_DESTROY(sufHighest);
+      CIRCBUF_DESTROY(preHighest);
+   }
+   else
+   {
+      highestIdx  = -1;
+      highest     = 0.0;
+
+      while( today <= endIdx )
+      {
+         tmp = inReal[today];
+
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmp = inReal[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+         }
+         else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+         }
+
+         outReal[outIdx++] = highest;
+         trailingIdx++;
+         today++;
+      }
    }
 
    /* Keep the outBegIdx relative to the

--- a/ta_codegen/input/midpoint/midpoint.c
+++ b/ta_codegen/input/midpoint/midpoint.c
@@ -28,6 +28,10 @@ TA_RetCode midpoint(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   CIRCBUF_PROLOG(sufHighest,double,30);
+   CIRCBUF_PROLOG(preHighest,double,30);
+   CIRCBUF_PROLOG(sufLowest,double,30);
+   CIRCBUF_PROLOG(preLowest,double,30);
    double lowest, highest, tmpLow, tmpHigh;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, lowestIdx, highestIdx, today, i;
@@ -79,66 +83,194 @@ TA_RetCode midpoint(int startIdx, int endIdx,
     * (and the reverse on the way down). A flat stretch pins
     * both. Random-walk input is the favourable case, where
     * rescans are rare. See issue #147.
+    *
+    * The batch tier does not use that automaton: it takes the first arm
+    * for every period in range (the threshold is the declared maximum),
+    * and the automaton above is what the streaming tier transitions on.
+    * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+    * form: the p outputs belonging to one block boundary are produced
+    * together, one backward pass for the older block's suffix extrema,
+    * one forward pass for the newer block's prefix extrema, and a third
+    * pass to combine. Both extrema travel in the same passes. All the
+    * loops are straight-line with no data-dependent branching, which is
+    * what lets a compiler vectorize them, and the work per bar is a
+    * fixed number of comparisons regardless of period. Every scratch
+    * array holds COPIES, so input and output may alias.
     */
    outIdx = 0;
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
-   highestIdx  = -1;
-   highest     = 0.0;
-   lowestIdx   = -1;
-   lowest      = 0.0;
 
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpLow = tmpHigh = inReal[today];
+      int blockStart, nAvail, m, blockNext;
 
-      if( highestIdx < trailingIdx )
+      CIRCBUF_INIT( sufHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( preHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( sufLowest, double, optInTimePeriod );
+      CIRCBUF_INIT( preLowest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
+      while( today <= endIdx )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
          TA_UNROLL(4)
-         while( ++i<=today )
+         while( i > blockStart )
          {
+            i--;
             tmpHigh = inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
+            if( tmpHigh < lowest )
+            {
+               lowest = tmpHigh;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
+         }
+
+         outReal[outIdx++] = (sufHighest[0]+sufLowest[0])/2.0;
+         trailingIdx++;
+         today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i++;
+            }
+
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest+lowest)/2.0;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
          }
       }
-      else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
 
-      if( lowestIdx < trailingIdx )
+      CIRCBUF_DESTROY(sufHighest);
+      CIRCBUF_DESTROY(preHighest);
+      CIRCBUF_DESTROY(sufLowest);
+      CIRCBUF_DESTROY(preLowest);
+   }
+   else
+   {
+      highestIdx  = -1;
+      highest     = 0.0;
+      lowestIdx   = -1;
+      lowest      = 0.0;
+
+      while( today <= endIdx )
       {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i<=today )
+         tmpLow = tmpHigh = inReal[today];
+
+         if( highestIdx < trailingIdx )
          {
-            tmpLow = inReal[i];
-            if( tmpLow < lowest )
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               tmpHigh = inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
             }
          }
-      }
-      else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
-      }
+         else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
 
-      outReal[outIdx++] = (highest+lowest)/2.0;
-      trailingIdx++;
-      today++;
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmpLow = inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         }
+         else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+
+         outReal[outIdx++] = (highest+lowest)/2.0;
+         trailingIdx++;
+         today++;
+      }
    }
 
    /* Keep the outBegIdx relative to the

--- a/ta_codegen/input/midprice/midprice.c
+++ b/ta_codegen/input/midprice/midprice.c
@@ -32,6 +32,10 @@ TA_RetCode midprice(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   CIRCBUF_PROLOG(sufHighest,double,30);
+   CIRCBUF_PROLOG(preHighest,double,30);
+   CIRCBUF_PROLOG(sufLowest,double,30);
+   CIRCBUF_PROLOG(preLowest,double,30);
    double lowest, highest, tmpLow, tmpHigh;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, lowestIdx, highestIdx, today, i;
@@ -66,16 +70,21 @@ TA_RetCode midprice(int startIdx, int endIdx,
     * Note that this algorithm allows the input and
     * output to be the same buffer.
     *
-    * Two equivalent algorithms, picked by period. Their outputs are
-    * bit-identical; only the scan strategy differs:
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), and
+    * the second arm is what the streaming tier transitions on:
     *
-    * - Small periods (<= 20): rescan the whole window on every bar.
-    *   The two independent comparison chains auto-vectorize on modern
-    *   compilers, which beats any per-bar bookkeeping while the window
-    *   is short. The threshold sits near the measured crossover
-    *   (~period 19-20 with gcc/clang -O3 on x86-64).
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass for the older block's suffix extrema, one
+    *   forward pass for the newer block's prefix extrema, and a third
+    *   pass to combine. High and low travel in the same passes. All the
+    *   loops are straight-line with no data-dependent branching, which
+    *   is what lets a compiler vectorize them, and the work per bar is a
+    *   fixed number of comparisons regardless of period. Every scratch
+    *   array holds COPIES, so input and output may alias.
     *
-    * - Larger periods: cache the highest high/lowest low with its
+    * - Streaming: cache the highest high/lowest low with its
     *   index; the window is rescanned only when the cached extremum
     *   drops out of the window. That is O(1) per bar while the
     *   extremum sits away from the trailing edge, but it is not
@@ -94,24 +103,118 @@ TA_RetCode midprice(int startIdx, int endIdx,
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
 
-   if( optInTimePeriod <= 20 )
+   if( optInTimePeriod <= 100000 )
    {
+      int blockStart, nAvail, m, blockNext;
+
+      CIRCBUF_INIT( sufHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( preHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( sufLowest, double, optInTimePeriod );
+      CIRCBUF_INIT( preLowest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
       while( today <= endIdx )
       {
-         lowest  = inLow[trailingIdx];
-         highest = inHigh[trailingIdx];
-         trailingIdx++;
-         for( i=trailingIdx; i <= today; i++ )
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inHigh[i];
+         lowest = inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
+         TA_UNROLL(4)
+         while( i > blockStart )
          {
-            tmpLow = inLow[i];
-            if( tmpLow < lowest ) lowest = tmpLow;
+            i--;
             tmpHigh = inHigh[i];
-            if( tmpHigh > highest ) highest = tmpHigh;
+            if( tmpHigh > highest )
+            {
+               highest = tmpHigh;
+            }
+            tmpLow = inLow[i];
+            if( tmpLow < lowest )
+            {
+               lowest = tmpLow;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
 
-         outReal[outIdx++] = (highest+lowest)/2.0;
+         outReal[outIdx++] = (sufHighest[0]+sufLowest[0])/2.0;
+         trailingIdx++;
          today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inHigh[blockNext];
+            lowest = inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inHigh[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               tmpLow = inLow[blockNext + i];
+               if( tmpLow < lowest )
+               {
+                  lowest = tmpLow;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i++;
+            }
+
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = (highest+lowest)/2.0;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
+
+      CIRCBUF_DESTROY(sufHighest);
+      CIRCBUF_DESTROY(preHighest);
+      CIRCBUF_DESTROY(sufLowest);
+      CIRCBUF_DESTROY(preLowest);
    }
    else
    {

--- a/ta_codegen/input/min/min.c
+++ b/ta_codegen/input/min/min.c
@@ -27,6 +27,8 @@ TA_RetCode min(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   CIRCBUF_PROLOG(sufLowest,double,30);
+   CIRCBUF_PROLOG(preLowest,double,30);
    double lowest, tmp;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, lowestIdx, today, i;
@@ -54,42 +56,155 @@ TA_RetCode min(int startIdx, int endIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. All three are straight-line loops with no
+    *   data-dependent branching, which is what lets a compiler vectorize
+    *   them, and the work is 3 comparisons per bar regardless of period.
+    *   Both scratch arrays hold COPIES, so input and output may alias.
+    *
+    * - Streaming: cache the lowest value with its index; rescan only
+    *   when the cached extremum leaves the window. O(1) per bar while the
+    *   extremum sits away from the trailing edge, but not amortized O(1):
+    *   an extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar for
+    *   as long as that persists.
     */
    outIdx = 0;
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
-   lowestIdx   = -1;
-   lowest      = 0.0;
 
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmp = inReal[today];
+      int blockStart, nAvail, m;
 
-      if( lowestIdx < trailingIdx )
+      CIRCBUF_INIT( sufLowest, double, optInTimePeriod );
+      CIRCBUF_INIT( preLowest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
+      while( today <= endIdx )
       {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         lowest = inReal[i];
+         sufLowest[optInTimePeriod - 1] = lowest;
          TA_UNROLL(4)
-         while( ++i<=today )
+         while( i > blockStart )
          {
+            i--;
             tmp = inReal[i];
             if( tmp < lowest )
             {
-               lowestIdx = i;
                lowest = tmp;
             }
+            sufLowest[i - blockStart] = lowest;
+         }
+
+         lowest = sufLowest[0];
+         outReal[outIdx++] = lowest;
+         trailingIdx++;
+         today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            lowest = inReal[blockStart + optInTimePeriod];
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inReal[blockStart + optInTimePeriod + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preLowest[i] = lowest;
+               i++;
+            }
+
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outReal[outIdx++] = lowest;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
          }
       }
-      else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
-      }
 
-      outReal[outIdx++] = lowest;
-      trailingIdx++;
-      today++;
+      CIRCBUF_DESTROY(sufLowest);
+      CIRCBUF_DESTROY(preLowest);
+   }
+   else
+   {
+      lowestIdx   = -1;
+      lowest      = 0.0;
+
+      while( today <= endIdx )
+      {
+         tmp = inReal[today];
+
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmp = inReal[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+         }
+         else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+         }
+
+         outReal[outIdx++] = lowest;
+         trailingIdx++;
+         today++;
+      }
    }
 
    /* Keep the outBegIdx relative to the

--- a/ta_codegen/input/minmax/minmax.c
+++ b/ta_codegen/input/minmax/minmax.c
@@ -24,6 +24,10 @@ TA_RetCode minmax(int startIdx, int endIdx,
    double outMin[],
    double outMax[])
 {
+   CIRCBUF_PROLOG(sufHighest,double,30);
+   CIRCBUF_PROLOG(preHighest,double,30);
+   CIRCBUF_PROLOG(sufLowest,double,30);
+   CIRCBUF_PROLOG(preLowest,double,30);
    double highest, lowest, tmpHigh, tmpLow;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, today, i, highestIdx, lowestIdx;
@@ -51,68 +55,213 @@ TA_RetCode minmax(int startIdx, int endIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), so
+    * the second arm exists to be the streaming tier's transition; see
+    * issue #147.
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass builds the older block's suffix extrema, one
+    *   forward pass builds the newer block's prefix extrema, and a third
+    *   pass combines them. Both extrema travel in the same passes, so the
+    *   two outputs cost one traversal, not two. All the loops are
+    *   straight-line with no data-dependent branching, which is what lets
+    *   a compiler vectorize them, and the work is a fixed number of
+    *   comparisons per bar regardless of period. Every scratch array holds
+    *   COPIES, so input and output may alias.
+    *
+    * - Streaming: cache each extremum with its index; rescan only when
+    *   the cached one leaves the window. O(1) per bar while the extremum
+    *   sits away from the trailing edge, but not amortized O(1): an
+    *   extremum on the oldest in-window bar drops out on the very next
+    *   bar, so the rescan repeats and the cost stays O(period) per bar
+    *   for as long as that persists. Tracking both extrema keeps that
+    *   state going through a trend: while the highest is refreshed by
+    *   each new bar, the lowest stays pinned at the oldest bar for the
+    *   whole leg (and the reverse on the way down).
     */
    outIdx = 0;
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
-   highestIdx  = -1;
-   highest     = 0.0;
-   lowestIdx   = -1;
-   lowest      = 0.0;
 
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      tmpLow = tmpHigh = inReal[today];
+      int blockStart, nAvail, m, blockNext;
 
-      if( highestIdx < trailingIdx )
+      CIRCBUF_INIT( sufHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( preHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( sufLowest, double, optInTimePeriod );
+      CIRCBUF_INIT( preLowest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
+      while( today <= endIdx )
       {
-         highestIdx = trailingIdx;
-         highest = inReal[highestIdx];
-         i = highestIdx;
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inReal[i];
+         lowest = highest;
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
          TA_UNROLL(4)
-         while( ++i<=today )
+         while( i > blockStart )
          {
+            i--;
             tmpHigh = inReal[i];
             if( tmpHigh > highest )
             {
-               highestIdx = i;
                highest = tmpHigh;
             }
+            if( tmpHigh < lowest )
+            {
+               lowest = tmpHigh;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
+         }
+
+         outMax[outIdx] = sufHighest[0];
+         outMin[outIdx] = sufLowest[0];
+         outIdx++;
+         trailingIdx++;
+         today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inReal[blockNext];
+            lowest = highest;
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmpHigh = inReal[blockNext + i];
+               if( tmpHigh > highest )
+               {
+                  highest = tmpHigh;
+               }
+               if( tmpHigh < lowest )
+               {
+                  lowest = tmpHigh;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i++;
+            }
+
+            /* Combine. The suffix half is the older one, so preferring it
+             * on a tie keeps the earliest-wins rule.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               outMax[outIdx] = highest;
+               outMin[outIdx] = lowest;
+               outIdx++;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
          }
       }
-      else if( tmpHigh >= highest )
-      {
-         highestIdx = today;
-         highest = tmpHigh;
-      }
 
-      if( lowestIdx < trailingIdx )
+      CIRCBUF_DESTROY(sufHighest);
+      CIRCBUF_DESTROY(preHighest);
+      CIRCBUF_DESTROY(sufLowest);
+      CIRCBUF_DESTROY(preLowest);
+   }
+   else
+   {
+      highestIdx  = -1;
+      highest     = 0.0;
+      lowestIdx   = -1;
+      lowest      = 0.0;
+
+      while( today <= endIdx )
       {
-         lowestIdx = trailingIdx;
-         lowest = inReal[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i<=today )
+         tmpLow = tmpHigh = inReal[today];
+
+         if( highestIdx < trailingIdx )
          {
-            tmpLow = inReal[i];
-            if( tmpLow < lowest )
+            highestIdx = trailingIdx;
+            highest = inReal[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
             {
-               lowestIdx = i;
-               lowest = tmpLow;
+               tmpHigh = inReal[i];
+               if( tmpHigh > highest )
+               {
+                  highestIdx = i;
+                  highest = tmpHigh;
+               }
             }
          }
-      }
-      else if( tmpLow <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmpLow;
-      }
+         else if( tmpHigh >= highest )
+         {
+            highestIdx = today;
+            highest = tmpHigh;
+         }
 
-      outMax[outIdx] = highest;
-      outMin[outIdx] = lowest;
-      outIdx++;
-      trailingIdx++;
-      today++;
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inReal[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmpLow = inReal[i];
+               if( tmpLow < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmpLow;
+               }
+            }
+         }
+         else if( tmpLow <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmpLow;
+         }
+
+         outMax[outIdx] = highest;
+         outMin[outIdx] = lowest;
+         outIdx++;
+         trailingIdx++;
+         today++;
+      }
    }
 
    /* Keep the outBegIdx relative to the

--- a/ta_codegen/input/willr/willr.c
+++ b/ta_codegen/input/willr/willr.c
@@ -27,6 +27,10 @@ TA_RetCode willr(int startIdx, int endIdx,
    int *outBegIdx, int *outNBElement,
    double outReal[])
 {
+   CIRCBUF_PROLOG(sufHighest,double,30);
+   CIRCBUF_PROLOG(preHighest,double,30);
+   CIRCBUF_PROLOG(sufLowest,double,30);
+   CIRCBUF_PROLOG(preLowest,double,30);
    double lowest, highest, tmp, diff;
    int outIdx, nbInitialElementNeeded;
    int trailingIdx, lowestIdx, highestIdx;
@@ -58,74 +62,229 @@ TA_RetCode willr(int startIdx, int endIdx,
    /* Proceed with the calculation for the requested range.
     * Note that this algorithm allows the input and
     * output to be the same buffer.
+    *
+    * Two equivalent algorithms. The batch tier takes the first arm for
+    * every period in range (the threshold is the declared maximum), and
+    * the second arm is what the streaming tier transitions on:
+    *
+    * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+    *   p outputs belonging to one block boundary are produced together:
+    *   one backward pass for the older block's suffix extrema, one
+    *   forward pass for the newer block's prefix extrema, and a third
+    *   pass to combine and emit. High and low travel in the same passes.
+    *   All the loops are straight-line with no data-dependent branching,
+    *   which is what lets a compiler vectorize them, and the work per
+    *   bar is a fixed number of comparisons regardless of period. Every
+    *   scratch array holds COPIES, so input and output may alias.
+    *
+    *   'diff' is recomputed on every bar here rather than only when an
+    *   extremum moves. That is the same value: the streaming arm leaves
+    *   diff untouched exactly when neither extremum changed, in which
+    *   case (highest-lowest) is unchanged too.
+    *
+    * - Streaming: cache the highest high/lowest low with its index and
+    *   rescan only when the cached extremum leaves the window. O(1) per
+    *   bar while the extremum sits away from the trailing edge, but not
+    *   amortized O(1): an extremum on the oldest in-window bar drops out
+    *   on the very next bar, so the rescan repeats and the cost stays
+    *   O(period) per bar for as long as that persists. See issue #147.
     */
    outIdx      = 0;
    today       = startIdx;
    trailingIdx = startIdx-nbInitialElementNeeded;
-   lowestIdx   = highestIdx = -1;
-   diff = highest = lowest  = 0.0;
 
-   while( today <= endIdx )
+   if( optInTimePeriod <= 100000 )
    {
-      /* Set the lowest low */
-      tmp = inLow[today];
-      if( lowestIdx < trailingIdx )
-      {
-         lowestIdx = trailingIdx;
-         lowest = inLow[lowestIdx];
-         i = lowestIdx;
-         TA_UNROLL(4)
-         while( ++i<=today )
-         {
-            tmp = inLow[i];
-            if( tmp < lowest )
-            {
-               lowestIdx = i;
-               lowest = tmp;
-            }
-         }
-         diff = (highest - lowest)/(-100.0);
-      }
-      else if( tmp <= lowest )
-      {
-         lowestIdx = today;
-         lowest = tmp;
-         diff = (highest - lowest)/(-100.0);
-      }
+      int blockStart, nAvail, m, blockNext;
 
-      /* Set the highest high */
-      tmp = inHigh[today];
-      if( highestIdx < trailingIdx )
+      CIRCBUF_INIT( sufHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( preHighest, double, optInTimePeriod );
+      CIRCBUF_INIT( sufLowest, double, optInTimePeriod );
+      CIRCBUF_INIT( preLowest, double, optInTimePeriod );
+
+      blockStart = trailingIdx;
+
+      while( today <= endIdx )
       {
-         highestIdx = trailingIdx;
-         highest = inHigh[highestIdx];
-         i = highestIdx;
+         /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+          * is fully available here: today == blockStart+p-1 <= endIdx.
+          * Scanning backward while keeping the incumbent on a tie
+          * leaves the later element holding a tie, which is what lets this
+          * compile to a single min/max instruction.
+          */
+         i = blockStart + optInTimePeriod - 1;
+         highest = inHigh[i];
+         lowest = inLow[i];
+         sufHighest[optInTimePeriod - 1] = highest;
+         sufLowest[optInTimePeriod - 1] = lowest;
          TA_UNROLL(4)
-         while( ++i<=today )
+         while( i > blockStart )
          {
+            i--;
             tmp = inHigh[i];
             if( tmp > highest )
             {
-               highestIdx = i;
                highest = tmp;
             }
+            tmp = inLow[i];
+            if( tmp < lowest )
+            {
+               lowest = tmp;
+            }
+            sufHighest[i - blockStart] = highest;
+            sufLowest[i - blockStart] = lowest;
          }
+
+         highest = sufHighest[0];
+         lowest = sufLowest[0];
          diff = (highest - lowest)/(-100.0);
+         if( diff != 0.0 )
+            outReal[outIdx++] = (highest-inClose[today])/diff;
+         else
+            outReal[outIdx++] = 0.0;
+         trailingIdx++;
+         today++;
+         if( today > endIdx )
+         {
+            blockStart = blockStart + optInTimePeriod;
+         }
+         else
+         {
+            /* Prefix extrema of the next block, clamped to what remains.
+             * Forward, keeping the incumbent on a tie: earliest wins again.
+             */
+            blockNext = blockStart + optInTimePeriod;
+            nAvail = endIdx - blockNext + 1;
+            if( nAvail > optInTimePeriod - 1 )
+            {
+               nAvail = optInTimePeriod - 1;
+            }
+            highest = inHigh[blockNext];
+            lowest = inLow[blockNext];
+            preHighest[0] = highest;
+            preLowest[0] = lowest;
+            i = 1;
+            TA_UNROLL(4)
+            while( i < nAvail )
+            {
+               tmp = inHigh[blockNext + i];
+               if( tmp > highest )
+               {
+                  highest = tmp;
+               }
+               tmp = inLow[blockNext + i];
+               if( tmp < lowest )
+               {
+                  lowest = tmp;
+               }
+               preHighest[i] = highest;
+               preLowest[i] = lowest;
+               i++;
+            }
+
+            /* Combine and emit. The suffix half is the older one, so
+             * preferring it on a tie keeps the earliest-wins rule. The
+             * bar being emitted for offset m is today+m-1: 'today' was
+             * advanced once above and is not touched inside this loop.
+             */
+            m = 1;
+            while( m <= nAvail )
+            {
+               highest = sufHighest[m];
+               if( preHighest[m - 1] > highest )
+               {
+                  highest = preHighest[m - 1];
+               }
+               lowest = sufLowest[m];
+               if( preLowest[m - 1] < lowest )
+               {
+                  lowest = preLowest[m - 1];
+               }
+               diff = (highest - lowest)/(-100.0);
+               if( diff != 0.0 )
+                  outReal[outIdx++] = (highest-inClose[today + m - 1])/diff;
+               else
+                  outReal[outIdx++] = 0.0;
+               m++;
+            }
+            trailingIdx = trailingIdx + nAvail;
+            today = today + nAvail;
+            blockStart = blockStart + optInTimePeriod;
+         }
       }
-      else if( tmp >= highest )
+
+      CIRCBUF_DESTROY(sufHighest);
+      CIRCBUF_DESTROY(preHighest);
+      CIRCBUF_DESTROY(sufLowest);
+      CIRCBUF_DESTROY(preLowest);
+   }
+   else
+   {
+      lowestIdx   = highestIdx = -1;
+      diff = highest = lowest  = 0.0;
+
+      while( today <= endIdx )
       {
-         highestIdx = today;
-         highest = tmp;
-         diff = (highest - lowest)/(-100.0);
+         /* Set the lowest low */
+         tmp = inLow[today];
+         if( lowestIdx < trailingIdx )
+         {
+            lowestIdx = trailingIdx;
+            lowest = inLow[lowestIdx];
+            i = lowestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmp = inLow[i];
+               if( tmp < lowest )
+               {
+                  lowestIdx = i;
+                  lowest = tmp;
+               }
+            }
+            diff = (highest - lowest)/(-100.0);
+         }
+         else if( tmp <= lowest )
+         {
+            lowestIdx = today;
+            lowest = tmp;
+            diff = (highest - lowest)/(-100.0);
+         }
+
+         /* Set the highest high */
+         tmp = inHigh[today];
+         if( highestIdx < trailingIdx )
+         {
+            highestIdx = trailingIdx;
+            highest = inHigh[highestIdx];
+            i = highestIdx;
+            TA_UNROLL(4)
+            while( ++i<=today )
+            {
+               tmp = inHigh[i];
+               if( tmp > highest )
+               {
+                  highestIdx = i;
+                  highest = tmp;
+               }
+            }
+            diff = (highest - lowest)/(-100.0);
+         }
+         else if( tmp >= highest )
+         {
+            highestIdx = today;
+            highest = tmp;
+            diff = (highest - lowest)/(-100.0);
+         }
+
+         if( diff != 0.0 )
+            outReal[outIdx++] = (highest-inClose[today])/diff;
+         else
+            outReal[outIdx++] = 0.0;
+
+         trailingIdx++;
+         today++;
       }
-
-      if( diff != 0.0 )
-         outReal[outIdx++] = (highest-inClose[today])/diff;
-      else
-         outReal[outIdx++] = 0.0;
-
-      trailingIdx++;
-      today++;
    }
 
    /* Keep the outBegIdx relative to the

--- a/ta_codegen/output/csharp/library/src/Core_MAX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAX.cs
@@ -90,6 +90,12 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -129,32 +135,128 @@ public partial class Core
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -173,6 +275,12 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -204,28 +312,91 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx = startIdx;
       outNBElement = outIdx;

--- a/ta_codegen/output/csharp/library/src/Core_MIDPOINT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIDPOINT.cs
@@ -91,6 +91,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -156,50 +168,163 @@ public partial class Core
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -218,6 +343,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -252,46 +389,134 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx = startIdx;
       outNBElement = outIdx;

--- a/ta_codegen/output/csharp/library/src/Core_MIDPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIDPRICE.cs
@@ -95,6 +95,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -143,16 +155,21 @@ public partial class Core
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not
@@ -170,23 +187,105 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = inLow[trailingIdx];
-            highest = inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;
@@ -249,6 +348,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -283,23 +394,93 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = (double)inLow[trailingIdx];
-            highest = (double)inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = (double)inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = (double)inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = (double)inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;

--- a/ta_codegen/output/csharp/library/src/Core_MIN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIN.cs
@@ -90,6 +90,12 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -129,32 +135,128 @@ public partial class Core
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            lowest = inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -173,6 +275,12 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -204,28 +312,91 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            lowest = (double)inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = (double)inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx = startIdx;
       outNBElement = outIdx;

--- a/ta_codegen/output/csharp/library/src/Core_MINMAX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MINMAX.cs
@@ -87,6 +87,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -132,52 +144,182 @@ public partial class Core
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -197,6 +339,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -234,48 +388,140 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx = startIdx;
       outNBElement = outIdx;

--- a/ta_codegen/output/csharp/library/src/Core_WILLR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_WILLR.cs
@@ -90,6 +90,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -134,61 +146,203 @@ public partial class Core
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         /* Set the lowest low */
-         tmp = inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         /* Set the highest high */
-         tmp = inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine and emit. The suffix half is the older one, so
+                * preferring it on a tie keeps the earliest-wins rule. The
+                * bar being emitted for offset m is today+m-1: 'today' was
+                * advanced once above and is not touched inside this loop.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            /* Set the lowest low */
+            tmp = inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            /* Set the highest high */
+            tmp = inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -209,6 +363,18 @@ public partial class Core
    {
       outBegIdx = 0;
       outNBElement = 0;
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -244,55 +410,157 @@ public partial class Core
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         tmp = (double)inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = (double)inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         tmp = (double)inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = (double)inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = (double)inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - (double)inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            tmp = (double)inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            tmp = (double)inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       outBegIdx = startIdx;
       outNBElement = outIdx;

--- a/ta_codegen/output/java/fragments/Core_MAX.java
+++ b/ta_codegen/output/java/fragments/Core_MAX.java
@@ -44,6 +44,12 @@
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -83,32 +89,128 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -125,6 +227,12 @@
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -156,28 +264,91 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -404,6 +575,12 @@
    }
    private RetCode MAX_OpenCore( MAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -445,6 +622,27 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/fragments/Core_MIDPOINT.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPOINT.java
@@ -45,6 +45,18 @@
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -110,50 +122,163 @@
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -170,6 +295,18 @@
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -204,46 +341,134 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -496,6 +721,18 @@
    }
    private RetCode MIDPOINT_OpenCore( MIDPOINT_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -563,6 +800,19 @@
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/fragments/Core_MIDPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPRICE.java
@@ -50,6 +50,18 @@
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -98,16 +110,21 @@
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not
@@ -125,23 +142,105 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = inLow[trailingIdx];
-            highest = inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;
@@ -202,6 +301,18 @@
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -236,23 +347,93 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = (double)inLow[trailingIdx];
-            highest = (double)inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = (double)inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = (double)inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = (double)inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;
@@ -553,6 +734,18 @@
    }
    private RetCode MIDPRICE_OpenCore( MIDPRICE_Stream sp, double inHigh[], double inLow[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -603,16 +796,21 @@
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not

--- a/ta_codegen/output/java/fragments/Core_MIN.java
+++ b/ta_codegen/output/java/fragments/Core_MIN.java
@@ -44,6 +44,12 @@
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -83,32 +89,128 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            lowest = inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -125,6 +227,12 @@
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -156,28 +264,91 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            lowest = (double)inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = (double)inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -402,6 +573,12 @@
    }
    private RetCode MIN_OpenCore( MIN_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -443,6 +620,27 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/fragments/Core_MINMAX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAX.java
@@ -41,6 +41,18 @@
                             double outMin[],
                             double outMax[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -86,52 +98,182 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -149,6 +291,18 @@
                             double outMin[],
                             double outMax[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -186,48 +340,140 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -501,6 +747,18 @@
    }
    private RetCode MINMAX_OpenCore( MINMAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outMin[], double outMax[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -545,6 +803,32 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/fragments/Core_WILLR.java
+++ b/ta_codegen/output/java/fragments/Core_WILLR.java
@@ -44,6 +44,18 @@
                            MInteger outNBElement,
                            double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -88,61 +100,203 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         /* Set the lowest low */
-         tmp = inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         /* Set the highest high */
-         tmp = inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine and emit. The suffix half is the older one, so
+                * preferring it on a tie keeps the earliest-wins rule. The
+                * bar being emitted for offset m is today+m-1: 'today' was
+                * advanced once above and is not touched inside this loop.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            /* Set the lowest low */
+            tmp = inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            /* Set the highest high */
+            tmp = inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -161,6 +315,18 @@
                            MInteger outNBElement,
                            double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -196,55 +362,157 @@
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         tmp = (double)inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = (double)inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         tmp = (double)inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = (double)inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = (double)inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - (double)inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            tmp = (double)inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            tmp = (double)inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -522,6 +790,18 @@
    }
    private RetCode WILLR_OpenCore( WILLR_Stream sp, double inHigh[], double inLow[], double inClose[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -568,6 +848,32 @@
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -88364,6 +88364,12 @@ public final class Core {
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -88403,32 +88409,128 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -88445,6 +88547,12 @@ public final class Core {
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -88476,28 +88584,91 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               sufHighest[i - blockStart] = highest;
             }
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
+            highest = sufHighest[0];
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockStart + optInTimePeriod];
+               preHighest[0] = highest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  outReal[outIdx++] = highest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = highest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+            }
+            outReal[outIdx++] = highest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -88724,6 +88895,12 @@ public final class Core {
    }
    private RetCode MAX_OpenCore( MAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
       double highest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -88765,6 +88942,27 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the highest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
@@ -90650,6 +90848,18 @@ public final class Core {
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -90715,50 +90925,163 @@ public final class Core {
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -90775,6 +91098,18 @@ public final class Core {
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -90809,46 +91144,134 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = (highest + lowest) / 2.0;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outReal[outIdx++] = (highest + lowest) / 2.0;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -91101,6 +91524,18 @@ public final class Core {
    }
    private RetCode MIDPOINT_OpenCore( MIDPOINT_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -91168,6 +91603,19 @@ public final class Core {
        * (and the reverse on the way down). A flat stretch pins
        * both. Random-walk input is the favourable case, where
        * rescans are rare. See issue #147.
+       *
+       * The batch tier does not use that automaton: it takes the first arm
+       * for every period in range (the threshold is the declared maximum),
+       * and the automaton above is what the streaming tier transitions on.
+       * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+       * form: the p outputs belonging to one block boundary are produced
+       * together, one backward pass for the older block's suffix extrema,
+       * one forward pass for the newer block's prefix extrema, and a third
+       * pass to combine. Both extrema travel in the same passes. All the
+       * loops are straight-line with no data-dependent branching, which is
+       * what lets a compiler vectorize them, and the work per bar is a
+       * fixed number of comparisons regardless of period. Every scratch
+       * array holds COPIES, so input and output may alias.
        */
       outIdx = 0;
       today = startIdx;
@@ -91365,6 +91813,18 @@ public final class Core {
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -91413,16 +91873,21 @@ public final class Core {
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not
@@ -91440,23 +91905,105 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = inLow[trailingIdx];
-            highest = inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;
@@ -91517,6 +92064,18 @@ public final class Core {
                               MInteger outNBElement,
                               double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -91551,23 +92110,93 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      if( optInTimePeriod <= 20 ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
          while( today <= endIdx ) {
-            lowest = (double)inLow[trailingIdx];
-            highest = (double)inHigh[trailingIdx];
-            trailingIdx += 1;
-            for( i = trailingIdx; i <= today; i += 1 ) {
-               tmpLow = (double)inLow[i];
-               if( tmpLow < lowest ) {
-                  lowest = tmpLow;
-               }
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inHigh[i];
                if( tmpHigh > highest ) {
                   highest = tmpHigh;
                }
+               tmpLow = (double)inLow[i];
+               if( tmpLow < lowest ) {
+                  lowest = tmpLow;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-            outReal[outIdx++] = (highest + lowest) / 2.0;
+            outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+            trailingIdx += 1;
             today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inHigh[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  tmpLow = (double)inLow[blockNext + i];
+                  if( tmpLow < lowest ) {
+                     lowest = tmpLow;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = (highest + lowest) / 2.0;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
       } else {
          highestIdx = 0 - 1;
@@ -91868,6 +92497,18 @@ public final class Core {
    }
    private RetCode MIDPRICE_OpenCore( MIDPRICE_Stream sp, double inHigh[], double inLow[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmpLow = 0;
@@ -91918,16 +92559,21 @@ public final class Core {
        * Note that this algorithm allows the input and
        * output to be the same buffer.
        *
-       * Two equivalent algorithms, picked by period. Their outputs are
-       * bit-identical; only the scan strategy differs:
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
        *
-       * - Small periods (<= 20): rescan the whole window on every bar.
-       *   The two independent comparison chains auto-vectorize on modern
-       *   compilers, which beats any per-bar bookkeeping while the window
-       *   is short. The threshold sits near the measured crossover
-       *   (~period 19-20 with gcc/clang -O3 on x86-64).
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine. High and low travel in the same passes. All the
+       *   loops are straight-line with no data-dependent branching, which
+       *   is what lets a compiler vectorize them, and the work per bar is a
+       *   fixed number of comparisons regardless of period. Every scratch
+       *   array holds COPIES, so input and output may alias.
        *
-       * - Larger periods: cache the highest high/lowest low with its
+       * - Streaming: cache the highest high/lowest low with its
        *   index; the window is rescanned only when the cached extremum
        *   drops out of the window. That is O(1) per bar while the
        *   extremum sits away from the trailing edge, but it is not
@@ -92133,6 +92779,12 @@ public final class Core {
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -92172,32 +92824,128 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            lowest = inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -92214,6 +92962,12 @@ public final class Core {
                          MInteger outNBElement,
                          double outReal[] )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -92245,28 +92999,91 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmp = (double)inReal[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            lowest = (double)inReal[i];
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inReal[i];
                if( tmp < lowest ) {
-                  lowestIdx = i;
                   lowest = tmp;
                }
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
+            lowest = sufLowest[0];
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               lowest = (double)inReal[blockStart + optInTimePeriod];
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outReal[outIdx++] = lowest;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outReal[outIdx++] = lowest;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmp = (double)inReal[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inReal[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+            }
+            outReal[outIdx++] = lowest;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -92491,6 +93308,12 @@ public final class Core {
    }
    private RetCode MIN_OpenCore( MIN_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double tmp = 0;
       int outIdx = 0;
@@ -92532,6 +93355,27 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. All three are straight-line loops with no
+       *   data-dependent branching, which is what lets a compiler vectorize
+       *   them, and the work is 3 comparisons per bar regardless of period.
+       *   Both scratch arrays hold COPIES, so input and output may alias.
+       *
+       * - Streaming: cache the lowest value with its index; rescan only
+       *   when the cached extremum leaves the window. O(1) per bar while the
+       *   extremum sits away from the trailing edge, but not amortized O(1):
+       *   an extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar for
+       *   as long as that persists.
        */
       outIdx = 0;
       today = startIdx;
@@ -93279,6 +94123,18 @@ public final class Core {
                             double outMin[],
                             double outMax[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -93324,52 +94180,182 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine. The suffix half is the older one, so preferring it
+                * on a tie keeps the earliest-wins rule.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -93387,6 +94373,18 @@ public final class Core {
                             double outMin[],
                             double outMax[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -93424,48 +94422,140 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      highest = 0.0;
-      lowestIdx = 0 - 1;
-      lowest = 0.0;
-      while( today <= endIdx ) {
-         tmpHigh = (double)inReal[today];
-         tmpLow = tmpHigh;
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inReal[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inReal[i];
+            lowest = highest;
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmpHigh = (double)inReal[i];
                if( tmpHigh > highest ) {
-                  highestIdx = i;
                   highest = tmpHigh;
                }
-            }
-         } else if( tmpHigh >= highest ) {
-            highestIdx = today;
-            highest = tmpHigh;
-         }
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inReal[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmpLow = (double)inReal[i];
-               if( tmpLow < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmpLow;
+               if( tmpHigh < lowest ) {
+                  lowest = tmpHigh;
                }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
-         } else if( tmpLow <= lowest ) {
-            lowestIdx = today;
-            lowest = tmpLow;
+            outMax[outIdx] = sufHighest[0];
+            outMin[outIdx] = sufLowest[0];
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inReal[blockNext];
+               lowest = highest;
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmpHigh = (double)inReal[blockNext + i];
+                  if( tmpHigh > highest ) {
+                     highest = tmpHigh;
+                  }
+                  if( tmpHigh < lowest ) {
+                     lowest = tmpHigh;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  outMax[outIdx] = highest;
+                  outMin[outIdx] = lowest;
+                  outIdx += 1;
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         outMax[outIdx] = highest;
-         outMin[outIdx] = lowest;
-         outIdx += 1;
-         trailingIdx += 1;
-         today += 1;
+      } else {
+         highestIdx = 0 - 1;
+         highest = 0.0;
+         lowestIdx = 0 - 1;
+         lowest = 0.0;
+         while( today <= endIdx ) {
+            tmpHigh = (double)inReal[today];
+            tmpLow = tmpHigh;
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inReal[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmpHigh = (double)inReal[i];
+                  if( tmpHigh > highest ) {
+                     highestIdx = i;
+                     highest = tmpHigh;
+                  }
+               }
+            } else if( tmpHigh >= highest ) {
+               highestIdx = today;
+               highest = tmpHigh;
+            }
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inReal[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmpLow = (double)inReal[i];
+                  if( tmpLow < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmpLow;
+                  }
+               }
+            } else if( tmpLow <= lowest ) {
+               lowestIdx = today;
+               lowest = tmpLow;
+            }
+            outMax[outIdx] = highest;
+            outMin[outIdx] = lowest;
+            outIdx += 1;
+            trailingIdx += 1;
+            today += 1;
+         }
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -93739,6 +94829,18 @@ public final class Core {
    }
    private RetCode MINMAX_OpenCore( MINMAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outMin[], double outMax[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double highest = 0;
       double lowest = 0;
       double tmpHigh = 0;
@@ -93783,6 +94885,32 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), so
+       * the second arm exists to be the streaming tier's transition; see
+       * issue #147.
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass builds the older block's suffix extrema, one
+       *   forward pass builds the newer block's prefix extrema, and a third
+       *   pass combines them. Both extrema travel in the same passes, so the
+       *   two outputs cost one traversal, not two. All the loops are
+       *   straight-line with no data-dependent branching, which is what lets
+       *   a compiler vectorize them, and the work is a fixed number of
+       *   comparisons per bar regardless of period. Every scratch array holds
+       *   COPIES, so input and output may alias.
+       *
+       * - Streaming: cache each extremum with its index; rescan only when
+       *   the cached one leaves the window. O(1) per bar while the extremum
+       *   sits away from the trailing edge, but not amortized O(1): an
+       *   extremum on the oldest in-window bar drops out on the very next
+       *   bar, so the rescan repeats and the cost stays O(period) per bar
+       *   for as long as that persists. Tracking both extrema keeps that
+       *   state going through a trend: while the highest is refreshed by
+       *   each new bar, the lowest stays pinned at the oldest bar for the
+       *   whole leg (and the reverse on the way down).
        */
       outIdx = 0;
       today = startIdx;
@@ -123841,6 +124969,18 @@ public final class Core {
                            MInteger outNBElement,
                            double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -123885,61 +125025,203 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         /* Set the lowest low */
-         tmp = inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         /* Set the highest high */
-         tmp = inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+             * is fully available here: today == blockStart+p-1 <= endIdx.
+             * Scanning backward while keeping the incumbent on a tie
+             * leaves the later element holding a tie, which is what lets this
+             * compile to a single min/max instruction.
+             */
+            i = blockStart + optInTimePeriod - 1;
+            highest = inHigh[i];
+            lowest = inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               /* Prefix extrema of the next block, clamped to what remains.
+                * Forward, keeping the incumbent on a tie: earliest wins again.
+                */
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = inHigh[blockNext];
+               lowest = inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               /* Combine and emit. The suffix half is the older one, so
+                * preferring it on a tie keeps the earliest-wins rule. The
+                * bar being emitted for offset m is today+m-1: 'today' was
+                * advanced once above and is not touched inside this loop.
+                */
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            /* Set the lowest low */
+            tmp = inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            /* Set the highest high */
+            tmp = inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       /* Keep the outBegIdx relative to the
        * caller input before returning.
@@ -123958,6 +125240,18 @@ public final class Core {
                            MInteger outNBElement,
                            double outReal[] )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -123993,55 +125287,157 @@ public final class Core {
       outIdx = 0;
       today = startIdx;
       trailingIdx = startIdx - nbInitialElementNeeded;
-      highestIdx = 0 - 1;
-      lowestIdx = highestIdx;
-      lowest = 0.0;
-      highest = lowest;
-      diff = highest;
-      while( today <= endIdx ) {
-         tmp = (double)inLow[today];
-         if( lowestIdx < trailingIdx ) {
-            lowestIdx = trailingIdx;
-            lowest = (double)inLow[lowestIdx];
-            i = lowestIdx;
-            while( ++i <= today ) {
-               tmp = (double)inLow[i];
-               if( tmp < lowest ) {
-                  lowestIdx = i;
-                  lowest = tmp;
-               }
-            }
-            diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp <= lowest ) {
-            lowestIdx = today;
-            lowest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
-         }
-         tmp = (double)inHigh[today];
-         if( highestIdx < trailingIdx ) {
-            highestIdx = trailingIdx;
-            highest = (double)inHigh[highestIdx];
-            i = highestIdx;
-            while( ++i <= today ) {
+      if( optInTimePeriod <= 100000 ) {
+         int blockStart;
+         int nAvail;
+         int m;
+         int blockNext;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufHighest = new double[optInTimePeriod];
+         maxIdx_sufHighest = (optInTimePeriod)-1;
+         sufHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preHighest = new double[optInTimePeriod];
+         maxIdx_preHighest = (optInTimePeriod)-1;
+         preHighest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         sufLowest = new double[optInTimePeriod];
+         maxIdx_sufLowest = (optInTimePeriod)-1;
+         sufLowest_Idx = 0;
+         if( optInTimePeriod < 1 ) return RetCode.InternalError;
+         preLowest = new double[optInTimePeriod];
+         maxIdx_preLowest = (optInTimePeriod)-1;
+         preLowest_Idx = 0;
+         blockStart = trailingIdx;
+         while( today <= endIdx ) {
+            i = blockStart + optInTimePeriod - 1;
+            highest = (double)inHigh[i];
+            lowest = (double)inLow[i];
+            sufHighest[optInTimePeriod - 1] = highest;
+            sufLowest[optInTimePeriod - 1] = lowest;
+            while( i > blockStart ) {
+               i -= 1;
                tmp = (double)inHigh[i];
                if( tmp > highest ) {
-                  highestIdx = i;
                   highest = tmp;
                }
+               tmp = (double)inLow[i];
+               if( tmp < lowest ) {
+                  lowest = tmp;
+               }
+               sufHighest[i - blockStart] = highest;
+               sufLowest[i - blockStart] = lowest;
             }
+            highest = sufHighest[0];
+            lowest = sufLowest[0];
             diff = (highest - lowest) / (0 - 100.0);
-         } else if( tmp >= highest ) {
-            highestIdx = today;
-            highest = tmp;
-            diff = (highest - lowest) / (0 - 100.0);
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
+            if( today > endIdx ) {
+               blockStart = blockStart + optInTimePeriod;
+            } else {
+               blockNext = blockStart + optInTimePeriod;
+               nAvail = endIdx - blockNext + 1;
+               if( nAvail > optInTimePeriod - 1 ) {
+                  nAvail = optInTimePeriod - 1;
+               }
+               highest = (double)inHigh[blockNext];
+               lowest = (double)inLow[blockNext];
+               preHighest[0] = highest;
+               preLowest[0] = lowest;
+               i = 1;
+               while( i < nAvail ) {
+                  tmp = (double)inHigh[blockNext + i];
+                  if( tmp > highest ) {
+                     highest = tmp;
+                  }
+                  tmp = (double)inLow[blockNext + i];
+                  if( tmp < lowest ) {
+                     lowest = tmp;
+                  }
+                  preHighest[i] = highest;
+                  preLowest[i] = lowest;
+                  i += 1;
+               }
+               m = 1;
+               while( m <= nAvail ) {
+                  highest = sufHighest[m];
+                  if( preHighest[m - 1] > highest ) {
+                     highest = preHighest[m - 1];
+                  }
+                  lowest = sufLowest[m];
+                  if( preLowest[m - 1] < lowest ) {
+                     lowest = preLowest[m - 1];
+                  }
+                  diff = (highest - lowest) / (0 - 100.0);
+                  if( diff != 0.0 ) {
+                     outReal[outIdx++] = (highest - (double)inClose[today + m - 1]) / diff;
+                  } else {
+                     outReal[outIdx++] = 0.0;
+                  }
+                  m += 1;
+               }
+               trailingIdx = trailingIdx + nAvail;
+               today = today + nAvail;
+               blockStart = blockStart + optInTimePeriod;
+            }
          }
-         if( diff != 0.0 ) {
-            outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
-         } else {
-            outReal[outIdx++] = 0.0;
+      } else {
+         highestIdx = 0 - 1;
+         lowestIdx = highestIdx;
+         lowest = 0.0;
+         highest = lowest;
+         diff = highest;
+         while( today <= endIdx ) {
+            tmp = (double)inLow[today];
+            if( lowestIdx < trailingIdx ) {
+               lowestIdx = trailingIdx;
+               lowest = (double)inLow[lowestIdx];
+               i = lowestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inLow[i];
+                  if( tmp < lowest ) {
+                     lowestIdx = i;
+                     lowest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp <= lowest ) {
+               lowestIdx = today;
+               lowest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            tmp = (double)inHigh[today];
+            if( highestIdx < trailingIdx ) {
+               highestIdx = trailingIdx;
+               highest = (double)inHigh[highestIdx];
+               i = highestIdx;
+               while( ++i <= today ) {
+                  tmp = (double)inHigh[i];
+                  if( tmp > highest ) {
+                     highestIdx = i;
+                     highest = tmp;
+                  }
+               }
+               diff = (highest - lowest) / (0 - 100.0);
+            } else if( tmp >= highest ) {
+               highestIdx = today;
+               highest = tmp;
+               diff = (highest - lowest) / (0 - 100.0);
+            }
+            if( diff != 0.0 ) {
+               outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+            } else {
+               outReal[outIdx++] = 0.0;
+            }
+            trailingIdx += 1;
+            today += 1;
          }
-         trailingIdx += 1;
-         today += 1;
       }
       outBegIdx.value = startIdx;
       outNBElement.value = outIdx;
@@ -124319,6 +125715,18 @@ public final class Core {
    }
    private RetCode WILLR_OpenCore( WILLR_Stream sp, double inHigh[], double inLow[], double inClose[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
    {
+      double[] sufHighest;
+      int sufHighest_Idx = 0;
+      int maxIdx_sufHighest = (30)-1;
+      double[] preHighest;
+      int preHighest_Idx = 0;
+      int maxIdx_preHighest = (30)-1;
+      double[] sufLowest;
+      int sufLowest_Idx = 0;
+      int maxIdx_sufLowest = (30)-1;
+      double[] preLowest;
+      int preLowest_Idx = 0;
+      int maxIdx_preLowest = (30)-1;
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
@@ -124365,6 +125773,32 @@ public final class Core {
       /* Proceed with the calculation for the requested range.
        * Note that this algorithm allows the input and
        * output to be the same buffer.
+       *
+       * Two equivalent algorithms. The batch tier takes the first arm for
+       * every period in range (the threshold is the declared maximum), and
+       * the second arm is what the streaming tier transitions on:
+       *
+       * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+       *   p outputs belonging to one block boundary are produced together:
+       *   one backward pass for the older block's suffix extrema, one
+       *   forward pass for the newer block's prefix extrema, and a third
+       *   pass to combine and emit. High and low travel in the same passes.
+       *   All the loops are straight-line with no data-dependent branching,
+       *   which is what lets a compiler vectorize them, and the work per
+       *   bar is a fixed number of comparisons regardless of period. Every
+       *   scratch array holds COPIES, so input and output may alias.
+       *
+       *   'diff' is recomputed on every bar here rather than only when an
+       *   extremum moves. That is the same value: the streaming arm leaves
+       *   diff untouched exactly when neither extremum changed, in which
+       *   case (highest-lowest) is unchanged too.
+       *
+       * - Streaming: cache the highest high/lowest low with its index and
+       *   rescan only when the cached extremum leaves the window. O(1) per
+       *   bar while the extremum sits away from the trailing edge, but not
+       *   amortized O(1): an extremum on the oldest in-window bar drops out
+       *   on the very next bar, so the rescan repeats and the cost stays
+       *   O(period) per bar for as long as that persists. See issue #147.
        */
       outIdx = 0;
       today = startIdx;

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -88178,6 +88178,12 @@ class Core {
                              MInteger outNBElement,
                              double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
           double highest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -88217,32 +88223,128 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. All three are straight-line loops with no
+           *   data-dependent branching, which is what lets a compiler vectorize
+           *   them, and the work is 3 comparisons per bar regardless of period.
+           *   Both scratch arrays hold COPIES, so input and output may alias.
+           *
+           * - Streaming: cache the highest value with its index; rescan only
+           *   when the cached extremum leaves the window. O(1) per bar while the
+           *   extremum sits away from the trailing edge, but not amortized O(1):
+           *   an extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar for
+           *   as long as that persists.
            */
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          while( today <= endIdx ) {
-             tmp = inReal[today];
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single max instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                highest = inReal[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = inReal[i];
                    if( tmp > highest ) {
-                      highestIdx = i;
                       highest = tmp;
                    }
+                   sufHighest[i - blockStart] = highest;
                 }
-             } else if( tmp >= highest ) {
-                highestIdx = today;
-                highest = tmp;
+                highest = sufHighest[0];
+                outReal[outIdx++] = highest;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = inReal[blockStart + optInTimePeriod];
+                   preHighest[0] = highest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = inReal[blockStart + optInTimePeriod + i];
+                      if( tmp > highest ) {
+                         highest = tmp;
+                      }
+                      preHighest[i] = highest;
+                      i += 1;
+                   }
+                   /* Combine. The suffix half is the older one, so preferring it
+                    * on a tie keeps the earliest-wins rule.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      outReal[outIdx++] = highest;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = highest;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             while( today <= endIdx ) {
+                tmp = inReal[today];
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmp = inReal[i];
+                      if( tmp > highest ) {
+                         highestIdx = i;
+                         highest = tmp;
+                      }
+                   }
+                } else if( tmp >= highest ) {
+                   highestIdx = today;
+                   highest = tmp;
+                }
+                outReal[outIdx++] = highest;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           /* Keep the outBegIdx relative to the
            * caller input before returning.
@@ -88259,6 +88361,12 @@ class Core {
                              MInteger outNBElement,
                              double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
           double highest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -88290,28 +88398,91 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          while( today <= endIdx ) {
-             tmp = (double)inReal[today];
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = (double)inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                i = blockStart + optInTimePeriod - 1;
+                highest = (double)inReal[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = (double)inReal[i];
                    if( tmp > highest ) {
-                      highestIdx = i;
                       highest = tmp;
                    }
+                   sufHighest[i - blockStart] = highest;
                 }
-             } else if( tmp >= highest ) {
-                highestIdx = today;
-                highest = tmp;
+                highest = sufHighest[0];
+                outReal[outIdx++] = highest;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = (double)inReal[blockStart + optInTimePeriod];
+                   preHighest[0] = highest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                      if( tmp > highest ) {
+                         highest = tmp;
+                      }
+                      preHighest[i] = highest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      outReal[outIdx++] = highest;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = highest;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             while( today <= endIdx ) {
+                tmp = (double)inReal[today];
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = (double)inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmp = (double)inReal[i];
+                      if( tmp > highest ) {
+                         highestIdx = i;
+                         highest = tmp;
+                      }
+                   }
+                } else if( tmp >= highest ) {
+                   highestIdx = today;
+                   highest = tmp;
+                }
+                outReal[outIdx++] = highest;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           outBegIdx.value = startIdx;
           outNBElement.value = outIdx;
@@ -88538,6 +88709,12 @@ class Core {
        }
        private RetCode MAX_OpenCore( MAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
           double highest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -88579,6 +88756,27 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. All three are straight-line loops with no
+           *   data-dependent branching, which is what lets a compiler vectorize
+           *   them, and the work is 3 comparisons per bar regardless of period.
+           *   Both scratch arrays hold COPIES, so input and output may alias.
+           *
+           * - Streaming: cache the highest value with its index; rescan only
+           *   when the cached extremum leaves the window. O(1) per bar while the
+           *   extremum sits away from the trailing edge, but not amortized O(1):
+           *   an extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar for
+           *   as long as that persists.
            */
           outIdx = 0;
           today = startIdx;
@@ -90464,6 +90662,18 @@ class Core {
                                   MInteger outNBElement,
                                   double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -90529,50 +90739,163 @@ class Core {
            * (and the reverse on the way down). A flat stretch pins
            * both. Random-walk input is the favourable case, where
            * rescans are rare. See issue #147.
+           *
+           * The batch tier does not use that automaton: it takes the first arm
+           * for every period in range (the threshold is the declared maximum),
+           * and the automaton above is what the streaming tier transitions on.
+           * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+           * form: the p outputs belonging to one block boundary are produced
+           * together, one backward pass for the older block's suffix extrema,
+           * one forward pass for the newer block's prefix extrema, and a third
+           * pass to combine. Both extrema travel in the same passes. All the
+           * loops are straight-line with no data-dependent branching, which is
+           * what lets a compiler vectorize them, and the work per bar is a
+           * fixed number of comparisons regardless of period. Every scratch
+           * array holds COPIES, so input and output may alias.
            */
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmpHigh = inReal[today];
-             tmpLow = tmpHigh;
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single min/max instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                highest = inReal[i];
+                lowest = highest;
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = inReal[i];
                    if( tmpHigh > highest ) {
-                      highestIdx = i;
                       highest = tmpHigh;
                    }
-                }
-             } else if( tmpHigh >= highest ) {
-                highestIdx = today;
-                highest = tmpHigh;
-             }
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmpLow = inReal[i];
-                   if( tmpLow < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmpLow;
+                   if( tmpHigh < lowest ) {
+                      lowest = tmpHigh;
                    }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmpLow <= lowest ) {
-                lowestIdx = today;
-                lowest = tmpLow;
+                outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = inReal[blockNext];
+                   lowest = highest;
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = inReal[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      if( tmpHigh < lowest ) {
+                         lowest = tmpHigh;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   /* Combine. The suffix half is the older one, so preferring it
+                    * on a tie keeps the earliest-wins rule.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = (highest + lowest) / 2.0;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = (highest + lowest) / 2.0;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmpHigh = inReal[today];
+                tmpLow = tmpHigh;
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmpHigh = inReal[i];
+                      if( tmpHigh > highest ) {
+                         highestIdx = i;
+                         highest = tmpHigh;
+                      }
+                   }
+                } else if( tmpHigh >= highest ) {
+                   highestIdx = today;
+                   highest = tmpHigh;
+                }
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmpLow = inReal[i];
+                      if( tmpLow < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmpLow;
+                      }
+                   }
+                } else if( tmpLow <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmpLow;
+                }
+                outReal[outIdx++] = (highest + lowest) / 2.0;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           /* Keep the outBegIdx relative to the
            * caller input before returning.
@@ -90589,6 +90912,18 @@ class Core {
                                   MInteger outNBElement,
                                   double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -90623,46 +90958,134 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmpHigh = (double)inReal[today];
-             tmpLow = tmpHigh;
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = (double)inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                i = blockStart + optInTimePeriod - 1;
+                highest = (double)inReal[i];
+                lowest = highest;
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = (double)inReal[i];
                    if( tmpHigh > highest ) {
-                      highestIdx = i;
                       highest = tmpHigh;
                    }
-                }
-             } else if( tmpHigh >= highest ) {
-                highestIdx = today;
-                highest = tmpHigh;
-             }
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = (double)inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmpLow = (double)inReal[i];
-                   if( tmpLow < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmpLow;
+                   if( tmpHigh < lowest ) {
+                      lowest = tmpHigh;
                    }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmpLow <= lowest ) {
-                lowestIdx = today;
-                lowest = tmpLow;
+                outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = (double)inReal[blockNext];
+                   lowest = highest;
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = (double)inReal[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      if( tmpHigh < lowest ) {
+                         lowest = tmpHigh;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = (highest + lowest) / 2.0;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = (highest + lowest) / 2.0;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmpHigh = (double)inReal[today];
+                tmpLow = tmpHigh;
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = (double)inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmpHigh = (double)inReal[i];
+                      if( tmpHigh > highest ) {
+                         highestIdx = i;
+                         highest = tmpHigh;
+                      }
+                   }
+                } else if( tmpHigh >= highest ) {
+                   highestIdx = today;
+                   highest = tmpHigh;
+                }
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = (double)inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmpLow = (double)inReal[i];
+                      if( tmpLow < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmpLow;
+                      }
+                   }
+                } else if( tmpLow <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmpLow;
+                }
+                outReal[outIdx++] = (highest + lowest) / 2.0;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           outBegIdx.value = startIdx;
           outNBElement.value = outIdx;
@@ -90915,6 +91338,18 @@ class Core {
        }
        private RetCode MIDPOINT_OpenCore( MIDPOINT_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -90982,6 +91417,19 @@ class Core {
            * (and the reverse on the way down). A flat stretch pins
            * both. Random-walk input is the favourable case, where
            * rescans are rare. See issue #147.
+           *
+           * The batch tier does not use that automaton: it takes the first arm
+           * for every period in range (the threshold is the declared maximum),
+           * and the automaton above is what the streaming tier transitions on.
+           * Batch runs a Van Herk / Gil-Werman block scan in block-batched
+           * form: the p outputs belonging to one block boundary are produced
+           * together, one backward pass for the older block's suffix extrema,
+           * one forward pass for the newer block's prefix extrema, and a third
+           * pass to combine. Both extrema travel in the same passes. All the
+           * loops are straight-line with no data-dependent branching, which is
+           * what lets a compiler vectorize them, and the work per bar is a
+           * fixed number of comparisons regardless of period. Every scratch
+           * array holds COPIES, so input and output may alias.
            */
           outIdx = 0;
           today = startIdx;
@@ -91179,6 +91627,18 @@ class Core {
                                   MInteger outNBElement,
                                   double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -91227,16 +91687,21 @@ class Core {
            * Note that this algorithm allows the input and
            * output to be the same buffer.
            *
-           * Two equivalent algorithms, picked by period. Their outputs are
-           * bit-identical; only the scan strategy differs:
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), and
+           * the second arm is what the streaming tier transitions on:
            *
-           * - Small periods (<= 20): rescan the whole window on every bar.
-           *   The two independent comparison chains auto-vectorize on modern
-           *   compilers, which beats any per-bar bookkeeping while the window
-           *   is short. The threshold sits near the measured crossover
-           *   (~period 19-20 with gcc/clang -O3 on x86-64).
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass for the older block's suffix extrema, one
+           *   forward pass for the newer block's prefix extrema, and a third
+           *   pass to combine. High and low travel in the same passes. All the
+           *   loops are straight-line with no data-dependent branching, which
+           *   is what lets a compiler vectorize them, and the work per bar is a
+           *   fixed number of comparisons regardless of period. Every scratch
+           *   array holds COPIES, so input and output may alias.
            *
-           * - Larger periods: cache the highest high/lowest low with its
+           * - Streaming: cache the highest high/lowest low with its
            *   index; the window is rescanned only when the cached extremum
            *   drops out of the window. That is O(1) per bar while the
            *   extremum sits away from the trailing edge, but it is not
@@ -91254,23 +91719,105 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          if( optInTimePeriod <= 20 ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
              while( today <= endIdx ) {
-                lowest = inLow[trailingIdx];
-                highest = inHigh[trailingIdx];
-                trailingIdx += 1;
-                for( i = trailingIdx; i <= today; i += 1 ) {
-                   tmpLow = inLow[i];
-                   if( tmpLow < lowest ) {
-                      lowest = tmpLow;
-                   }
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single min/max instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                highest = inHigh[i];
+                lowest = inLow[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = inHigh[i];
                    if( tmpHigh > highest ) {
                       highest = tmpHigh;
                    }
+                   tmpLow = inLow[i];
+                   if( tmpLow < lowest ) {
+                      lowest = tmpLow;
+                   }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-                outReal[outIdx++] = (highest + lowest) / 2.0;
+                outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+                trailingIdx += 1;
                 today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = inHigh[blockNext];
+                   lowest = inLow[blockNext];
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = inHigh[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      tmpLow = inLow[blockNext + i];
+                      if( tmpLow < lowest ) {
+                         lowest = tmpLow;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   /* Combine. The suffix half is the older one, so preferring it
+                    * on a tie keeps the earliest-wins rule.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = (highest + lowest) / 2.0;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
           } else {
              highestIdx = 0 - 1;
@@ -91331,6 +91878,18 @@ class Core {
                                   MInteger outNBElement,
                                   double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -91365,23 +91924,93 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          if( optInTimePeriod <= 20 ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
              while( today <= endIdx ) {
-                lowest = (double)inLow[trailingIdx];
-                highest = (double)inHigh[trailingIdx];
-                trailingIdx += 1;
-                for( i = trailingIdx; i <= today; i += 1 ) {
-                   tmpLow = (double)inLow[i];
-                   if( tmpLow < lowest ) {
-                      lowest = tmpLow;
-                   }
+                i = blockStart + optInTimePeriod - 1;
+                highest = (double)inHigh[i];
+                lowest = (double)inLow[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = (double)inHigh[i];
                    if( tmpHigh > highest ) {
                       highest = tmpHigh;
                    }
+                   tmpLow = (double)inLow[i];
+                   if( tmpLow < lowest ) {
+                      lowest = tmpLow;
+                   }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-                outReal[outIdx++] = (highest + lowest) / 2.0;
+                outReal[outIdx++] = (sufHighest[0] + sufLowest[0]) / 2.0;
+                trailingIdx += 1;
                 today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = (double)inHigh[blockNext];
+                   lowest = (double)inLow[blockNext];
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = (double)inHigh[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      tmpLow = (double)inLow[blockNext + i];
+                      if( tmpLow < lowest ) {
+                         lowest = tmpLow;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = (highest + lowest) / 2.0;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
           } else {
              highestIdx = 0 - 1;
@@ -91682,6 +92311,18 @@ class Core {
        }
        private RetCode MIDPRICE_OpenCore( MIDPRICE_Stream sp, double inHigh[], double inLow[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmpLow = 0;
@@ -91732,16 +92373,21 @@ class Core {
            * Note that this algorithm allows the input and
            * output to be the same buffer.
            *
-           * Two equivalent algorithms, picked by period. Their outputs are
-           * bit-identical; only the scan strategy differs:
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), and
+           * the second arm is what the streaming tier transitions on:
            *
-           * - Small periods (<= 20): rescan the whole window on every bar.
-           *   The two independent comparison chains auto-vectorize on modern
-           *   compilers, which beats any per-bar bookkeeping while the window
-           *   is short. The threshold sits near the measured crossover
-           *   (~period 19-20 with gcc/clang -O3 on x86-64).
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass for the older block's suffix extrema, one
+           *   forward pass for the newer block's prefix extrema, and a third
+           *   pass to combine. High and low travel in the same passes. All the
+           *   loops are straight-line with no data-dependent branching, which
+           *   is what lets a compiler vectorize them, and the work per bar is a
+           *   fixed number of comparisons regardless of period. Every scratch
+           *   array holds COPIES, so input and output may alias.
            *
-           * - Larger periods: cache the highest high/lowest low with its
+           * - Streaming: cache the highest high/lowest low with its
            *   index; the window is rescanned only when the cached extremum
            *   drops out of the window. That is O(1) per bar while the
            *   extremum sits away from the trailing edge, but it is not
@@ -91947,6 +92593,12 @@ class Core {
                              MInteger outNBElement,
                              double outReal[] )
        {
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -91986,32 +92638,128 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. All three are straight-line loops with no
+           *   data-dependent branching, which is what lets a compiler vectorize
+           *   them, and the work is 3 comparisons per bar regardless of period.
+           *   Both scratch arrays hold COPIES, so input and output may alias.
+           *
+           * - Streaming: cache the lowest value with its index; rescan only
+           *   when the cached extremum leaves the window. O(1) per bar while the
+           *   extremum sits away from the trailing edge, but not amortized O(1):
+           *   an extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar for
+           *   as long as that persists.
            */
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmp = inReal[today];
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single min instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                lowest = inReal[i];
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = inReal[i];
                    if( tmp < lowest ) {
-                      lowestIdx = i;
                       lowest = tmp;
                    }
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmp <= lowest ) {
-                lowestIdx = today;
-                lowest = tmp;
+                lowest = sufLowest[0];
+                outReal[outIdx++] = lowest;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   lowest = inReal[blockStart + optInTimePeriod];
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = inReal[blockStart + optInTimePeriod + i];
+                      if( tmp < lowest ) {
+                         lowest = tmp;
+                      }
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   /* Combine. The suffix half is the older one, so preferring it
+                    * on a tie keeps the earliest-wins rule.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = lowest;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = lowest;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmp = inReal[today];
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmp = inReal[i];
+                      if( tmp < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmp;
+                      }
+                   }
+                } else if( tmp <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmp;
+                }
+                outReal[outIdx++] = lowest;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           /* Keep the outBegIdx relative to the
            * caller input before returning.
@@ -92028,6 +92776,12 @@ class Core {
                              MInteger outNBElement,
                              double outReal[] )
        {
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -92059,28 +92813,91 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmp = (double)inReal[today];
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = (double)inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                i = blockStart + optInTimePeriod - 1;
+                lowest = (double)inReal[i];
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = (double)inReal[i];
                    if( tmp < lowest ) {
-                      lowestIdx = i;
                       lowest = tmp;
                    }
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmp <= lowest ) {
-                lowestIdx = today;
-                lowest = tmp;
+                lowest = sufLowest[0];
+                outReal[outIdx++] = lowest;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   nAvail = endIdx - (blockStart + optInTimePeriod) + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   lowest = (double)inReal[blockStart + optInTimePeriod];
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = (double)inReal[blockStart + optInTimePeriod + i];
+                      if( tmp < lowest ) {
+                         lowest = tmp;
+                      }
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outReal[outIdx++] = lowest;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outReal[outIdx++] = lowest;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmp = (double)inReal[today];
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = (double)inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmp = (double)inReal[i];
+                      if( tmp < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmp;
+                      }
+                   }
+                } else if( tmp <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmp;
+                }
+                outReal[outIdx++] = lowest;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           outBegIdx.value = startIdx;
           outNBElement.value = outIdx;
@@ -92305,6 +93122,12 @@ class Core {
        }
        private RetCode MIN_OpenCore( MIN_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
        {
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double tmp = 0;
           int outIdx = 0;
@@ -92346,6 +93169,27 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. All three are straight-line loops with no
+           *   data-dependent branching, which is what lets a compiler vectorize
+           *   them, and the work is 3 comparisons per bar regardless of period.
+           *   Both scratch arrays hold COPIES, so input and output may alias.
+           *
+           * - Streaming: cache the lowest value with its index; rescan only
+           *   when the cached extremum leaves the window. O(1) per bar while the
+           *   extremum sits away from the trailing edge, but not amortized O(1):
+           *   an extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar for
+           *   as long as that persists.
            */
           outIdx = 0;
           today = startIdx;
@@ -93093,6 +93937,18 @@ class Core {
                                 double outMin[],
                                 double outMax[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double highest = 0;
           double lowest = 0;
           double tmpHigh = 0;
@@ -93138,52 +93994,182 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. Both extrema travel in the same passes, so the
+           *   two outputs cost one traversal, not two. All the loops are
+           *   straight-line with no data-dependent branching, which is what lets
+           *   a compiler vectorize them, and the work is a fixed number of
+           *   comparisons per bar regardless of period. Every scratch array holds
+           *   COPIES, so input and output may alias.
+           *
+           * - Streaming: cache each extremum with its index; rescan only when
+           *   the cached one leaves the window. O(1) per bar while the extremum
+           *   sits away from the trailing edge, but not amortized O(1): an
+           *   extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar
+           *   for as long as that persists. Tracking both extrema keeps that
+           *   state going through a trend: while the highest is refreshed by
+           *   each new bar, the lowest stays pinned at the oldest bar for the
+           *   whole leg (and the reverse on the way down).
            */
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmpHigh = inReal[today];
-             tmpLow = tmpHigh;
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single min/max instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                highest = inReal[i];
+                lowest = highest;
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = inReal[i];
                    if( tmpHigh > highest ) {
-                      highestIdx = i;
                       highest = tmpHigh;
                    }
-                }
-             } else if( tmpHigh >= highest ) {
-                highestIdx = today;
-                highest = tmpHigh;
-             }
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmpLow = inReal[i];
-                   if( tmpLow < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmpLow;
+                   if( tmpHigh < lowest ) {
+                      lowest = tmpHigh;
                    }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmpLow <= lowest ) {
-                lowestIdx = today;
-                lowest = tmpLow;
+                outMax[outIdx] = sufHighest[0];
+                outMin[outIdx] = sufLowest[0];
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = inReal[blockNext];
+                   lowest = highest;
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = inReal[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      if( tmpHigh < lowest ) {
+                         lowest = tmpHigh;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   /* Combine. The suffix half is the older one, so preferring it
+                    * on a tie keeps the earliest-wins rule.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outMax[outIdx] = highest;
+                      outMin[outIdx] = lowest;
+                      outIdx += 1;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outMax[outIdx] = highest;
-             outMin[outIdx] = lowest;
-             outIdx += 1;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmpHigh = inReal[today];
+                tmpLow = tmpHigh;
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmpHigh = inReal[i];
+                      if( tmpHigh > highest ) {
+                         highestIdx = i;
+                         highest = tmpHigh;
+                      }
+                   }
+                } else if( tmpHigh >= highest ) {
+                   highestIdx = today;
+                   highest = tmpHigh;
+                }
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmpLow = inReal[i];
+                      if( tmpLow < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmpLow;
+                      }
+                   }
+                } else if( tmpLow <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmpLow;
+                }
+                outMax[outIdx] = highest;
+                outMin[outIdx] = lowest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           /* Keep the outBegIdx relative to the
            * caller input before returning.
@@ -93201,6 +94187,18 @@ class Core {
                                 double outMin[],
                                 double outMax[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double highest = 0;
           double lowest = 0;
           double tmpHigh = 0;
@@ -93238,48 +94236,140 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          highest = 0.0;
-          lowestIdx = 0 - 1;
-          lowest = 0.0;
-          while( today <= endIdx ) {
-             tmpHigh = (double)inReal[today];
-             tmpLow = tmpHigh;
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = (double)inReal[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                i = blockStart + optInTimePeriod - 1;
+                highest = (double)inReal[i];
+                lowest = highest;
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmpHigh = (double)inReal[i];
                    if( tmpHigh > highest ) {
-                      highestIdx = i;
                       highest = tmpHigh;
                    }
-                }
-             } else if( tmpHigh >= highest ) {
-                highestIdx = today;
-                highest = tmpHigh;
-             }
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = (double)inReal[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmpLow = (double)inReal[i];
-                   if( tmpLow < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmpLow;
+                   if( tmpHigh < lowest ) {
+                      lowest = tmpHigh;
                    }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
-             } else if( tmpLow <= lowest ) {
-                lowestIdx = today;
-                lowest = tmpLow;
+                outMax[outIdx] = sufHighest[0];
+                outMin[outIdx] = sufLowest[0];
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = (double)inReal[blockNext];
+                   lowest = highest;
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmpHigh = (double)inReal[blockNext + i];
+                      if( tmpHigh > highest ) {
+                         highest = tmpHigh;
+                      }
+                      if( tmpHigh < lowest ) {
+                         lowest = tmpHigh;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      outMax[outIdx] = highest;
+                      outMin[outIdx] = lowest;
+                      outIdx += 1;
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             outMax[outIdx] = highest;
-             outMin[outIdx] = lowest;
-             outIdx += 1;
-             trailingIdx += 1;
-             today += 1;
+          } else {
+             highestIdx = 0 - 1;
+             highest = 0.0;
+             lowestIdx = 0 - 1;
+             lowest = 0.0;
+             while( today <= endIdx ) {
+                tmpHigh = (double)inReal[today];
+                tmpLow = tmpHigh;
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = (double)inReal[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmpHigh = (double)inReal[i];
+                      if( tmpHigh > highest ) {
+                         highestIdx = i;
+                         highest = tmpHigh;
+                      }
+                   }
+                } else if( tmpHigh >= highest ) {
+                   highestIdx = today;
+                   highest = tmpHigh;
+                }
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = (double)inReal[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmpLow = (double)inReal[i];
+                      if( tmpLow < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmpLow;
+                      }
+                   }
+                } else if( tmpLow <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmpLow;
+                }
+                outMax[outIdx] = highest;
+                outMin[outIdx] = lowest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+             }
           }
           outBegIdx.value = startIdx;
           outNBElement.value = outIdx;
@@ -93553,6 +94643,18 @@ class Core {
        }
        private RetCode MINMAX_OpenCore( MINMAX_Stream sp, double inReal[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outMin[], double outMax[], int outStride )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double highest = 0;
           double lowest = 0;
           double tmpHigh = 0;
@@ -93597,6 +94699,32 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), so
+           * the second arm exists to be the streaming tier's transition; see
+           * issue #147.
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass builds the older block's suffix extrema, one
+           *   forward pass builds the newer block's prefix extrema, and a third
+           *   pass combines them. Both extrema travel in the same passes, so the
+           *   two outputs cost one traversal, not two. All the loops are
+           *   straight-line with no data-dependent branching, which is what lets
+           *   a compiler vectorize them, and the work is a fixed number of
+           *   comparisons per bar regardless of period. Every scratch array holds
+           *   COPIES, so input and output may alias.
+           *
+           * - Streaming: cache each extremum with its index; rescan only when
+           *   the cached one leaves the window. O(1) per bar while the extremum
+           *   sits away from the trailing edge, but not amortized O(1): an
+           *   extremum on the oldest in-window bar drops out on the very next
+           *   bar, so the rescan repeats and the cost stays O(period) per bar
+           *   for as long as that persists. Tracking both extrema keeps that
+           *   state going through a trend: while the highest is refreshed by
+           *   each new bar, the lowest stays pinned at the oldest bar for the
+           *   whole leg (and the reverse on the way down).
            */
           outIdx = 0;
           today = startIdx;
@@ -123655,6 +124783,18 @@ class Core {
                                MInteger outNBElement,
                                double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
@@ -123699,61 +124839,203 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), and
+           * the second arm is what the streaming tier transitions on:
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass for the older block's suffix extrema, one
+           *   forward pass for the newer block's prefix extrema, and a third
+           *   pass to combine and emit. High and low travel in the same passes.
+           *   All the loops are straight-line with no data-dependent branching,
+           *   which is what lets a compiler vectorize them, and the work per
+           *   bar is a fixed number of comparisons regardless of period. Every
+           *   scratch array holds COPIES, so input and output may alias.
+           *
+           *   'diff' is recomputed on every bar here rather than only when an
+           *   extremum moves. That is the same value: the streaming arm leaves
+           *   diff untouched exactly when neither extremum changed, in which
+           *   case (highest-lowest) is unchanged too.
+           *
+           * - Streaming: cache the highest high/lowest low with its index and
+           *   rescan only when the cached extremum leaves the window. O(1) per
+           *   bar while the extremum sits away from the trailing edge, but not
+           *   amortized O(1): an extremum on the oldest in-window bar drops out
+           *   on the very next bar, so the rescan repeats and the cost stays
+           *   O(period) per bar for as long as that persists. See issue #147.
            */
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          lowestIdx = highestIdx;
-          lowest = 0.0;
-          highest = lowest;
-          diff = highest;
-          while( today <= endIdx ) {
-             /* Set the lowest low */
-             tmp = inLow[today];
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = inLow[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmp = inLow[i];
-                   if( tmp < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmp;
-                   }
-                }
-                diff = (highest - lowest) / (0 - 100.0);
-             } else if( tmp <= lowest ) {
-                lowestIdx = today;
-                lowest = tmp;
-                diff = (highest - lowest) / (0 - 100.0);
-             }
-             /* Set the highest high */
-             tmp = inHigh[today];
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = inHigh[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                /* Suffix extrema of the block [blockStart, blockStart+p-1], which
+                 * is fully available here: today == blockStart+p-1 <= endIdx.
+                 * Scanning backward while keeping the incumbent on a tie
+                 * leaves the later element holding a tie, which is what lets this
+                 * compile to a single min/max instruction.
+                 */
+                i = blockStart + optInTimePeriod - 1;
+                highest = inHigh[i];
+                lowest = inLow[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = inHigh[i];
                    if( tmp > highest ) {
-                      highestIdx = i;
                       highest = tmp;
                    }
+                   tmp = inLow[i];
+                   if( tmp < lowest ) {
+                      lowest = tmp;
+                   }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
+                highest = sufHighest[0];
+                lowest = sufLowest[0];
                 diff = (highest - lowest) / (0 - 100.0);
-             } else if( tmp >= highest ) {
-                highestIdx = today;
-                highest = tmp;
-                diff = (highest - lowest) / (0 - 100.0);
+                if( diff != 0.0 ) {
+                   outReal[outIdx++] = (highest - inClose[today]) / diff;
+                } else {
+                   outReal[outIdx++] = 0.0;
+                }
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   /* Prefix extrema of the next block, clamped to what remains.
+                    * Forward, keeping the incumbent on a tie: earliest wins again.
+                    */
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = inHigh[blockNext];
+                   lowest = inLow[blockNext];
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = inHigh[blockNext + i];
+                      if( tmp > highest ) {
+                         highest = tmp;
+                      }
+                      tmp = inLow[blockNext + i];
+                      if( tmp < lowest ) {
+                         lowest = tmp;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   /* Combine and emit. The suffix half is the older one, so
+                    * preferring it on a tie keeps the earliest-wins rule. The
+                    * bar being emitted for offset m is today+m-1: 'today' was
+                    * advanced once above and is not touched inside this loop.
+                    */
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      diff = (highest - lowest) / (0 - 100.0);
+                      if( diff != 0.0 ) {
+                         outReal[outIdx++] = (highest - inClose[today + m - 1]) / diff;
+                      } else {
+                         outReal[outIdx++] = 0.0;
+                      }
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             if( diff != 0.0 ) {
-                outReal[outIdx++] = (highest - inClose[today]) / diff;
-             } else {
-                outReal[outIdx++] = 0.0;
+          } else {
+             highestIdx = 0 - 1;
+             lowestIdx = highestIdx;
+             lowest = 0.0;
+             highest = lowest;
+             diff = highest;
+             while( today <= endIdx ) {
+                /* Set the lowest low */
+                tmp = inLow[today];
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = inLow[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmp = inLow[i];
+                      if( tmp < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmp;
+                      }
+                   }
+                   diff = (highest - lowest) / (0 - 100.0);
+                } else if( tmp <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmp;
+                   diff = (highest - lowest) / (0 - 100.0);
+                }
+                /* Set the highest high */
+                tmp = inHigh[today];
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = inHigh[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmp = inHigh[i];
+                      if( tmp > highest ) {
+                         highestIdx = i;
+                         highest = tmp;
+                      }
+                   }
+                   diff = (highest - lowest) / (0 - 100.0);
+                } else if( tmp >= highest ) {
+                   highestIdx = today;
+                   highest = tmp;
+                   diff = (highest - lowest) / (0 - 100.0);
+                }
+                if( diff != 0.0 ) {
+                   outReal[outIdx++] = (highest - inClose[today]) / diff;
+                } else {
+                   outReal[outIdx++] = 0.0;
+                }
+                trailingIdx += 1;
+                today += 1;
              }
-             trailingIdx += 1;
-             today += 1;
           }
           /* Keep the outBegIdx relative to the
            * caller input before returning.
@@ -123772,6 +125054,18 @@ class Core {
                                MInteger outNBElement,
                                double outReal[] )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
@@ -123807,55 +125101,157 @@ class Core {
           outIdx = 0;
           today = startIdx;
           trailingIdx = startIdx - nbInitialElementNeeded;
-          highestIdx = 0 - 1;
-          lowestIdx = highestIdx;
-          lowest = 0.0;
-          highest = lowest;
-          diff = highest;
-          while( today <= endIdx ) {
-             tmp = (double)inLow[today];
-             if( lowestIdx < trailingIdx ) {
-                lowestIdx = trailingIdx;
-                lowest = (double)inLow[lowestIdx];
-                i = lowestIdx;
-                while( ++i <= today ) {
-                   tmp = (double)inLow[i];
-                   if( tmp < lowest ) {
-                      lowestIdx = i;
-                      lowest = tmp;
-                   }
-                }
-                diff = (highest - lowest) / (0 - 100.0);
-             } else if( tmp <= lowest ) {
-                lowestIdx = today;
-                lowest = tmp;
-                diff = (highest - lowest) / (0 - 100.0);
-             }
-             tmp = (double)inHigh[today];
-             if( highestIdx < trailingIdx ) {
-                highestIdx = trailingIdx;
-                highest = (double)inHigh[highestIdx];
-                i = highestIdx;
-                while( ++i <= today ) {
+          if( optInTimePeriod <= 100000 ) {
+             int blockStart;
+             int nAvail;
+             int m;
+             int blockNext;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufHighest = new double[optInTimePeriod];
+             maxIdx_sufHighest = (optInTimePeriod)-1;
+             sufHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preHighest = new double[optInTimePeriod];
+             maxIdx_preHighest = (optInTimePeriod)-1;
+             preHighest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             sufLowest = new double[optInTimePeriod];
+             maxIdx_sufLowest = (optInTimePeriod)-1;
+             sufLowest_Idx = 0;
+             if( optInTimePeriod < 1 ) return RetCode.InternalError;
+             preLowest = new double[optInTimePeriod];
+             maxIdx_preLowest = (optInTimePeriod)-1;
+             preLowest_Idx = 0;
+             blockStart = trailingIdx;
+             while( today <= endIdx ) {
+                i = blockStart + optInTimePeriod - 1;
+                highest = (double)inHigh[i];
+                lowest = (double)inLow[i];
+                sufHighest[optInTimePeriod - 1] = highest;
+                sufLowest[optInTimePeriod - 1] = lowest;
+                while( i > blockStart ) {
+                   i -= 1;
                    tmp = (double)inHigh[i];
                    if( tmp > highest ) {
-                      highestIdx = i;
                       highest = tmp;
                    }
+                   tmp = (double)inLow[i];
+                   if( tmp < lowest ) {
+                      lowest = tmp;
+                   }
+                   sufHighest[i - blockStart] = highest;
+                   sufLowest[i - blockStart] = lowest;
                 }
+                highest = sufHighest[0];
+                lowest = sufLowest[0];
                 diff = (highest - lowest) / (0 - 100.0);
-             } else if( tmp >= highest ) {
-                highestIdx = today;
-                highest = tmp;
-                diff = (highest - lowest) / (0 - 100.0);
+                if( diff != 0.0 ) {
+                   outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+                } else {
+                   outReal[outIdx++] = 0.0;
+                }
+                trailingIdx += 1;
+                today += 1;
+                if( today > endIdx ) {
+                   blockStart = blockStart + optInTimePeriod;
+                } else {
+                   blockNext = blockStart + optInTimePeriod;
+                   nAvail = endIdx - blockNext + 1;
+                   if( nAvail > optInTimePeriod - 1 ) {
+                      nAvail = optInTimePeriod - 1;
+                   }
+                   highest = (double)inHigh[blockNext];
+                   lowest = (double)inLow[blockNext];
+                   preHighest[0] = highest;
+                   preLowest[0] = lowest;
+                   i = 1;
+                   while( i < nAvail ) {
+                      tmp = (double)inHigh[blockNext + i];
+                      if( tmp > highest ) {
+                         highest = tmp;
+                      }
+                      tmp = (double)inLow[blockNext + i];
+                      if( tmp < lowest ) {
+                         lowest = tmp;
+                      }
+                      preHighest[i] = highest;
+                      preLowest[i] = lowest;
+                      i += 1;
+                   }
+                   m = 1;
+                   while( m <= nAvail ) {
+                      highest = sufHighest[m];
+                      if( preHighest[m - 1] > highest ) {
+                         highest = preHighest[m - 1];
+                      }
+                      lowest = sufLowest[m];
+                      if( preLowest[m - 1] < lowest ) {
+                         lowest = preLowest[m - 1];
+                      }
+                      diff = (highest - lowest) / (0 - 100.0);
+                      if( diff != 0.0 ) {
+                         outReal[outIdx++] = (highest - (double)inClose[today + m - 1]) / diff;
+                      } else {
+                         outReal[outIdx++] = 0.0;
+                      }
+                      m += 1;
+                   }
+                   trailingIdx = trailingIdx + nAvail;
+                   today = today + nAvail;
+                   blockStart = blockStart + optInTimePeriod;
+                }
              }
-             if( diff != 0.0 ) {
-                outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
-             } else {
-                outReal[outIdx++] = 0.0;
+          } else {
+             highestIdx = 0 - 1;
+             lowestIdx = highestIdx;
+             lowest = 0.0;
+             highest = lowest;
+             diff = highest;
+             while( today <= endIdx ) {
+                tmp = (double)inLow[today];
+                if( lowestIdx < trailingIdx ) {
+                   lowestIdx = trailingIdx;
+                   lowest = (double)inLow[lowestIdx];
+                   i = lowestIdx;
+                   while( ++i <= today ) {
+                      tmp = (double)inLow[i];
+                      if( tmp < lowest ) {
+                         lowestIdx = i;
+                         lowest = tmp;
+                      }
+                   }
+                   diff = (highest - lowest) / (0 - 100.0);
+                } else if( tmp <= lowest ) {
+                   lowestIdx = today;
+                   lowest = tmp;
+                   diff = (highest - lowest) / (0 - 100.0);
+                }
+                tmp = (double)inHigh[today];
+                if( highestIdx < trailingIdx ) {
+                   highestIdx = trailingIdx;
+                   highest = (double)inHigh[highestIdx];
+                   i = highestIdx;
+                   while( ++i <= today ) {
+                      tmp = (double)inHigh[i];
+                      if( tmp > highest ) {
+                         highestIdx = i;
+                         highest = tmp;
+                      }
+                   }
+                   diff = (highest - lowest) / (0 - 100.0);
+                } else if( tmp >= highest ) {
+                   highestIdx = today;
+                   highest = tmp;
+                   diff = (highest - lowest) / (0 - 100.0);
+                }
+                if( diff != 0.0 ) {
+                   outReal[outIdx++] = (highest - (double)inClose[today]) / diff;
+                } else {
+                   outReal[outIdx++] = 0.0;
+                }
+                trailingIdx += 1;
+                today += 1;
              }
-             trailingIdx += 1;
-             today += 1;
           }
           outBegIdx.value = startIdx;
           outNBElement.value = outIdx;
@@ -124133,6 +125529,18 @@ class Core {
        }
        private RetCode WILLR_OpenCore( WILLR_Stream sp, double inHigh[], double inLow[], double inClose[], int startIdx, int optInTimePeriod, MInteger outBegIdx, MInteger outNBElement, double outReal[], int outStride )
        {
+          double[] sufHighest;
+          int sufHighest_Idx = 0;
+          int maxIdx_sufHighest = (30)-1;
+          double[] preHighest;
+          int preHighest_Idx = 0;
+          int maxIdx_preHighest = (30)-1;
+          double[] sufLowest;
+          int sufLowest_Idx = 0;
+          int maxIdx_sufLowest = (30)-1;
+          double[] preLowest;
+          int preLowest_Idx = 0;
+          int maxIdx_preLowest = (30)-1;
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
@@ -124179,6 +125587,32 @@ class Core {
           /* Proceed with the calculation for the requested range.
            * Note that this algorithm allows the input and
            * output to be the same buffer.
+           *
+           * Two equivalent algorithms. The batch tier takes the first arm for
+           * every period in range (the threshold is the declared maximum), and
+           * the second arm is what the streaming tier transitions on:
+           *
+           * - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+           *   p outputs belonging to one block boundary are produced together:
+           *   one backward pass for the older block's suffix extrema, one
+           *   forward pass for the newer block's prefix extrema, and a third
+           *   pass to combine and emit. High and low travel in the same passes.
+           *   All the loops are straight-line with no data-dependent branching,
+           *   which is what lets a compiler vectorize them, and the work per
+           *   bar is a fixed number of comparisons regardless of period. Every
+           *   scratch array holds COPIES, so input and output may alias.
+           *
+           *   'diff' is recomputed on every bar here rather than only when an
+           *   extremum moves. That is the same value: the streaming arm leaves
+           *   diff untouched exactly when neither extremum changed, in which
+           *   case (highest-lowest) is unchanged too.
+           *
+           * - Streaming: cache the highest high/lowest low with its index and
+           *   rescan only when the cached extremum leaves the window. O(1) per
+           *   bar while the extremum sits away from the trailing edge, but not
+           *   amortized O(1): an extremum on the oldest in-window bar drops out
+           *   on the very next bar, so the rescan repeats and the cost stays
+           *   O(period) per bar for as long as that persists. See issue #147.
            */
           outIdx = 0;
           today = startIdx;

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -169,6 +169,16 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outReal.len());
         let mut startIdx = startIdx;
+        let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest: &mut [f64] = &mut [];
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut local_preHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preHighest: Vec<f64> = Vec::new();
+        let mut preHighest: &mut [f64] = &mut [];
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
         let mut outIdx: usize = 0_usize;
@@ -195,32 +205,137 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. All three are straight-line loops with no
+        //   data-dependent branching, which is what lets a compiler vectorize
+        //   them, and the work is 3 comparisons per bar regardless of period.
+        //   Both scratch arrays hold COPIES, so input and output may alias.
+        //
+        // - Streaming: cache the highest value with its index; rescan only
+        //   when the cached extremum leaves the window. O(1) per bar while the
+        //   extremum sits away from the trailing edge, but not amortized O(1):
+        //   an extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar for
+        //   as long as that persists.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        highestIdx = 0 - 1;
-        highest = 0.0;
-        while today <= endIdx {
-            tmp = inReal[today];
-            if highestIdx < ((trailingIdx) as i32) {
-                highestIdx = (trailingIdx) as i32;
-                highest = inReal[(highestIdx) as usize];
-                i = (highestIdx) as usize;
-                while { i += 1; i } <= today {
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufHighest = &mut local_sufHighest;
+            } else {
+                heap_sufHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufHighest = &mut heap_sufHighest;
+            }
+            maxIdx_sufHighest = ((optInTimePeriod) as usize) - 1;
+            sufHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preHighest = &mut local_preHighest;
+            } else {
+                heap_preHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preHighest = &mut heap_preHighest;
+            }
+            maxIdx_preHighest = ((optInTimePeriod) as usize) - 1;
+            preHighest_Idx = 0;
+            blockStart = trailingIdx;
+            while today <= endIdx {
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single max instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                highest = inReal[i];
+                sufHighest[(optInTimePeriod - 1) as usize] = highest;
+                while i > blockStart {
+                    i -= 1;
                     tmp = inReal[i];
                     if tmp > highest {
-                        highestIdx = (i) as i32;
                         highest = tmp;
                     }
+                    sufHighest[i - blockStart] = highest;
                 }
-            } else if tmp >= highest {
-                highestIdx = (today) as i32;
-                highest = tmp;
+                highest = sufHighest[0];
+                outReal[outIdx] = highest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    nAvail = endIdx - (blockStart + ((optInTimePeriod) as usize)) + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    highest = inReal[(blockStart + ((optInTimePeriod) as usize)) as usize];
+                    preHighest[0] = highest;
+                    i = 1;
+                    while i < nAvail {
+                        tmp = inReal[(blockStart + ((optInTimePeriod) as usize) + i) as usize];
+                        if tmp > highest {
+                            highest = tmp;
+                        }
+                        preHighest[i] = highest;
+                        i += 1;
+                    }
+                    // Combine. The suffix half is the older one, so preferring it
+                    // on a tie keeps the earliest-wins rule.
+                    m = 1;
+                    while m <= nAvail {
+                        highest = sufHighest[m];
+                        if preHighest[m - 1] > highest {
+                            highest = preHighest[m - 1];
+                        }
+                        outReal[outIdx] = highest;
+                        outIdx += 1;
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
-            outReal[outIdx] = highest;
-            outIdx += 1;
-            trailingIdx += 1;
-            today += 1;
+        } else {
+            highestIdx = 0 - 1;
+            highest = 0.0;
+            while today <= endIdx {
+                tmp = inReal[today];
+                if highestIdx < ((trailingIdx) as i32) {
+                    highestIdx = (trailingIdx) as i32;
+                    highest = inReal[(highestIdx) as usize];
+                    i = (highestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmp = inReal[i];
+                        if tmp > highest {
+                            highestIdx = (i) as i32;
+                            highest = tmp;
+                        }
+                    }
+                } else if tmp >= highest {
+                    highestIdx = (today) as i32;
+                    highest = tmp;
+                }
+                outReal[outIdx] = highest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+            }
         }
         // Keep the outBegIdx relative to the
         // caller input before returning.
@@ -314,6 +429,12 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut preHighest: Vec<f64> = Vec::new();
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
         let mut outIdx: usize = 0_usize;
@@ -340,6 +461,27 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. All three are straight-line loops with no
+        //   data-dependent branching, which is what lets a compiler vectorize
+        //   them, and the work is 3 comparisons per bar regardless of period.
+        //   Both scratch arrays hold COPIES, so input and output may alias.
+        //
+        // - Streaming: cache the highest value with its index; rescan only
+        //   when the cached extremum leaves the window. O(1) per bar while the
+        //   extremum sits away from the trailing edge, but not amortized O(1):
+        //   an extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar for
+        //   as long as that persists.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -168,6 +168,26 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outReal.len());
         let mut startIdx = startIdx;
+        let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest: &mut [f64] = &mut [];
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut local_preHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preHighest: Vec<f64> = Vec::new();
+        let mut preHighest: &mut [f64] = &mut [];
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut local_sufLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest: &mut [f64] = &mut [];
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut local_preLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preLowest: Vec<f64> = Vec::new();
+        let mut preLowest: &mut [f64] = &mut [];
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
@@ -219,50 +239,182 @@ impl Core {
         // (and the reverse on the way down). A flat stretch pins
         // both. Random-walk input is the favourable case, where
         // rescans are rare. See issue #147.
+        //
+        // The batch tier does not use that automaton: it takes the first arm
+        // for every period in range (the threshold is the declared maximum),
+        // and the automaton above is what the streaming tier transitions on.
+        // Batch runs a Van Herk / Gil-Werman block scan in block-batched
+        // form: the p outputs belonging to one block boundary are produced
+        // together, one backward pass for the older block's suffix extrema,
+        // one forward pass for the newer block's prefix extrema, and a third
+        // pass to combine. Both extrema travel in the same passes. All the
+        // loops are straight-line with no data-dependent branching, which is
+        // what lets a compiler vectorize them, and the work per bar is a
+        // fixed number of comparisons regardless of period. Every scratch
+        // array holds COPIES, so input and output may alias.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        highestIdx = 0 - 1;
-        highest = 0.0;
-        lowestIdx = 0 - 1;
-        lowest = 0.0;
-        while today <= endIdx {
-            tmpHigh = inReal[today];
-            tmpLow = tmpHigh;
-            if highestIdx < ((trailingIdx) as i32) {
-                highestIdx = (trailingIdx) as i32;
-                highest = inReal[(highestIdx) as usize];
-                i = (highestIdx) as usize;
-                while { i += 1; i } <= today {
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            let mut blockNext: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufHighest = &mut local_sufHighest;
+            } else {
+                heap_sufHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufHighest = &mut heap_sufHighest;
+            }
+            maxIdx_sufHighest = ((optInTimePeriod) as usize) - 1;
+            sufHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preHighest = &mut local_preHighest;
+            } else {
+                heap_preHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preHighest = &mut heap_preHighest;
+            }
+            maxIdx_preHighest = ((optInTimePeriod) as usize) - 1;
+            preHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufLowest = &mut local_sufLowest;
+            } else {
+                heap_sufLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufLowest = &mut heap_sufLowest;
+            }
+            maxIdx_sufLowest = ((optInTimePeriod) as usize) - 1;
+            sufLowest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preLowest = &mut local_preLowest;
+            } else {
+                heap_preLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preLowest = &mut heap_preLowest;
+            }
+            maxIdx_preLowest = ((optInTimePeriod) as usize) - 1;
+            preLowest_Idx = 0;
+            blockStart = trailingIdx;
+            while today <= endIdx {
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single min/max instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                highest = inReal[i];
+                lowest = highest;
+                sufHighest[(optInTimePeriod - 1) as usize] = highest;
+                sufLowest[(optInTimePeriod - 1) as usize] = lowest;
+                while i > blockStart {
+                    i -= 1;
                     tmpHigh = inReal[i];
                     if tmpHigh > highest {
-                        highestIdx = (i) as i32;
                         highest = tmpHigh;
                     }
-                }
-            } else if tmpHigh >= highest {
-                highestIdx = (today) as i32;
-                highest = tmpHigh;
-            }
-            if lowestIdx < ((trailingIdx) as i32) {
-                lowestIdx = (trailingIdx) as i32;
-                lowest = inReal[(lowestIdx) as usize];
-                i = (lowestIdx) as usize;
-                while { i += 1; i } <= today {
-                    tmpLow = inReal[i];
-                    if tmpLow < lowest {
-                        lowestIdx = (i) as i32;
-                        lowest = tmpLow;
+                    if tmpHigh < lowest {
+                        lowest = tmpHigh;
                     }
+                    sufHighest[i - blockStart] = highest;
+                    sufLowest[i - blockStart] = lowest;
                 }
-            } else if tmpLow <= lowest {
-                lowestIdx = (today) as i32;
-                lowest = tmpLow;
+                outReal[outIdx] = (((sufHighest[0] + sufLowest[0]) / 2.0) as f64);
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    blockNext = blockStart + ((optInTimePeriod) as usize);
+                    nAvail = endIdx - blockNext + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    highest = inReal[blockNext];
+                    lowest = highest;
+                    preHighest[0] = highest;
+                    preLowest[0] = lowest;
+                    i = 1;
+                    while i < nAvail {
+                        tmpHigh = inReal[blockNext + i];
+                        if tmpHigh > highest {
+                            highest = tmpHigh;
+                        }
+                        if tmpHigh < lowest {
+                            lowest = tmpHigh;
+                        }
+                        preHighest[i] = highest;
+                        preLowest[i] = lowest;
+                        i += 1;
+                    }
+                    // Combine. The suffix half is the older one, so preferring it
+                    // on a tie keeps the earliest-wins rule.
+                    m = 1;
+                    while m <= nAvail {
+                        highest = sufHighest[m];
+                        if preHighest[m - 1] > highest {
+                            highest = preHighest[m - 1];
+                        }
+                        lowest = sufLowest[m];
+                        if preLowest[m - 1] < lowest {
+                            lowest = preLowest[m - 1];
+                        }
+                        outReal[outIdx] = (highest + lowest) / 2.0;
+                        outIdx += 1;
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
-            outReal[outIdx] = (highest + lowest) / 2.0;
-            outIdx += 1;
-            trailingIdx += 1;
-            today += 1;
+        } else {
+            highestIdx = 0 - 1;
+            highest = 0.0;
+            lowestIdx = 0 - 1;
+            lowest = 0.0;
+            while today <= endIdx {
+                tmpHigh = inReal[today];
+                tmpLow = tmpHigh;
+                if highestIdx < ((trailingIdx) as i32) {
+                    highestIdx = (trailingIdx) as i32;
+                    highest = inReal[(highestIdx) as usize];
+                    i = (highestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmpHigh = inReal[i];
+                        if tmpHigh > highest {
+                            highestIdx = (i) as i32;
+                            highest = tmpHigh;
+                        }
+                    }
+                } else if tmpHigh >= highest {
+                    highestIdx = (today) as i32;
+                    highest = tmpHigh;
+                }
+                if lowestIdx < ((trailingIdx) as i32) {
+                    lowestIdx = (trailingIdx) as i32;
+                    lowest = inReal[(lowestIdx) as usize];
+                    i = (lowestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmpLow = inReal[i];
+                        if tmpLow < lowest {
+                            lowestIdx = (i) as i32;
+                            lowest = tmpLow;
+                        }
+                    }
+                } else if tmpLow <= lowest {
+                    lowestIdx = (today) as i32;
+                    lowest = tmpLow;
+                }
+                outReal[outIdx] = (highest + lowest) / 2.0;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+            }
         }
         // Keep the outBegIdx relative to the
         // caller input before returning.
@@ -376,6 +528,18 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut preHighest: Vec<f64> = Vec::new();
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut preLowest: Vec<f64> = Vec::new();
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
@@ -427,6 +591,19 @@ impl Core {
         // (and the reverse on the way down). A flat stretch pins
         // both. Random-walk input is the favourable case, where
         // rescans are rare. See issue #147.
+        //
+        // The batch tier does not use that automaton: it takes the first arm
+        // for every period in range (the threshold is the declared maximum),
+        // and the automaton above is what the streaming tier transitions on.
+        // Batch runs a Van Herk / Gil-Werman block scan in block-batched
+        // form: the p outputs belonging to one block boundary are produced
+        // together, one backward pass for the older block's suffix extrema,
+        // one forward pass for the newer block's prefix extrema, and a third
+        // pass to combine. Both extrema travel in the same passes. All the
+        // loops are straight-line with no data-dependent branching, which is
+        // what lets a compiler vectorize them, and the work per bar is a
+        // fixed number of comparisons regardless of period. Every scratch
+        // array holds COPIES, so input and output may alias.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -180,6 +180,26 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inLow.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outReal.len());
         let mut startIdx = startIdx;
+        let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest: &mut [f64] = &mut [];
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut local_preHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preHighest: Vec<f64> = Vec::new();
+        let mut preHighest: &mut [f64] = &mut [];
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut local_sufLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest: &mut [f64] = &mut [];
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut local_preLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preLowest: Vec<f64> = Vec::new();
+        let mut preLowest: &mut [f64] = &mut [];
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
@@ -214,16 +234,21 @@ impl Core {
         // Note that this algorithm allows the input and
         // output to be the same buffer.
         //
-        // Two equivalent algorithms, picked by period. Their outputs are
-        // bit-identical; only the scan strategy differs:
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), and
+        // the second arm is what the streaming tier transitions on:
         //
-        // - Small periods (<= 20): rescan the whole window on every bar.
-        //   The two independent comparison chains auto-vectorize on modern
-        //   compilers, which beats any per-bar bookkeeping while the window
-        //   is short. The threshold sits near the measured crossover
-        //   (~period 19-20 with gcc/clang -O3 on x86-64).
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass for the older block's suffix extrema, one
+        //   forward pass for the newer block's prefix extrema, and a third
+        //   pass to combine. High and low travel in the same passes. All the
+        //   loops are straight-line with no data-dependent branching, which
+        //   is what lets a compiler vectorize them, and the work per bar is a
+        //   fixed number of comparisons regardless of period. Every scratch
+        //   array holds COPIES, so input and output may alias.
         //
-        // - Larger periods: cache the highest high/lowest low with its
+        // - Streaming: cache the highest high/lowest low with its
         //   index; the window is rescanned only when the cached extremum
         //   drops out of the window. That is O(1) per bar while the
         //   extremum sits away from the trailing edge, but it is not
@@ -240,25 +265,124 @@ impl Core {
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        if optInTimePeriod <= 20 {
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            let mut blockNext: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufHighest = &mut local_sufHighest;
+            } else {
+                heap_sufHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufHighest = &mut heap_sufHighest;
+            }
+            maxIdx_sufHighest = ((optInTimePeriod) as usize) - 1;
+            sufHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preHighest = &mut local_preHighest;
+            } else {
+                heap_preHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preHighest = &mut heap_preHighest;
+            }
+            maxIdx_preHighest = ((optInTimePeriod) as usize) - 1;
+            preHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufLowest = &mut local_sufLowest;
+            } else {
+                heap_sufLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufLowest = &mut heap_sufLowest;
+            }
+            maxIdx_sufLowest = ((optInTimePeriod) as usize) - 1;
+            sufLowest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preLowest = &mut local_preLowest;
+            } else {
+                heap_preLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preLowest = &mut heap_preLowest;
+            }
+            maxIdx_preLowest = ((optInTimePeriod) as usize) - 1;
+            preLowest_Idx = 0;
+            blockStart = trailingIdx;
             while today <= endIdx {
-                lowest = inLow[trailingIdx];
-                highest = inHigh[trailingIdx];
-                trailingIdx += 1;
-                for i in (trailingIdx as usize)..(today as usize) + 1 {
-                    tmpLow = inLow[i];
-                    if tmpLow < lowest {
-                        lowest = tmpLow;
-                    }
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single min/max instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                highest = inHigh[i];
+                lowest = inLow[i];
+                sufHighest[(optInTimePeriod - 1) as usize] = highest;
+                sufLowest[(optInTimePeriod - 1) as usize] = lowest;
+                while i > blockStart {
+                    i -= 1;
                     tmpHigh = inHigh[i];
                     if tmpHigh > highest {
                         highest = tmpHigh;
                     }
+                    tmpLow = inLow[i];
+                    if tmpLow < lowest {
+                        lowest = tmpLow;
+                    }
+                    sufHighest[i - blockStart] = highest;
+                    sufLowest[i - blockStart] = lowest;
                 }
-                i = (today as usize) + 1;
-                outReal[outIdx] = (highest + lowest) / 2.0;
+                outReal[outIdx] = (((sufHighest[0] + sufLowest[0]) / 2.0) as f64);
                 outIdx += 1;
+                trailingIdx += 1;
                 today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    blockNext = blockStart + ((optInTimePeriod) as usize);
+                    nAvail = endIdx - blockNext + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    highest = inHigh[blockNext];
+                    lowest = inLow[blockNext];
+                    preHighest[0] = highest;
+                    preLowest[0] = lowest;
+                    i = 1;
+                    while i < nAvail {
+                        tmpHigh = inHigh[blockNext + i];
+                        if tmpHigh > highest {
+                            highest = tmpHigh;
+                        }
+                        tmpLow = inLow[blockNext + i];
+                        if tmpLow < lowest {
+                            lowest = tmpLow;
+                        }
+                        preHighest[i] = highest;
+                        preLowest[i] = lowest;
+                        i += 1;
+                    }
+                    // Combine. The suffix half is the older one, so preferring it
+                    // on a tie keeps the earliest-wins rule.
+                    m = 1;
+                    while m <= nAvail {
+                        highest = sufHighest[m];
+                        if preHighest[m - 1] > highest {
+                            highest = preHighest[m - 1];
+                        }
+                        lowest = sufLowest[m];
+                        if preLowest[m - 1] < lowest {
+                            lowest = preLowest[m - 1];
+                        }
+                        outReal[outIdx] = (highest + lowest) / 2.0;
+                        outIdx += 1;
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
         } else {
             highestIdx = 0 - 1;
@@ -418,6 +542,18 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut preHighest: Vec<f64> = Vec::new();
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut preLowest: Vec<f64> = Vec::new();
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
@@ -452,16 +588,21 @@ impl Core {
         // Note that this algorithm allows the input and
         // output to be the same buffer.
         //
-        // Two equivalent algorithms, picked by period. Their outputs are
-        // bit-identical; only the scan strategy differs:
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), and
+        // the second arm is what the streaming tier transitions on:
         //
-        // - Small periods (<= 20): rescan the whole window on every bar.
-        //   The two independent comparison chains auto-vectorize on modern
-        //   compilers, which beats any per-bar bookkeeping while the window
-        //   is short. The threshold sits near the measured crossover
-        //   (~period 19-20 with gcc/clang -O3 on x86-64).
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass for the older block's suffix extrema, one
+        //   forward pass for the newer block's prefix extrema, and a third
+        //   pass to combine. High and low travel in the same passes. All the
+        //   loops are straight-line with no data-dependent branching, which
+        //   is what lets a compiler vectorize them, and the work per bar is a
+        //   fixed number of comparisons regardless of period. Every scratch
+        //   array holds COPIES, so input and output may alias.
         //
-        // - Larger periods: cache the highest high/lowest low with its
+        // - Streaming: cache the highest high/lowest low with its
         //   index; the window is rescanned only when the cached extremum
         //   drops out of the window. That is O(1) per bar while the
         //   extremum sits away from the trailing edge, but it is not

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -168,6 +168,16 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outReal.len());
         let mut startIdx = startIdx;
+        let mut local_sufLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest: &mut [f64] = &mut [];
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut local_preLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preLowest: Vec<f64> = Vec::new();
+        let mut preLowest: &mut [f64] = &mut [];
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
         let mut outIdx: usize = 0_usize;
@@ -194,32 +204,137 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. All three are straight-line loops with no
+        //   data-dependent branching, which is what lets a compiler vectorize
+        //   them, and the work is 3 comparisons per bar regardless of period.
+        //   Both scratch arrays hold COPIES, so input and output may alias.
+        //
+        // - Streaming: cache the lowest value with its index; rescan only
+        //   when the cached extremum leaves the window. O(1) per bar while the
+        //   extremum sits away from the trailing edge, but not amortized O(1):
+        //   an extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar for
+        //   as long as that persists.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        lowestIdx = 0 - 1;
-        lowest = 0.0;
-        while today <= endIdx {
-            tmp = inReal[today];
-            if lowestIdx < ((trailingIdx) as i32) {
-                lowestIdx = (trailingIdx) as i32;
-                lowest = inReal[(lowestIdx) as usize];
-                i = (lowestIdx) as usize;
-                while { i += 1; i } <= today {
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufLowest = &mut local_sufLowest;
+            } else {
+                heap_sufLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufLowest = &mut heap_sufLowest;
+            }
+            maxIdx_sufLowest = ((optInTimePeriod) as usize) - 1;
+            sufLowest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preLowest = &mut local_preLowest;
+            } else {
+                heap_preLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preLowest = &mut heap_preLowest;
+            }
+            maxIdx_preLowest = ((optInTimePeriod) as usize) - 1;
+            preLowest_Idx = 0;
+            blockStart = trailingIdx;
+            while today <= endIdx {
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single min instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                lowest = inReal[i];
+                sufLowest[(optInTimePeriod - 1) as usize] = lowest;
+                while i > blockStart {
+                    i -= 1;
                     tmp = inReal[i];
                     if tmp < lowest {
-                        lowestIdx = (i) as i32;
                         lowest = tmp;
                     }
+                    sufLowest[i - blockStart] = lowest;
                 }
-            } else if tmp <= lowest {
-                lowestIdx = (today) as i32;
-                lowest = tmp;
+                lowest = sufLowest[0];
+                outReal[outIdx] = lowest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    nAvail = endIdx - (blockStart + ((optInTimePeriod) as usize)) + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    lowest = inReal[(blockStart + ((optInTimePeriod) as usize)) as usize];
+                    preLowest[0] = lowest;
+                    i = 1;
+                    while i < nAvail {
+                        tmp = inReal[(blockStart + ((optInTimePeriod) as usize) + i) as usize];
+                        if tmp < lowest {
+                            lowest = tmp;
+                        }
+                        preLowest[i] = lowest;
+                        i += 1;
+                    }
+                    // Combine. The suffix half is the older one, so preferring it
+                    // on a tie keeps the earliest-wins rule.
+                    m = 1;
+                    while m <= nAvail {
+                        lowest = sufLowest[m];
+                        if preLowest[m - 1] < lowest {
+                            lowest = preLowest[m - 1];
+                        }
+                        outReal[outIdx] = lowest;
+                        outIdx += 1;
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
-            outReal[outIdx] = lowest;
-            outIdx += 1;
-            trailingIdx += 1;
-            today += 1;
+        } else {
+            lowestIdx = 0 - 1;
+            lowest = 0.0;
+            while today <= endIdx {
+                tmp = inReal[today];
+                if lowestIdx < ((trailingIdx) as i32) {
+                    lowestIdx = (trailingIdx) as i32;
+                    lowest = inReal[(lowestIdx) as usize];
+                    i = (lowestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmp = inReal[i];
+                        if tmp < lowest {
+                            lowestIdx = (i) as i32;
+                            lowest = tmp;
+                        }
+                    }
+                } else if tmp <= lowest {
+                    lowestIdx = (today) as i32;
+                    lowest = tmp;
+                }
+                outReal[outIdx] = lowest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+            }
         }
         // Keep the outBegIdx relative to the
         // caller input before returning.
@@ -313,6 +428,12 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut preLowest: Vec<f64> = Vec::new();
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
         let mut outIdx: usize = 0_usize;
@@ -339,6 +460,27 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. All three are straight-line loops with no
+        //   data-dependent branching, which is what lets a compiler vectorize
+        //   them, and the work is 3 comparisons per bar regardless of period.
+        //   Both scratch arrays hold COPIES, so input and output may alias.
+        //
+        // - Streaming: cache the lowest value with its index; rescan only
+        //   when the cached extremum leaves the window. O(1) per bar while the
+        //   extremum sits away from the trailing edge, but not amortized O(1):
+        //   an extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar for
+        //   as long as that persists.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -169,6 +169,26 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMin.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMax.len());
         let mut startIdx = startIdx;
+        let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest: &mut [f64] = &mut [];
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut local_preHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preHighest: Vec<f64> = Vec::new();
+        let mut preHighest: &mut [f64] = &mut [];
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut local_sufLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest: &mut [f64] = &mut [];
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut local_preLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preLowest: Vec<f64> = Vec::new();
+        let mut preLowest: &mut [f64] = &mut [];
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut highest: f64 = 0.0_f64;
         let mut lowest: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
@@ -198,51 +218,198 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. Both extrema travel in the same passes, so the
+        //   two outputs cost one traversal, not two. All the loops are
+        //   straight-line with no data-dependent branching, which is what lets
+        //   a compiler vectorize them, and the work is a fixed number of
+        //   comparisons per bar regardless of period. Every scratch array holds
+        //   COPIES, so input and output may alias.
+        //
+        // - Streaming: cache each extremum with its index; rescan only when
+        //   the cached one leaves the window. O(1) per bar while the extremum
+        //   sits away from the trailing edge, but not amortized O(1): an
+        //   extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar
+        //   for as long as that persists. Tracking both extrema keeps that
+        //   state going through a trend: while the highest is refreshed by
+        //   each new bar, the lowest stays pinned at the oldest bar for the
+        //   whole leg (and the reverse on the way down).
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        highestIdx = 0 - 1;
-        highest = 0.0;
-        lowestIdx = 0 - 1;
-        lowest = 0.0;
-        while today <= endIdx {
-            tmpHigh = inReal[today];
-            tmpLow = tmpHigh;
-            if highestIdx < ((trailingIdx) as i32) {
-                highestIdx = (trailingIdx) as i32;
-                highest = inReal[(highestIdx) as usize];
-                i = (highestIdx) as usize;
-                while { i += 1; i } <= today {
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            let mut blockNext: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufHighest = &mut local_sufHighest;
+            } else {
+                heap_sufHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufHighest = &mut heap_sufHighest;
+            }
+            maxIdx_sufHighest = ((optInTimePeriod) as usize) - 1;
+            sufHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preHighest = &mut local_preHighest;
+            } else {
+                heap_preHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preHighest = &mut heap_preHighest;
+            }
+            maxIdx_preHighest = ((optInTimePeriod) as usize) - 1;
+            preHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufLowest = &mut local_sufLowest;
+            } else {
+                heap_sufLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufLowest = &mut heap_sufLowest;
+            }
+            maxIdx_sufLowest = ((optInTimePeriod) as usize) - 1;
+            sufLowest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preLowest = &mut local_preLowest;
+            } else {
+                heap_preLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preLowest = &mut heap_preLowest;
+            }
+            maxIdx_preLowest = ((optInTimePeriod) as usize) - 1;
+            preLowest_Idx = 0;
+            blockStart = trailingIdx;
+            while today <= endIdx {
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single min/max instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                highest = inReal[i];
+                lowest = highest;
+                sufHighest[(optInTimePeriod - 1) as usize] = highest;
+                sufLowest[(optInTimePeriod - 1) as usize] = lowest;
+                while i > blockStart {
+                    i -= 1;
                     tmpHigh = inReal[i];
                     if tmpHigh > highest {
-                        highestIdx = (i) as i32;
                         highest = tmpHigh;
                     }
-                }
-            } else if tmpHigh >= highest {
-                highestIdx = (today) as i32;
-                highest = tmpHigh;
-            }
-            if lowestIdx < ((trailingIdx) as i32) {
-                lowestIdx = (trailingIdx) as i32;
-                lowest = inReal[(lowestIdx) as usize];
-                i = (lowestIdx) as usize;
-                while { i += 1; i } <= today {
-                    tmpLow = inReal[i];
-                    if tmpLow < lowest {
-                        lowestIdx = (i) as i32;
-                        lowest = tmpLow;
+                    if tmpHigh < lowest {
+                        lowest = tmpHigh;
                     }
+                    sufHighest[i - blockStart] = highest;
+                    sufLowest[i - blockStart] = lowest;
                 }
-            } else if tmpLow <= lowest {
-                lowestIdx = (today) as i32;
-                lowest = tmpLow;
+                outMax[outIdx] = ((sufHighest[0]) as f64);
+                outMin[outIdx] = ((sufLowest[0]) as f64);
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    blockNext = blockStart + ((optInTimePeriod) as usize);
+                    nAvail = endIdx - blockNext + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    highest = inReal[blockNext];
+                    lowest = highest;
+                    preHighest[0] = highest;
+                    preLowest[0] = lowest;
+                    i = 1;
+                    while i < nAvail {
+                        tmpHigh = inReal[blockNext + i];
+                        if tmpHigh > highest {
+                            highest = tmpHigh;
+                        }
+                        if tmpHigh < lowest {
+                            lowest = tmpHigh;
+                        }
+                        preHighest[i] = highest;
+                        preLowest[i] = lowest;
+                        i += 1;
+                    }
+                    // Combine. The suffix half is the older one, so preferring it
+                    // on a tie keeps the earliest-wins rule.
+                    m = 1;
+                    while m <= nAvail {
+                        highest = sufHighest[m];
+                        if preHighest[m - 1] > highest {
+                            highest = preHighest[m - 1];
+                        }
+                        lowest = sufLowest[m];
+                        if preLowest[m - 1] < lowest {
+                            lowest = preLowest[m - 1];
+                        }
+                        outMax[outIdx] = highest;
+                        outMin[outIdx] = lowest;
+                        outIdx += 1;
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
-            outMax[outIdx] = highest;
-            outMin[outIdx] = lowest;
-            outIdx += 1;
-            trailingIdx += 1;
-            today += 1;
+        } else {
+            highestIdx = 0 - 1;
+            highest = 0.0;
+            lowestIdx = 0 - 1;
+            lowest = 0.0;
+            while today <= endIdx {
+                tmpHigh = inReal[today];
+                tmpLow = tmpHigh;
+                if highestIdx < ((trailingIdx) as i32) {
+                    highestIdx = (trailingIdx) as i32;
+                    highest = inReal[(highestIdx) as usize];
+                    i = (highestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmpHigh = inReal[i];
+                        if tmpHigh > highest {
+                            highestIdx = (i) as i32;
+                            highest = tmpHigh;
+                        }
+                    }
+                } else if tmpHigh >= highest {
+                    highestIdx = (today) as i32;
+                    highest = tmpHigh;
+                }
+                if lowestIdx < ((trailingIdx) as i32) {
+                    lowestIdx = (trailingIdx) as i32;
+                    lowest = inReal[(lowestIdx) as usize];
+                    i = (lowestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmpLow = inReal[i];
+                        if tmpLow < lowest {
+                            lowestIdx = (i) as i32;
+                            lowest = tmpLow;
+                        }
+                    }
+                } else if tmpLow <= lowest {
+                    lowestIdx = (today) as i32;
+                    lowest = tmpLow;
+                }
+                outMax[outIdx] = highest;
+                outMin[outIdx] = lowest;
+                outIdx += 1;
+                trailingIdx += 1;
+                today += 1;
+            }
         }
         // Keep the outBegIdx relative to the
         // caller input before returning.
@@ -357,6 +524,18 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut preHighest: Vec<f64> = Vec::new();
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut preLowest: Vec<f64> = Vec::new();
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut highest: f64 = 0.0_f64;
         let mut lowest: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
@@ -386,6 +565,32 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), so
+        // the second arm exists to be the streaming tier's transition; see
+        // issue #147.
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass builds the older block's suffix extrema, one
+        //   forward pass builds the newer block's prefix extrema, and a third
+        //   pass combines them. Both extrema travel in the same passes, so the
+        //   two outputs cost one traversal, not two. All the loops are
+        //   straight-line with no data-dependent branching, which is what lets
+        //   a compiler vectorize them, and the work is a fixed number of
+        //   comparisons per bar regardless of period. Every scratch array holds
+        //   COPIES, so input and output may alias.
+        //
+        // - Streaming: cache each extremum with its index; rescan only when
+        //   the cached one leaves the window. O(1) per bar while the extremum
+        //   sits away from the trailing edge, but not amortized O(1): an
+        //   extremum on the oldest in-window bar drops out on the very next
+        //   bar, so the rescan repeats and the cost stays O(period) per bar
+        //   for as long as that persists. Tracking both extrema keeps that
+        //   state going through a trend: while the highest is refreshed by
+        //   each new bar, the lowest stays pinned at the oldest bar for the
+        //   whole leg (and the reverse on the way down).
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -181,6 +181,26 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inClose.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outReal.len());
         let mut startIdx = startIdx;
+        let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest: &mut [f64] = &mut [];
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut local_preHighest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preHighest: Vec<f64> = Vec::new();
+        let mut preHighest: &mut [f64] = &mut [];
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut local_sufLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest: &mut [f64] = &mut [];
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut local_preLowest: [f64; 30] = [0.0_f64; 30];
+        let mut heap_preLowest: Vec<f64> = Vec::new();
+        let mut preLowest: &mut [f64] = &mut [];
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
@@ -212,62 +232,225 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), and
+        // the second arm is what the streaming tier transitions on:
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass for the older block's suffix extrema, one
+        //   forward pass for the newer block's prefix extrema, and a third
+        //   pass to combine and emit. High and low travel in the same passes.
+        //   All the loops are straight-line with no data-dependent branching,
+        //   which is what lets a compiler vectorize them, and the work per
+        //   bar is a fixed number of comparisons regardless of period. Every
+        //   scratch array holds COPIES, so input and output may alias.
+        //
+        //   'diff' is recomputed on every bar here rather than only when an
+        //   extremum moves. That is the same value: the streaming arm leaves
+        //   diff untouched exactly when neither extremum changed, in which
+        //   case (highest-lowest) is unchanged too.
+        //
+        // - Streaming: cache the highest high/lowest low with its index and
+        //   rescan only when the cached extremum leaves the window. O(1) per
+        //   bar while the extremum sits away from the trailing edge, but not
+        //   amortized O(1): an extremum on the oldest in-window bar drops out
+        //   on the very next bar, so the rescan repeats and the cost stays
+        //   O(period) per bar for as long as that persists. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;
-        highestIdx = 0 - 1;
-        lowestIdx = highestIdx;
-        lowest = 0.0;
-        highest = lowest;
-        diff = highest;
-        while today <= endIdx {
-            // Set the lowest low
-            tmp = inLow[today];
-            if lowestIdx < ((trailingIdx) as i32) {
-                lowestIdx = (trailingIdx) as i32;
-                lowest = inLow[(lowestIdx) as usize];
-                i = (lowestIdx) as usize;
-                while { i += 1; i } <= today {
-                    tmp = inLow[i];
-                    if tmp < lowest {
-                        lowestIdx = (i) as i32;
-                        lowest = tmp;
-                    }
-                }
-                diff = (highest - lowest) / (0_f64 - 100.0);
-            } else if tmp <= lowest {
-                lowestIdx = (today) as i32;
-                lowest = tmp;
-                diff = (highest - lowest) / (0_f64 - 100.0);
+        if optInTimePeriod <= 100000 {
+            let mut blockStart: usize = 0_usize;
+            let mut nAvail: usize = 0_usize;
+            let mut m: usize = 0_usize;
+            let mut blockNext: usize = 0_usize;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufHighest = &mut local_sufHighest;
+            } else {
+                heap_sufHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufHighest = &mut heap_sufHighest;
             }
-            // Set the highest high
-            tmp = inHigh[today];
-            if highestIdx < ((trailingIdx) as i32) {
-                highestIdx = (trailingIdx) as i32;
-                highest = inHigh[(highestIdx) as usize];
-                i = (highestIdx) as usize;
-                while { i += 1; i } <= today {
+            maxIdx_sufHighest = ((optInTimePeriod) as usize) - 1;
+            sufHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preHighest = &mut local_preHighest;
+            } else {
+                heap_preHighest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preHighest = &mut heap_preHighest;
+            }
+            maxIdx_preHighest = ((optInTimePeriod) as usize) - 1;
+            preHighest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                sufLowest = &mut local_sufLowest;
+            } else {
+                heap_sufLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                sufLowest = &mut heap_sufLowest;
+            }
+            maxIdx_sufLowest = ((optInTimePeriod) as usize) - 1;
+            sufLowest_Idx = 0;
+            if optInTimePeriod < 1 { return RetCode::InternalError; }
+            if (optInTimePeriod) as usize <= 30usize {
+                preLowest = &mut local_preLowest;
+            } else {
+                heap_preLowest = vec![0.0_f64; (optInTimePeriod) as usize];
+                preLowest = &mut heap_preLowest;
+            }
+            maxIdx_preLowest = ((optInTimePeriod) as usize) - 1;
+            preLowest_Idx = 0;
+            blockStart = trailingIdx;
+            while today <= endIdx {
+                // Suffix extrema of the block [blockStart, blockStart+p-1], which
+                // is fully available here: today == blockStart+p-1 <= endIdx.
+                // Scanning backward while keeping the incumbent on a tie
+                // leaves the later element holding a tie, which is what lets this
+                // compile to a single min/max instruction.
+                i = blockStart + ((optInTimePeriod) as usize) - 1;
+                highest = inHigh[i];
+                lowest = inLow[i];
+                sufHighest[(optInTimePeriod - 1) as usize] = highest;
+                sufLowest[(optInTimePeriod - 1) as usize] = lowest;
+                while i > blockStart {
+                    i -= 1;
                     tmp = inHigh[i];
                     if tmp > highest {
-                        highestIdx = (i) as i32;
                         highest = tmp;
                     }
+                    tmp = inLow[i];
+                    if tmp < lowest {
+                        lowest = tmp;
+                    }
+                    sufHighest[i - blockStart] = highest;
+                    sufLowest[i - blockStart] = lowest;
                 }
+                highest = sufHighest[0];
+                lowest = sufLowest[0];
                 diff = (highest - lowest) / (0_f64 - 100.0);
-            } else if tmp >= highest {
-                highestIdx = (today) as i32;
-                highest = tmp;
-                diff = (highest - lowest) / (0_f64 - 100.0);
+                if diff != 0.0 {
+                    outReal[outIdx] = (((highest - inClose[today]) / diff) as f64);
+                    outIdx += 1;
+                } else {
+                    outReal[outIdx] = 0.0;
+                    outIdx += 1;
+                }
+                trailingIdx += 1;
+                today += 1;
+                if today > endIdx {
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                } else {
+                    // Prefix extrema of the next block, clamped to what remains.
+                    // Forward, keeping the incumbent on a tie: earliest wins again.
+                    blockNext = blockStart + ((optInTimePeriod) as usize);
+                    nAvail = endIdx - blockNext + 1;
+                    if nAvail > ((optInTimePeriod - 1) as usize) {
+                        nAvail = (optInTimePeriod - 1) as usize;
+                    }
+                    highest = inHigh[blockNext];
+                    lowest = inLow[blockNext];
+                    preHighest[0] = highest;
+                    preLowest[0] = lowest;
+                    i = 1;
+                    while i < nAvail {
+                        tmp = inHigh[blockNext + i];
+                        if tmp > highest {
+                            highest = tmp;
+                        }
+                        tmp = inLow[blockNext + i];
+                        if tmp < lowest {
+                            lowest = tmp;
+                        }
+                        preHighest[i] = highest;
+                        preLowest[i] = lowest;
+                        i += 1;
+                    }
+                    // Combine and emit. The suffix half is the older one, so
+                    // preferring it on a tie keeps the earliest-wins rule. The
+                    // bar being emitted for offset m is today+m-1: 'today' was
+                    // advanced once above and is not touched inside this loop.
+                    m = 1;
+                    while m <= nAvail {
+                        highest = sufHighest[m];
+                        if preHighest[m - 1] > highest {
+                            highest = preHighest[m - 1];
+                        }
+                        lowest = sufLowest[m];
+                        if preLowest[m - 1] < lowest {
+                            lowest = preLowest[m - 1];
+                        }
+                        diff = (highest - lowest) / (0_f64 - 100.0);
+                        if diff != 0.0 {
+                            outReal[outIdx] = (((highest - inClose[today + m - 1]) / diff) as f64);
+                            outIdx += 1;
+                        } else {
+                            outReal[outIdx] = 0.0;
+                            outIdx += 1;
+                        }
+                        m += 1;
+                    }
+                    trailingIdx = trailingIdx + nAvail;
+                    today = today + nAvail;
+                    blockStart = blockStart + ((optInTimePeriod) as usize);
+                }
             }
-            if diff != 0.0 {
-                outReal[outIdx] = (((highest - inClose[today]) / diff) as f64);
-                outIdx += 1;
-            } else {
-                outReal[outIdx] = 0.0;
-                outIdx += 1;
+        } else {
+            highestIdx = 0 - 1;
+            lowestIdx = highestIdx;
+            lowest = 0.0;
+            highest = lowest;
+            diff = highest;
+            while today <= endIdx {
+                // Set the lowest low
+                tmp = inLow[today];
+                if lowestIdx < ((trailingIdx) as i32) {
+                    lowestIdx = (trailingIdx) as i32;
+                    lowest = inLow[(lowestIdx) as usize];
+                    i = (lowestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmp = inLow[i];
+                        if tmp < lowest {
+                            lowestIdx = (i) as i32;
+                            lowest = tmp;
+                        }
+                    }
+                    diff = (highest - lowest) / (0_f64 - 100.0);
+                } else if tmp <= lowest {
+                    lowestIdx = (today) as i32;
+                    lowest = tmp;
+                    diff = (highest - lowest) / (0_f64 - 100.0);
+                }
+                // Set the highest high
+                tmp = inHigh[today];
+                if highestIdx < ((trailingIdx) as i32) {
+                    highestIdx = (trailingIdx) as i32;
+                    highest = inHigh[(highestIdx) as usize];
+                    i = (highestIdx) as usize;
+                    while { i += 1; i } <= today {
+                        tmp = inHigh[i];
+                        if tmp > highest {
+                            highestIdx = (i) as i32;
+                            highest = tmp;
+                        }
+                    }
+                    diff = (highest - lowest) / (0_f64 - 100.0);
+                } else if tmp >= highest {
+                    highestIdx = (today) as i32;
+                    highest = tmp;
+                    diff = (highest - lowest) / (0_f64 - 100.0);
+                }
+                if diff != 0.0 {
+                    outReal[outIdx] = (((highest - inClose[today]) / diff) as f64);
+                    outIdx += 1;
+                } else {
+                    outReal[outIdx] = 0.0;
+                    outIdx += 1;
+                }
+                trailingIdx += 1;
+                today += 1;
             }
-            trailingIdx += 1;
-            today += 1;
         }
         // Keep the outBegIdx relative to the
         // caller input before returning.
@@ -395,6 +578,18 @@ impl Core {
         let mut startIdx = startIdx;
         let mut dummyBegIdx: usize = 0;
         let mut dummyNBElement: usize = 0;
+        let mut sufHighest: Vec<f64> = Vec::new();
+        let mut sufHighest_Idx: usize = 0;
+        let mut maxIdx_sufHighest: usize = 29;
+        let mut preHighest: Vec<f64> = Vec::new();
+        let mut preHighest_Idx: usize = 0;
+        let mut maxIdx_preHighest: usize = 29;
+        let mut sufLowest: Vec<f64> = Vec::new();
+        let mut sufLowest_Idx: usize = 0;
+        let mut maxIdx_sufLowest: usize = 29;
+        let mut preLowest: Vec<f64> = Vec::new();
+        let mut preLowest_Idx: usize = 0;
+        let mut maxIdx_preLowest: usize = 29;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
@@ -426,6 +621,32 @@ impl Core {
         // Proceed with the calculation for the requested range.
         // Note that this algorithm allows the input and
         // output to be the same buffer.
+        //
+        // Two equivalent algorithms. The batch tier takes the first arm for
+        // every period in range (the threshold is the declared maximum), and
+        // the second arm is what the streaming tier transitions on:
+        //
+        // - Batch: Van Herk / Gil-Werman block scan, block-batched form. The
+        //   p outputs belonging to one block boundary are produced together:
+        //   one backward pass for the older block's suffix extrema, one
+        //   forward pass for the newer block's prefix extrema, and a third
+        //   pass to combine and emit. High and low travel in the same passes.
+        //   All the loops are straight-line with no data-dependent branching,
+        //   which is what lets a compiler vectorize them, and the work per
+        //   bar is a fixed number of comparisons regardless of period. Every
+        //   scratch array holds COPIES, so input and output may alias.
+        //
+        //   'diff' is recomputed on every bar here rather than only when an
+        //   extremum moves. That is the same value: the streaming arm leaves
+        //   diff untouched exactly when neither extremum changed, in which
+        //   case (highest-lowest) is unchanged too.
+        //
+        // - Streaming: cache the highest high/lowest low with its index and
+        //   rescan only when the cached extremum leaves the window. O(1) per
+        //   bar while the extremum sits away from the trailing edge, but not
+        //   amortized O(1): an extremum on the oldest in-window bar drops out
+        //   on the very next bar, so the rescan repeats and the cost stays
+        //   O(period) per bar for as long as that persists. See issue #147.
         outIdx = 0;
         today = startIdx;
         trailingIdx = startIdx - nbInitialElementNeeded;


### PR DESCRIPTION
Closes #147. C2 as decided, on `fba2adeaa` so the cross-tier ±0 arm is in.

## What lands

Batch runs a Van Herk / Gil-Werman block scan in block-batched form: the p outputs belonging to one block boundary are produced together by a backward suffix pass, a forward prefix pass and a combine pass. Straight-line loops, no data-dependent branching, a fixed number of comparisons per bar at any period.

Per your calls: strict comparisons throughout (3.1 of your last comment), no small-range guard (Call 2), `CIRCBUF` scratch so a default period never allocates (3.3), MIDPRICE's `<= 20` naive arm removed (3.1), streaming untouched (3.4).

The streaming tier is byte-identical to `dev` — comment-stripped hashes of `StepInternal`-to-EOF, all six, 187–281 lines each. The batch/stream split is the declared one: the threshold literal is the parameter's declared maximum, so `analyze_fastpath_skip` streams the general arm.

## Numbers

Full-series batch, `branch / dev`, the tree's own corpus, lower is better.

| | | randwalk | gbm | tc-1p | mono-up | mono-down | constant |
|---|---|---|---|---|---|---|---|
| **MIN** | clang x86-64 | .332 | .327 | .307 | .078 | **1.580** | .078 |
| | arm64 M5 Max | .575 | .570 | .514 | .120 | **1.509** | .120 |
| | MSVC x86-64 | .201 | .271 | .124 | .048 | **1.040** | .045 |
| | gcc 13 x86-64 | .288 | .257 | .272 | .066 | **2.557** | .067 |
| **MAX** | clang x86-64 | .326 | .331 | .282 | **1.464** | .077 | .077 |
| | arm64 M5 Max | .542 | .559 | .492 | **1.499** | .103 | .103 |
| | MSVC x86-64 | .353 | .420 | .152 | **1.300** | .056 | .056 |
| | gcc 13 x86-64 | .264 | .322 | .269 | **1.794** | .070 | .066 |
| **MINMAX** | clang x86-64 | .263 | .268 | .242 | .120 | .118 | .063 |
| **MIDPOINT** | clang x86-64 | .262 | .261 | .244 | .265 | .268 | .152 |
| **MIDPRICE** | clang x86-64 | .632 | .607 | .650 | .623 | .640 | .631 |
| **WILLR** | clang x86-64 | .373 | .389 | .362 | .349 | .323 | .172 |

The monotone tail you named reproduces on all four toolchains and only in each function's own direction — MAX on mono-up, MIN on mono-down, never both, never MINMAX. gcc is the worst of the four (MIN 2.56x) and MSVC the mildest (1.04x); in absolute terms it stays under 1 ns/bar.

`batch_last_ns`, one bar recomputed through the batch call, same protocol on every platform (`--points=20000 --iters=5000`):

| | clang x86-64 | arm64 | MSVC | gcc |
|---|---|---|---|---|
| MIN | 2.17x | 2.10x | **0.33x** | 1.17x |
| MAX | 2.35x | 1.96x | **0.45x** | 1.10x |
| MINMAX | 2.23x | 1.59x | **0.26x** | 0.94x |
| MIDPOINT | 1.41x | 2.11x | **0.40x** | 1.19x |
| MIDPRICE | 1.47x | 1.47x | 2.38x | 1.54x |
| WILLR | 1.29x | 1.21x | **0.41x** | 1.18x |

No guard, per Call 2. The trade-off inverts by platform — MSVC's automaton baseline is 45–101 ns for that call where clang manages 8–15 — so a threshold tuned on clang would hand away the MSVC win.

Benchmark tables were measured at `755800275`; the six batch bodies are unchanged since, and the upstream commits in between touch the stream path and the generator, not these algorithms.

## Gates

```
scripts/regtest.py    all green, four servers
Variant parity        168 functions x 42,864 vectors, bit-identical
Stream verify         19,220 legs (C) / 16,678 (Rust, Java), 0 value failures
                      benign signed-zero: C 147, Rust 147, Java 166
                        MIN 41/41/45   MAX 22/22/26   MINMAX 63/63/71
                        MIDPOINT 21/21/24;  MIDPRICE and WILLR 0
OpenAndFill verify    168 functions, filled array == batch(0,n-1) bitwise
--fuzz-064            171,230 comparisons, 0 failures
                      benign(signed-zero) 30 on dev -> 195 here
--xlang-hash          Rust 240,672 cases / 0 mismatches
                      C#   240,564 cases / 0 mismatches
                      Java 239,498 cases / 28, all TA_HT_TRENDMODE (pre-existing;
                      the count moved 14 -> 28 with the corpus, not with this branch)
```

**The `Stream verify` benign count is non-zero, and it is a real one.** A clean `dev` at the same commit, same vectors, same leg counts, gives 0 on all three servers — so every one of these is C2 vs the automaton disagreeing on which zero to keep, which is the class the arm exists to measure. It lands only on the four functions that can exhibit it: MIDPRICE and WILLR read `high`/`low`, which the generator perturbs off zero, and they are 0.

**One thing I could not explain.** Java reports 166 where C and Rust report 147 — uniformly +4 on MIN, +4 on MAX, +8 on MINMAX (two outputs), +3 on MIDPOINT. It is not the algorithm: `--xlang-hash` has Java's batch bit-identical to C across all six, so the extra cases can only come from Java's stream side choosing a different zero on some ties. I did not chase it further; flagging it rather than leaving it in a total.

## Eval branch

Harness, `METHOD.md`, the twelve-layout sweep and the per-candidate logs stay out of tree, on [`eval/147-rolling-extrema-phase1`](https://github.com/kevinlincg/ta-lib/tree/eval/147-rolling-extrema-phase1).
