### PR TITLE
test(marketfi): pin the zero-volume guard to +0.0 bitwise

### DIFF
--- a/src/tools/ta_regtest/ta_test_func/test_marketfi.c
+++ b/src/tools/ta_regtest/ta_test_func/test_marketfi.c
@@ -277,12 +277,30 @@ static ErrorNumber test_marketfi_zero_volume( void )
 
    /* Bar 1 has volume 0 with a real range; bar 3 has volume 0 and a zero range,
     * which is the 0/0 that would produce NaN rather than Inf. Both report 0.
+    *
+    * Compared BITWISE against +0.0 rather than with `!= 0.0`, which is also
+    * false for -0.0 and would accept a guard that wrote the wrong zero. That
+    * is the issue #147 class, and it is reachable here: the guard's value is a
+    * literal in the generated C, so nothing but an edit to the guard can move
+    * it -- which is precisely what this leg exists to catch.
+    *
+    * Worth recording for whoever mutates this next: -0.0 cannot be introduced
+    * through ta_codegen/input/marketfi/marketfi.c. Writing it there and
+    * regenerating yields `= 0.0;` in src/ta_func/ta_MARKETFI.c -- the literal
+    * is normalised on the way through -- so a sabotage run at the input tier
+    * silently tests nothing and reads as "this check has no discriminating
+    * power". Patch the generated C to prove this leg bites.
     */
-   if( out[1] != 0.0 || out[3] != 0.0 )
    {
-      printf( "Fail: TA_MARKETFI zero-volume out[1]=%f out[3]=%f, expected 0/0\n",
-              out[1], out[3] );
-      return TA_TESTUTIL_TFRR_BAD_PARAM;
+      const TA_Real posZero = 0.0;
+      if( memcmp( &out[1], &posZero, sizeof(TA_Real) ) != 0 ||
+          memcmp( &out[3], &posZero, sizeof(TA_Real) ) != 0 )
+      {
+         printf( "Fail: TA_MARKETFI zero-volume out[1]=%.17g out[3]=%.17g, "
+                 "expected exactly +0.0 (a -0.0 here passes a != 0.0 check)\n",
+                 out[1], out[3] );
+         return TA_TESTUTIL_TFRR_BAD_PARAM;
+      }
    }
 
    /* The traded bars must be unaffected by the guard. */


### PR DESCRIPTION
One leg, one file, on top of your `717453336`.

`out[1] != 0.0` is also false for `-0.0`, so the leg that verifies MARKETFI's #112 divergence would accept a guard that wrote the wrong zero. That is issue #147's class — which I worked on, and should have carried across to my own test. Same fix you applied to QSTICK leg (4) in `14c6810f7`; this is the MARKETFI instance of it.

### The mutation has to be applied to the generated C

Worth stating because my first attempt produced a **false negative I nearly reported as a result**: editing `ta_codegen/input/marketfi/marketfi.c` to write `-0.0` and regenerating leaves `= 0.0;` in `src/ta_func/ta_MARKETFI.c` — the literal is normalised on the way through — so the mutation never exists and the run reads as "this check has no discriminating power". `grep '= -0.0;' src/ta_func/ta_MARKETFI.c` returning 0 is what caught it.

Patching the generated C does reach it:

```
Fail: TA_MARKETFI zero-volume out[1]=-0 out[3]=-0, expected exactly +0.0
      (a -0.0 here passes a != 0.0 check)
```

Green again on restore. That fact is recorded at the call site so the next person mutating a signed-zero contract does not repeat it.

### On #194

Its content was already merged in `ceb5747ab`; I force-pushed a rebase afterwards without noticing, which is why it still shows open with a head that is not an ancestor of `dev`. Closing it in favour of this one, which carries only the change that is actually missing from `dev`.

### And a correction I owe you on that PR

I wrote that no usable external vector exists for MARKETFI. That was wrong, and wrong in a way worth naming: Tulip's *published test file* is genuinely vacuous at three decimals, but I generalised from "I cannot run the oracle servers on this box" to "no external anchor exists" — while having named `ta_tulip_serve` / `ta_pandas_serve` in my own first PR description. Your live capture from both, agreeing with `TA_MARKETFI` bitwise across the full corpus, is the answer I should not have foreclosed. Same for the zero-volume guard reaching only the C batch entry point: I checked the contract on one surface and described it as covered.

### Verified

744 generator tests pass; `scripts/regtest.py` green on all four servers, `Stream verify: 172 functions, 17272 legs bit-exact vs batch`.
