### PR TITLE
fix: validate avgPeriod and factor in the candle-settings setter

### DIFF
--- a/src/ta_common/ta_global.c
+++ b/src/ta_common/ta_global.c
@@ -129,6 +129,35 @@ TA_RetCode TA_SetCandleSettings( TA_CandleSettingType settingType,
     /*printf("setcdlset:%d  ",settingType);*/
     if( settingType >= TA_AllCandleSettings )
         return TA_BAD_PARAM;
+
+    /* The average period is subtracted from startIdx to seed the trailing
+     * average, so a negative one moves the seeding loop's start PAST startIdx:
+     * the `while( i < startIdx )` never runs and the main loop begins
+     * avgPeriod bars late, while *outBegIdx still reports startIdx. Every
+     * output is then shifted underneath a correct-looking outBegIdx -- silent
+     * wrong values rather than a memory error. It also makes the lookback
+     * report a negative while the call returns TA_SUCCESS, which the
+     * lookback/call invariant forbids.
+     *
+     * The ceiling is the one TA_SetUnstablePeriod already uses for the same
+     * reason (#144): the period is added to a lookback that becomes an index,
+     * and an average longer than the largest addressable series could never
+     * produce output, so nothing legitimate is refused. Guarding here rather
+     * than in each of the 61 CDL* bodies keeps the invariant in one place.
+     */
+    if( avgPeriod < 0 || avgPeriod > TA_MAX_INDEX )
+        return TA_BAD_PARAM;
+
+    /* factor scales a range that is already non-negative, and every CDL*
+     * body multiplies rather than indexes with it, so a negative one cannot
+     * misalign output -- it only makes the comparison it feeds always false.
+     * NaN is the exception worth refusing: it makes every comparison false
+     * silently, which reads as "no pattern ever matches" rather than as a
+     * rejected setting.
+     */
+    if( factor != factor )
+        return TA_BAD_PARAM;
+
     TA_Globals->candleSettings[settingType].settingType = settingType;
     TA_Globals->candleSettings[settingType].rangeType = rangeType;
     TA_Globals->candleSettings[settingType].avgPeriod = avgPeriod;

--- a/ta_codegen/generator/templates/rust/types.rs
+++ b/ta_codegen/generator/templates/rust/types.rs
@@ -355,8 +355,30 @@ impl CoreBuilder {
     /// Panics if `setting_type` is [`CandleSettingType::AllCandleSettings`].
     /// That variant is a wildcard, not a setting, so there is nothing to
     /// override — C returns `TA_BAD_PARAM` and Java throws for the same call.
+    ///
+    /// Panics if `setting.avg_period` is negative or above [`MAX_INDEX`]. The
+    /// average period is subtracted from `startIdx` to seed the trailing
+    /// average, so a negative one starts the main loop that many bars late
+    /// while `outBegIdx` still reports `startIdx` — every output shifted
+    /// underneath a correct-looking index. C rejects the same value with
+    /// `TA_BAD_PARAM`.
+    ///
+    /// Panics if `setting.factor` is NaN: it makes every comparison it feeds
+    /// silently false, which reads as "no pattern ever matches" rather than as
+    /// a refused setting.
     #[must_use]
     pub fn candle_setting(mut self, setting_type: CandleSettingType, setting: CandleSetting) -> Self {
+        assert!(
+            setting.avg_period >= 0,
+            "avg_period must be >= 0, got {}",
+            setting.avg_period
+        );
+        assert!(
+            (setting.avg_period as usize) <= MAX_INDEX,
+            "avg_period must be <= {MAX_INDEX}, got {}",
+            setting.avg_period
+        );
+        assert!(!setting.factor.is_nan(), "factor must not be NaN");
         match setting_type {
             CandleSettingType::BodyLong => self.candle_settings.body_long = setting,
             CandleSettingType::BodyVeryLong => self.candle_settings.body_very_long = setting,
@@ -492,6 +514,51 @@ mod tests {
         // for the same call (#144).
         let custom = CandleSetting { range_type: 2, avg_period: 99, factor: 9.0 };
         let _ = Core::builder().candle_setting(CandleSettingType::AllCandleSettings, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "avg_period must be >= 0")]
+    fn candle_setting_rejects_a_negative_avg_period() {
+        // The period is subtracted from startIdx to seed the trailing average,
+        // so a negative one starts the main loop that many bars late while
+        // outBegIdx still reports startIdx: every value shifted underneath a
+        // correct-looking index, and a lookback that reports negative while the
+        // call succeeds (#185).
+        let custom = CandleSetting { range_type: 1, avg_period: -1, factor: 0.1 };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    fn candle_setting_accepts_a_zero_avg_period() {
+        // The boundary on the legal side: zero means "no averaging", which every
+        // CDL* body handles, so a guard written as `<= 0` would refuse a valid
+        // setting.
+        let custom = CandleSetting { range_type: 1, avg_period: 0, factor: 0.1 };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "avg_period must be <=")]
+    fn candle_setting_rejects_an_avg_period_past_max_index() {
+        // Same ceiling the unstable period already carries: an average longer
+        // than the largest addressable series could never produce output, and an
+        // unbounded one overflows the lookback it feeds.
+        let custom = CandleSetting {
+            range_type: 1,
+            avg_period: (MAX_INDEX as i32).saturating_add(1),
+            factor: 0.1,
+        };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "factor must not be NaN")]
+    fn candle_setting_rejects_a_nan_factor() {
+        // NaN makes every comparison it feeds false, so the patterns simply stop
+        // matching -- indistinguishable from "this shape never occurs" unless the
+        // setter refuses it.
+        let custom = CandleSetting { range_type: 1, avg_period: 10, factor: f64::NAN };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
     }
 
     #[test]

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/CoreBuilder.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/CoreBuilder.java
@@ -130,6 +130,13 @@ public final class CoreBuilder {
       if (avgPeriod < 0) {
          throw new IllegalArgumentException("avgPeriod must be >= 0, got " + avgPeriod);
       }
+      if (avgPeriod > Core.MAX_INDEX) {
+         throw new IllegalArgumentException(
+            "avgPeriod must be <= " + Core.MAX_INDEX + ", got " + avgPeriod);
+      }
+      if (Double.isNaN(factor)) {
+         throw new IllegalArgumentException("factor must not be NaN");
+      }
       candleSettings[settingType.ordinal()] =
          new CandleSetting(settingType, rangeType, avgPeriod, factor);
       return this;

--- a/ta_codegen/output/rust/library/src/ta_func/types.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/types.rs
@@ -355,8 +355,30 @@ impl CoreBuilder {
     /// Panics if `setting_type` is [`CandleSettingType::AllCandleSettings`].
     /// That variant is a wildcard, not a setting, so there is nothing to
     /// override — C returns `TA_BAD_PARAM` and Java throws for the same call.
+    ///
+    /// Panics if `setting.avg_period` is negative or above [`MAX_INDEX`]. The
+    /// average period is subtracted from `startIdx` to seed the trailing
+    /// average, so a negative one starts the main loop that many bars late
+    /// while `outBegIdx` still reports `startIdx` — every output shifted
+    /// underneath a correct-looking index. C rejects the same value with
+    /// `TA_BAD_PARAM`.
+    ///
+    /// Panics if `setting.factor` is NaN: it makes every comparison it feeds
+    /// silently false, which reads as "no pattern ever matches" rather than as
+    /// a refused setting.
     #[must_use]
     pub fn candle_setting(mut self, setting_type: CandleSettingType, setting: CandleSetting) -> Self {
+        assert!(
+            setting.avg_period >= 0,
+            "avg_period must be >= 0, got {}",
+            setting.avg_period
+        );
+        assert!(
+            (setting.avg_period as usize) <= MAX_INDEX,
+            "avg_period must be <= {MAX_INDEX}, got {}",
+            setting.avg_period
+        );
+        assert!(!setting.factor.is_nan(), "factor must not be NaN");
         match setting_type {
             CandleSettingType::BodyLong => self.candle_settings.body_long = setting,
             CandleSettingType::BodyVeryLong => self.candle_settings.body_very_long = setting,
@@ -492,6 +514,51 @@ mod tests {
         // for the same call (#144).
         let custom = CandleSetting { range_type: 2, avg_period: 99, factor: 9.0 };
         let _ = Core::builder().candle_setting(CandleSettingType::AllCandleSettings, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "avg_period must be >= 0")]
+    fn candle_setting_rejects_a_negative_avg_period() {
+        // The period is subtracted from startIdx to seed the trailing average,
+        // so a negative one starts the main loop that many bars late while
+        // outBegIdx still reports startIdx: every value shifted underneath a
+        // correct-looking index, and a lookback that reports negative while the
+        // call succeeds (#185).
+        let custom = CandleSetting { range_type: 1, avg_period: -1, factor: 0.1 };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    fn candle_setting_accepts_a_zero_avg_period() {
+        // The boundary on the legal side: zero means "no averaging", which every
+        // CDL* body handles, so a guard written as `<= 0` would refuse a valid
+        // setting.
+        let custom = CandleSetting { range_type: 1, avg_period: 0, factor: 0.1 };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "avg_period must be <=")]
+    fn candle_setting_rejects_an_avg_period_past_max_index() {
+        // Same ceiling the unstable period already carries: an average longer
+        // than the largest addressable series could never produce output, and an
+        // unbounded one overflows the lookback it feeds.
+        let custom = CandleSetting {
+            range_type: 1,
+            avg_period: (MAX_INDEX as i32).saturating_add(1),
+            factor: 0.1,
+        };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
+    }
+
+    #[test]
+    #[should_panic(expected = "factor must not be NaN")]
+    fn candle_setting_rejects_a_nan_factor() {
+        // NaN makes every comparison it feeds false, so the patterns simply stop
+        // matching -- indistinguishable from "this shape never occurs" unless the
+        // setter refuses it.
+        let custom = CandleSetting { range_type: 1, avg_period: 10, factor: f64::NAN };
+        let _ = Core::builder().candle_setting(CandleSettingType::BodyDoji, custom);
     }
 
     #[test]


### PR DESCRIPTION
Closes #185.

## The guard

`TA_SetCandleSettings` validated `settingType` and nothing else. The reproduction from the issue, before and after:

```
                                                    before      after
default CDLDOJI_Lookback                              10          10
TA_SetCandleSettings(BodyDoji, HighLow, -1, 0.1)      rc=0        rc=TA_BAD_PARAM
  CDLDOJI_Lookback                                    -1          10
```

The period is subtracted from `startIdx` to seed the trailing average, so a negative one moves the seeding loop's start past `startIdx`: `while( i < startIdx )` never runs and the main loop begins `|avgPeriod|` bars late while `*outBegIdx` still reports `startIdx`. Silent shifted output, and a lookback reporting negative while the call returns `TA_SUCCESS`.

Ceiling is `TA_MAX_INDEX`, for the reason #144 gives for the unstable period: the value feeds a lookback that becomes an index, and an average longer than the largest addressable series could never produce output, so nothing legitimate is refused. In the setter rather than in each of the 61 `CDL*` bodies.

## Why `factor` is only checked for NaN

A negative factor scales a range that is already non-negative, and every body multiplies rather than indexes with it — it cannot misalign output, it only makes the comparison it feeds always false. That is a plausible thing to ask for deliberately. NaN produces the same silence without being asked for, so it is refused.

If you would rather have a bound on `factor` too, say what it should be and I will add it.

## Backends

You noted in the issue that the C guard alone would leave the four divergent.

| | before | after |
|---|---|---|
| C | `settingType` only | `avgPeriod < 0 \|\| > TA_MAX_INDEX` → `TA_BAD_PARAM`; NaN `factor` → `TA_BAD_PARAM` |
| Rust | panics on the `AllCandleSettings` wildcard | `assert!` on the same three, matching that existing panic contract |
| Java | had `avgPeriod < 0` | adds the upper bound and NaN |
| C# | no candle-settings setter at all | unchanged |

C# is left alone deliberately: there is nothing to bring into line, and whether it should have a setter is the question #186 raises about the shipped surface. Rust takes the panic route rather than a `Result` for the same reason you gave in #186 option 1 — `candle_setting` already panics on the wildcard, so a second failure mode in the same method would otherwise be reported two different ways.

## Verification

```
issue reproduction     avgPeriod=-1 rejected, lookback stays 10
boundary, legal side   avgPeriod 0, 10, TA_MAX_INDEX all accepted
boundary, illegal      TA_MAX_INDEX+1 and NaN factor refused
Rust tests             4 new, 34 in types.rs, 371 in the crate — all pass
scripts/regtest.py     green on all four servers
Variant parity         168 functions x 42,864 vectors, bit-identical
Stream verify          147 / 147 / 166 — unchanged from dev after #187
```

One of the four Rust tests pins `avg_period == 0` as **accepted**. Zero means "no averaging", which every body handles, so a guard written `<= 0` would refuse a valid setting and still pass a suite that only tested rejections.
