### PR TITLE
perf(stream): one derived ring where a trailing index feeds one scalar (#229)

### DIFF
--- a/src/ta_func/ta_AC.c
+++ b/src/ta_func/ta_AC.c
@@ -446,16 +446,12 @@ struct TA_AC_Stream {
    int maxIdx_oscBuffer;
    int ringPos_trailingFastIdx;
    int ringCap_trailingFastIdx;
-   double *ring_trailingFastIdx_inHigh;
-   double *ringMirror_trailingFastIdx_inHigh;
-   double *ring_trailingFastIdx_inLow;
-   double *ringMirror_trailingFastIdx_inLow;
+   double *ring_trailingFastIdx_derived;
+   double *ringMirror_trailingFastIdx_derived;
    int ringPos_trailingSlowIdx;
    int ringCap_trailingSlowIdx;
-   double *ring_trailingSlowIdx_inHigh;
-   double *ringMirror_trailingSlowIdx_inHigh;
-   double *ring_trailingSlowIdx_inLow;
-   double *ringMirror_trailingSlowIdx_inLow;
+   double *ring_trailingSlowIdx_derived;
+   double *ringMirror_trailingSlowIdx_derived;
    int cbSize_oscBuffer;
    double *cb_oscBuffer;
    double *cbMirror_oscBuffer;
@@ -465,14 +461,10 @@ struct TA_AC_Stream {
 static void TA_AC_ReleaseInternal( struct TA_AC_Stream *sp )
 {
    if( !sp ) return;
-   if( sp->ring_trailingFastIdx_inHigh ) TA_Free( sp->ring_trailingFastIdx_inHigh );
-   if( sp->ringMirror_trailingFastIdx_inHigh ) TA_Free( sp->ringMirror_trailingFastIdx_inHigh );
-   if( sp->ring_trailingFastIdx_inLow ) TA_Free( sp->ring_trailingFastIdx_inLow );
-   if( sp->ringMirror_trailingFastIdx_inLow ) TA_Free( sp->ringMirror_trailingFastIdx_inLow );
-   if( sp->ring_trailingSlowIdx_inHigh ) TA_Free( sp->ring_trailingSlowIdx_inHigh );
-   if( sp->ringMirror_trailingSlowIdx_inHigh ) TA_Free( sp->ringMirror_trailingSlowIdx_inHigh );
-   if( sp->ring_trailingSlowIdx_inLow ) TA_Free( sp->ring_trailingSlowIdx_inLow );
-   if( sp->ringMirror_trailingSlowIdx_inLow ) TA_Free( sp->ringMirror_trailingSlowIdx_inLow );
+   if( sp->ring_trailingFastIdx_derived ) TA_Free( sp->ring_trailingFastIdx_derived );
+   if( sp->ringMirror_trailingFastIdx_derived ) TA_Free( sp->ringMirror_trailingFastIdx_derived );
+   if( sp->ring_trailingSlowIdx_derived ) TA_Free( sp->ring_trailingSlowIdx_derived );
+   if( sp->ringMirror_trailingSlowIdx_derived ) TA_Free( sp->ringMirror_trailingSlowIdx_derived );
    if( sp->cb_oscBuffer ) TA_Free( sp->cb_oscBuffer );
    if( sp->cbMirror_oscBuffer ) TA_Free( sp->cbMirror_oscBuffer );
    TA_Free( sp );
@@ -485,13 +477,11 @@ static void TA_AC_StepInternal( struct TA_AC_Stream *sp, double inHigh, double i
 
    if( sp->ringCap_trailingFastIdx == 0 )
    {
-      sp->ring_trailingFastIdx_inHigh[0] = inHigh;
-      sp->ring_trailingFastIdx_inLow[0] = inLow;
+      sp->ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
    }
    if( sp->ringCap_trailingSlowIdx == 0 )
    {
-      sp->ring_trailingSlowIdx_inHigh[0] = inHigh;
-      sp->ring_trailingSlowIdx_inLow[0] = inLow;
+      sp->ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
    }
    medianPrice = (inHigh + inLow) / 2.0;
    sp->sumFast += medianPrice;
@@ -500,8 +490,8 @@ static void TA_AC_StepInternal( struct TA_AC_Stream *sp, double inHigh, double i
     * mirroring the add-new / snapshot / subtract-old order of TA_SMA.
     */
    sp->osc = sp->sumFast / (double)sp->optInFastPeriod - sp->sumSlow / (double)sp->optInSlowPeriod;
-   sp->sumFast -= (sp->ring_trailingFastIdx_inHigh[sp->ringPos_trailingFastIdx] + sp->ring_trailingFastIdx_inLow[sp->ringPos_trailingFastIdx]) / 2.0;
-   sp->sumSlow -= (sp->ring_trailingSlowIdx_inHigh[sp->ringPos_trailingSlowIdx] + sp->ring_trailingSlowIdx_inLow[sp->ringPos_trailingSlowIdx]) / 2.0;
+   sp->sumFast -= sp->ring_trailingFastIdx_derived[sp->ringPos_trailingFastIdx];
+   sp->sumSlow -= sp->ring_trailingSlowIdx_derived[sp->ringPos_trailingSlowIdx];
    /* Today's oscillator enters the signal window at its own slot, and the
     * bar leaving that window is read only after the ring has advanced onto
     * it -- writing first is what makes the slot the loop is about to
@@ -525,15 +515,13 @@ static void TA_AC_StepInternal( struct TA_AC_Stream *sp, double inHigh, double i
     * the collision ao.c has to guard against.
     */
    *outReal= sp->tempReal;
-   sp->ring_trailingFastIdx_inHigh[sp->ringPos_trailingFastIdx] = inHigh;
-   sp->ring_trailingFastIdx_inLow[sp->ringPos_trailingFastIdx] = inLow;
+   sp->ring_trailingFastIdx_derived[sp->ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
    sp->ringPos_trailingFastIdx = sp->ringPos_trailingFastIdx + 1;
    if( sp->ringPos_trailingFastIdx >= sp->ringCap_trailingFastIdx )
    {
       sp->ringPos_trailingFastIdx = 0;
    }
-   sp->ring_trailingSlowIdx_inHigh[sp->ringPos_trailingSlowIdx] = inHigh;
-   sp->ring_trailingSlowIdx_inLow[sp->ringPos_trailingSlowIdx] = inLow;
+   sp->ring_trailingSlowIdx_derived[sp->ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
    sp->ringPos_trailingSlowIdx = sp->ringPos_trailingSlowIdx + 1;
    if( sp->ringPos_trailingSlowIdx >= sp->ringCap_trailingSlowIdx )
    {
@@ -763,31 +751,27 @@ static TA_RetCode TA_AC_OpenCore( struct TA_AC_Stream **stream, const double inH
       sp->ringCap_trailingFastIdx = (int)(i - trailingFastIdx);
       if( sp->ringCap_trailingFastIdx < 0 || sp->ringCap_trailingFastIdx > historyLen ) { TA_AC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
       { size_t allocN = (size_t)(sp->ringCap_trailingFastIdx > 0 ? sp->ringCap_trailingFastIdx : 1);
-        sp->ring_trailingFastIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingFastIdx_inHigh ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingFastIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingFastIdx_inHigh ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingFastIdx_inHigh, inHigh + (historyLen - sp->ringCap_trailingFastIdx), sizeof(double) * (size_t)sp->ringCap_trailingFastIdx );
-        sp->ring_trailingFastIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingFastIdx_inLow ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingFastIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingFastIdx_inLow ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingFastIdx_inLow, inLow + (historyLen - sp->ringCap_trailingFastIdx), sizeof(double) * (size_t)sp->ringCap_trailingFastIdx );
+        sp->ring_trailingFastIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ring_trailingFastIdx_derived ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        sp->ringMirror_trailingFastIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ringMirror_trailingFastIdx_derived ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        { int fillJ;
+          for( fillJ = historyLen - sp->ringCap_trailingFastIdx; fillJ < historyLen; fillJ++ )
+             sp->ring_trailingFastIdx_derived[fillJ - (historyLen - sp->ringCap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+        }
       }
       sp->ringPos_trailingFastIdx = 0;
       sp->ringCap_trailingSlowIdx = (int)(i - trailingSlowIdx);
       if( sp->ringCap_trailingSlowIdx < 0 || sp->ringCap_trailingSlowIdx > historyLen ) { TA_AC_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
       { size_t allocN = (size_t)(sp->ringCap_trailingSlowIdx > 0 ? sp->ringCap_trailingSlowIdx : 1);
-        sp->ring_trailingSlowIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingSlowIdx_inHigh ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingSlowIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingSlowIdx_inHigh ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingSlowIdx_inHigh, inHigh + (historyLen - sp->ringCap_trailingSlowIdx), sizeof(double) * (size_t)sp->ringCap_trailingSlowIdx );
-        sp->ring_trailingSlowIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingSlowIdx_inLow ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingSlowIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingSlowIdx_inLow ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingSlowIdx_inLow, inLow + (historyLen - sp->ringCap_trailingSlowIdx), sizeof(double) * (size_t)sp->ringCap_trailingSlowIdx );
+        sp->ring_trailingSlowIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ring_trailingSlowIdx_derived ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        sp->ringMirror_trailingSlowIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ringMirror_trailingSlowIdx_derived ) { TA_AC_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        { int fillJ;
+          for( fillJ = historyLen - sp->ringCap_trailingSlowIdx; fillJ < historyLen; fillJ++ )
+             sp->ring_trailingSlowIdx_derived[fillJ - (historyLen - sp->ringCap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+        }
       }
       sp->ringPos_trailingSlowIdx = 0;
       sp->cbSize_oscBuffer = maxIdx_oscBuffer + 1;
@@ -873,14 +857,10 @@ TA_LIB_API TA_RetCode TA_AC_Peek( const TA_AC_Stream *stream, double inHigh, dou
    if( !stream || !outReal ) return TA_BAD_PARAM;
    if( !TA_IS_FINITE( inHigh ) || !TA_IS_FINITE( inLow ) ) return TA_BAD_PARAM;
    scratch = *stream;
-   scratch.ring_trailingFastIdx_inHigh = stream->ringMirror_trailingFastIdx_inHigh;
-   memcpy( scratch.ring_trailingFastIdx_inHigh, stream->ring_trailingFastIdx_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
-   scratch.ring_trailingFastIdx_inLow = stream->ringMirror_trailingFastIdx_inLow;
-   memcpy( scratch.ring_trailingFastIdx_inLow, stream->ring_trailingFastIdx_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
-   scratch.ring_trailingSlowIdx_inHigh = stream->ringMirror_trailingSlowIdx_inHigh;
-   memcpy( scratch.ring_trailingSlowIdx_inHigh, stream->ring_trailingSlowIdx_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
-   scratch.ring_trailingSlowIdx_inLow = stream->ringMirror_trailingSlowIdx_inLow;
-   memcpy( scratch.ring_trailingSlowIdx_inLow, stream->ring_trailingSlowIdx_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
+   scratch.ring_trailingFastIdx_derived = stream->ringMirror_trailingFastIdx_derived;
+   memcpy( scratch.ring_trailingFastIdx_derived, stream->ring_trailingFastIdx_derived, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
+   scratch.ring_trailingSlowIdx_derived = stream->ringMirror_trailingSlowIdx_derived;
+   memcpy( scratch.ring_trailingSlowIdx_derived, stream->ring_trailingSlowIdx_derived, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
    scratch.cb_oscBuffer = stream->cbMirror_oscBuffer;
    memcpy( scratch.cb_oscBuffer, stream->cb_oscBuffer, sizeof(double) * (size_t)stream->cbSize_oscBuffer );
    TA_AC_StepInternal( &scratch, inHigh, inLow, outReal );

--- a/src/ta_func/ta_AO.c
+++ b/src/ta_func/ta_AO.c
@@ -317,30 +317,22 @@ struct TA_AO_Stream {
    double tempReal;
    int ringPos_trailingFastIdx;
    int ringCap_trailingFastIdx;
-   double *ring_trailingFastIdx_inHigh;
-   double *ringMirror_trailingFastIdx_inHigh;
-   double *ring_trailingFastIdx_inLow;
-   double *ringMirror_trailingFastIdx_inLow;
+   double *ring_trailingFastIdx_derived;
+   double *ringMirror_trailingFastIdx_derived;
    int ringPos_trailingSlowIdx;
    int ringCap_trailingSlowIdx;
-   double *ring_trailingSlowIdx_inHigh;
-   double *ringMirror_trailingSlowIdx_inHigh;
-   double *ring_trailingSlowIdx_inLow;
-   double *ringMirror_trailingSlowIdx_inLow;
+   double *ring_trailingSlowIdx_derived;
+   double *ringMirror_trailingSlowIdx_derived;
 };
 
 /* Private function, not in public API. */
 static void TA_AO_ReleaseInternal( struct TA_AO_Stream *sp )
 {
    if( !sp ) return;
-   if( sp->ring_trailingFastIdx_inHigh ) TA_Free( sp->ring_trailingFastIdx_inHigh );
-   if( sp->ringMirror_trailingFastIdx_inHigh ) TA_Free( sp->ringMirror_trailingFastIdx_inHigh );
-   if( sp->ring_trailingFastIdx_inLow ) TA_Free( sp->ring_trailingFastIdx_inLow );
-   if( sp->ringMirror_trailingFastIdx_inLow ) TA_Free( sp->ringMirror_trailingFastIdx_inLow );
-   if( sp->ring_trailingSlowIdx_inHigh ) TA_Free( sp->ring_trailingSlowIdx_inHigh );
-   if( sp->ringMirror_trailingSlowIdx_inHigh ) TA_Free( sp->ringMirror_trailingSlowIdx_inHigh );
-   if( sp->ring_trailingSlowIdx_inLow ) TA_Free( sp->ring_trailingSlowIdx_inLow );
-   if( sp->ringMirror_trailingSlowIdx_inLow ) TA_Free( sp->ringMirror_trailingSlowIdx_inLow );
+   if( sp->ring_trailingFastIdx_derived ) TA_Free( sp->ring_trailingFastIdx_derived );
+   if( sp->ringMirror_trailingFastIdx_derived ) TA_Free( sp->ringMirror_trailingFastIdx_derived );
+   if( sp->ring_trailingSlowIdx_derived ) TA_Free( sp->ring_trailingSlowIdx_derived );
+   if( sp->ringMirror_trailingSlowIdx_derived ) TA_Free( sp->ringMirror_trailingSlowIdx_derived );
    TA_Free( sp );
 }
 
@@ -351,13 +343,11 @@ static void TA_AO_StepInternal( struct TA_AO_Stream *sp, double inHigh, double i
 
    if( sp->ringCap_trailingFastIdx == 0 )
    {
-      sp->ring_trailingFastIdx_inHigh[0] = inHigh;
-      sp->ring_trailingFastIdx_inLow[0] = inLow;
+      sp->ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
    }
    if( sp->ringCap_trailingSlowIdx == 0 )
    {
-      sp->ring_trailingSlowIdx_inHigh[0] = inHigh;
-      sp->ring_trailingSlowIdx_inLow[0] = inLow;
+      sp->ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
    }
    medianPrice = (inHigh + inLow) / 2.0;
    sp->sumFast += medianPrice;
@@ -372,18 +362,16 @@ static void TA_AO_StepInternal( struct TA_AO_Stream *sp, double inHigh, double i
     * value it had just overwritten whenever the caller aliases outReal
     * over inHigh or inLow.
     */
-   sp->sumFast -= (sp->ring_trailingFastIdx_inHigh[sp->ringPos_trailingFastIdx] + sp->ring_trailingFastIdx_inLow[sp->ringPos_trailingFastIdx]) / 2.0;
-   sp->sumSlow -= (sp->ring_trailingSlowIdx_inHigh[sp->ringPos_trailingSlowIdx] + sp->ring_trailingSlowIdx_inLow[sp->ringPos_trailingSlowIdx]) / 2.0;
+   sp->sumFast -= sp->ring_trailingFastIdx_derived[sp->ringPos_trailingFastIdx];
+   sp->sumSlow -= sp->ring_trailingSlowIdx_derived[sp->ringPos_trailingSlowIdx];
    *outReal= sp->tempReal;
-   sp->ring_trailingFastIdx_inHigh[sp->ringPos_trailingFastIdx] = inHigh;
-   sp->ring_trailingFastIdx_inLow[sp->ringPos_trailingFastIdx] = inLow;
+   sp->ring_trailingFastIdx_derived[sp->ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
    sp->ringPos_trailingFastIdx = sp->ringPos_trailingFastIdx + 1;
    if( sp->ringPos_trailingFastIdx >= sp->ringCap_trailingFastIdx )
    {
       sp->ringPos_trailingFastIdx = 0;
    }
-   sp->ring_trailingSlowIdx_inHigh[sp->ringPos_trailingSlowIdx] = inHigh;
-   sp->ring_trailingSlowIdx_inLow[sp->ringPos_trailingSlowIdx] = inLow;
+   sp->ring_trailingSlowIdx_derived[sp->ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
    sp->ringPos_trailingSlowIdx = sp->ringPos_trailingSlowIdx + 1;
    if( sp->ringPos_trailingSlowIdx >= sp->ringCap_trailingSlowIdx )
    {
@@ -542,31 +530,27 @@ static TA_RetCode TA_AO_OpenCore( struct TA_AO_Stream **stream, const double inH
       sp->ringCap_trailingFastIdx = (int)(i - trailingFastIdx);
       if( sp->ringCap_trailingFastIdx < 0 || sp->ringCap_trailingFastIdx > historyLen ) { TA_AO_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
       { size_t allocN = (size_t)(sp->ringCap_trailingFastIdx > 0 ? sp->ringCap_trailingFastIdx : 1);
-        sp->ring_trailingFastIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingFastIdx_inHigh ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingFastIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingFastIdx_inHigh ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingFastIdx_inHigh, inHigh + (historyLen - sp->ringCap_trailingFastIdx), sizeof(double) * (size_t)sp->ringCap_trailingFastIdx );
-        sp->ring_trailingFastIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingFastIdx_inLow ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingFastIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingFastIdx_inLow ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingFastIdx_inLow, inLow + (historyLen - sp->ringCap_trailingFastIdx), sizeof(double) * (size_t)sp->ringCap_trailingFastIdx );
+        sp->ring_trailingFastIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ring_trailingFastIdx_derived ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        sp->ringMirror_trailingFastIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ringMirror_trailingFastIdx_derived ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        { int fillJ;
+          for( fillJ = historyLen - sp->ringCap_trailingFastIdx; fillJ < historyLen; fillJ++ )
+             sp->ring_trailingFastIdx_derived[fillJ - (historyLen - sp->ringCap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+        }
       }
       sp->ringPos_trailingFastIdx = 0;
       sp->ringCap_trailingSlowIdx = (int)(i - trailingSlowIdx);
       if( sp->ringCap_trailingSlowIdx < 0 || sp->ringCap_trailingSlowIdx > historyLen ) { TA_AO_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
       { size_t allocN = (size_t)(sp->ringCap_trailingSlowIdx > 0 ? sp->ringCap_trailingSlowIdx : 1);
-        sp->ring_trailingSlowIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingSlowIdx_inHigh ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingSlowIdx_inHigh = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingSlowIdx_inHigh ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingSlowIdx_inHigh, inHigh + (historyLen - sp->ringCap_trailingSlowIdx), sizeof(double) * (size_t)sp->ringCap_trailingSlowIdx );
-        sp->ring_trailingSlowIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingSlowIdx_inLow ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingSlowIdx_inLow = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingSlowIdx_inLow ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingSlowIdx_inLow, inLow + (historyLen - sp->ringCap_trailingSlowIdx), sizeof(double) * (size_t)sp->ringCap_trailingSlowIdx );
+        sp->ring_trailingSlowIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ring_trailingSlowIdx_derived ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        sp->ringMirror_trailingSlowIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ringMirror_trailingSlowIdx_derived ) { TA_AO_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        { int fillJ;
+          for( fillJ = historyLen - sp->ringCap_trailingSlowIdx; fillJ < historyLen; fillJ++ )
+             sp->ring_trailingSlowIdx_derived[fillJ - (historyLen - sp->ringCap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+        }
       }
       sp->ringPos_trailingSlowIdx = 0;
       *stream = sp;
@@ -644,14 +628,10 @@ TA_LIB_API TA_RetCode TA_AO_Peek( const TA_AO_Stream *stream, double inHigh, dou
    if( !stream || !outReal ) return TA_BAD_PARAM;
    if( !TA_IS_FINITE( inHigh ) || !TA_IS_FINITE( inLow ) ) return TA_BAD_PARAM;
    scratch = *stream;
-   scratch.ring_trailingFastIdx_inHigh = stream->ringMirror_trailingFastIdx_inHigh;
-   memcpy( scratch.ring_trailingFastIdx_inHigh, stream->ring_trailingFastIdx_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
-   scratch.ring_trailingFastIdx_inLow = stream->ringMirror_trailingFastIdx_inLow;
-   memcpy( scratch.ring_trailingFastIdx_inLow, stream->ring_trailingFastIdx_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
-   scratch.ring_trailingSlowIdx_inHigh = stream->ringMirror_trailingSlowIdx_inHigh;
-   memcpy( scratch.ring_trailingSlowIdx_inHigh, stream->ring_trailingSlowIdx_inHigh, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
-   scratch.ring_trailingSlowIdx_inLow = stream->ringMirror_trailingSlowIdx_inLow;
-   memcpy( scratch.ring_trailingSlowIdx_inLow, stream->ring_trailingSlowIdx_inLow, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
+   scratch.ring_trailingFastIdx_derived = stream->ringMirror_trailingFastIdx_derived;
+   memcpy( scratch.ring_trailingFastIdx_derived, stream->ring_trailingFastIdx_derived, sizeof(double) * (size_t)(stream->ringCap_trailingFastIdx > 0 ? stream->ringCap_trailingFastIdx : 1) );
+   scratch.ring_trailingSlowIdx_derived = stream->ringMirror_trailingSlowIdx_derived;
+   memcpy( scratch.ring_trailingSlowIdx_derived, stream->ring_trailingSlowIdx_derived, sizeof(double) * (size_t)(stream->ringCap_trailingSlowIdx > 0 ? stream->ringCap_trailingSlowIdx : 1) );
    TA_AO_StepInternal( &scratch, inHigh, inLow, outReal );
    return TA_SUCCESS;
 }

--- a/src/ta_func/ta_QSTICK.c
+++ b/src/ta_func/ta_QSTICK.c
@@ -244,20 +244,16 @@ struct TA_QSTICK_Stream {
    double tempReal;
    int ringPos_trailingIdx;
    int ringCap_trailingIdx;
-   double *ring_trailingIdx_inOpen;
-   double *ringMirror_trailingIdx_inOpen;
-   double *ring_trailingIdx_inClose;
-   double *ringMirror_trailingIdx_inClose;
+   double *ring_trailingIdx_derived;
+   double *ringMirror_trailingIdx_derived;
 };
 
 /* Private function, not in public API. */
 static void TA_QSTICK_ReleaseInternal( struct TA_QSTICK_Stream *sp )
 {
    if( !sp ) return;
-   if( sp->ring_trailingIdx_inOpen ) TA_Free( sp->ring_trailingIdx_inOpen );
-   if( sp->ringMirror_trailingIdx_inOpen ) TA_Free( sp->ringMirror_trailingIdx_inOpen );
-   if( sp->ring_trailingIdx_inClose ) TA_Free( sp->ring_trailingIdx_inClose );
-   if( sp->ringMirror_trailingIdx_inClose ) TA_Free( sp->ringMirror_trailingIdx_inClose );
+   if( sp->ring_trailingIdx_derived ) TA_Free( sp->ring_trailingIdx_derived );
+   if( sp->ringMirror_trailingIdx_derived ) TA_Free( sp->ringMirror_trailingIdx_derived );
    TA_Free( sp );
 }
 
@@ -266,15 +262,13 @@ static void TA_QSTICK_StepInternal( struct TA_QSTICK_Stream *sp, double inOpen, 
 {
    if( sp->ringCap_trailingIdx == 0 )
    {
-      sp->ring_trailingIdx_inOpen[0] = inOpen;
-      sp->ring_trailingIdx_inClose[0] = inClose;
+      sp->ring_trailingIdx_derived[0] = (double)(inClose - inOpen);
    }
    sp->periodTotal += (double)(inClose - inOpen);
    sp->tempReal = sp->periodTotal;
-   sp->periodTotal -= (double)(sp->ring_trailingIdx_inClose[sp->ringPos_trailingIdx] - sp->ring_trailingIdx_inOpen[sp->ringPos_trailingIdx]);
+   sp->periodTotal -= sp->ring_trailingIdx_derived[sp->ringPos_trailingIdx];
    *outReal= sp->tempReal / (double)sp->optInTimePeriod;
-   sp->ring_trailingIdx_inOpen[sp->ringPos_trailingIdx] = inOpen;
-   sp->ring_trailingIdx_inClose[sp->ringPos_trailingIdx] = inClose;
+   sp->ring_trailingIdx_derived[sp->ringPos_trailingIdx] = (double)(inClose - inOpen);
    sp->ringPos_trailingIdx = sp->ringPos_trailingIdx + 1;
    if( sp->ringPos_trailingIdx >= sp->ringCap_trailingIdx )
    {
@@ -389,16 +383,14 @@ static TA_RetCode TA_QSTICK_OpenCore( struct TA_QSTICK_Stream **stream, const do
       sp->ringCap_trailingIdx = (int)(i - trailingIdx);
       if( sp->ringCap_trailingIdx < 0 || sp->ringCap_trailingIdx > historyLen ) { TA_QSTICK_ReleaseInternal( sp ); return TA_INTERNAL_ERROR; }
       { size_t allocN = (size_t)(sp->ringCap_trailingIdx > 0 ? sp->ringCap_trailingIdx : 1);
-        sp->ring_trailingIdx_inOpen = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx_inOpen ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx_inOpen = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx_inOpen ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingIdx_inOpen, inOpen + (historyLen - sp->ringCap_trailingIdx), sizeof(double) * (size_t)sp->ringCap_trailingIdx );
-        sp->ring_trailingIdx_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ring_trailingIdx_inClose ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        sp->ringMirror_trailingIdx_inClose = (double *)TA_Malloc( sizeof(double) * allocN );
-        if( !sp->ringMirror_trailingIdx_inClose ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
-        memcpy( sp->ring_trailingIdx_inClose, inClose + (historyLen - sp->ringCap_trailingIdx), sizeof(double) * (size_t)sp->ringCap_trailingIdx );
+        sp->ring_trailingIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ring_trailingIdx_derived ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        sp->ringMirror_trailingIdx_derived = (double *)TA_Malloc( sizeof(double) * allocN );
+        if( !sp->ringMirror_trailingIdx_derived ) { TA_QSTICK_ReleaseInternal( sp ); return TA_ALLOC_ERR; }
+        { int fillJ;
+          for( fillJ = historyLen - sp->ringCap_trailingIdx; fillJ < historyLen; fillJ++ )
+             sp->ring_trailingIdx_derived[fillJ - (historyLen - sp->ringCap_trailingIdx)] = (double)(inClose[fillJ] - inOpen[fillJ]);
+        }
       }
       sp->ringPos_trailingIdx = 0;
       *stream = sp;
@@ -476,10 +468,8 @@ TA_LIB_API TA_RetCode TA_QSTICK_Peek( const TA_QSTICK_Stream *stream, double inO
    if( !stream || !outReal ) return TA_BAD_PARAM;
    if( !TA_IS_FINITE( inOpen ) || !TA_IS_FINITE( inClose ) ) return TA_BAD_PARAM;
    scratch = *stream;
-   scratch.ring_trailingIdx_inOpen = stream->ringMirror_trailingIdx_inOpen;
-   memcpy( scratch.ring_trailingIdx_inOpen, stream->ring_trailingIdx_inOpen, sizeof(double) * (size_t)(stream->ringCap_trailingIdx > 0 ? stream->ringCap_trailingIdx : 1) );
-   scratch.ring_trailingIdx_inClose = stream->ringMirror_trailingIdx_inClose;
-   memcpy( scratch.ring_trailingIdx_inClose, stream->ring_trailingIdx_inClose, sizeof(double) * (size_t)(stream->ringCap_trailingIdx > 0 ? stream->ringCap_trailingIdx : 1) );
+   scratch.ring_trailingIdx_derived = stream->ringMirror_trailingIdx_derived;
+   memcpy( scratch.ring_trailingIdx_derived, stream->ring_trailingIdx_derived, sizeof(double) * (size_t)(stream->ringCap_trailingIdx > 0 ? stream->ringCap_trailingIdx : 1) );
    TA_QSTICK_StepInternal( &scratch, inOpen, inClose, outReal );
    return TA_SUCCESS;
 }

--- a/ta_codegen/generator/src/backends/c_stream.rs
+++ b/ta_codegen/generator/src/backends/c_stream.rs
@@ -3395,6 +3395,118 @@ fn pre_fail_stmt(pre_fail: &str) -> String {
 /// Peek's scratch mirrors are pre-allocated. On the identity path
 /// (`with_state == false`) capacities are zero and 1-slot buffers keep the
 /// transition's cap-0 guard and Peek's mirror copy well-defined.
+/// A derived ring stores one scalar per bar, so `open` cannot memcpy a raw
+/// column into it -- it has to evaluate the expression over the history. The
+/// expression is rendered with every array read re-indexed to `idx_var`, the
+/// fill loop's counter (#229).
+fn derived_fill_expr(
+    dr: &streaming::DerivedRing,
+    idx_var: &str,
+    registry: &Registry,
+    helpers: &HelperRegistry,
+    counter: &Cell<usize>,
+) -> String {
+    fn reindex(e: &Expr, idx_var: &str) -> Expr {
+        match e {
+            Expr::ArrayAccess(arr, _) => {
+                Expr::ArrayAccess(arr.clone(), Box::new(Expr::Var(idx_var.to_string())))
+            }
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(reindex(lhs, idx_var)),
+                op.clone(),
+                Box::new(reindex(rhs, idx_var)),
+            ),
+            Expr::FuncCall(name, args) => Expr::FuncCall(
+                name.clone(),
+                args.iter().map(|a| reindex(a, idx_var)).collect(),
+            ),
+            Expr::Cast(t, inner) => Expr::Cast(t.clone(), Box::new(reindex(inner, idx_var))),
+            Expr::Not(inner) => Expr::Not(Box::new(reindex(inner, idx_var))),
+            Expr::BitwiseNot(inner) => Expr::BitwiseNot(Box::new(reindex(inner, idx_var))),
+            Expr::Ternary(cond, then_e, else_e) => Expr::Ternary(
+                Box::new(reindex(cond, idx_var)),
+                Box::new(reindex(then_e, idx_var)),
+                Box::new(reindex(else_e, idx_var)),
+            ),
+            other => other.clone(),
+        }
+    }
+    render_expression(&reindex(&dr.expr, idx_var), registry, helpers, counter)
+}
+
+/// Emit one ring's per-slot allocation and its open-time fill. Split out of
+/// `alloc_and_capture` because the derived case (#229) turned the fill from a
+/// single `memcpy` into three shapes and pushed that function past the
+/// line limit.
+fn emit_ring_slots(
+    s: &mut String,
+    ring: &streaming::RingSpec,
+    v: &str,
+    pad: &str,
+    fail: &str,
+    with_state: bool,
+    registry: &Registry,
+    helpers: &HelperRegistry,
+    counter: &Cell<usize>,
+) {
+    for arr in &ring.arrays {
+        let _ = writeln!(
+            s,
+            "{pad}  sp->ring_{v}_{arr} = (double *)TA_Malloc( sizeof(double) * allocN );"
+        );
+        let _ = writeln!(s, "{pad}  if( !sp->ring_{v}_{arr} ) {fail}");
+        let _ = writeln!(
+            s,
+            "{pad}  sp->ringMirror_{v}_{arr} = (double *)TA_Malloc( sizeof(double) * allocN );"
+        );
+        let _ = writeln!(s, "{pad}  if( !sp->ringMirror_{v}_{arr} ) {fail}");
+        if with_state {
+            // A derived ring holds f(bar), not a raw column, so both fill
+            // shapes evaluate the expression per bar instead of copying.
+            let fill_val = ring
+                .derived
+                .as_ref()
+                .map(|dr| derived_fill_expr(dr, "fillJ", registry, helpers, counter));
+            if ring.back > 0 {
+                let rhs = fill_val.clone().unwrap_or_else(|| format!("{arr}[fillJ]"));
+                let _ = writeln!(s, "{pad}  {{ int fillJ;");
+                let _ = writeln!(
+                    s,
+                    "{pad}    for( fillJ = historyLen - sp->ringCap_{v}; fillJ < historyLen; fillJ++ )"
+                );
+                let _ = writeln!(
+                    s,
+                    "{pad}       sp->ring_{v}_{arr}[fillJ % sp->ringCap_{v}] = {rhs};"
+                );
+                let _ = writeln!(s, "{pad}  }}");
+            } else if let Some(rhs) = fill_val {
+                let _ = writeln!(s, "{pad}  {{ int fillJ;");
+                let _ = writeln!(
+                    s,
+                    "{pad}    for( fillJ = historyLen - sp->ringCap_{v}; fillJ < historyLen; fillJ++ )"
+                );
+                let _ = writeln!(
+                    s,
+                    "{pad}       sp->ring_{v}_{arr}[fillJ - (historyLen - sp->ringCap_{v})] = {rhs};"
+                );
+                let _ = writeln!(s, "{pad}  }}");
+            } else {
+                let _ = writeln!(
+                    s,
+                    "{pad}  memcpy( sp->ring_{v}_{arr}, {arr} + (historyLen - sp->ringCap_{v}), sizeof(double) * (size_t)sp->ringCap_{v} );"
+                );
+            }
+        } else {
+            // Identity path never reads the ring, but Peek's mirror
+            // memcpy must not copy uninitialized heap (MSan).
+            let _ = writeln!(
+            s,
+                "{pad}  memset( sp->ring_{v}_{arr}, 0, sizeof(double) * allocN );"
+            );
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn alloc_and_capture(
     func: &FuncDef,
@@ -3495,44 +3607,9 @@ fn alloc_and_capture(
             s,
             "{pad}{{ size_t allocN = (size_t)(sp->ringCap_{v} > 0 ? sp->ringCap_{v} : 1);"
         );
-        for arr in &ring.arrays {
-            let _ = writeln!(
-                s,
-                "{pad}  sp->ring_{v}_{arr} = (double *)TA_Malloc( sizeof(double) * allocN );"
-            );
-            let _ = writeln!(s, "{pad}  if( !sp->ring_{v}_{arr} ) {fail}");
-            let _ = writeln!(
-                s,
-                "{pad}  sp->ringMirror_{v}_{arr} = (double *)TA_Malloc( sizeof(double) * allocN );"
-            );
-            let _ = writeln!(s, "{pad}  if( !sp->ringMirror_{v}_{arr} ) {fail}");
-            if with_state {
-                if ring.back > 0 {
-                    let _ = writeln!(s, "{pad}  {{ int fillJ;");
-                    let _ = writeln!(
-                        s,
-                        "{pad}    for( fillJ = historyLen - sp->ringCap_{v}; fillJ < historyLen; fillJ++ )"
-                    );
-                    let _ = writeln!(
-                        s,
-                        "{pad}       sp->ring_{v}_{arr}[fillJ % sp->ringCap_{v}] = {arr}[fillJ];"
-                    );
-                    let _ = writeln!(s, "{pad}  }}");
-                } else {
-                    let _ = writeln!(
-                        s,
-                        "{pad}  memcpy( sp->ring_{v}_{arr}, {arr} + (historyLen - sp->ringCap_{v}), sizeof(double) * (size_t)sp->ringCap_{v} );"
-                    );
-                }
-            } else {
-                // Identity path never reads the ring, but Peek's mirror
-                // memcpy must not copy uninitialized heap (MSan).
-                let _ = writeln!(
-                    s,
-                    "{pad}  memset( sp->ring_{v}_{arr}, 0, sizeof(double) * allocN );"
-                );
-            }
-        }
+        emit_ring_slots(
+            &mut s, ring, v, pad, &fail, with_state, registry, helpers, counter,
+        );
         let _ = writeln!(s, "{pad}}}");
         if ring.back > 0 && with_state {
             let _ = writeln!(s, "{pad}sp->ringPos_{v} = historyLen % sp->ringCap_{v};");

--- a/ta_codegen/generator/src/backends/csharp_stream.rs
+++ b/ta_codegen/generator/src/backends/csharp_stream.rs
@@ -1965,6 +1965,43 @@ fn emit_identity_fast_path(
 /// the still-live batch locals, build the buffers, then store every handle
 /// field. CIRCBUF capture MOVES the batch-materialized storage reference
 /// (contents AND rotation phase — the CCI-class summation-order requirement).
+/// Derived ring (#229): `open` evaluates f(bar) over the history instead of
+/// slicing a raw column that no longer exists under that name.
+fn derived_fill_expr_cs(
+    dr: &streaming::DerivedRing,
+    idx_var: &str,
+    ctx: &CsRenderCtx,
+    registry: &Registry,
+    helpers: &HelperRegistry,
+) -> String {
+    fn reindex(e: &Expr, idx_var: &str) -> Expr {
+        match e {
+            Expr::ArrayAccess(arr, _) => {
+                Expr::ArrayAccess(arr.clone(), Box::new(Expr::Var(idx_var.to_string())))
+            }
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(reindex(lhs, idx_var)),
+                op.clone(),
+                Box::new(reindex(rhs, idx_var)),
+            ),
+            Expr::FuncCall(name, args) => Expr::FuncCall(
+                name.clone(),
+                args.iter().map(|a| reindex(a, idx_var)).collect(),
+            ),
+            Expr::Cast(t, inner) => Expr::Cast(t.clone(), Box::new(reindex(inner, idx_var))),
+            Expr::Not(inner) => Expr::Not(Box::new(reindex(inner, idx_var))),
+            Expr::BitwiseNot(inner) => Expr::BitwiseNot(Box::new(reindex(inner, idx_var))),
+            Expr::Ternary(cond, then_e, else_e) => Expr::Ternary(
+                Box::new(reindex(cond, idx_var)),
+                Box::new(reindex(then_e, idx_var)),
+                Box::new(reindex(else_e, idx_var)),
+            ),
+            other => other.clone(),
+        }
+    }
+    render_expr(&reindex(&dr.expr, idx_var), ctx, registry, helpers)
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn emit_capture(
     o: &mut String,
@@ -2011,6 +2048,19 @@ fn emit_capture(
                     "      for( int fillJ = historyLen - cap_{v}; fillJ < historyLen; fillJ++ ) {{"
                 );
                 let _ = writeln!(o, "         capRing_{v}_{arr}[fillJ % cap_{v}] = {arr}[fillJ];");
+                let _ = writeln!(o, "      }}");
+            } else if let Some(dr) = ring.derived.as_ref() {
+                let empty_fill = HashSet::new();
+                let fill_ctx = stream_ctx(&empty_fill, counter, stream_fma);
+                let rhs = derived_fill_expr_cs(dr, "fillJ", &fill_ctx, registry, helpers);
+                let _ = writeln!(
+                    o,
+                    "      for( int fillJ = historyLen - cap_{v}; fillJ < historyLen; fillJ++ ) {{"
+                );
+                let _ = writeln!(
+                    o,
+                    "         capRing_{v}_{arr}[fillJ - (historyLen - cap_{v})] = {rhs};"
+                );
                 let _ = writeln!(o, "      }}");
             } else {
                 let _ = writeln!(

--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -1645,6 +1645,44 @@ fn capture_value_expr(func: &FuncDef) -> String {
 /// needed in Java), build the buffers, then store every handle field.
 /// CIRCBUF capture MOVES the batch-materialized storage reference (contents
 /// AND rotation phase — the CCI-class summation-order requirement).
+/// Derived ring (#229): `open` evaluates f(bar) over the history instead of
+/// copying a raw column, which no longer exists under that name. Mirrors
+/// `derived_fill_expr` (C) and `derived_fill_expr_rust`.
+fn derived_fill_expr_java(
+    dr: &streaming::DerivedRing,
+    idx_var: &str,
+    ctx: &JavaRenderCtx,
+    registry: &Registry,
+    helpers: &HelperRegistry,
+) -> String {
+    fn reindex(e: &Expr, idx_var: &str) -> Expr {
+        match e {
+            Expr::ArrayAccess(arr, _) => {
+                Expr::ArrayAccess(arr.clone(), Box::new(Expr::Var(idx_var.to_string())))
+            }
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(reindex(lhs, idx_var)),
+                op.clone(),
+                Box::new(reindex(rhs, idx_var)),
+            ),
+            Expr::FuncCall(name, args) => Expr::FuncCall(
+                name.clone(),
+                args.iter().map(|a| reindex(a, idx_var)).collect(),
+            ),
+            Expr::Cast(t, inner) => Expr::Cast(t.clone(), Box::new(reindex(inner, idx_var))),
+            Expr::Not(inner) => Expr::Not(Box::new(reindex(inner, idx_var))),
+            Expr::BitwiseNot(inner) => Expr::BitwiseNot(Box::new(reindex(inner, idx_var))),
+            Expr::Ternary(cond, then_e, else_e) => Expr::Ternary(
+                Box::new(reindex(cond, idx_var)),
+                Box::new(reindex(then_e, idx_var)),
+                Box::new(reindex(else_e, idx_var)),
+            ),
+            other => other.clone(),
+        }
+    }
+    render_expr(&reindex(&dr.expr, idx_var), ctx, registry, helpers)
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn emit_capture(
     o: &mut String,
@@ -1691,6 +1729,19 @@ fn emit_capture(
                     "      for( int fillJ = historyLen - cap_{v}; fillJ < historyLen; fillJ++ ) {{"
                 );
                 let _ = writeln!(o, "         capRing_{v}_{arr}[fillJ % cap_{v}] = {arr}[fillJ];");
+                let _ = writeln!(o, "      }}");
+            } else if let Some(dr) = ring.derived.as_ref() {
+                let empty_fill = HashSet::new();
+                let fill_ctx = stream_ctx(&empty_fill, counter, stream_fma);
+                let rhs = derived_fill_expr_java(dr, "fillJ", &fill_ctx, registry, helpers);
+                let _ = writeln!(
+                    o,
+                    "      for( int fillJ = historyLen - cap_{v}; fillJ < historyLen; fillJ++ ) {{"
+                );
+                let _ = writeln!(
+                    o,
+                    "         capRing_{v}_{arr}[fillJ - (historyLen - cap_{v})] = {rhs};"
+                );
                 let _ = writeln!(o, "      }}");
             } else {
                 let _ = writeln!(

--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -1708,6 +1708,52 @@ fn emit_identity_fast_path(
 /// with the state-struct literal. CIRCBUF capture MOVES the batch-materialized
 /// storage (contents AND rotation phase — the CCI-class summation-order
 /// requirement) instead of copying.
+/// A derived ring (#229) stores one scalar per bar, so `open` evaluates the
+/// expression over the history instead of copying a raw column. Mirrors
+/// `derived_fill_expr` in the C backend; both re-index every array read to the
+/// fill loop's counter.
+fn derived_fill_expr_rust(
+    dr: &streaming::DerivedRing,
+    idx_var: &str,
+    typing: &Typing,
+    opt_real_params: &[String],
+    registry: &Registry,
+    helpers: &HelperRegistry,
+) -> String {
+    fn reindex(e: &Expr, idx_var: &str) -> Expr {
+        match e {
+            Expr::ArrayAccess(arr, _) => {
+                Expr::ArrayAccess(arr.clone(), Box::new(Expr::Var(idx_var.to_string())))
+            }
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(reindex(lhs, idx_var)),
+                op.clone(),
+                Box::new(reindex(rhs, idx_var)),
+            ),
+            Expr::FuncCall(name, args) => Expr::FuncCall(
+                name.clone(),
+                args.iter().map(|a| reindex(a, idx_var)).collect(),
+            ),
+            Expr::Cast(t, inner) => Expr::Cast(t.clone(), Box::new(reindex(inner, idx_var))),
+            Expr::Not(inner) => Expr::Not(Box::new(reindex(inner, idx_var))),
+            Expr::BitwiseNot(inner) => Expr::BitwiseNot(Box::new(reindex(inner, idx_var))),
+            Expr::Ternary(cond, then_e, else_e) => Expr::Ternary(
+                Box::new(reindex(cond, idx_var)),
+                Box::new(reindex(then_e, idx_var)),
+                Box::new(reindex(else_e, idx_var)),
+            ),
+            other => other.clone(),
+        }
+    }
+    render_expr(
+        &reindex(&dr.expr, idx_var),
+        &typing.ctx,
+        opt_real_params,
+        registry,
+        helpers,
+    )
+}
+
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn emit_capture(
     o: &mut String,
@@ -1723,6 +1769,12 @@ fn emit_capture(
     let state = state_type_name(func);
     let _ = counter;
 
+    let opt_real_params_cap: Vec<String> = func
+        .optional_inputs
+        .iter()
+        .filter(|p| matches!(p.param_type, ParamType::Real))
+        .map(|p| p.name.clone())
+        .collect();
     for ring in model.rings() {
         let v = &ring.var;
         let back = ring.back;
@@ -1772,6 +1824,24 @@ fn emit_capture(
                 let _ = writeln!(
                     o,
                     "                ring_{v}_{arr}[fillJ % cap_{v} as usize] = {arr}[fillJ];"
+                );
+                let _ = writeln!(o, "                fillJ += 1;");
+                let _ = writeln!(o, "            }}");
+                let _ = writeln!(o, "        }}");
+            } else if let Some(dr) = ring.derived.as_ref() {
+                // Derived ring: evaluate f(bar) per history bar (#229).
+                let rhs = derived_fill_expr_rust(
+                    dr, "fillJ", typing, &opt_real_params_cap, registry, helpers,
+                );
+                let _ = writeln!(o, "        {{");
+                let _ = writeln!(
+                    o,
+                    "            let mut fillJ: usize = historyLen - cap_{v} as usize;"
+                );
+                let _ = writeln!(o, "            while fillJ < historyLen {{");
+                let _ = writeln!(
+                    o,
+                    "                ring_{v}_{arr}[fillJ - (historyLen - cap_{v} as usize)] = {rhs};"
                 );
                 let _ = writeln!(o, "                fillJ += 1;");
                 let _ = writeln!(o, "            }}");

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -89,7 +89,8 @@ pub struct SubLagRing {
 /// slot). Batch code that iterates a buffer in storage order (CCI-class
 /// CIRCBUF sums) has a rotation-phase-dependent FP order and is handled by
 /// the CIRCBUF tranche, not this model.
-#[derive(Debug, Clone, PartialEq, Eq)]
+// No `Eq`: `derived` carries an `Expr`, which holds an f64 literal.
+#[derive(Debug, Clone, PartialEq)]
 pub struct RingSpec {
     /// The batch trailing index variable (dropped from the transition).
     pub var: String,
@@ -104,6 +105,24 @@ pub struct RingSpec {
     /// is >= fwd (batch legality guarantees it; Open re-checks and fails
     /// TA_INTERNAL_ERROR otherwise).
     pub fwd: i64,
+    /// Set when every read through this index is one derived scalar (#229).
+    /// `arrays` then holds the single synthetic slot name and this carries the
+    /// expression to evaluate per bar; `raw_arrays` keeps the columns it reads
+    /// so `open` can still backfill from history.
+    pub derived: Option<DerivedRing>,
+}
+
+/// One trailing index collapsed to a single derived scalar per bar.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DerivedRing {
+    /// Synthetic slot name; the ring buffer is `ring_<var>_<slot>`.
+    pub slot: String,
+    /// The expression, written against the batch index variable. Its array
+    /// reads are all at that index; everything else in it is loop-invariant.
+    pub expr: Expr,
+    /// Columns `expr` reads, in signature order -- needed by the open-time
+    /// backfill, which evaluates `expr` per historical bar instead of copying.
+    pub raw_arrays: Vec<String>,
 }
 
 /// One bounded rescan window: an inner loop reads `in[cursor - w]` where `w`
@@ -1552,9 +1571,25 @@ pub fn analyze_region_scoped<'a>(
         windows: scanned_windows,
         out_index_vars,
     } = scanned;
+    // #229: a trailing index whose arrays are read ONLY through one derived
+    // scalar keeps a single ring of that scalar instead of one ring per array.
+    // `eligible_derived` holds back anything reading candle settings, so this
+    // is AO, AC and QSTICK today -- the candlestick tranche waits on whether a
+    // stream may freeze the range type at Open.
+    let derived_slots: BTreeMap<String, DerivedRing> =
+        eligible_derived(&steady_stmts, &trailing, &bar_inputs);
+    let steady_stmts = fold_derived_reads(&steady_stmts, &derived_slots);
+
     let ring_vars: BTreeSet<String> = trailing.keys().cloned().collect();
     check_window_disjoint(&scanned_windows, &ring_vars, &cursor)?;
-    let rings = assemble_rings(trailing.clone(), &ring_back, &ring_fwd, &bar_inputs);
+    let mut rings = assemble_rings(trailing.clone(), &ring_back, &ring_fwd, &bar_inputs);
+    for ring in &mut rings {
+        if let Some(dr) = derived_slots.get(&ring.var) {
+            ring.arrays = vec![dr.slot.clone()];
+            ring.derived = Some(dr.clone());
+        }
+    }
+    derived_ring_census(&steady_stmts, &trailing, &func.name);
     let windows = assemble_windows(scanned_windows, &bar_inputs);
 
     let out_feedback = collect_out_feedback(&steady_stmts, &outputs);
@@ -1578,7 +1613,17 @@ pub fn analyze_region_scoped<'a>(
         parity_field: parity.as_ref().map(|p| p.field.as_str()),
     };
     let (extrema, (mut state, temps)) =
-        classify_or_extrema(&ctx, &ring_vars, &trailing, &windows, &circs)?;
+        classify_or_extrema(
+            &ctx,
+            &derived_slots
+                .values()
+                .map(|d| d.slot.clone())
+                .collect::<BTreeSet<_>>(),
+            &ring_vars,
+            &trailing,
+            &windows,
+            &circs,
+        )?;
     force_circ_index_state(&circs, &mut state, &temps);
     // The carried parity field is synthetic (no VarDecl): classify_locals skips
     // it, so append it as an ordinary int state field here (emitter seeds/flips
@@ -3946,6 +3991,7 @@ type Classified = (Vec<ScalarField>, Vec<ScalarField>);
 /// ring.
 fn classify_or_extrema(
     ctx: &ClassifyCtx,
+    derived_slots: &BTreeSet<String>,
     ring_vars: &BTreeSet<String>,
     trailing: &BTreeMap<String, BTreeSet<String>>,
     windows: &[WindowSpec],
@@ -3964,6 +4010,7 @@ fn classify_or_extrema(
             ctx.outputs,
             ctx.circ_extra,
             ctx.parity_field,
+            derived_slots,
         )
     };
     match run(ring_vars) {
@@ -4230,6 +4277,373 @@ fn derive_tier(
     }
 }
 
+/// How a subtree relates to one trailing index.
+enum VShape {
+    /// Contains no read at this index.
+    None,
+    /// Contains reads at this index, and the WHOLE subtree is a function of
+    /// that bar alone: every array read in it is at this index, and every
+    /// other leaf is a literal or a loop-invariant scalar.
+    Derived,
+    /// Contains reads at this index but is not a function of that bar alone --
+    /// it also reads another bar, or a loop-carried scalar.
+    Mixed,
+}
+
+/// Classify `expr` against trailing var `var`, collecting the MAXIMAL `Derived`
+/// subtrees. A subtree is maximal when it is Derived and its parent is not.
+fn classify_v(
+    expr: &Expr,
+    var: &str,
+    assigned: &BTreeSet<String>,
+    pure_calls: &BTreeSet<String>,
+    out: &mut Vec<Expr>,
+) -> VShape {
+    let kids: Vec<&Expr> = match expr {
+        Expr::ArrayAccess(_, idx) => {
+            // A read at `var` is Derived on its own; a read at any other index
+            // is Mixed -- it is another bar, so nothing here is a function of
+            // the trailing one.
+            return if expr_mentions(idx, var) {
+                VShape::Derived
+            } else {
+                VShape::Mixed
+            };
+        }
+        Expr::Literal(_) | Expr::IntLiteral(_) => return VShape::None,
+        Expr::Var(name) | Expr::PointerDeref(name) => {
+            // Written in the loop -> loop-carried, so a subtree naming it is
+            // not a function of the trailing bar. Everything else (parameters,
+            // settings, lookback constants) is invariant and harmless.
+            return if assigned.contains(name) {
+                VShape::Mixed
+            } else {
+                VShape::None
+            };
+        }
+        Expr::FuncCall(name, args) => {
+            if !pure_calls.contains(name) {
+                // Unknown callee: refuse to reason through it, but the args it
+                // was given may still hold maximal derived subtrees.
+                for arg in args {
+                    if matches!(
+                        classify_v(arg, var, assigned, pure_calls, out),
+                        VShape::Derived
+                    ) {
+                        out.push(arg.clone());
+                    }
+                }
+                return VShape::Mixed;
+            }
+            args.iter().collect()
+        }
+        Expr::BinOp(lhs, _, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+        Expr::Cast(_, inner)
+        | Expr::Not(inner)
+        | Expr::BitwiseNot(inner)
+        | Expr::AddressOf(inner) => vec![inner.as_ref()],
+        Expr::PostIncrement(inner)
+        | Expr::PostDecrement(inner)
+        | Expr::PreIncrement(inner)
+        | Expr::PreDecrement(inner) => {
+            // Mutating: never fold one into a ring.
+            if matches!(
+                classify_v(inner, var, assigned, pure_calls, out),
+                VShape::Derived
+            ) {
+                out.push((**inner).clone());
+            }
+            return VShape::Mixed;
+        }
+        Expr::Ternary(cond, then_e, else_e) => {
+            vec![cond.as_ref(), then_e.as_ref(), else_e.as_ref()]
+        }
+    };
+    let shapes: Vec<VShape> = kids
+        .iter()
+        .map(|kid| classify_v(kid, var, assigned, pure_calls, out))
+        .collect();
+    let any_derived = shapes.iter().any(|sh| matches!(sh, VShape::Derived));
+    let any_mixed = shapes.iter().any(|sh| matches!(sh, VShape::Mixed));
+    if any_derived && !any_mixed {
+        VShape::Derived
+    } else if any_derived || any_mixed {
+        // This node breaks the chain, so every Derived child was maximal.
+        for (kid, sh) in kids.iter().zip(shapes.iter()) {
+            if matches!(sh, VShape::Derived) {
+                out.push((*kid).clone());
+            }
+        }
+        VShape::Mixed
+    } else {
+        VShape::None
+    }
+}
+
+/// Names written anywhere in the steady loop -- everything else a scalar leaf
+/// can name is loop-invariant (a parameter, a setting, a lookback constant).
+fn assigned_in(stmts: &[Statement]) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for st in stmts {
+        walk_stmt_targets(st, &mut out);
+    }
+    out
+}
+
+fn walk_stmt_targets(s: &Statement, out: &mut BTreeSet<String>) {
+    if let Statement::Assign { target, .. } = s {
+        expr_var_names(target, out);
+    }
+    if let Statement::VarDecl { name, .. } = s {
+        out.insert(name.clone());
+    }
+    walk_stmt_exprs(s, &mut |e| {
+        walk_expr(e, &mut |x| match x {
+            Expr::PostIncrement(t)
+            | Expr::PostDecrement(t)
+            | Expr::PreIncrement(t)
+            | Expr::PreDecrement(t) => expr_var_names(t, out),
+            _ => {}
+        });
+    });
+    match s {
+        Statement::While { body, .. } | Statement::DoWhile { body, .. } => {
+            for b in body {
+                walk_stmt_targets(b, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Helpers are pure functions of their arguments -- all fourteen in
+/// `input/helpers/` are single-expression or local-only bodies with no state.
+/// Listed rather than inferred for now; the analysis refuses any callee not
+/// named here, so an unlisted helper costs an optimization, never a wrong
+/// answer.
+fn pure_helper_names() -> BTreeSet<String> {
+    [
+        "ta_realbody",
+        "ta_candlecolor",
+        "ta_uppershadow",
+        "ta_lowershadow",
+        "ta_highlowrange",
+        "ta_realbodygapup",
+        "ta_realbodygapdown",
+        "ta_candlegapup",
+        "ta_candlegapdown",
+        "ta_candlerange",
+        "ta_true_range",
+        "ta_round_pos",
+        "ta_sar_rounding",
+    ]
+    .iter()
+    .map(|s| (*s).to_string())
+    .collect()
+}
+
+/// Two derived reads through the same trailing index differ only by the offset
+/// when they are the same function of a bar read at `v`, `v-4`, `v+1`, ...
+/// CDLMORNINGSTAR subtracts `ta_candlerange(..., [T])` and
+/// `ta_candlerange(..., [T+1])`; CDLRISEFALL3METHODS spans `[T-4]` to `[T]`.
+/// A ring already addresses multiple offsets through `back`/`fwd`, so the
+/// shape is compared with the index blanked out and the offsets recorded
+/// separately -- otherwise one derived function reads as several and the
+/// collapse is refused for the three functions that need it most.
+fn shape_key(e: &Expr) -> String {
+    fn blank(e: &Expr) -> Expr {
+        match e {
+            Expr::ArrayAccess(a, _) => Expr::ArrayAccess(a.clone(), Box::new(Expr::IntLiteral(0))),
+            Expr::BinOp(l, op, r) => {
+                Expr::BinOp(Box::new(blank(l)), op.clone(), Box::new(blank(r)))
+            }
+            Expr::FuncCall(n, args) => {
+                Expr::FuncCall(n.clone(), args.iter().map(blank).collect())
+            }
+            Expr::Cast(t, x) => Expr::Cast(t.clone(), Box::new(blank(x))),
+            Expr::Not(x) => Expr::Not(Box::new(blank(x))),
+            Expr::BitwiseNot(x) => Expr::BitwiseNot(Box::new(blank(x))),
+            Expr::Ternary(c, t, f) => Expr::Ternary(
+                Box::new(blank(c)),
+                Box::new(blank(t)),
+                Box::new(blank(f)),
+            ),
+            other => other.clone(),
+        }
+    }
+    format!("{:?}", blank(e))
+}
+
+/// #229: for each trailing index carrying more than one array, the distinct
+/// maximal derived subtrees its reads sit in. One shape covering every read
+/// means one ring of that scalar replaces the per-array rings.
+fn derived_ring_census(
+    stmts: &[Statement],
+    trailing: &BTreeMap<String, BTreeSet<String>>,
+    fname: &str,
+) {
+    if std::env::var("TA_RING_REPORT").is_err() {
+        return;
+    }
+    let assigned = assigned_in(stmts);
+    let pure = pure_helper_names();
+    for (v, arrs) in trailing {
+        if arrs.len() < 2 {
+            continue;
+        }
+        let mut shapes: Vec<Expr> = Vec::new();
+        for st in stmts {
+            walk_stmt_exprs(st, &mut |e| {
+                let mut found = Vec::new();
+                let sh = classify_v(e, v, &assigned, &pure, &mut found);
+                if matches!(sh, VShape::Derived) {
+                    found.push(e.clone());
+                }
+                shapes.extend(found);
+            });
+        }
+        let mut uniq: Vec<String> = shapes.iter().map(shape_key).collect();
+        uniq.sort();
+        uniq.dedup();
+        let saving = if uniq.len() == 1 && arrs.len() > 1 {
+            arrs.len() - 1
+        } else {
+            0
+        };
+        eprintln!(
+            "DERIVED\t{fname}\t{v}\tarrays={}\tshapes={}\tsaving={saving}",
+            arrs.len(),
+            uniq.len()
+        );
+    }
+}
+
+/// Candle settings reach an expression as `<Setting>_rangeType` and friends,
+/// resolved from the mutable globals. A derived ring freezes whatever they say
+/// when the bar is buffered, which is a semantic question rather than a
+/// mechanical one (#229), so expressions naming them are held back until that
+/// is settled. Everything else -- AO's `(high+low)/2`, QSTICK's `close-open` --
+/// is a pure function of the bar and can be collapsed today.
+fn mentions_candle_settings(e: &Expr) -> bool {
+    let mut found = false;
+    walk_expr(e, &mut |x| {
+        if let Expr::Var(n) = x {
+            if n.ends_with("_rangeType") || n.ends_with("_avgPeriod") || n.ends_with("_factor") {
+                found = true;
+            }
+        }
+    });
+    found
+}
+
+/// The eligible derived rings: one shape covering every read at that index,
+/// more than one array behind it, and no settings dependency.
+fn eligible_derived(
+    stmts: &[Statement],
+    trailing: &BTreeMap<String, BTreeSet<String>>,
+    bar_inputs: &[String],
+) -> BTreeMap<String, DerivedRing> {
+    let assigned = assigned_in(stmts);
+    let pure = pure_helper_names();
+    let mut out = BTreeMap::new();
+    for (v, arrs) in trailing {
+        if arrs.len() < 2 {
+            continue;
+        }
+        let mut shapes: Vec<Expr> = Vec::new();
+        for st in stmts {
+            walk_stmt_exprs(st, &mut |e| {
+                let mut found = Vec::new();
+                let sh = classify_v(e, v, &assigned, &pure, &mut found);
+                if matches!(sh, VShape::Derived) {
+                    found.push(e.clone());
+                }
+                shapes.extend(found);
+            });
+        }
+        if shapes.is_empty() {
+            continue;
+        }
+        let mut keys: Vec<String> = shapes.iter().map(shape_key).collect();
+        keys.sort();
+        keys.dedup();
+        if keys.len() != 1 {
+            continue;
+        }
+        let expr = shapes[0].clone();
+        if mentions_candle_settings(&expr) {
+            continue;
+        }
+        let mut raw: BTreeSet<String> = BTreeSet::new();
+        walk_expr(&expr, &mut |x| {
+            if let Expr::ArrayAccess(n, _) = x {
+                raw.insert(n.clone());
+            }
+        });
+        let raw_arrays: Vec<String> = bar_inputs
+            .iter()
+            .filter(|a| raw.contains(*a))
+            .cloned()
+            .collect();
+        if raw_arrays.len() < 2 {
+            continue;
+        }
+        out.insert(
+            v.clone(),
+            DerivedRing {
+                slot: "derived".to_string(),
+                expr,
+                raw_arrays,
+            },
+        );
+    }
+    out
+}
+
+/// Replace every maximal derived subtree at `var` with a read of the synthetic
+/// slot, keeping the original index expression so `classify_input_index` still
+/// resolves it to the same ring and `ring_offset_read` needs no change.
+///
+/// Must run BEFORE `rewrite_bar_reads`: that pass is bottom-up, so by the time
+/// it reaches the enclosing `FuncCall` its `ArrayAccess` children are already
+/// ring reads and the shape is gone. `rewrite_stmts` is bottom-up too, which is
+/// safe here only because the match is on the WHOLE shape -- a child of
+/// `ta_candlerange(...)` keys as `ArrayAccess(inOpen, _)` and cannot collide
+/// with the call's own key.
+fn fold_derived_reads(
+    stmts: &[Statement],
+    derived: &BTreeMap<String, DerivedRing>,
+) -> Vec<Statement> {
+    let mut cur = stmts.to_vec();
+    for (var, dr) in derived {
+        let key = shape_key(&dr.expr);
+        let var = var.clone();
+        let slot = dr.slot.clone();
+        cur = rewrite_stmts(
+            &cur,
+            &move |e: Expr| {
+                if shape_key(&e) != key {
+                    return e;
+                }
+                let mut idx: Option<Expr> = None;
+                walk_expr(&e, &mut |x| {
+                    if let Expr::ArrayAccess(_, i) = x {
+                        if idx.is_none() && expr_mentions(i, &var) {
+                            idx = Some((**i).clone());
+                        }
+                    }
+                });
+                match idx {
+                    Some(i) => Expr::ArrayAccess(slot.clone(), Box::new(i)),
+                    None => e,
+                }
+            },
+            &Some,
+        );
+    }
+    cur
+}
+
 /// Rings in a stable order: by variable name, arrays in signature order.
 fn assemble_rings(
     trailing: BTreeMap<String, BTreeSet<String>>,
@@ -4240,6 +4654,7 @@ fn assemble_rings(
     trailing
         .into_iter()
         .map(|(var, arrs)| RingSpec {
+            derived: None,
             back: ring_back
                 .get(&var)
                 .copied()
@@ -4290,6 +4705,9 @@ fn classify_locals(
     outputs: &[String],
     circ_extra: &[(String, VarType)],
     parity_field: Option<&str>,
+    // #229 synthetic slots: a folded derived ring reads `slot[trailingIdx]`,
+    // which is a real reference in the loop but never a declared symbol.
+    derived_slots: &BTreeSet<String>,
 ) -> Result<(Vec<ScalarField>, Vec<ScalarField>), StreamError> {
     let mut decls = BTreeMap::new();
     collect_var_decls(body, &mut decls);
@@ -4350,6 +4768,7 @@ fn classify_locals(
             || circ_buffers.contains(v)
             || param_names.contains(v)
             || bar_inputs.contains(v)
+            || derived_slots.contains(v)
             || outputs.contains(v)
             || candle_locals.contains(v)
             || Some(v.as_str()) == parity_field
@@ -5162,7 +5581,10 @@ fn insert_transition_prologue(
                             names.ring_buf(&ring.var, arr),
                             Box::new(Expr::Var(names.ring_pos(&ring.var))),
                         ),
-                        value: Expr::Var(names.bar(arr)),
+                        value: match &ring.derived {
+                            Some(dr) => derived_bar_value(dr, names),
+                            None => Expr::Var(names.bar(arr)),
+                        },
                         compound: false,
                     },
                 );
@@ -5562,6 +5984,80 @@ fn ring_offset_read(
     )
 }
 
+/// Is `name` the synthetic slot of some derived ring (#229)?
+fn is_derived_slot(model: &StreamModel, name: &str) -> bool {
+    model
+        .rings()
+        .iter()
+        .any(|r| r.derived.as_ref().is_some_and(|d| d.slot == name))
+}
+
+/// Resolve a read of a derived slot to the ring slot that holds it. The index
+/// expression is the batch's own, so this is the same resolution the raw
+/// columns get -- only the buffer name differs.
+fn derived_slot_read(
+    slot: &str,
+    idx: &Expr,
+    model: &StreamModel,
+    names: &dyn NameMap,
+) -> Option<Expr> {
+    let find = |v: &str| model.rings().iter().find(|r| r.var == v);
+    match classify_input_index(idx, &model.cursor) {
+        InputIndex::OtherVar(v) => {
+            let ring = find(&v)?;
+            Some(if ring.back > 0 {
+                ring_offset_read(ring, slot, Some(0), None, names)
+            } else {
+                Expr::ArrayAccess(
+                    names.ring_buf(&v, slot),
+                    Box::new(Expr::Var(names.ring_pos(&v))),
+                )
+            })
+        }
+        InputIndex::OtherVarLag(v, k) => {
+            Some(ring_offset_read(find(&v)?, slot, Some(k), None, names))
+        }
+        InputIndex::OtherVarWinLag(v, w) => Some(ring_offset_read(
+            find(&v)?,
+            slot,
+            None,
+            Some(Expr::Var(w)),
+            names,
+        )),
+        _ => None,
+    }
+}
+
+/// The value a derived ring stores for the CURRENT bar: the expression with
+/// every `in<Array>[idx]` swapped for the scalar `update` parameter carrying
+/// that array's bar. Same operations on the same doubles as the batch performs
+/// at subtraction time, which is what keeps the collapse bit-exact.
+fn derived_bar_value(dr: &DerivedRing, names: &dyn NameMap) -> Expr {
+    fn go(e: &Expr, names: &dyn NameMap) -> Expr {
+        match e {
+            Expr::ArrayAccess(arr, _) => Expr::Var(names.bar(arr)),
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(go(lhs, names)),
+                op.clone(),
+                Box::new(go(rhs, names)),
+            ),
+            Expr::FuncCall(name, args) => {
+                Expr::FuncCall(name.clone(), args.iter().map(|a| go(a, names)).collect())
+            }
+            Expr::Cast(t, inner) => Expr::Cast(t.clone(), Box::new(go(inner, names))),
+            Expr::Not(inner) => Expr::Not(Box::new(go(inner, names))),
+            Expr::BitwiseNot(inner) => Expr::BitwiseNot(Box::new(go(inner, names))),
+            Expr::Ternary(cond, then_e, else_e) => Expr::Ternary(
+                Box::new(go(cond, names)),
+                Box::new(go(then_e, names)),
+                Box::new(go(else_e, names)),
+            ),
+            other => other.clone(),
+        }
+    }
+    go(&dr.expr, names)
+}
+
 /// `if (cap == 0) ring[0] = bar;` for every array of a ring — makes the
 /// zero-lag degenerate case read the current bar through the same slot.
 fn ring_cap0_guard(ring: &RingSpec, names: &dyn NameMap) -> Statement {
@@ -5573,7 +6069,10 @@ fn ring_cap0_guard(ring: &RingSpec, names: &dyn NameMap) -> Statement {
                 names.ring_buf(&ring.var, arr),
                 Box::new(Expr::IntLiteral(0)),
             ),
-            value: Expr::Var(names.bar(arr)),
+            value: match &ring.derived {
+                Some(dr) => derived_bar_value(dr, names),
+                None => Expr::Var(names.bar(arr)),
+            },
             compound: false,
         })
         .collect();
@@ -5603,6 +6102,9 @@ fn ring_cap0_guard(ring: &RingSpec, names: &dyn NameMap) -> Statement {
 /// mutually-exclusive arms of the period branch — one per path, not two per
 /// bar.)
 fn push_ring_advance(out: &mut Vec<Statement>, ring: &RingSpec, names: &dyn NameMap) {
+    // The dead-store elision above is orthogonal to what gets stored: a derived
+    // ring holds f(bar) rather than a raw column, so the value still comes from
+    // the expression when there is one.
     if ring.back == 0 {
         for arr in &ring.arrays {
             out.push(Statement::Assign {
@@ -5610,7 +6112,10 @@ fn push_ring_advance(out: &mut Vec<Statement>, ring: &RingSpec, names: &dyn Name
                     names.ring_buf(&ring.var, arr),
                     Box::new(Expr::Var(names.ring_pos(&ring.var))),
                 ),
-                value: Expr::Var(names.bar(arr)),
+                value: match &ring.derived {
+                    Some(dr) => derived_bar_value(dr, names),
+                    None => Expr::Var(names.bar(arr)),
+                },
                 compound: false,
             });
         }
@@ -5662,6 +6167,11 @@ fn rewrite_expr_for_transition(
         }
         Expr::ArrayAccess(n, idx) if state_names.contains(&n) => {
             Expr::ArrayAccess(names.state(&n), idx)
+        }
+        // #229 derived slot: not a real input column, so it must be matched
+        // before the bar-input arm and resolved by the ring it belongs to.
+        Expr::ArrayAccess(ref n, ref idx) if is_derived_slot(model, n) => {
+            derived_slot_read(n, idx, model, names).unwrap_or(e)
         }
         Expr::ArrayAccess(n, idx) if model.bar_inputs.contains(&n) => {
             match classify_input_index(&idx, &model.cursor) {

--- a/ta_codegen/output/csharp/library/src/Core_AC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AC.cs
@@ -595,12 +595,10 @@ public partial class Core
       internal int maxIdx_oscBuffer;
       internal int ringPos_trailingFastIdx;
       internal int ringCap_trailingFastIdx;
-      internal double[] ring_trailingFastIdx_inHigh = [];
-      internal double[] ring_trailingFastIdx_inLow = [];
+      internal double[] ring_trailingFastIdx_derived = [];
       internal int ringPos_trailingSlowIdx;
       internal int ringCap_trailingSlowIdx;
-      internal double[] ring_trailingSlowIdx_inHigh = [];
-      internal double[] ring_trailingSlowIdx_inLow = [];
+      internal double[] ring_trailingSlowIdx_derived = [];
       internal int cbSize_oscBuffer;
       internal double[] cb_oscBuffer = [];
       internal double cur_outReal;
@@ -631,16 +629,12 @@ public partial class Core
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = new double[other.ring_trailingFastIdx_inHigh.Length];
-         Array.Copy( other.ring_trailingFastIdx_inHigh, this.ring_trailingFastIdx_inHigh, other.ring_trailingFastIdx_inHigh.Length );
-         this.ring_trailingFastIdx_inLow = new double[other.ring_trailingFastIdx_inLow.Length];
-         Array.Copy( other.ring_trailingFastIdx_inLow, this.ring_trailingFastIdx_inLow, other.ring_trailingFastIdx_inLow.Length );
+         this.ring_trailingFastIdx_derived = new double[other.ring_trailingFastIdx_derived.Length];
+         Array.Copy( other.ring_trailingFastIdx_derived, this.ring_trailingFastIdx_derived, other.ring_trailingFastIdx_derived.Length );
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = new double[other.ring_trailingSlowIdx_inHigh.Length];
-         Array.Copy( other.ring_trailingSlowIdx_inHigh, this.ring_trailingSlowIdx_inHigh, other.ring_trailingSlowIdx_inHigh.Length );
-         this.ring_trailingSlowIdx_inLow = new double[other.ring_trailingSlowIdx_inLow.Length];
-         Array.Copy( other.ring_trailingSlowIdx_inLow, this.ring_trailingSlowIdx_inLow, other.ring_trailingSlowIdx_inLow.Length );
+         this.ring_trailingSlowIdx_derived = new double[other.ring_trailingSlowIdx_derived.Length];
+         Array.Copy( other.ring_trailingSlowIdx_derived, this.ring_trailingSlowIdx_derived, other.ring_trailingSlowIdx_derived.Length );
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          this.cb_oscBuffer = new double[other.cb_oscBuffer.Length];
          Array.Copy( other.cb_oscBuffer, this.cb_oscBuffer, other.cb_oscBuffer.Length );
@@ -663,24 +657,16 @@ public partial class Core
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh.Length != other.ring_trailingFastIdx_inHigh.Length ) {
-            this.ring_trailingFastIdx_inHigh = new double[other.ring_trailingFastIdx_inHigh.Length];
+         if( this.ring_trailingFastIdx_derived.Length != other.ring_trailingFastIdx_derived.Length ) {
+            this.ring_trailingFastIdx_derived = new double[other.ring_trailingFastIdx_derived.Length];
          }
-         Array.Copy( other.ring_trailingFastIdx_inHigh, this.ring_trailingFastIdx_inHigh, other.ring_trailingFastIdx_inHigh.Length );
-         if( this.ring_trailingFastIdx_inLow.Length != other.ring_trailingFastIdx_inLow.Length ) {
-            this.ring_trailingFastIdx_inLow = new double[other.ring_trailingFastIdx_inLow.Length];
-         }
-         Array.Copy( other.ring_trailingFastIdx_inLow, this.ring_trailingFastIdx_inLow, other.ring_trailingFastIdx_inLow.Length );
+         Array.Copy( other.ring_trailingFastIdx_derived, this.ring_trailingFastIdx_derived, other.ring_trailingFastIdx_derived.Length );
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh.Length != other.ring_trailingSlowIdx_inHigh.Length ) {
-            this.ring_trailingSlowIdx_inHigh = new double[other.ring_trailingSlowIdx_inHigh.Length];
+         if( this.ring_trailingSlowIdx_derived.Length != other.ring_trailingSlowIdx_derived.Length ) {
+            this.ring_trailingSlowIdx_derived = new double[other.ring_trailingSlowIdx_derived.Length];
          }
-         Array.Copy( other.ring_trailingSlowIdx_inHigh, this.ring_trailingSlowIdx_inHigh, other.ring_trailingSlowIdx_inHigh.Length );
-         if( this.ring_trailingSlowIdx_inLow.Length != other.ring_trailingSlowIdx_inLow.Length ) {
-            this.ring_trailingSlowIdx_inLow = new double[other.ring_trailingSlowIdx_inLow.Length];
-         }
-         Array.Copy( other.ring_trailingSlowIdx_inLow, this.ring_trailingSlowIdx_inLow, other.ring_trailingSlowIdx_inLow.Length );
+         Array.Copy( other.ring_trailingSlowIdx_derived, this.ring_trailingSlowIdx_derived, other.ring_trailingSlowIdx_derived.Length );
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          if( this.cb_oscBuffer.Length != other.cb_oscBuffer.Length ) {
             this.cb_oscBuffer = new double[other.cb_oscBuffer.Length];
@@ -760,12 +746,10 @@ public partial class Core
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -774,8 +758,8 @@ public partial class Core
        * mirroring the add-new / snapshot / subtract-old order of TA_SMA.
        */
       sp.osc = sp.sumFast / (double)sp.optInFastPeriod - sp.sumSlow / (double)sp.optInSlowPeriod;
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       /* Today's oscillator enters the signal window at its own slot, and the
        * bar leaving that window is read only after the ring has advanced onto
        * it -- writing first is what makes the slot the loop is about to
@@ -798,14 +782,12 @@ public partial class Core
        * the collision ao.c has to guard against.
        */
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -999,19 +981,19 @@ public partial class Core
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      inHigh.Slice(historyLen - cap_trailingFastIdx, cap_trailingFastIdx).CopyTo(capRing_trailingFastIdx_inHigh);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      inLow.Slice(historyLen - cap_trailingFastIdx, cap_trailingFastIdx).CopyTo(capRing_trailingFastIdx_inLow);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      inHigh.Slice(historyLen - cap_trailingSlowIdx, cap_trailingSlowIdx).CopyTo(capRing_trailingSlowIdx_inHigh);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      inLow.Slice(historyLen - cap_trailingSlowIdx, cap_trailingSlowIdx).CopyTo(capRing_trailingSlowIdx_inLow);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int capCb_oscBuffer = maxIdx_oscBuffer + 1;
       if( capCb_oscBuffer > historyLen + 1 ) {
          return RetCode.InternalError;
@@ -1028,12 +1010,10 @@ public partial class Core
       sp.maxIdx_oscBuffer = maxIdx_oscBuffer;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cbSize_oscBuffer = capCb_oscBuffer;
       sp.cb_oscBuffer = oscBuffer;
       sp.cur_outReal = outReal[(outNBElement - 1) * outStride];

--- a/ta_codegen/output/csharp/library/src/Core_AO.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AO.cs
@@ -479,12 +479,10 @@ public partial class Core
       internal double tempReal;
       internal int ringPos_trailingFastIdx;
       internal int ringCap_trailingFastIdx;
-      internal double[] ring_trailingFastIdx_inHigh = [];
-      internal double[] ring_trailingFastIdx_inLow = [];
+      internal double[] ring_trailingFastIdx_derived = [];
       internal int ringPos_trailingSlowIdx;
       internal int ringCap_trailingSlowIdx;
-      internal double[] ring_trailingSlowIdx_inHigh = [];
-      internal double[] ring_trailingSlowIdx_inLow = [];
+      internal double[] ring_trailingSlowIdx_derived = [];
       internal double cur_outReal;
       internal OutRange fillRange = OutRange.Empty;
 
@@ -508,16 +506,12 @@ public partial class Core
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = new double[other.ring_trailingFastIdx_inHigh.Length];
-         Array.Copy( other.ring_trailingFastIdx_inHigh, this.ring_trailingFastIdx_inHigh, other.ring_trailingFastIdx_inHigh.Length );
-         this.ring_trailingFastIdx_inLow = new double[other.ring_trailingFastIdx_inLow.Length];
-         Array.Copy( other.ring_trailingFastIdx_inLow, this.ring_trailingFastIdx_inLow, other.ring_trailingFastIdx_inLow.Length );
+         this.ring_trailingFastIdx_derived = new double[other.ring_trailingFastIdx_derived.Length];
+         Array.Copy( other.ring_trailingFastIdx_derived, this.ring_trailingFastIdx_derived, other.ring_trailingFastIdx_derived.Length );
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = new double[other.ring_trailingSlowIdx_inHigh.Length];
-         Array.Copy( other.ring_trailingSlowIdx_inHigh, this.ring_trailingSlowIdx_inHigh, other.ring_trailingSlowIdx_inHigh.Length );
-         this.ring_trailingSlowIdx_inLow = new double[other.ring_trailingSlowIdx_inLow.Length];
-         Array.Copy( other.ring_trailingSlowIdx_inLow, this.ring_trailingSlowIdx_inLow, other.ring_trailingSlowIdx_inLow.Length );
+         this.ring_trailingSlowIdx_derived = new double[other.ring_trailingSlowIdx_derived.Length];
+         Array.Copy( other.ring_trailingSlowIdx_derived, this.ring_trailingSlowIdx_derived, other.ring_trailingSlowIdx_derived.Length );
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -532,24 +526,16 @@ public partial class Core
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh.Length != other.ring_trailingFastIdx_inHigh.Length ) {
-            this.ring_trailingFastIdx_inHigh = new double[other.ring_trailingFastIdx_inHigh.Length];
+         if( this.ring_trailingFastIdx_derived.Length != other.ring_trailingFastIdx_derived.Length ) {
+            this.ring_trailingFastIdx_derived = new double[other.ring_trailingFastIdx_derived.Length];
          }
-         Array.Copy( other.ring_trailingFastIdx_inHigh, this.ring_trailingFastIdx_inHigh, other.ring_trailingFastIdx_inHigh.Length );
-         if( this.ring_trailingFastIdx_inLow.Length != other.ring_trailingFastIdx_inLow.Length ) {
-            this.ring_trailingFastIdx_inLow = new double[other.ring_trailingFastIdx_inLow.Length];
-         }
-         Array.Copy( other.ring_trailingFastIdx_inLow, this.ring_trailingFastIdx_inLow, other.ring_trailingFastIdx_inLow.Length );
+         Array.Copy( other.ring_trailingFastIdx_derived, this.ring_trailingFastIdx_derived, other.ring_trailingFastIdx_derived.Length );
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh.Length != other.ring_trailingSlowIdx_inHigh.Length ) {
-            this.ring_trailingSlowIdx_inHigh = new double[other.ring_trailingSlowIdx_inHigh.Length];
+         if( this.ring_trailingSlowIdx_derived.Length != other.ring_trailingSlowIdx_derived.Length ) {
+            this.ring_trailingSlowIdx_derived = new double[other.ring_trailingSlowIdx_derived.Length];
          }
-         Array.Copy( other.ring_trailingSlowIdx_inHigh, this.ring_trailingSlowIdx_inHigh, other.ring_trailingSlowIdx_inHigh.Length );
-         if( this.ring_trailingSlowIdx_inLow.Length != other.ring_trailingSlowIdx_inLow.Length ) {
-            this.ring_trailingSlowIdx_inLow = new double[other.ring_trailingSlowIdx_inLow.Length];
-         }
-         Array.Copy( other.ring_trailingSlowIdx_inLow, this.ring_trailingSlowIdx_inLow, other.ring_trailingSlowIdx_inLow.Length );
+         Array.Copy( other.ring_trailingSlowIdx_derived, this.ring_trailingSlowIdx_derived, other.ring_trailingSlowIdx_derived.Length );
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -624,12 +610,10 @@ public partial class Core
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -644,17 +628,15 @@ public partial class Core
        * value it had just overwritten whenever the caller aliases outReal
        * over inHigh or inLow.
        */
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -794,19 +776,19 @@ public partial class Core
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      inHigh.Slice(historyLen - cap_trailingFastIdx, cap_trailingFastIdx).CopyTo(capRing_trailingFastIdx_inHigh);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      inLow.Slice(historyLen - cap_trailingFastIdx, cap_trailingFastIdx).CopyTo(capRing_trailingFastIdx_inLow);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      inHigh.Slice(historyLen - cap_trailingSlowIdx, cap_trailingSlowIdx).CopyTo(capRing_trailingSlowIdx_inHigh);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      inLow.Slice(historyLen - cap_trailingSlowIdx, cap_trailingSlowIdx).CopyTo(capRing_trailingSlowIdx_inLow);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       sp.optInFastPeriod = optInFastPeriod;
       sp.optInSlowPeriod = optInSlowPeriod;
       sp.sumFast = sumFast;
@@ -814,12 +796,10 @@ public partial class Core
       sp.tempReal = tempReal;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cur_outReal = outReal[(outNBElement - 1) * outStride];
       return RetCode.Success;
    }

--- a/ta_codegen/output/csharp/library/src/Core_QSTICK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_QSTICK.cs
@@ -377,8 +377,7 @@ public partial class Core
       internal double tempReal;
       internal int ringPos_trailingIdx;
       internal int ringCap_trailingIdx;
-      internal double[] ring_trailingIdx_inOpen = [];
-      internal double[] ring_trailingIdx_inClose = [];
+      internal double[] ring_trailingIdx_derived = [];
       internal double cur_outReal;
       internal OutRange fillRange = OutRange.Empty;
 
@@ -401,10 +400,8 @@ public partial class Core
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         this.ring_trailingIdx_inOpen = new double[other.ring_trailingIdx_inOpen.Length];
-         Array.Copy( other.ring_trailingIdx_inOpen, this.ring_trailingIdx_inOpen, other.ring_trailingIdx_inOpen.Length );
-         this.ring_trailingIdx_inClose = new double[other.ring_trailingIdx_inClose.Length];
-         Array.Copy( other.ring_trailingIdx_inClose, this.ring_trailingIdx_inClose, other.ring_trailingIdx_inClose.Length );
+         this.ring_trailingIdx_derived = new double[other.ring_trailingIdx_derived.Length];
+         Array.Copy( other.ring_trailingIdx_derived, this.ring_trailingIdx_derived, other.ring_trailingIdx_derived.Length );
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -417,20 +414,13 @@ public partial class Core
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         if( this.ring_trailingIdx_inOpen.Length != other.ring_trailingIdx_inOpen.Length ) {
-            this.ring_trailingIdx_inOpen = new double[other.ring_trailingIdx_inOpen.Length];
+         if( this.ring_trailingIdx_derived.Length != other.ring_trailingIdx_derived.Length ) {
+            this.ring_trailingIdx_derived = new double[other.ring_trailingIdx_derived.Length];
          }
-         Array.Copy( other.ring_trailingIdx_inOpen, this.ring_trailingIdx_inOpen, other.ring_trailingIdx_inOpen.Length );
-         if( this.ring_trailingIdx_inClose.Length != other.ring_trailingIdx_inClose.Length ) {
-            this.ring_trailingIdx_inClose = new double[other.ring_trailingIdx_inClose.Length];
-         }
-         Array.Copy( other.ring_trailingIdx_inClose, this.ring_trailingIdx_inClose, other.ring_trailingIdx_inClose.Length );
+         Array.Copy( other.ring_trailingIdx_derived, this.ring_trailingIdx_derived, other.ring_trailingIdx_derived.Length );
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
-
-      /* Peek's reusable scratch — one per thread, see CopyFrom. */
-      [ThreadStatic] private static QSTICK_Stream? peekScratch;
 
       /// <summary>Commit one closed bar, returning the new current value.</summary>
       /// <remarks>
@@ -458,9 +448,9 @@ public partial class Core
       /// <para>Bit-identical to what the next <see cref="Update"/> with the same bar
       /// would return — it is the same generated code, run on a copy. Never writes
       /// this handle, so peeks may run concurrently with each other.</para>
-      /// <para>It runs on a scratch handle held per thread and reused, so it allocates
-      /// nothing after this thread's first peek of this indicator. That scratch is
-      /// retained for the life of the thread.</para>
+      /// <para>It runs on a fresh copy of this handle, so it allocates one — proportional
+      /// to the state this indicator carries. If you peek on every tick and that
+      /// matters, hold the value <see cref="Update"/> returns instead.</para>
       /// </remarks>
       /// <param name="inOpen">This bar's open price.</param>
       /// <param name="inClose">This bar's close price.</param>
@@ -468,13 +458,7 @@ public partial class Core
       public double Peek( double inOpen, double inClose )
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inClose) ) throw Core.StreamFailure("QSTICK", "peek", RetCode.BadParam);
-         QSTICK_Stream? scratch = peekScratch;
-         if( scratch is null ) {
-            scratch = new QSTICK_Stream(this);
-            peekScratch = scratch;
-         } else {
-            scratch.CopyFrom(this);
-         }
+         QSTICK_Stream scratch = new QSTICK_Stream(this);
          core.QSTICK_StreamStep(scratch, inOpen, inClose);
          return scratch.cur_outReal;
       }
@@ -498,15 +482,13 @@ public partial class Core
    internal void QSTICK_StreamStep( QSTICK_Stream sp, double inOpen, double inClose )
    {
       if( sp.ringCap_trailingIdx == 0 ) {
-         sp.ring_trailingIdx_inOpen[0] = inOpen;
-         sp.ring_trailingIdx_inClose[0] = inClose;
+         sp.ring_trailingIdx_derived[0] = (double)(inClose - inOpen);
       }
       sp.periodTotal += (double)(inClose - inOpen);
       sp.tempReal = sp.periodTotal;
-      sp.periodTotal -= (double)(sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] - sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx]);
+      sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
       sp.cur_outReal = sp.tempReal / (double)sp.optInTimePeriod;
-      sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx] = inOpen;
-      sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
+      sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (double)(inClose - inOpen);
       sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
       if( sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
          sp.ringPos_trailingIdx = 0;
@@ -604,17 +586,16 @@ public partial class Core
          return RetCode.InternalError;
       }
       int allocN_trailingIdx = (cap_trailingIdx > 0)? cap_trailingIdx : 1;
-      double[] capRing_trailingIdx_inOpen = new double[allocN_trailingIdx];
-      inOpen.Slice(historyLen - cap_trailingIdx, cap_trailingIdx).CopyTo(capRing_trailingIdx_inOpen);
-      double[] capRing_trailingIdx_inClose = new double[allocN_trailingIdx];
-      inClose.Slice(historyLen - cap_trailingIdx, cap_trailingIdx).CopyTo(capRing_trailingIdx_inClose);
+      double[] capRing_trailingIdx_derived = new double[allocN_trailingIdx];
+      for( int fillJ = historyLen - cap_trailingIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingIdx_derived[fillJ - (historyLen - cap_trailingIdx)] = (double)(inClose[fillJ] - inOpen[fillJ]);
+      }
       sp.optInTimePeriod = optInTimePeriod;
       sp.periodTotal = periodTotal;
       sp.tempReal = tempReal;
       sp.ringPos_trailingIdx = 0;
       sp.ringCap_trailingIdx = cap_trailingIdx;
-      sp.ring_trailingIdx_inOpen = capRing_trailingIdx_inOpen;
-      sp.ring_trailingIdx_inClose = capRing_trailingIdx_inClose;
+      sp.ring_trailingIdx_derived = capRing_trailingIdx_derived;
       sp.cur_outReal = outReal[(outNBElement - 1) * outStride];
       return RetCode.Success;
    }

--- a/ta_codegen/output/java/fragments/Core_AC.java
+++ b/ta_codegen/output/java/fragments/Core_AC.java
@@ -543,12 +543,10 @@
       int maxIdx_oscBuffer;
       int ringPos_trailingFastIdx;
       int ringCap_trailingFastIdx;
-      double[] ring_trailingFastIdx_inHigh;
-      double[] ring_trailingFastIdx_inLow;
+      double[] ring_trailingFastIdx_derived;
       int ringPos_trailingSlowIdx;
       int ringCap_trailingSlowIdx;
-      double[] ring_trailingSlowIdx_inHigh;
-      double[] ring_trailingSlowIdx_inLow;
+      double[] ring_trailingSlowIdx_derived;
       int cbSize_oscBuffer;
       double[] cb_oscBuffer;
       double cur_outReal;
@@ -579,12 +577,10 @@
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+         this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+         this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          this.cb_oscBuffer = other.cb_oscBuffer.clone();
          this.cur_outReal = other.cur_outReal;
@@ -605,27 +601,17 @@
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+         if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
          } else {
-            this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         }
-         if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-         } else {
-            this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+            this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          }
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+         if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
          } else {
-            this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         }
-         if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-         } else {
-            this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+            this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          }
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          if( this.cb_oscBuffer != null && this.cb_oscBuffer.length == other.cb_oscBuffer.length ) {
@@ -703,12 +689,10 @@
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -717,8 +701,8 @@
        * mirroring the add-new / snapshot / subtract-old order of TA_SMA.
        */
       sp.osc = sp.sumFast / (double)sp.optInFastPeriod - sp.sumSlow / (double)sp.optInSlowPeriod;
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       /* Today's oscillator enters the signal window at its own slot, and the
        * bar leaving that window is read only after the ring has advanced onto
        * it -- writing first is what makes the slot the loop is about to
@@ -741,14 +725,12 @@
        * the collision ao.c has to guard against.
        */
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -939,19 +921,19 @@
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int capCb_oscBuffer = maxIdx_oscBuffer + 1;
       if( capCb_oscBuffer > historyLen + 1 ) {
          return RetCode.InternalError;
@@ -968,12 +950,10 @@
       sp.maxIdx_oscBuffer = maxIdx_oscBuffer;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cbSize_oscBuffer = capCb_oscBuffer;
       sp.cb_oscBuffer = oscBuffer;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];

--- a/ta_codegen/output/java/fragments/Core_AO.java
+++ b/ta_codegen/output/java/fragments/Core_AO.java
@@ -422,12 +422,10 @@
       double tempReal;
       int ringPos_trailingFastIdx;
       int ringCap_trailingFastIdx;
-      double[] ring_trailingFastIdx_inHigh;
-      double[] ring_trailingFastIdx_inLow;
+      double[] ring_trailingFastIdx_derived;
       int ringPos_trailingSlowIdx;
       int ringCap_trailingSlowIdx;
-      double[] ring_trailingSlowIdx_inHigh;
-      double[] ring_trailingSlowIdx_inLow;
+      double[] ring_trailingSlowIdx_derived;
       double cur_outReal;
       OutRange fillRange = OutRange.EMPTY;
 
@@ -451,12 +449,10 @@
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+         this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+         this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -470,27 +466,17 @@
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+         if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
          } else {
-            this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         }
-         if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-         } else {
-            this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+            this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          }
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+         if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
          } else {
-            this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         }
-         if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-         } else {
-            this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+            this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          }
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
@@ -562,12 +548,10 @@
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -582,17 +566,15 @@
        * value it had just overwritten whenever the caller aliases outReal
        * over inHigh or inLow.
        */
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -729,19 +711,19 @@
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       sp.optInFastPeriod = optInFastPeriod;
       sp.optInSlowPeriod = optInSlowPeriod;
       sp.sumFast = sumFast;
@@ -749,12 +731,10 @@
       sp.tempReal = tempReal;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
       return RetCode.Success;
    }

--- a/ta_codegen/output/java/fragments/Core_QSTICK.java
+++ b/ta_codegen/output/java/fragments/Core_QSTICK.java
@@ -318,8 +318,7 @@
       double tempReal;
       int ringPos_trailingIdx;
       int ringCap_trailingIdx;
-      double[] ring_trailingIdx_inOpen;
-      double[] ring_trailingIdx_inClose;
+      double[] ring_trailingIdx_derived;
       double cur_outReal;
       OutRange fillRange = OutRange.EMPTY;
 
@@ -341,8 +340,7 @@
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-         this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+         this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -354,22 +352,14 @@
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         if( this.ring_trailingIdx_inOpen != null && this.ring_trailingIdx_inOpen.length == other.ring_trailingIdx_inOpen.length ) {
-            System.arraycopy( other.ring_trailingIdx_inOpen, 0, this.ring_trailingIdx_inOpen, 0, other.ring_trailingIdx_inOpen.length );
+         if( this.ring_trailingIdx_derived != null && this.ring_trailingIdx_derived.length == other.ring_trailingIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingIdx_derived, 0, this.ring_trailingIdx_derived, 0, other.ring_trailingIdx_derived.length );
          } else {
-            this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-         }
-         if( this.ring_trailingIdx_inClose != null && this.ring_trailingIdx_inClose.length == other.ring_trailingIdx_inClose.length ) {
-            System.arraycopy( other.ring_trailingIdx_inClose, 0, this.ring_trailingIdx_inClose, 0, other.ring_trailingIdx_inClose.length );
-         } else {
-            this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+            this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
          }
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
-
-      /** {@code peek}'s reusable scratch — one per thread, see {@code copyFrom}. */
-      private static final ThreadLocal<QSTICK_Stream> PEEK_SCRATCH = new ThreadLocal<>();
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -394,21 +384,13 @@
        * Evaluate a forming bar without committing — bit-identical to what the
        * next {@code update} with the same bar would return (it is the same
        * generated code, run on a copy). Never writes this handle, so peeks may
-       * run concurrently with each other. It runs on a scratch handle held per thread and
-       * reused, so the copy allocates nothing after the first peek of this
-       * indicator on this thread. That scratch is retained for the life of
-       * the thread.
+       * run concurrently with each other. It runs on a throwaway copy, which for this
+       * handle's shape is cheaper than reusing one.
        */
       public double peek( double inOpen, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inClose) )
             throw new IllegalArgumentException("QSTICK peek: BadParam");
-         QSTICK_Stream scratch = PEEK_SCRATCH.get();
-         if( scratch == null ) {
-            scratch = new QSTICK_Stream(this);
-            PEEK_SCRATCH.set(scratch);
-         } else {
-            scratch.copyFrom(this);
-         }
+         QSTICK_Stream scratch = new QSTICK_Stream(this);
          core.QSTICK_StreamStep(scratch, inOpen, inClose);
          return scratch.cur_outReal;
       }
@@ -433,15 +415,13 @@
    void QSTICK_StreamStep( QSTICK_Stream sp, double inOpen, double inClose )
    {
       if( sp.ringCap_trailingIdx == 0 ) {
-         sp.ring_trailingIdx_inOpen[0] = inOpen;
-         sp.ring_trailingIdx_inClose[0] = inClose;
+         sp.ring_trailingIdx_derived[0] = (double)(inClose - inOpen);
       }
       sp.periodTotal += (double)(inClose - inOpen);
       sp.tempReal = sp.periodTotal;
-      sp.periodTotal -= (double)(sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] - sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx]);
+      sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
       sp.cur_outReal = sp.tempReal / (double)sp.optInTimePeriod;
-      sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx] = inOpen;
-      sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
+      sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (double)(inClose - inOpen);
       sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
       if( sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
          sp.ringPos_trailingIdx = 0;
@@ -536,17 +516,16 @@
          return RetCode.InternalError;
       }
       int allocN_trailingIdx = (cap_trailingIdx > 0)? cap_trailingIdx : 1;
-      double[] capRing_trailingIdx_inOpen = new double[allocN_trailingIdx];
-      System.arraycopy(inOpen, historyLen - cap_trailingIdx, capRing_trailingIdx_inOpen, 0, cap_trailingIdx);
-      double[] capRing_trailingIdx_inClose = new double[allocN_trailingIdx];
-      System.arraycopy(inClose, historyLen - cap_trailingIdx, capRing_trailingIdx_inClose, 0, cap_trailingIdx);
+      double[] capRing_trailingIdx_derived = new double[allocN_trailingIdx];
+      for( int fillJ = historyLen - cap_trailingIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingIdx_derived[fillJ - (historyLen - cap_trailingIdx)] = (double)(inClose[fillJ] - inOpen[fillJ]);
+      }
       sp.optInTimePeriod = optInTimePeriod;
       sp.periodTotal = periodTotal;
       sp.tempReal = tempReal;
       sp.ringPos_trailingIdx = 0;
       sp.ringCap_trailingIdx = cap_trailingIdx;
-      sp.ring_trailingIdx_inOpen = capRing_trailingIdx_inOpen;
-      sp.ring_trailingIdx_inClose = capRing_trailingIdx_inClose;
+      sp.ring_trailingIdx_derived = capRing_trailingIdx_derived;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
       return RetCode.Success;
    }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -823,12 +823,10 @@ public final class Core {
       int maxIdx_oscBuffer;
       int ringPos_trailingFastIdx;
       int ringCap_trailingFastIdx;
-      double[] ring_trailingFastIdx_inHigh;
-      double[] ring_trailingFastIdx_inLow;
+      double[] ring_trailingFastIdx_derived;
       int ringPos_trailingSlowIdx;
       int ringCap_trailingSlowIdx;
-      double[] ring_trailingSlowIdx_inHigh;
-      double[] ring_trailingSlowIdx_inLow;
+      double[] ring_trailingSlowIdx_derived;
       int cbSize_oscBuffer;
       double[] cb_oscBuffer;
       double cur_outReal;
@@ -859,12 +857,10 @@ public final class Core {
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+         this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+         this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          this.cb_oscBuffer = other.cb_oscBuffer.clone();
          this.cur_outReal = other.cur_outReal;
@@ -885,27 +881,17 @@ public final class Core {
          this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+         if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
          } else {
-            this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         }
-         if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-         } else {
-            this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+            this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          }
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+         if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
          } else {
-            this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         }
-         if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-         } else {
-            this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+            this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          }
          this.cbSize_oscBuffer = other.cbSize_oscBuffer;
          if( this.cb_oscBuffer != null && this.cb_oscBuffer.length == other.cb_oscBuffer.length ) {
@@ -983,12 +969,10 @@ public final class Core {
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -997,8 +981,8 @@ public final class Core {
        * mirroring the add-new / snapshot / subtract-old order of TA_SMA.
        */
       sp.osc = sp.sumFast / (double)sp.optInFastPeriod - sp.sumSlow / (double)sp.optInSlowPeriod;
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       /* Today's oscillator enters the signal window at its own slot, and the
        * bar leaving that window is read only after the ring has advanced onto
        * it -- writing first is what makes the slot the loop is about to
@@ -1021,14 +1005,12 @@ public final class Core {
        * the collision ao.c has to guard against.
        */
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -1219,19 +1201,19 @@ public final class Core {
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int capCb_oscBuffer = maxIdx_oscBuffer + 1;
       if( capCb_oscBuffer > historyLen + 1 ) {
          return RetCode.InternalError;
@@ -1248,12 +1230,10 @@ public final class Core {
       sp.maxIdx_oscBuffer = maxIdx_oscBuffer;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cbSize_oscBuffer = capCb_oscBuffer;
       sp.cb_oscBuffer = oscBuffer;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
@@ -6840,12 +6820,10 @@ public final class Core {
       double tempReal;
       int ringPos_trailingFastIdx;
       int ringCap_trailingFastIdx;
-      double[] ring_trailingFastIdx_inHigh;
-      double[] ring_trailingFastIdx_inLow;
+      double[] ring_trailingFastIdx_derived;
       int ringPos_trailingSlowIdx;
       int ringCap_trailingSlowIdx;
-      double[] ring_trailingSlowIdx_inHigh;
-      double[] ring_trailingSlowIdx_inLow;
+      double[] ring_trailingSlowIdx_derived;
       double cur_outReal;
       OutRange fillRange = OutRange.EMPTY;
 
@@ -6869,12 +6847,10 @@ public final class Core {
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+         this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+         this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -6888,27 +6864,17 @@ public final class Core {
          this.tempReal = other.tempReal;
          this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
          this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-         if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+         if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
          } else {
-            this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-         }
-         if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-         } else {
-            this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+            this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
          }
          this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
          this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-         if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+         if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
          } else {
-            this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-         }
-         if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-            System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-         } else {
-            this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+            this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
          }
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
@@ -6980,12 +6946,10 @@ public final class Core {
    {
       double medianPrice = 0.0;
       if( sp.ringCap_trailingFastIdx == 0 ) {
-         sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-         sp.ring_trailingFastIdx_inLow[0] = inLow;
+         sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       if( sp.ringCap_trailingSlowIdx == 0 ) {
-         sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-         sp.ring_trailingSlowIdx_inLow[0] = inLow;
+         sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
       }
       medianPrice = (inHigh + inLow) / 2.0;
       sp.sumFast += medianPrice;
@@ -7000,17 +6964,15 @@ public final class Core {
        * value it had just overwritten whenever the caller aliases outReal
        * over inHigh or inLow.
        */
-      sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-      sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+      sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+      sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
       sp.cur_outReal = sp.tempReal;
-      sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-      sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+      sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
       if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
          sp.ringPos_trailingFastIdx = 0;
       }
-      sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-      sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+      sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
       sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
       if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
          sp.ringPos_trailingSlowIdx = 0;
@@ -7147,19 +7109,19 @@ public final class Core {
          return RetCode.InternalError;
       }
       int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-      double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-      double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+      double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+      for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       int cap_trailingSlowIdx = i - trailingSlowIdx;
       if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
          return RetCode.InternalError;
       }
       int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-      double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-      double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-      System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+      double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+      for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+      }
       sp.optInFastPeriod = optInFastPeriod;
       sp.optInSlowPeriod = optInSlowPeriod;
       sp.sumFast = sumFast;
@@ -7167,12 +7129,10 @@ public final class Core {
       sp.tempReal = tempReal;
       sp.ringPos_trailingFastIdx = 0;
       sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-      sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-      sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+      sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
       sp.ringPos_trailingSlowIdx = 0;
       sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-      sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-      sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+      sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
       return RetCode.Success;
    }
@@ -122142,8 +122102,7 @@ public final class Core {
       double tempReal;
       int ringPos_trailingIdx;
       int ringCap_trailingIdx;
-      double[] ring_trailingIdx_inOpen;
-      double[] ring_trailingIdx_inClose;
+      double[] ring_trailingIdx_derived;
       double cur_outReal;
       OutRange fillRange = OutRange.EMPTY;
 
@@ -122165,8 +122124,7 @@ public final class Core {
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-         this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+         this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
@@ -122178,22 +122136,14 @@ public final class Core {
          this.tempReal = other.tempReal;
          this.ringPos_trailingIdx = other.ringPos_trailingIdx;
          this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-         if( this.ring_trailingIdx_inOpen != null && this.ring_trailingIdx_inOpen.length == other.ring_trailingIdx_inOpen.length ) {
-            System.arraycopy( other.ring_trailingIdx_inOpen, 0, this.ring_trailingIdx_inOpen, 0, other.ring_trailingIdx_inOpen.length );
+         if( this.ring_trailingIdx_derived != null && this.ring_trailingIdx_derived.length == other.ring_trailingIdx_derived.length ) {
+            System.arraycopy( other.ring_trailingIdx_derived, 0, this.ring_trailingIdx_derived, 0, other.ring_trailingIdx_derived.length );
          } else {
-            this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-         }
-         if( this.ring_trailingIdx_inClose != null && this.ring_trailingIdx_inClose.length == other.ring_trailingIdx_inClose.length ) {
-            System.arraycopy( other.ring_trailingIdx_inClose, 0, this.ring_trailingIdx_inClose, 0, other.ring_trailingIdx_inClose.length );
-         } else {
-            this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+            this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
          }
          this.cur_outReal = other.cur_outReal;
          this.fillRange = other.fillRange;
       }
-
-      /** {@code peek}'s reusable scratch — one per thread, see {@code copyFrom}. */
-      private static final ThreadLocal<QSTICK_Stream> PEEK_SCRATCH = new ThreadLocal<>();
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -122218,21 +122168,13 @@ public final class Core {
        * Evaluate a forming bar without committing — bit-identical to what the
        * next {@code update} with the same bar would return (it is the same
        * generated code, run on a copy). Never writes this handle, so peeks may
-       * run concurrently with each other. It runs on a scratch handle held per thread and
-       * reused, so the copy allocates nothing after the first peek of this
-       * indicator on this thread. That scratch is retained for the life of
-       * the thread.
+       * run concurrently with each other. It runs on a throwaway copy, which for this
+       * handle's shape is cheaper than reusing one.
        */
       public double peek( double inOpen, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inClose) )
             throw new IllegalArgumentException("QSTICK peek: BadParam");
-         QSTICK_Stream scratch = PEEK_SCRATCH.get();
-         if( scratch == null ) {
-            scratch = new QSTICK_Stream(this);
-            PEEK_SCRATCH.set(scratch);
-         } else {
-            scratch.copyFrom(this);
-         }
+         QSTICK_Stream scratch = new QSTICK_Stream(this);
          core.QSTICK_StreamStep(scratch, inOpen, inClose);
          return scratch.cur_outReal;
       }
@@ -122257,15 +122199,13 @@ public final class Core {
    void QSTICK_StreamStep( QSTICK_Stream sp, double inOpen, double inClose )
    {
       if( sp.ringCap_trailingIdx == 0 ) {
-         sp.ring_trailingIdx_inOpen[0] = inOpen;
-         sp.ring_trailingIdx_inClose[0] = inClose;
+         sp.ring_trailingIdx_derived[0] = (double)(inClose - inOpen);
       }
       sp.periodTotal += (double)(inClose - inOpen);
       sp.tempReal = sp.periodTotal;
-      sp.periodTotal -= (double)(sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] - sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx]);
+      sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
       sp.cur_outReal = sp.tempReal / (double)sp.optInTimePeriod;
-      sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx] = inOpen;
-      sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
+      sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (double)(inClose - inOpen);
       sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
       if( sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
          sp.ringPos_trailingIdx = 0;
@@ -122360,17 +122300,16 @@ public final class Core {
          return RetCode.InternalError;
       }
       int allocN_trailingIdx = (cap_trailingIdx > 0)? cap_trailingIdx : 1;
-      double[] capRing_trailingIdx_inOpen = new double[allocN_trailingIdx];
-      System.arraycopy(inOpen, historyLen - cap_trailingIdx, capRing_trailingIdx_inOpen, 0, cap_trailingIdx);
-      double[] capRing_trailingIdx_inClose = new double[allocN_trailingIdx];
-      System.arraycopy(inClose, historyLen - cap_trailingIdx, capRing_trailingIdx_inClose, 0, cap_trailingIdx);
+      double[] capRing_trailingIdx_derived = new double[allocN_trailingIdx];
+      for( int fillJ = historyLen - cap_trailingIdx; fillJ < historyLen; fillJ++ ) {
+         capRing_trailingIdx_derived[fillJ - (historyLen - cap_trailingIdx)] = (double)(inClose[fillJ] - inOpen[fillJ]);
+      }
       sp.optInTimePeriod = optInTimePeriod;
       sp.periodTotal = periodTotal;
       sp.tempReal = tempReal;
       sp.ringPos_trailingIdx = 0;
       sp.ringCap_trailingIdx = cap_trailingIdx;
-      sp.ring_trailingIdx_inOpen = capRing_trailingIdx_inOpen;
-      sp.ring_trailingIdx_inClose = capRing_trailingIdx_inClose;
+      sp.ring_trailingIdx_derived = capRing_trailingIdx_derived;
       sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
       return RetCode.Success;
    }

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -639,12 +639,10 @@ class Core {
           int maxIdx_oscBuffer;
           int ringPos_trailingFastIdx;
           int ringCap_trailingFastIdx;
-          double[] ring_trailingFastIdx_inHigh;
-          double[] ring_trailingFastIdx_inLow;
+          double[] ring_trailingFastIdx_derived;
           int ringPos_trailingSlowIdx;
           int ringCap_trailingSlowIdx;
-          double[] ring_trailingSlowIdx_inHigh;
-          double[] ring_trailingSlowIdx_inLow;
+          double[] ring_trailingSlowIdx_derived;
           int cbSize_oscBuffer;
           double[] cb_oscBuffer;
           double cur_outReal;
@@ -675,12 +673,10 @@ class Core {
              this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
              this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
              this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-             this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-             this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+             this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
              this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
              this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-             this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-             this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+             this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
              this.cbSize_oscBuffer = other.cbSize_oscBuffer;
              this.cb_oscBuffer = other.cb_oscBuffer.clone();
              this.cur_outReal = other.cur_outReal;
@@ -701,27 +697,17 @@ class Core {
              this.maxIdx_oscBuffer = other.maxIdx_oscBuffer;
              this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
              this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-             if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-                System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+             if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+                System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
              } else {
-                this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-             }
-             if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-                System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-             } else {
-                this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+                this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
              }
              this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
              this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-             if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-                System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+             if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+                System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
              } else {
-                this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-             }
-             if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-                System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-             } else {
-                this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+                this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
              }
              this.cbSize_oscBuffer = other.cbSize_oscBuffer;
              if( this.cb_oscBuffer != null && this.cb_oscBuffer.length == other.cb_oscBuffer.length ) {
@@ -799,12 +785,10 @@ class Core {
        {
           double medianPrice = 0.0;
           if( sp.ringCap_trailingFastIdx == 0 ) {
-             sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-             sp.ring_trailingFastIdx_inLow[0] = inLow;
+             sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
           }
           if( sp.ringCap_trailingSlowIdx == 0 ) {
-             sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-             sp.ring_trailingSlowIdx_inLow[0] = inLow;
+             sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
           }
           medianPrice = (inHigh + inLow) / 2.0;
           sp.sumFast += medianPrice;
@@ -813,8 +797,8 @@ class Core {
            * mirroring the add-new / snapshot / subtract-old order of TA_SMA.
            */
           sp.osc = sp.sumFast / (double)sp.optInFastPeriod - sp.sumSlow / (double)sp.optInSlowPeriod;
-          sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-          sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+          sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+          sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
           /* Today's oscillator enters the signal window at its own slot, and the
            * bar leaving that window is read only after the ring has advanced onto
            * it -- writing first is what makes the slot the loop is about to
@@ -837,14 +821,12 @@ class Core {
            * the collision ao.c has to guard against.
            */
           sp.cur_outReal = sp.tempReal;
-          sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-          sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+          sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
           sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
           if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
              sp.ringPos_trailingFastIdx = 0;
           }
-          sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-          sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+          sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
           sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
           if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
              sp.ringPos_trailingSlowIdx = 0;
@@ -1035,19 +1017,19 @@ class Core {
              return RetCode.InternalError;
           }
           int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-          double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-          System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-          double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-          System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+          double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+          for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+             capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+          }
           int cap_trailingSlowIdx = i - trailingSlowIdx;
           if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
              return RetCode.InternalError;
           }
           int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-          double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-          System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-          double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-          System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+          double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+          for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+             capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+          }
           int capCb_oscBuffer = maxIdx_oscBuffer + 1;
           if( capCb_oscBuffer > historyLen + 1 ) {
              return RetCode.InternalError;
@@ -1064,12 +1046,10 @@ class Core {
           sp.maxIdx_oscBuffer = maxIdx_oscBuffer;
           sp.ringPos_trailingFastIdx = 0;
           sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-          sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-          sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+          sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
           sp.ringPos_trailingSlowIdx = 0;
           sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-          sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-          sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+          sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
           sp.cbSize_oscBuffer = capCb_oscBuffer;
           sp.cb_oscBuffer = oscBuffer;
           sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
@@ -6656,12 +6636,10 @@ class Core {
           double tempReal;
           int ringPos_trailingFastIdx;
           int ringCap_trailingFastIdx;
-          double[] ring_trailingFastIdx_inHigh;
-          double[] ring_trailingFastIdx_inLow;
+          double[] ring_trailingFastIdx_derived;
           int ringPos_trailingSlowIdx;
           int ringCap_trailingSlowIdx;
-          double[] ring_trailingSlowIdx_inHigh;
-          double[] ring_trailingSlowIdx_inLow;
+          double[] ring_trailingSlowIdx_derived;
           double cur_outReal;
           OutRange fillRange = OutRange.EMPTY;
 
@@ -6685,12 +6663,10 @@ class Core {
              this.tempReal = other.tempReal;
              this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
              this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-             this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-             this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+             this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
              this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
              this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-             this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-             this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+             this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
              this.cur_outReal = other.cur_outReal;
              this.fillRange = other.fillRange;
           }
@@ -6704,27 +6680,17 @@ class Core {
              this.tempReal = other.tempReal;
              this.ringPos_trailingFastIdx = other.ringPos_trailingFastIdx;
              this.ringCap_trailingFastIdx = other.ringCap_trailingFastIdx;
-             if( this.ring_trailingFastIdx_inHigh != null && this.ring_trailingFastIdx_inHigh.length == other.ring_trailingFastIdx_inHigh.length ) {
-                System.arraycopy( other.ring_trailingFastIdx_inHigh, 0, this.ring_trailingFastIdx_inHigh, 0, other.ring_trailingFastIdx_inHigh.length );
+             if( this.ring_trailingFastIdx_derived != null && this.ring_trailingFastIdx_derived.length == other.ring_trailingFastIdx_derived.length ) {
+                System.arraycopy( other.ring_trailingFastIdx_derived, 0, this.ring_trailingFastIdx_derived, 0, other.ring_trailingFastIdx_derived.length );
              } else {
-                this.ring_trailingFastIdx_inHigh = other.ring_trailingFastIdx_inHigh.clone();
-             }
-             if( this.ring_trailingFastIdx_inLow != null && this.ring_trailingFastIdx_inLow.length == other.ring_trailingFastIdx_inLow.length ) {
-                System.arraycopy( other.ring_trailingFastIdx_inLow, 0, this.ring_trailingFastIdx_inLow, 0, other.ring_trailingFastIdx_inLow.length );
-             } else {
-                this.ring_trailingFastIdx_inLow = other.ring_trailingFastIdx_inLow.clone();
+                this.ring_trailingFastIdx_derived = other.ring_trailingFastIdx_derived.clone();
              }
              this.ringPos_trailingSlowIdx = other.ringPos_trailingSlowIdx;
              this.ringCap_trailingSlowIdx = other.ringCap_trailingSlowIdx;
-             if( this.ring_trailingSlowIdx_inHigh != null && this.ring_trailingSlowIdx_inHigh.length == other.ring_trailingSlowIdx_inHigh.length ) {
-                System.arraycopy( other.ring_trailingSlowIdx_inHigh, 0, this.ring_trailingSlowIdx_inHigh, 0, other.ring_trailingSlowIdx_inHigh.length );
+             if( this.ring_trailingSlowIdx_derived != null && this.ring_trailingSlowIdx_derived.length == other.ring_trailingSlowIdx_derived.length ) {
+                System.arraycopy( other.ring_trailingSlowIdx_derived, 0, this.ring_trailingSlowIdx_derived, 0, other.ring_trailingSlowIdx_derived.length );
              } else {
-                this.ring_trailingSlowIdx_inHigh = other.ring_trailingSlowIdx_inHigh.clone();
-             }
-             if( this.ring_trailingSlowIdx_inLow != null && this.ring_trailingSlowIdx_inLow.length == other.ring_trailingSlowIdx_inLow.length ) {
-                System.arraycopy( other.ring_trailingSlowIdx_inLow, 0, this.ring_trailingSlowIdx_inLow, 0, other.ring_trailingSlowIdx_inLow.length );
-             } else {
-                this.ring_trailingSlowIdx_inLow = other.ring_trailingSlowIdx_inLow.clone();
+                this.ring_trailingSlowIdx_derived = other.ring_trailingSlowIdx_derived.clone();
              }
              this.cur_outReal = other.cur_outReal;
              this.fillRange = other.fillRange;
@@ -6796,12 +6762,10 @@ class Core {
        {
           double medianPrice = 0.0;
           if( sp.ringCap_trailingFastIdx == 0 ) {
-             sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-             sp.ring_trailingFastIdx_inLow[0] = inLow;
+             sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
           }
           if( sp.ringCap_trailingSlowIdx == 0 ) {
-             sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-             sp.ring_trailingSlowIdx_inLow[0] = inLow;
+             sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
           }
           medianPrice = (inHigh + inLow) / 2.0;
           sp.sumFast += medianPrice;
@@ -6816,17 +6780,15 @@ class Core {
            * value it had just overwritten whenever the caller aliases outReal
            * over inHigh or inLow.
            */
-          sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-          sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+          sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+          sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
           sp.cur_outReal = sp.tempReal;
-          sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-          sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+          sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
           sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
           if( sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx ) {
              sp.ringPos_trailingFastIdx = 0;
           }
-          sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-          sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+          sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
           sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
           if( sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx ) {
              sp.ringPos_trailingSlowIdx = 0;
@@ -6963,19 +6925,19 @@ class Core {
              return RetCode.InternalError;
           }
           int allocN_trailingFastIdx = (cap_trailingFastIdx > 0)? cap_trailingFastIdx : 1;
-          double[] capRing_trailingFastIdx_inHigh = new double[allocN_trailingFastIdx];
-          System.arraycopy(inHigh, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inHigh, 0, cap_trailingFastIdx);
-          double[] capRing_trailingFastIdx_inLow = new double[allocN_trailingFastIdx];
-          System.arraycopy(inLow, historyLen - cap_trailingFastIdx, capRing_trailingFastIdx_inLow, 0, cap_trailingFastIdx);
+          double[] capRing_trailingFastIdx_derived = new double[allocN_trailingFastIdx];
+          for( int fillJ = historyLen - cap_trailingFastIdx; fillJ < historyLen; fillJ++ ) {
+             capRing_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+          }
           int cap_trailingSlowIdx = i - trailingSlowIdx;
           if( cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen ) {
              return RetCode.InternalError;
           }
           int allocN_trailingSlowIdx = (cap_trailingSlowIdx > 0)? cap_trailingSlowIdx : 1;
-          double[] capRing_trailingSlowIdx_inHigh = new double[allocN_trailingSlowIdx];
-          System.arraycopy(inHigh, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inHigh, 0, cap_trailingSlowIdx);
-          double[] capRing_trailingSlowIdx_inLow = new double[allocN_trailingSlowIdx];
-          System.arraycopy(inLow, historyLen - cap_trailingSlowIdx, capRing_trailingSlowIdx_inLow, 0, cap_trailingSlowIdx);
+          double[] capRing_trailingSlowIdx_derived = new double[allocN_trailingSlowIdx];
+          for( int fillJ = historyLen - cap_trailingSlowIdx; fillJ < historyLen; fillJ++ ) {
+             capRing_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx)] = (inHigh[fillJ] + inLow[fillJ]) / 2.0;
+          }
           sp.optInFastPeriod = optInFastPeriod;
           sp.optInSlowPeriod = optInSlowPeriod;
           sp.sumFast = sumFast;
@@ -6983,12 +6945,10 @@ class Core {
           sp.tempReal = tempReal;
           sp.ringPos_trailingFastIdx = 0;
           sp.ringCap_trailingFastIdx = cap_trailingFastIdx;
-          sp.ring_trailingFastIdx_inHigh = capRing_trailingFastIdx_inHigh;
-          sp.ring_trailingFastIdx_inLow = capRing_trailingFastIdx_inLow;
+          sp.ring_trailingFastIdx_derived = capRing_trailingFastIdx_derived;
           sp.ringPos_trailingSlowIdx = 0;
           sp.ringCap_trailingSlowIdx = cap_trailingSlowIdx;
-          sp.ring_trailingSlowIdx_inHigh = capRing_trailingSlowIdx_inHigh;
-          sp.ring_trailingSlowIdx_inLow = capRing_trailingSlowIdx_inLow;
+          sp.ring_trailingSlowIdx_derived = capRing_trailingSlowIdx_derived;
           sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
           return RetCode.Success;
        }
@@ -121958,8 +121918,7 @@ class Core {
           double tempReal;
           int ringPos_trailingIdx;
           int ringCap_trailingIdx;
-          double[] ring_trailingIdx_inOpen;
-          double[] ring_trailingIdx_inClose;
+          double[] ring_trailingIdx_derived;
           double cur_outReal;
           OutRange fillRange = OutRange.EMPTY;
 
@@ -121981,8 +121940,7 @@ class Core {
              this.tempReal = other.tempReal;
              this.ringPos_trailingIdx = other.ringPos_trailingIdx;
              this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-             this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-             this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+             this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
              this.cur_outReal = other.cur_outReal;
              this.fillRange = other.fillRange;
           }
@@ -121994,22 +121952,14 @@ class Core {
              this.tempReal = other.tempReal;
              this.ringPos_trailingIdx = other.ringPos_trailingIdx;
              this.ringCap_trailingIdx = other.ringCap_trailingIdx;
-             if( this.ring_trailingIdx_inOpen != null && this.ring_trailingIdx_inOpen.length == other.ring_trailingIdx_inOpen.length ) {
-                System.arraycopy( other.ring_trailingIdx_inOpen, 0, this.ring_trailingIdx_inOpen, 0, other.ring_trailingIdx_inOpen.length );
+             if( this.ring_trailingIdx_derived != null && this.ring_trailingIdx_derived.length == other.ring_trailingIdx_derived.length ) {
+                System.arraycopy( other.ring_trailingIdx_derived, 0, this.ring_trailingIdx_derived, 0, other.ring_trailingIdx_derived.length );
              } else {
-                this.ring_trailingIdx_inOpen = other.ring_trailingIdx_inOpen.clone();
-             }
-             if( this.ring_trailingIdx_inClose != null && this.ring_trailingIdx_inClose.length == other.ring_trailingIdx_inClose.length ) {
-                System.arraycopy( other.ring_trailingIdx_inClose, 0, this.ring_trailingIdx_inClose, 0, other.ring_trailingIdx_inClose.length );
-             } else {
-                this.ring_trailingIdx_inClose = other.ring_trailingIdx_inClose.clone();
+                this.ring_trailingIdx_derived = other.ring_trailingIdx_derived.clone();
              }
              this.cur_outReal = other.cur_outReal;
              this.fillRange = other.fillRange;
           }
-
-          /** {@code peek}'s reusable scratch — one per thread, see {@code copyFrom}. */
-          private static final ThreadLocal<QSTICK_Stream> PEEK_SCRATCH = new ThreadLocal<>();
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -122034,21 +121984,13 @@ class Core {
            * Evaluate a forming bar without committing — bit-identical to what the
            * next {@code update} with the same bar would return (it is the same
            * generated code, run on a copy). Never writes this handle, so peeks may
-           * run concurrently with each other. It runs on a scratch handle held per thread and
-           * reused, so the copy allocates nothing after the first peek of this
-           * indicator on this thread. That scratch is retained for the life of
-           * the thread.
+           * run concurrently with each other. It runs on a throwaway copy, which for this
+           * handle's shape is cheaper than reusing one.
            */
           public double peek( double inOpen, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inClose) )
                 throw new IllegalArgumentException("QSTICK peek: BadParam");
-             QSTICK_Stream scratch = PEEK_SCRATCH.get();
-             if( scratch == null ) {
-                scratch = new QSTICK_Stream(this);
-                PEEK_SCRATCH.set(scratch);
-             } else {
-                scratch.copyFrom(this);
-             }
+             QSTICK_Stream scratch = new QSTICK_Stream(this);
              core.QSTICK_StreamStep(scratch, inOpen, inClose);
              return scratch.cur_outReal;
           }
@@ -122073,15 +122015,13 @@ class Core {
        void QSTICK_StreamStep( QSTICK_Stream sp, double inOpen, double inClose )
        {
           if( sp.ringCap_trailingIdx == 0 ) {
-             sp.ring_trailingIdx_inOpen[0] = inOpen;
-             sp.ring_trailingIdx_inClose[0] = inClose;
+             sp.ring_trailingIdx_derived[0] = (double)(inClose - inOpen);
           }
           sp.periodTotal += (double)(inClose - inOpen);
           sp.tempReal = sp.periodTotal;
-          sp.periodTotal -= (double)(sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] - sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx]);
+          sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
           sp.cur_outReal = sp.tempReal / (double)sp.optInTimePeriod;
-          sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx] = inOpen;
-          sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
+          sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (double)(inClose - inOpen);
           sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
           if( sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
              sp.ringPos_trailingIdx = 0;
@@ -122176,17 +122116,16 @@ class Core {
              return RetCode.InternalError;
           }
           int allocN_trailingIdx = (cap_trailingIdx > 0)? cap_trailingIdx : 1;
-          double[] capRing_trailingIdx_inOpen = new double[allocN_trailingIdx];
-          System.arraycopy(inOpen, historyLen - cap_trailingIdx, capRing_trailingIdx_inOpen, 0, cap_trailingIdx);
-          double[] capRing_trailingIdx_inClose = new double[allocN_trailingIdx];
-          System.arraycopy(inClose, historyLen - cap_trailingIdx, capRing_trailingIdx_inClose, 0, cap_trailingIdx);
+          double[] capRing_trailingIdx_derived = new double[allocN_trailingIdx];
+          for( int fillJ = historyLen - cap_trailingIdx; fillJ < historyLen; fillJ++ ) {
+             capRing_trailingIdx_derived[fillJ - (historyLen - cap_trailingIdx)] = (double)(inClose[fillJ] - inOpen[fillJ]);
+          }
           sp.optInTimePeriod = optInTimePeriod;
           sp.periodTotal = periodTotal;
           sp.tempReal = tempReal;
           sp.ringPos_trailingIdx = 0;
           sp.ringCap_trailingIdx = cap_trailingIdx;
-          sp.ring_trailingIdx_inOpen = capRing_trailingIdx_inOpen;
-          sp.ring_trailingIdx_inClose = capRing_trailingIdx_inClose;
+          sp.ring_trailingIdx_derived = capRing_trailingIdx_derived;
           sp.cur_outReal = outReal[(outNBElement.value - 1) * outStride];
           return RetCode.Success;
        }

--- a/ta_codegen/output/rust/library/src/ta_func/ac.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ac.rs
@@ -431,12 +431,10 @@ struct AC_StreamState {
     maxIdx_oscBuffer: usize,
     ringPos_trailingFastIdx: usize,
     ringCap_trailingFastIdx: usize,
-    ring_trailingFastIdx_inHigh: Vec<f64>,
-    ring_trailingFastIdx_inLow: Vec<f64>,
+    ring_trailingFastIdx_derived: Vec<f64>,
     ringPos_trailingSlowIdx: usize,
     ringCap_trailingSlowIdx: usize,
-    ring_trailingSlowIdx_inHigh: Vec<f64>,
-    ring_trailingSlowIdx_inLow: Vec<f64>,
+    ring_trailingSlowIdx_derived: Vec<f64>,
     cbSize_oscBuffer: usize,
     cb_oscBuffer: Vec<f64>,
 }
@@ -458,12 +456,10 @@ impl AC_StreamState {
         self.maxIdx_oscBuffer = src.maxIdx_oscBuffer;
         self.ringPos_trailingFastIdx = src.ringPos_trailingFastIdx;
         self.ringCap_trailingFastIdx = src.ringCap_trailingFastIdx;
-        self.ring_trailingFastIdx_inHigh.clone_from(&src.ring_trailingFastIdx_inHigh);
-        self.ring_trailingFastIdx_inLow.clone_from(&src.ring_trailingFastIdx_inLow);
+        self.ring_trailingFastIdx_derived.clone_from(&src.ring_trailingFastIdx_derived);
         self.ringPos_trailingSlowIdx = src.ringPos_trailingSlowIdx;
         self.ringCap_trailingSlowIdx = src.ringCap_trailingSlowIdx;
-        self.ring_trailingSlowIdx_inHigh.clone_from(&src.ring_trailingSlowIdx_inHigh);
-        self.ring_trailingSlowIdx_inLow.clone_from(&src.ring_trailingSlowIdx_inLow);
+        self.ring_trailingSlowIdx_derived.clone_from(&src.ring_trailingSlowIdx_derived);
         self.cbSize_oscBuffer = src.cbSize_oscBuffer;
         self.cb_oscBuffer.clone_from(&src.cb_oscBuffer);
     }
@@ -479,12 +475,10 @@ impl Core {
     fn AC_step_internal(&self, sp: &mut AC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         if sp.ringCap_trailingFastIdx == 0 {
-            sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-            sp.ring_trailingFastIdx_inLow[0] = inLow;
+            sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
         }
         if sp.ringCap_trailingSlowIdx == 0 {
-            sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-            sp.ring_trailingSlowIdx_inLow[0] = inLow;
+            sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
         }
         medianPrice = (inHigh + inLow) / 2.0;
         sp.sumFast += medianPrice;
@@ -492,8 +486,8 @@ impl Core {
         // Snapshot the oscillator before either total drops its trailing bar,
         // mirroring the add-new / snapshot / subtract-old order of TA_SMA.
         sp.osc = sp.sumFast / (sp.optInFastPeriod as f64) - sp.sumSlow / (sp.optInSlowPeriod as f64);
-        sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-        sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+        sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+        sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
         // Today's oscillator enters the signal window at its own slot, and the
         // bar leaving that window is read only after the ring has advanced onto
         // it -- writing first is what makes the slot the loop is about to
@@ -514,14 +508,12 @@ impl Core {
         // that admitting a signal period of 1 would not silently reintroduce
         // the collision ao.c has to guard against.
         (*outReal) = sp.tempReal;
-        sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-        sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+        sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
         sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
         if sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx {
             sp.ringPos_trailingFastIdx = 0;
         }
-        sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-        sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+        sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
         sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
         if sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx {
             sp.ringPos_trailingSlowIdx = 0;
@@ -709,23 +701,27 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let allocN_trailingFastIdx: usize = if cap_trailingFastIdx > 0 { cap_trailingFastIdx as usize } else { 1 };
-        let mut ring_trailingFastIdx_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
-        ring_trailingFastIdx_inHigh[..cap_trailingFastIdx as usize]
-            .copy_from_slice(&inHigh[historyLen - cap_trailingFastIdx as usize..]);
-        let mut ring_trailingFastIdx_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
-        ring_trailingFastIdx_inLow[..cap_trailingFastIdx as usize]
-            .copy_from_slice(&inLow[historyLen - cap_trailingFastIdx as usize..]);
+        let mut ring_trailingFastIdx_derived: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
+        {
+            let mut fillJ: usize = historyLen - cap_trailingFastIdx as usize;
+            while fillJ < historyLen {
+                ring_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx as usize)] = (inHigh[(fillJ) as usize] + inLow[(fillJ) as usize]) / 2.0;
+                fillJ += 1;
+            }
+        }
         let cap_trailingSlowIdx: i64 = (i as i64) - (trailingSlowIdx as i64);
         if cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
         let allocN_trailingSlowIdx: usize = if cap_trailingSlowIdx > 0 { cap_trailingSlowIdx as usize } else { 1 };
-        let mut ring_trailingSlowIdx_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
-        ring_trailingSlowIdx_inHigh[..cap_trailingSlowIdx as usize]
-            .copy_from_slice(&inHigh[historyLen - cap_trailingSlowIdx as usize..]);
-        let mut ring_trailingSlowIdx_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
-        ring_trailingSlowIdx_inLow[..cap_trailingSlowIdx as usize]
-            .copy_from_slice(&inLow[historyLen - cap_trailingSlowIdx as usize..]);
+        let mut ring_trailingSlowIdx_derived: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
+        {
+            let mut fillJ: usize = historyLen - cap_trailingSlowIdx as usize;
+            while fillJ < historyLen {
+                ring_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx as usize)] = (inHigh[(fillJ) as usize] + inLow[(fillJ) as usize]) / 2.0;
+                fillJ += 1;
+            }
+        }
         let cbSize_oscBuffer: usize = maxIdx_oscBuffer + 1;
         if cbSize_oscBuffer > historyLen + 1 {
             return Err(RetCode::InternalError);
@@ -743,12 +739,10 @@ impl Core {
             maxIdx_oscBuffer,
             ringPos_trailingFastIdx: 0_usize,
             ringCap_trailingFastIdx: cap_trailingFastIdx as usize,
-            ring_trailingFastIdx_inHigh,
-            ring_trailingFastIdx_inLow,
+            ring_trailingFastIdx_derived,
             ringPos_trailingSlowIdx: 0_usize,
             ringCap_trailingSlowIdx: cap_trailingSlowIdx as usize,
-            ring_trailingSlowIdx_inHigh,
-            ring_trailingSlowIdx_inLow,
+            ring_trailingSlowIdx_derived,
             cbSize_oscBuffer: cbSize_oscBuffer,
             cb_oscBuffer: oscBuffer,
         };

--- a/ta_codegen/output/rust/library/src/ta_func/ao.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ao.rs
@@ -356,12 +356,10 @@ struct AO_StreamState {
     tempReal: f64,
     ringPos_trailingFastIdx: usize,
     ringCap_trailingFastIdx: usize,
-    ring_trailingFastIdx_inHigh: Vec<f64>,
-    ring_trailingFastIdx_inLow: Vec<f64>,
+    ring_trailingFastIdx_derived: Vec<f64>,
     ringPos_trailingSlowIdx: usize,
     ringCap_trailingSlowIdx: usize,
-    ring_trailingSlowIdx_inHigh: Vec<f64>,
-    ring_trailingSlowIdx_inLow: Vec<f64>,
+    ring_trailingSlowIdx_derived: Vec<f64>,
 }
 
 #[allow(non_snake_case, dead_code)]
@@ -376,12 +374,10 @@ impl AO_StreamState {
         self.tempReal = src.tempReal;
         self.ringPos_trailingFastIdx = src.ringPos_trailingFastIdx;
         self.ringCap_trailingFastIdx = src.ringCap_trailingFastIdx;
-        self.ring_trailingFastIdx_inHigh.clone_from(&src.ring_trailingFastIdx_inHigh);
-        self.ring_trailingFastIdx_inLow.clone_from(&src.ring_trailingFastIdx_inLow);
+        self.ring_trailingFastIdx_derived.clone_from(&src.ring_trailingFastIdx_derived);
         self.ringPos_trailingSlowIdx = src.ringPos_trailingSlowIdx;
         self.ringCap_trailingSlowIdx = src.ringCap_trailingSlowIdx;
-        self.ring_trailingSlowIdx_inHigh.clone_from(&src.ring_trailingSlowIdx_inHigh);
-        self.ring_trailingSlowIdx_inLow.clone_from(&src.ring_trailingSlowIdx_inLow);
+        self.ring_trailingSlowIdx_derived.clone_from(&src.ring_trailingSlowIdx_derived);
     }
 }
 
@@ -395,12 +391,10 @@ impl Core {
     fn AO_step_internal(&self, sp: &mut AO_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         if sp.ringCap_trailingFastIdx == 0 {
-            sp.ring_trailingFastIdx_inHigh[0] = inHigh;
-            sp.ring_trailingFastIdx_inLow[0] = inLow;
+            sp.ring_trailingFastIdx_derived[0] = (inHigh + inLow) / 2.0;
         }
         if sp.ringCap_trailingSlowIdx == 0 {
-            sp.ring_trailingSlowIdx_inHigh[0] = inHigh;
-            sp.ring_trailingSlowIdx_inLow[0] = inLow;
+            sp.ring_trailingSlowIdx_derived[0] = (inHigh + inLow) / 2.0;
         }
         medianPrice = (inHigh + inLow) / 2.0;
         sp.sumFast += medianPrice;
@@ -413,17 +407,15 @@ impl Core {
         // outIdx exactly, so a store hoisted above this would read back the
         // value it had just overwritten whenever the caller aliases outReal
         // over inHigh or inLow.
-        sp.sumFast -= (sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] + sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx]) / 2.0;
-        sp.sumSlow -= (sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] + sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx]) / 2.0;
+        sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
+        sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
         (*outReal) = sp.tempReal;
-        sp.ring_trailingFastIdx_inHigh[sp.ringPos_trailingFastIdx] = inHigh;
-        sp.ring_trailingFastIdx_inLow[sp.ringPos_trailingFastIdx] = inLow;
+        sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx] = (inHigh + inLow) / 2.0;
         sp.ringPos_trailingFastIdx = sp.ringPos_trailingFastIdx + 1;
         if sp.ringPos_trailingFastIdx >= sp.ringCap_trailingFastIdx {
             sp.ringPos_trailingFastIdx = 0;
         }
-        sp.ring_trailingSlowIdx_inHigh[sp.ringPos_trailingSlowIdx] = inHigh;
-        sp.ring_trailingSlowIdx_inLow[sp.ringPos_trailingSlowIdx] = inLow;
+        sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx] = (inHigh + inLow) / 2.0;
         sp.ringPos_trailingSlowIdx = sp.ringPos_trailingSlowIdx + 1;
         if sp.ringPos_trailingSlowIdx >= sp.ringCap_trailingSlowIdx {
             sp.ringPos_trailingSlowIdx = 0;
@@ -561,23 +553,27 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let allocN_trailingFastIdx: usize = if cap_trailingFastIdx > 0 { cap_trailingFastIdx as usize } else { 1 };
-        let mut ring_trailingFastIdx_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
-        ring_trailingFastIdx_inHigh[..cap_trailingFastIdx as usize]
-            .copy_from_slice(&inHigh[historyLen - cap_trailingFastIdx as usize..]);
-        let mut ring_trailingFastIdx_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
-        ring_trailingFastIdx_inLow[..cap_trailingFastIdx as usize]
-            .copy_from_slice(&inLow[historyLen - cap_trailingFastIdx as usize..]);
+        let mut ring_trailingFastIdx_derived: Vec<f64> = vec![0.0_f64; allocN_trailingFastIdx];
+        {
+            let mut fillJ: usize = historyLen - cap_trailingFastIdx as usize;
+            while fillJ < historyLen {
+                ring_trailingFastIdx_derived[fillJ - (historyLen - cap_trailingFastIdx as usize)] = (inHigh[(fillJ) as usize] + inLow[(fillJ) as usize]) / 2.0;
+                fillJ += 1;
+            }
+        }
         let cap_trailingSlowIdx: i64 = (i as i64) - (trailingSlowIdx as i64);
         if cap_trailingSlowIdx < 0 || cap_trailingSlowIdx > historyLen as i64 {
             return Err(RetCode::InternalError);
         }
         let allocN_trailingSlowIdx: usize = if cap_trailingSlowIdx > 0 { cap_trailingSlowIdx as usize } else { 1 };
-        let mut ring_trailingSlowIdx_inHigh: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
-        ring_trailingSlowIdx_inHigh[..cap_trailingSlowIdx as usize]
-            .copy_from_slice(&inHigh[historyLen - cap_trailingSlowIdx as usize..]);
-        let mut ring_trailingSlowIdx_inLow: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
-        ring_trailingSlowIdx_inLow[..cap_trailingSlowIdx as usize]
-            .copy_from_slice(&inLow[historyLen - cap_trailingSlowIdx as usize..]);
+        let mut ring_trailingSlowIdx_derived: Vec<f64> = vec![0.0_f64; allocN_trailingSlowIdx];
+        {
+            let mut fillJ: usize = historyLen - cap_trailingSlowIdx as usize;
+            while fillJ < historyLen {
+                ring_trailingSlowIdx_derived[fillJ - (historyLen - cap_trailingSlowIdx as usize)] = (inHigh[(fillJ) as usize] + inLow[(fillJ) as usize]) / 2.0;
+                fillJ += 1;
+            }
+        }
         let state = AO_StreamState {
             optInFastPeriod,
             optInSlowPeriod,
@@ -586,12 +582,10 @@ impl Core {
             tempReal,
             ringPos_trailingFastIdx: 0_usize,
             ringCap_trailingFastIdx: cap_trailingFastIdx as usize,
-            ring_trailingFastIdx_inHigh,
-            ring_trailingFastIdx_inLow,
+            ring_trailingFastIdx_derived,
             ringPos_trailingSlowIdx: 0_usize,
             ringCap_trailingSlowIdx: cap_trailingSlowIdx as usize,
-            ring_trailingSlowIdx_inHigh,
-            ring_trailingSlowIdx_inLow,
+            ring_trailingSlowIdx_derived,
         };
         Ok(AO_Stream { core: self.clone(), state })
     }

--- a/ta_codegen/output/rust/library/src/ta_func/qstick.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/qstick.rs
@@ -293,8 +293,7 @@ struct QSTICK_StreamState {
     tempReal: f64,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
-    ring_trailingIdx_inOpen: Vec<f64>,
-    ring_trailingIdx_inClose: Vec<f64>,
+    ring_trailingIdx_derived: Vec<f64>,
 }
 
 #[allow(non_snake_case, dead_code)]
@@ -307,8 +306,7 @@ impl QSTICK_StreamState {
         self.tempReal = src.tempReal;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
-        self.ring_trailingIdx_inOpen.clone_from(&src.ring_trailingIdx_inOpen);
-        self.ring_trailingIdx_inClose.clone_from(&src.ring_trailingIdx_inClose);
+        self.ring_trailingIdx_derived.clone_from(&src.ring_trailingIdx_derived);
     }
 }
 
@@ -321,15 +319,13 @@ impl QSTICK_StreamState {
 impl Core {
     fn QSTICK_step_internal(&self, sp: &mut QSTICK_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
         if sp.ringCap_trailingIdx == 0 {
-            sp.ring_trailingIdx_inOpen[0] = inOpen;
-            sp.ring_trailingIdx_inClose[0] = inClose;
+            sp.ring_trailingIdx_derived[0] = (inClose - inOpen) as f64;
         }
         sp.periodTotal += (inClose - inOpen) as f64;
         sp.tempReal = sp.periodTotal;
-        sp.periodTotal -= (sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] - sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx]) as f64;
+        sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
         (*outReal) = sp.tempReal / (sp.optInTimePeriod as f64);
-        sp.ring_trailingIdx_inOpen[sp.ringPos_trailingIdx] = inOpen;
-        sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
+        sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (inClose - inOpen) as f64;
         sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
         if sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx {
             sp.ringPos_trailingIdx = 0;
@@ -428,20 +424,21 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let allocN_trailingIdx: usize = if cap_trailingIdx > 0 { cap_trailingIdx as usize } else { 1 };
-        let mut ring_trailingIdx_inOpen: Vec<f64> = vec![0.0_f64; allocN_trailingIdx];
-        ring_trailingIdx_inOpen[..cap_trailingIdx as usize]
-            .copy_from_slice(&inOpen[historyLen - cap_trailingIdx as usize..]);
-        let mut ring_trailingIdx_inClose: Vec<f64> = vec![0.0_f64; allocN_trailingIdx];
-        ring_trailingIdx_inClose[..cap_trailingIdx as usize]
-            .copy_from_slice(&inClose[historyLen - cap_trailingIdx as usize..]);
+        let mut ring_trailingIdx_derived: Vec<f64> = vec![0.0_f64; allocN_trailingIdx];
+        {
+            let mut fillJ: usize = historyLen - cap_trailingIdx as usize;
+            while fillJ < historyLen {
+                ring_trailingIdx_derived[fillJ - (historyLen - cap_trailingIdx as usize)] = (inClose[(fillJ) as usize] - inOpen[(fillJ) as usize]) as f64;
+                fillJ += 1;
+            }
+        }
         let state = QSTICK_StreamState {
             optInTimePeriod,
             periodTotal,
             tempReal,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
-            ring_trailingIdx_inOpen,
-            ring_trailingIdx_inClose,
+            ring_trailingIdx_derived,
         };
         Ok(QSTICK_Stream { core: self.clone(), state })
     }
@@ -513,14 +510,6 @@ impl Core {
 
 }
 
-thread_local! {
-    /// `peek`'s reusable scratch handle (see `QSTICK_StreamState::restore_from`).
-    /// Taken for the duration of the step and put back after, so a
-    /// panicking step costs the scratch, never leaves it borrowed.
-    static QSTICK_PEEK_SCRATCH: std::cell::Cell<Option<Box<QSTICK_Stream>>> =
-        const { std::cell::Cell::new(None) };
-}
-
 #[allow(non_snake_case)]
 #[allow(unused_variables)]
 impl QSTICK_Stream {
@@ -548,8 +537,10 @@ impl QSTICK_Stream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return (it is the same code, run
     /// on a scratch copy of the state). Never writes the handle, so peeks may
-    /// run concurrently with each other. The copy it runs on is held per thread and reused,
-    /// so only the first peek of this function on a thread allocates.
+    /// run concurrently with each other. The copy is a throwaway. Its buffer clone is
+    /// often removed outright by the optimizer, which is why nothing is
+    /// reused here, but that is not a guarantee: budget for a clone of the
+    /// window and prefer `update` on a `clone()` in a hot loop.
     ///
     /// # Errors
     ///
@@ -560,13 +551,8 @@ impl QSTICK_Stream {
         if !inOpen.is_finite() || !inClose.is_finite() {
             return Err(RetCode::BadParam);
         }
-        QSTICK_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inClose);
-            cell.set(Some(scratch));
-            value
-        })
+        let mut scratch = self.clone();
+        scratch.update(inOpen, inClose)
     }
 }
 


### PR DESCRIPTION
Closes the settings-free part of #229: AO, AC and QSTICK now keep one ring of the derived scalar instead of one ring per raw column.

| function | ring pointers before | after |
|---|---|---|
| AO | 8 | 4 |
| AC | 8 | 4 |
| QSTICK | 4 | 2 |

Five of the 365 collapsible rings in the census. The other 360 are the candlesticks and they are held back by one line — `mentions_candle_settings` — pending your call on the last comment in #229. Everything else in this PR is what they need.

## What the analysis decides

`saving = arrays - distinct derived shapes`, applied only when one shape covers every read at the index. A subtree counts as Derived when every array read inside it is at that index and every other leaf is a literal or a name not written in the loop — so a loop-carried accumulator disqualifies its parent, which is what makes the maximal Derived subtree exactly the subtrahend rather than the whole `sum -= ...` statement.

Two details that cost me a wrong answer each:

**Shapes are keyed with the index blanked.** CDLMORNINGSTAR subtracts `ta_candlerange(..., [T])` and `ta_candlerange(..., [T+1])`; CDLRISEFALL3METHODS spans `[T-4]` through `[T]`. Keying on the raw text reads one function at several offsets as several functions and refuses the collapse for the three widest-window candlesticks — 9 rings.

**`arrays - 1` is an upper bound, not the saving.** VWMA reads `inVolume[t]` inside `inReal[t]*inVolume[t]` *and* alone on the next line; ACCBANDS feeds its columns to four expressions across a branch; BETA and CORREL carry each raw value to the next bar as `trailing_last_price_x/y`. All four score 0 under the rule above and need no special case, which is the check working rather than an exemption.

## The fold has to run before the read rewrite

`rewrite_bar_reads` is bottom-up, so by the time it reaches the enclosing `FuncCall` its `ArrayAccess` children are already ring reads and the shape is gone. Folding first — subtree to `slot[originalIndex]` — leaves everything downstream untouched: `classify_input_index` still returns `OtherVar`/`OtherVarLag`, and `ring_offset_read` needs no edit at all. The two genuinely new emission sites are what gets stored per bar and how `open` seeds the ring.

## A defect this introduced, and how it surfaced

`RingSpec` losing its raw arrays affects **every** backend's capture path, and I only taught the C one to fill the new slot. Rust kept emitting

```rust
ring_trailingFastIdx_derived[..cap as usize]
    .copy_from_slice(&derived[historyLen - cap as usize..]);
```

against a name that no longer exists — six compile errors across AC, AO and QSTICK. Java and C# had the same defect in `System.arraycopy` and `Span.CopyTo` form. This is #217's shape again: one backend fixed, a C-only gate green over the rest.

What caught it was compiling the generated crate, not reading the emitter. All four backends now emit the same per-bar fill loop, and nothing under `ta_codegen/output` still references the vanished column.

## Verification

- `Stream verify: 174 functions, 20200 legs bit-exact vs batch` — and I confirmed this gate has teeth for exactly this change by injecting a wrong fill at the emitter and watching it fail (`STREAM MISMATCH [TA_AC]`, exit 87). My earlier claim on the issue that it missed such defects was wrong; it was an experiment that never rebuilt the server binary the check runs in.
- `C: 161 passed, 0 failed`; the generated Rust crate builds clean; clippy clean.
- `generate` is byte-identical for every function that does not collapse.

**Not claimed:** Java and C# are read, not run — JDK 11 and .NET 6/7 here, the same limit as #218. CI is the first place those two compile.
