### PR TITLE
perf(codegen): mask the streaming extrema ring in the Rust backend too

### DIFF
--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -170,6 +170,13 @@ impl streaming::NameMap for RustStreamNames {
     fn extrema_cap(&self) -> String {
         "sp.xCap".to_string()
     }
+    fn extrema_slot(&self, idx: Expr) -> Expr {
+        Expr::BinOp(
+            Box::new(idx),
+            crate::ir::BinOp::BitwiseAnd,
+            Box::new(Expr::Var("sp.xMask".to_string())),
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -419,6 +426,7 @@ fn state_fields_from(
     }
     if let Some(ex) = model.extrema() {
         fields.push(("xCap".into(), "i32".into(), "1_i32".into()));
+        fields.push(("xMask".into(), "i32".into(), "0_i32".into()));
         for arr in &ex.arrays {
             fields.push((
                 format!("x_{arr}"),
@@ -715,6 +723,7 @@ fn build_step_ctx(func: &FuncDef, models: &[&StreamModel], typing: &Typing) -> R
         }
         if let Some(ex) = model.extrema() {
             ctx.sentinel_vars.insert("xCap".to_string());
+            ctx.sentinel_vars.insert("xMask".to_string());
             for arr in &ex.arrays {
                 ctx.vec_vars.insert(format!("x_{arr}"));
                 ctx.real_array_vars.insert(format!("x_{arr}"));
@@ -897,7 +906,7 @@ fn emit_extrema_rebase(o: &mut String, model: &StreamModel, indent: usize) {
         let _ = writeln!(o, "{pad}if sp.{} >= 1073741824 {{", model.cursor);
         let _ = writeln!(
             o,
-            "{inner}let rebaseShift: i32 = (sp.{} / sp.xCap) * sp.xCap;",
+            "{inner}let rebaseShift: i32 = sp.{} & !sp.xMask;",
             ex.trailing
         );
         for v in &vars {
@@ -1529,10 +1538,17 @@ fn emit_capture(
             o,
             "        if capX < 1 || capX > historyLen as i64 {{\n            return Err(RetCode::InternalError);\n        }}"
         );
+        // The slot map is a mask, so the ring is allocated at the next power
+        // of two at or above the logical capacity: `idx & xMask` then equals
+        // `idx % physX`, still injective over any capX consecutive bars.
+        let _ = writeln!(o, "        let mut physX: i64 = 1;");
+        let _ = writeln!(o, "        while physX < capX {{");
+        let _ = writeln!(o, "            physX <<= 1;");
+        let _ = writeln!(o, "        }}");
         for arr in &ex.arrays {
             let _ = writeln!(
                 o,
-                "        let mut x_{arr}: Vec<f64> = vec![0.0_f64; capX as usize];"
+                "        let mut x_{arr}: Vec<f64> = vec![0.0_f64; physX as usize];"
             );
         }
         // Absolute slots: bar j lives at j % cap (a plain tail copy would
@@ -1541,7 +1557,7 @@ fn emit_capture(
         let _ = writeln!(o, "            let mut fillJ: usize = historyLen - capX as usize;");
         let _ = writeln!(o, "            while fillJ < historyLen {{");
         for arr in &ex.arrays {
-            let _ = writeln!(o, "                x_{arr}[fillJ % capX as usize] = {arr}[fillJ];");
+            let _ = writeln!(o, "                x_{arr}[fillJ & (physX as usize - 1)] = {arr}[fillJ];");
         }
         let _ = writeln!(o, "                fillJ += 1;");
         let _ = writeln!(o, "            }}");
@@ -1623,6 +1639,7 @@ fn emit_capture(
     }
     if let Some(ex) = model.extrema() {
         let _ = writeln!(o, "            xCap: capX as i32,");
+        let _ = writeln!(o, "            xMask: (physX - 1) as i32,");
         for arr in &ex.arrays {
             let _ = writeln!(o, "            x_{arr},");
         }
@@ -2656,6 +2673,13 @@ impl streaming::NameMap for RustComposedNames {
     }
     fn extrema_cap(&self) -> String {
         "sp.xCap".to_string()
+    }
+    fn extrema_slot(&self, idx: Expr) -> Expr {
+        Expr::BinOp(
+            Box::new(idx),
+            crate::ir::BinOp::BitwiseAnd,
+            Box::new(Expr::Var("sp.xMask".to_string())),
+        )
     }
 }
 

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -300,6 +300,7 @@ struct AROON_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
 }
@@ -314,23 +315,23 @@ impl Core {
     fn AROON_step_internal(&self, sp: &mut AROON_StreamState, inHigh: f64, inLow: f64, outAroonDown: &mut f64, outAroonUp: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
         // Keep track of the lowestIdx
-        tmp = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmp <= sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -341,13 +342,13 @@ impl Core {
             sp.lowest = tmp;
         }
         // Keep track of the highestIdx
-        tmp = sp.x_inHigh[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmp >= sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -476,13 +477,17 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
                 fillJ += 1;
             }
         }
@@ -497,6 +502,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
         };

--- a/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
@@ -312,6 +312,7 @@ struct AROONOSC_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
 }
@@ -326,23 +327,23 @@ impl Core {
     fn AROONOSC_step_internal(&self, sp: &mut AROONOSC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
         // Keep track of the lowestIdx
-        tmp = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmp <= sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -353,13 +354,13 @@ impl Core {
             sp.lowest = tmp;
         }
         // Keep track of the highestIdx
-        tmp = sp.x_inHigh[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmp >= sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -508,13 +509,17 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
                 fillJ += 1;
             }
         }
@@ -530,6 +535,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
         };

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -333,6 +333,7 @@ struct MAX_StreamState {
     highestIdx: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -346,20 +347,20 @@ impl Core {
     fn MAX_step_internal(&self, sp: &mut MAX_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        tmp = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        tmp = sp.x_inReal[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inReal[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inReal[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if tmp > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -467,11 +468,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -483,6 +488,7 @@ impl Core {
             highestIdx: (highestIdx) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MAX_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -254,6 +254,7 @@ struct MAXINDEX_StreamState {
     highestIdx: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -267,20 +268,20 @@ impl Core {
     fn MAXINDEX_step_internal(&self, sp: &mut MAXINDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        tmp = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        tmp = sp.x_inReal[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inReal[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inReal[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if tmp > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -378,11 +379,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -394,6 +399,7 @@ impl Core {
             highestIdx: (highestIdx) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MAXINDEX_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -389,6 +389,7 @@ struct MIDPOINT_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -401,22 +402,22 @@ struct MIDPOINT_StreamState {
 impl Core {
     fn MIDPOINT_step_internal(&self, sp: &mut MIDPOINT_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        sp.tmpHigh = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        sp.tmpHigh = sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.tmpLow = sp.tmpHigh;
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inReal[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inReal[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpHigh = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpHigh = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpHigh > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = sp.tmpHigh;
@@ -428,10 +429,10 @@ impl Core {
         }
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inReal[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inReal[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpLow = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpLow = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpLow < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = sp.tmpLow;
@@ -573,11 +574,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -593,6 +598,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MIDPOINT_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -400,6 +400,7 @@ struct MIDPRICE_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
 }
@@ -415,23 +416,23 @@ impl Core {
         let mut tmpLow: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
-        tmpHigh = sp.x_inHigh[(sp.today % sp.xCap) as usize];
-        tmpLow = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
+        tmpHigh = sp.x_inHigh[(sp.today & sp.xMask) as usize];
+        tmpLow = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmpHigh = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmpHigh = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmpHigh > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmpHigh;
@@ -443,10 +444,10 @@ impl Core {
         }
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmpLow = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmpLow = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmpLow < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmpLow;
@@ -586,13 +587,17 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
                 fillJ += 1;
             }
         }
@@ -606,6 +611,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
         };

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -331,6 +331,7 @@ struct MIN_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -344,20 +345,20 @@ impl Core {
     fn MIN_step_internal(&self, sp: &mut MIN_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        tmp = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        tmp = sp.x_inReal[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inReal[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inReal[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if tmp < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -463,11 +464,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -479,6 +484,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MIN_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -254,6 +254,7 @@ struct MININDEX_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -267,20 +268,20 @@ impl Core {
     fn MININDEX_step_internal(&self, sp: &mut MININDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        tmp = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        tmp = sp.x_inReal[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inReal[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inReal[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if tmp < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -378,11 +379,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -394,6 +399,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MININDEX_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -386,6 +386,7 @@ struct MINMAX_StreamState {
     lowestIdx: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -398,22 +399,22 @@ struct MINMAX_StreamState {
 impl Core {
     fn MINMAX_step_internal(&self, sp: &mut MINMAX_StreamState, inReal: f64, outMin: &mut f64, outMax: &mut f64) {
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        sp.tmpHigh = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        sp.tmpHigh = sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.tmpLow = sp.tmpHigh;
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inReal[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inReal[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpHigh = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpHigh = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpHigh > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = sp.tmpHigh;
@@ -425,10 +426,10 @@ impl Core {
         }
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inReal[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inReal[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpLow = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpLow = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpLow < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = sp.tmpLow;
@@ -567,11 +568,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -587,6 +592,7 @@ impl Core {
             lowestIdx: (lowestIdx) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MINMAX_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -288,6 +288,7 @@ struct MINMAXINDEX_StreamState {
     lowestIdx: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -300,22 +301,22 @@ struct MINMAXINDEX_StreamState {
 impl Core {
     fn MINMAXINDEX_step_internal(&self, sp: &mut MINMAXINDEX_StreamState, inReal: f64, outMinIdx: &mut i32, outMaxIdx: &mut i32) {
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inReal[(sp.today % sp.xCap) as usize] = inReal;
-        sp.tmpHigh = sp.x_inReal[(sp.today % sp.xCap) as usize];
+        sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
+        sp.tmpHigh = sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.tmpLow = sp.tmpHigh;
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inReal[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inReal[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpHigh = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpHigh = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpHigh > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = sp.tmpHigh;
@@ -327,10 +328,10 @@ impl Core {
         }
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inReal[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inReal[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                sp.tmpLow = sp.x_inReal[(sp.i % sp.xCap) as usize];
+                sp.tmpLow = sp.x_inReal[(sp.i & sp.xMask) as usize];
                 if sp.tmpLow < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = sp.tmpLow;
@@ -452,11 +453,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -472,6 +477,7 @@ impl Core {
             lowestIdx: (lowestIdx) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(MINMAXINDEX_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -491,6 +491,7 @@ struct STOCH_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
     x_inClose: Vec<f64>,
@@ -510,24 +511,24 @@ impl Core {
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outSlowD: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
-        sp.x_inClose[(sp.today % sp.xCap) as usize] = inClose;
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
+        sp.x_inClose[(sp.today & sp.xMask) as usize] = inClose;
         // Set the lowest low
-        tmp = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmp < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -540,13 +541,13 @@ impl Core {
             sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
         // Set the highest high
-        tmp = sp.x_inHigh[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmp > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -562,7 +563,7 @@ impl Core {
         // a machine-flat window leaves a sub-epsilon residue that an exact check
         // would divide into [0,100] noise (issue #107 / STOCHRSI).
         if !((sp.diff).abs() < 1e-14) {
-            cur_tempBuffer = (sp.x_inClose[(sp.today % sp.xCap) as usize] - sp.lowest) / sp.diff;
+            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / sp.diff;
         } else {
             cur_tempBuffer = 0.0;
         }
@@ -823,15 +824,19 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inClose: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inClose: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
-                x_inClose[fillJ % capX as usize] = inClose[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
+                x_inClose[fillJ & (physX as usize - 1)] = inClose[fillJ];
                 fillJ += 1;
             }
         }
@@ -850,6 +855,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
             x_inClose,

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -450,6 +450,7 @@ struct STOCHF_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
     x_inClose: Vec<f64>,
@@ -468,24 +469,24 @@ impl Core {
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outFastD: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
-        sp.x_inClose[(sp.today % sp.xCap) as usize] = inClose;
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
+        sp.x_inClose[(sp.today & sp.xMask) as usize] = inClose;
         // Set the lowest low
-        tmp = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmp < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -498,13 +499,13 @@ impl Core {
             sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
         // Set the highest high
-        tmp = sp.x_inHigh[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmp > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -520,7 +521,7 @@ impl Core {
         // a machine-flat window leaves a sub-epsilon residue that an exact check
         // would divide into [0,100] noise (issue #107 / STOCHRSI).
         if !((sp.diff).abs() < 1e-14) {
-            cur_tempBuffer = (sp.x_inClose[(sp.today % sp.xCap) as usize] - sp.lowest) / sp.diff;
+            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / sp.diff;
         } else {
             cur_tempBuffer = 0.0;
         }
@@ -762,15 +763,19 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inClose: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inClose: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
-                x_inClose[fillJ % capX as usize] = inClose[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
+                x_inClose[fillJ & (physX as usize - 1)] = inClose[fillJ];
                 fillJ += 1;
             }
         }
@@ -787,6 +792,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
             x_inClose,

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -337,6 +337,7 @@ struct VAR_StreamState {
     barsSinceReseed: usize,
     i: i32,
     xCap: i32,
+    xMask: i32,
     x_inReal: Vec<f64>,
 }
 
@@ -350,22 +351,22 @@ impl Core {
     fn VAR_step_internal(&self, sp: &mut VAR_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.i >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.i -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.j -= rebaseShift;
             sp.windowStart -= rebaseShift;
         }
-        sp.x_inReal[(sp.i % sp.xCap) as usize] = inReal;
+        sp.x_inReal[(sp.i & sp.xMask) as usize] = inReal;
         // Add the incoming value, measured against the shift.
-        tempReal = sp.x_inReal[(sp.i % sp.xCap) as usize] - sp.shift;
+        tempReal = sp.x_inReal[(sp.i & sp.xMask) as usize] - sp.shift;
         sp.periodTotal1 += tempReal;
         tempReal *= tempReal;
         sp.periodTotal2 += tempReal;
         sp.meanValue1 = sp.periodTotal1 * sp.invPeriod;
         sp.variance = sp.periodTotal2 * sp.invPeriod - sp.meanValue1 * sp.meanValue1;
         // Remove the trailing value (prepares the next window).
-        tempReal = sp.x_inReal[(sp.trailingIdx % sp.xCap) as usize] - sp.shift;
+        tempReal = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize] - sp.shift;
         sp.periodTotal1 -= tempReal;
         tempReal *= tempReal;
         sp.periodTotal2 -= tempReal;
@@ -390,7 +391,7 @@ impl Core {
             // for( sp.j = sp.windowStart; sp.j <= sp.i; sp.j += 1 )
             sp.j = sp.windowStart;
             while sp.j <= sp.i {
-                tempReal += sp.x_inReal[(sp.j % sp.xCap) as usize];
+                tempReal += sp.x_inReal[(sp.j & sp.xMask) as usize];
                 sp.j += 1;
             }
             sp.shift = tempReal * sp.invPeriod;
@@ -399,7 +400,7 @@ impl Core {
             // for( sp.j = sp.windowStart; sp.j <= sp.i; sp.j += 1 )
             sp.j = sp.windowStart;
             while sp.j <= sp.i {
-                tempReal = sp.x_inReal[(sp.j % sp.xCap) as usize] - sp.shift;
+                tempReal = sp.x_inReal[(sp.j & sp.xMask) as usize] - sp.shift;
                 sp.periodTotal1 += tempReal;
                 tempReal *= tempReal;
                 sp.periodTotal2 += tempReal;
@@ -409,7 +410,7 @@ impl Core {
             sp.variance = sp.periodTotal2 * sp.invPeriod - sp.meanValue1 * sp.meanValue1;
             // Re-remove the trailing value under the new shift so the carried state
             // matches the non-reseed path.
-            tempReal = sp.x_inReal[(sp.windowStart % sp.xCap) as usize] - sp.shift;
+            tempReal = sp.x_inReal[(sp.windowStart & sp.xMask) as usize] - sp.shift;
             sp.periodTotal1 -= tempReal;
             tempReal *= tempReal;
             sp.periodTotal2 -= tempReal;
@@ -562,11 +563,15 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inReal: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inReal: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inReal[fillJ % capX as usize] = inReal[fillJ];
+                x_inReal[fillJ & (physX as usize - 1)] = inReal[fillJ];
                 fillJ += 1;
             }
         }
@@ -586,6 +591,7 @@ impl Core {
             barsSinceReseed,
             i: (i) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inReal,
         };
         Ok(VAR_Stream { core: self.clone(), state })

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -416,6 +416,7 @@ struct WILLR_StreamState {
     i: i32,
     today: i32,
     xCap: i32,
+    xMask: i32,
     x_inHigh: Vec<f64>,
     x_inLow: Vec<f64>,
     x_inClose: Vec<f64>,
@@ -431,24 +432,24 @@ impl Core {
     fn WILLR_step_internal(&self, sp: &mut WILLR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
-            let rebaseShift: i32 = (sp.trailingIdx / sp.xCap) * sp.xCap;
+            let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
             sp.today -= rebaseShift;
             sp.trailingIdx -= rebaseShift;
             sp.highestIdx -= rebaseShift;
             sp.i -= rebaseShift;
             sp.lowestIdx -= rebaseShift;
         }
-        sp.x_inHigh[(sp.today % sp.xCap) as usize] = inHigh;
-        sp.x_inLow[(sp.today % sp.xCap) as usize] = inLow;
-        sp.x_inClose[(sp.today % sp.xCap) as usize] = inClose;
+        sp.x_inHigh[(sp.today & sp.xMask) as usize] = inHigh;
+        sp.x_inLow[(sp.today & sp.xMask) as usize] = inLow;
+        sp.x_inClose[(sp.today & sp.xMask) as usize] = inClose;
         // Set the lowest low
-        tmp = sp.x_inLow[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inLow[(sp.today & sp.xMask) as usize];
         if sp.lowestIdx < sp.trailingIdx {
             sp.lowestIdx = sp.trailingIdx;
-            sp.lowest = sp.x_inLow[(sp.lowestIdx % sp.xCap) as usize];
+            sp.lowest = sp.x_inLow[(sp.lowestIdx & sp.xMask) as usize];
             sp.i = sp.lowestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inLow[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inLow[(sp.i & sp.xMask) as usize];
                 if tmp < sp.lowest {
                     sp.lowestIdx = sp.i;
                     sp.lowest = tmp;
@@ -461,13 +462,13 @@ impl Core {
             sp.diff = (sp.highest - sp.lowest) / (0_f64 - 100.0);
         }
         // Set the highest high
-        tmp = sp.x_inHigh[(sp.today % sp.xCap) as usize];
+        tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
         if sp.highestIdx < sp.trailingIdx {
             sp.highestIdx = sp.trailingIdx;
-            sp.highest = sp.x_inHigh[(sp.highestIdx % sp.xCap) as usize];
+            sp.highest = sp.x_inHigh[(sp.highestIdx & sp.xMask) as usize];
             sp.i = sp.highestIdx;
             while (({ sp.i += 1; sp.i }) as i32) <= sp.today {
-                tmp = sp.x_inHigh[(sp.i % sp.xCap) as usize];
+                tmp = sp.x_inHigh[(sp.i & sp.xMask) as usize];
                 if tmp > sp.highest {
                     sp.highestIdx = sp.i;
                     sp.highest = tmp;
@@ -480,7 +481,7 @@ impl Core {
             sp.diff = (sp.highest - sp.lowest) / (0_f64 - 100.0);
         }
         if sp.diff != 0.0 {
-            (*outReal) = (sp.highest - sp.x_inClose[(sp.today % sp.xCap) as usize]) / sp.diff;
+            (*outReal) = (sp.highest - sp.x_inClose[(sp.today & sp.xMask) as usize]) / sp.diff;
         } else {
             (*outReal) = 0.0;
         }
@@ -622,15 +623,19 @@ impl Core {
         if capX < 1 || capX > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
-        let mut x_inHigh: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inLow: Vec<f64> = vec![0.0_f64; capX as usize];
-        let mut x_inClose: Vec<f64> = vec![0.0_f64; capX as usize];
+        let mut physX: i64 = 1;
+        while physX < capX {
+            physX <<= 1;
+        }
+        let mut x_inHigh: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inLow: Vec<f64> = vec![0.0_f64; physX as usize];
+        let mut x_inClose: Vec<f64> = vec![0.0_f64; physX as usize];
         {
             let mut fillJ: usize = historyLen - capX as usize;
             while fillJ < historyLen {
-                x_inHigh[fillJ % capX as usize] = inHigh[fillJ];
-                x_inLow[fillJ % capX as usize] = inLow[fillJ];
-                x_inClose[fillJ % capX as usize] = inClose[fillJ];
+                x_inHigh[fillJ & (physX as usize - 1)] = inHigh[fillJ];
+                x_inLow[fillJ & (physX as usize - 1)] = inLow[fillJ];
+                x_inClose[fillJ & (physX as usize - 1)] = inClose[fillJ];
                 fillJ += 1;
             }
         }
@@ -645,6 +650,7 @@ impl Core {
             i: (i) as i32,
             today: (today) as i32,
             xCap: capX as i32,
+            xMask: (physX - 1) as i32,
             x_inHigh,
             x_inLow,
             x_inClose,


### PR DESCRIPTION
Stacked on `bench-modulo-ring` (#193), not on `dev` — it only makes sense on top of your C change, and it is trivially rebaseable if you reshape that one.

Your C commit left the Rust stream emitter on the default `extrema_slot`, so the same 14 indicators still index their extrema ring through `% sp.xCap` there. This overrides it the same way.

The Rust side is slightly smaller than the C side: `Peek` clones the state rather than memcpy'ing into a mirror, so there is no `xPhys` field to carry — only `xMask` outlives `Open`. `xMask` joins the i32-forced sentinel set so the slot renders as `(sp.today & sp.xMask) as usize`, the same shape as the modulo it replaces, with no extra cast.

### Measured

Intel i7-10700K, rustc release with `lto = true`, `codegen-units = 1`. Update ns/bar, best-of-3 passes, **8 interleaved A/B runs per arm**, medians. Harness drives `Stream::update` directly over a fixed random-walk corpus with the same `it & 4095` bar feed `ta_bench_stream` uses.

| func | modulo ns | mask ns | chg |
|---|---:|---:|---:|
| MININDEX | 11.94 | 4.91 | −58.9% |
| MAXINDEX | 11.62 | 5.04 | −56.7% |
| MIN | 10.67 | 4.82 | −54.8% |
| MAX | 10.61 | 4.90 | −53.8% |
| MINMAX | 18.82 | 8.93 | −52.5% |
| MINMAXINDEX | 19.62 | 9.37 | −52.2% |
| WILLR | 20.44 | 10.43 | −49.0% |
| MIDPRICE | 17.54 | 9.35 | −46.7% |
| VAR | 8.23 | 4.45 | −45.9% |
| AROONOSC | 18.06 | 9.87 | −45.4% |
| MIDPOINT | 16.11 | 8.82 | −45.2% |
| AROON | 18.42 | 10.14 | −44.9% |
| STOCHF | 23.92 | 15.79 | −34.0% |
| STOCH | 29.55 | 21.02 | −28.9% |

Median **−47.8%** over the 14. Mechanism verified rather than inferred: `idivl` in the bench binary drops **110 → 34**, and `WILLR_Stream::update` goes from **6 to 0**.

**Where this measurement is weak, stated plainly:** my Rust harness has only 5 control functions, and one of them (WMA, untouched, on the `ringPos_` lowering) moves −39.6% *stably* across all 8 runs in each arm — 2.91 ns vs 1.76 ns, not noise. It is fully inlined into `main` along with everything else in a `codegen-units = 1` LTO binary, so changing 14 bodies moves the layout of the rest. That is the same effect your C table flags for IMI/MFI/PLUS_DM, but with 5 controls I cannot bound it the way your 154 can. So: the direction and the rough size are solid — the `idiv` counts and the C run's 154-function control carry that — but I would not defend the second digit of any single Rust row.

### Correctness

Full `scripts/regtest.py` on all four servers: 161 passed / 0 failed per language, and `Stream verify: 168 functions, 16678 legs bit-exact vs batch` on the Rust server.
