### PR TITLE
TEMP: verify the #211 PR codegen gate (do not merge, will be closed)

### DIFF
--- a/src/ta_func/ta_RSI.c
+++ b/src/ta_func/ta_RSI.c
@@ -65,6 +65,9 @@ TA_LIB_API int TA_RSI_Lookback( int optInTimePeriod )
       optInTimePeriod = 14;
    else if( (int)optInTimePeriod < 2 || (int)optInTimePeriod > 100000 )
       return -1;
+   /* Probe for the #211 PR gate: this comment reaches the generated
+    * output, so committing it without regenerating must fail CI.
+    */
    retValue = optInTimePeriod + TA_GLOBALS_UNSTABLE_PERIOD(TA_FUNC_UNST_RSI,Rsi);
    if( TA_GLOBALS_COMPATIBILITY == TA_COMPATIBILITY_METASTOCK )
    {

--- a/ta_codegen/input/rsi/rsi.c
+++ b/ta_codegen/input/rsi/rsi.c
@@ -16,6 +16,8 @@
 
 int rsi_lookback(int optInTimePeriod)
 {
+   /* Probe for the #211 PR gate: this comment reaches the generated
+    * output, so committing it without regenerating must fail CI. */
    int retValue;
 
    retValue = optInTimePeriod + TA_GetUnstablePeriod(TA_FUNC_UNST_RSI);

--- a/ta_codegen/output/csharp/library/src/Core_RSI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_RSI.cs
@@ -81,6 +81,9 @@ public partial class Core
          return -1;
       }
       int retValue = 0;
+      /* Probe for the #211 PR gate: this comment reaches the generated
+       * output, so committing it without regenerating must fail CI.
+       */
       retValue = optInTimePeriod + this.unstablePeriod[(int)FuncUnstId.RSI];
       return retValue ;
 

--- a/ta_codegen/output/java/fragments/Core_RSI.java
+++ b/ta_codegen/output/java/fragments/Core_RSI.java
@@ -36,6 +36,9 @@
          return -1;
       }
       int retValue;
+      /* Probe for the #211 PR gate: this comment reaches the generated
+       * output, so committing it without regenerating must fail CI.
+       */
       retValue = optInTimePeriod + this.unstablePeriod[FuncUnstId.RSI.ordinal()];
       return retValue ;
 

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -118474,6 +118474,9 @@ public final class Core {
          return -1;
       }
       int retValue;
+      /* Probe for the #211 PR gate: this comment reaches the generated
+       * output, so committing it without regenerating must fail CI.
+       */
       retValue = optInTimePeriod + this.unstablePeriod[FuncUnstId.RSI.ordinal()];
       return retValue ;
 

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -118288,6 +118288,9 @@ class Core {
              return -1;
           }
           int retValue;
+          /* Probe for the #211 PR gate: this comment reaches the generated
+           * output, so committing it without regenerating must fail CI.
+           */
           retValue = optInTimePeriod + this.unstablePeriod[FuncUnstId.RSI.ordinal()];
           return retValue ;
 

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -83,6 +83,8 @@ impl Core {
             return usize::MAX;
         }
         let mut retValue: usize = 0_usize;
+        // Probe for the #211 PR gate: this comment reaches the generated
+        // output, so committing it without regenerating must fail CI.
         retValue = (optInTimePeriod + self.unstable_period[FuncUnstId::RSI as usize]) as usize;
         if self.compatibility == Compatibility::Metastock {
             retValue = retValue - 1;


### PR DESCRIPTION
Throwaway PR. Its only purpose is to make the new PR codegen gate execute once,
so #211 can be closed on evidence rather than on a local run.

The first commit edits `ta_codegen/input/rsi/rsi.c` (a comment that does reach the
generated output) and deliberately does **not** commit the regenerated files, so
the `ta_codegen output up-to-date` check must go RED and name the drifted paths --
including `TaCodegenServe.java`, the file class #211 is about, which the previous
gate could not see.

A second commit adds the regeneration, which must turn the same check GREEN.

Then this PR is closed and the branch deleted. Nothing here is meant to merge.