### PR TITLE
fix(c): reject overlapping buffers at the produced extent (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ See [github commits](https://github.com/TA-Lib/ta-lib/commits) for complete list
 - ~10%: ATR and NATR
 
 ### Changed
+- (#225) C functions now return `TA_BAD_PARAM` when two output buffers overlap, or when an output *partially* overlaps an input. Computing wholly in place is unchanged and still supported; only partial overlap is refused, which previously corrupted the result silently. Calls that succeeded before and now fail were reading and writing the same memory at different offsets.
 - (#133) BBANDS default `optInTimePeriod` changed from 5 to 20, as intended by John Bollinger.
 - (#120) PPO and APO now default `optInMAType` to EMA (was SMA), matching Gerald Appel's original PPO/MACD definition. Pass `TA_MAType_SMA` explicitly to keep the previous behavior.
 - (#96) Fused multiply-add and other floating-point re-ordering produce minor output differences; an intentional modernization.

--- a/src/ta_func/ta_AC.c
+++ b/src/ta_func/ta_AC.c
@@ -128,6 +128,15 @@ TA_LIB_API TA_RetCode TA_AC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AC_Lookback(optInFastPeriod,optInSlowPeriod,optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Bill Williams' Accelerator/Decelerator Oscillator (New Trading
     * Dimensions, 1998): how fast the Awesome Oscillator is itself
@@ -341,6 +350,13 @@ TA_RetCode TA_S_AC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AC_Lookback(optInFastPeriod,optInSlowPeriod,optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_AC_Lookback(optInFastPeriod,optInSlowPeriod,optInSignalPeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_ACCBANDS.c
+++ b/src/ta_func/ta_ACCBANDS.c
@@ -118,8 +118,25 @@ TA_LIB_API TA_RetCode TA_ACCBANDS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outRealLowerBand )
       return TA_BAD_PARAM;
-   if( outRealUpperBand == outRealMiddleBand || outRealUpperBand == outRealLowerBand || outRealMiddleBand == outRealLowerBand )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ACCBANDS_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outRealUpperBand == outRealMiddleBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced))) ||
+          (outRealUpperBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (outRealMiddleBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (void *)(outRealUpperBand) != (void *)(inHigh) && TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outRealUpperBand) != (void *)(inLow) && TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outRealUpperBand) != (void *)(inClose) && TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outRealMiddleBand) != (void *)(inHigh) && TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outRealMiddleBand) != (void *)(inLow) && TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outRealMiddleBand) != (void *)(inClose) && TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outRealLowerBand) != (void *)(inHigh) && TA_RANGES_OVERLAP(outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outRealLowerBand) != (void *)(inLow) && TA_RANGES_OVERLAP(outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outRealLowerBand) != (void *)(inClose) && TA_RANGES_OVERLAP(outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -270,8 +287,16 @@ TA_RetCode TA_S_ACCBANDS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outRealLowerBand )
       return TA_BAD_PARAM;
-   if( outRealUpperBand == outRealMiddleBand || outRealUpperBand == outRealLowerBand || outRealMiddleBand == outRealLowerBand )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ACCBANDS_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outRealUpperBand == outRealMiddleBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced))) ||
+          (outRealUpperBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (outRealMiddleBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    lookbackTotal = TA_SMA_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_ACOS.c
+++ b/src/ta_func/ta_ACOS.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_ACOS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ACOS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_ACOS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ACOS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_AD.c
+++ b/src/ta_func/ta_AD.c
@@ -98,6 +98,17 @@ TA_LIB_API TA_RetCode TA_AD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Note: Results from this function might vary slightly
     *       from Metastock outputs. The reason being that
@@ -171,6 +182,13 @@ TA_RetCode TA_S_AD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbBar = endIdx - startIdx + 1;
    *outNBElement= nbBar;

--- a/src/ta_func/ta_ADD.c
+++ b/src/ta_func/ta_ADD.c
@@ -82,6 +82,15 @@ TA_LIB_API TA_RetCode TA_ADD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -114,6 +123,13 @@ TA_RetCode TA_S_ADD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_ADOSC.c
+++ b/src/ta_func/ta_ADOSC.c
@@ -132,6 +132,17 @@ TA_LIB_API TA_RetCode TA_ADOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADOSC_Lookback(optInFastPeriod,optInSlowPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Implementation Note:
     *     The fastEMA varaible is not neceseraly the
@@ -296,6 +307,13 @@ TA_RetCode TA_S_ADOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADOSC_Lookback(optInFastPeriod,optInSlowPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInFastPeriod < optInSlowPeriod )
    {

--- a/src/ta_func/ta_ADX.c
+++ b/src/ta_func/ta_ADX.c
@@ -117,6 +117,16 @@ TA_LIB_API TA_RetCode TA_ADX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -521,6 +531,13 @@ TA_RetCode TA_S_ADX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = 2 * optInTimePeriod + TA_GLOBALS_UNSTABLE_PERIOD(TA_FUNC_UNST_ADX,Adx) - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_ADXR.c
+++ b/src/ta_func/ta_ADXR.c
@@ -111,6 +111,16 @@ TA_LIB_API TA_RetCode TA_ADXR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADXR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Original implementation from Wilder's book was doing some integer
     * rounding in its calculations.
@@ -202,6 +212,13 @@ TA_RetCode TA_S_ADXR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ADXR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    adxrLookback = TA_ADXR_Lookback(optInTimePeriod);
    if( startIdx < adxrLookback )

--- a/src/ta_func/ta_AO.c
+++ b/src/ta_func/ta_AO.c
@@ -112,6 +112,15 @@ TA_LIB_API TA_RetCode TA_AO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AO_Lookback(optInFastPeriod,optInSlowPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Bill Williams' Awesome Oscillator (New Trading Dimensions, 1998): the
     * spread between a short and a long simple moving average of the median
@@ -257,6 +266,13 @@ TA_RetCode TA_S_AO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AO_Lookback(optInFastPeriod,optInSlowPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = (int)TA_AO_Lookback(optInFastPeriod,optInSlowPeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_APO.c
+++ b/src/ta_func/ta_APO.c
@@ -120,6 +120,14 @@ TA_LIB_API TA_RetCode TA_APO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_APO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Allocate an intermediate buffer. */
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
@@ -204,6 +212,13 @@ TA_RetCode TA_S_APO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_APO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
    if( !tempBuffer )

--- a/src/ta_func/ta_AROON.c
+++ b/src/ta_func/ta_AROON.c
@@ -105,8 +105,18 @@ TA_LIB_API TA_RetCode TA_AROON( int    startIdx,
       return TA_BAD_PARAM;
    if( !outAroonUp )
       return TA_BAD_PARAM;
-   if( outAroonDown == outAroonUp )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AROON_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outAroonDown == outAroonUp || TA_RANGES_OVERLAP(outAroonDown, TA_OUT_BYTES(outAroonDown,taProduced), outAroonUp, TA_OUT_BYTES(outAroonUp,taProduced))) ||
+          (void *)(outAroonDown) != (void *)(inHigh) && TA_RANGES_OVERLAP(outAroonDown, TA_OUT_BYTES(outAroonDown,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outAroonDown) != (void *)(inLow) && TA_RANGES_OVERLAP(outAroonDown, TA_OUT_BYTES(outAroonDown,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outAroonUp) != (void *)(inHigh) && TA_RANGES_OVERLAP(outAroonUp, TA_OUT_BYTES(outAroonUp,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outAroonUp) != (void *)(inLow) && TA_RANGES_OVERLAP(outAroonUp, TA_OUT_BYTES(outAroonUp,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* This function is using a speed optimized algorithm
     * for the min/max logic.
@@ -241,8 +251,14 @@ TA_RetCode TA_S_AROON( int    startIdx,
       return TA_BAD_PARAM;
    if( !outAroonUp )
       return TA_BAD_PARAM;
-   if( outAroonDown == outAroonUp )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AROON_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outAroonDown == outAroonUp || TA_RANGES_OVERLAP(outAroonDown, TA_OUT_BYTES(outAroonDown,taProduced), outAroonUp, TA_OUT_BYTES(outAroonUp,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_AROONOSC.c
+++ b/src/ta_func/ta_AROONOSC.c
@@ -104,6 +104,15 @@ TA_LIB_API TA_RetCode TA_AROONOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AROONOSC_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* This code is almost identical to the TA_AROON function
     * except that instead of outputing ArroonUp and AroonDown
@@ -250,6 +259,13 @@ TA_RetCode TA_S_AROONOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AROONOSC_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_ASIN.c
+++ b/src/ta_func/ta_ASIN.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_ASIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ASIN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_ASIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ASIN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_ATAN.c
+++ b/src/ta_func/ta_ATAN.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_ATAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ATAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Default return values */
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
@@ -109,6 +117,13 @@ TA_RetCode TA_S_ATAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ATAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_ATR.c
+++ b/src/ta_func/ta_ATR.c
@@ -116,6 +116,16 @@ TA_LIB_API TA_RetCode TA_ATR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ATR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Average True Range is the greatest of the following:
     *
@@ -302,6 +312,13 @@ TA_RetCode TA_S_ATR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ATR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_AVGDEV.c
+++ b/src/ta_func/ta_AVGDEV.c
@@ -89,6 +89,14 @@ TA_LIB_API TA_RetCode TA_AVGDEV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AVGDEV_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    lookback = optInTimePeriod - 1;
    if( startIdx < lookback )
@@ -154,6 +162,13 @@ TA_RetCode TA_S_AVGDEV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AVGDEV_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookback = optInTimePeriod - 1;
    if( startIdx < lookback )

--- a/src/ta_func/ta_AVGPRICE.c
+++ b/src/ta_func/ta_AVGPRICE.c
@@ -92,6 +92,17 @@ TA_LIB_API TA_RetCode TA_AVGPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AVGPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inOpen) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inOpen, TA_IN_BYTES(inOpen)) ||
+          (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Average price = (High + Low + Open + Close) / 4 */
    outIdx = 0;
@@ -132,6 +143,13 @@ TA_RetCode TA_S_AVGPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_AVGPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_BBANDS.c
+++ b/src/ta_func/ta_BBANDS.c
@@ -163,8 +163,19 @@ TA_LIB_API TA_RetCode TA_BBANDS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outRealLowerBand )
       return TA_BAD_PARAM;
-   if( outRealUpperBand == outRealMiddleBand || outRealUpperBand == outRealLowerBand || outRealMiddleBand == outRealLowerBand )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BBANDS_Lookback(optInTimePeriod,optInNbDevUp,optInNbDevDn,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outRealUpperBand == outRealMiddleBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced))) ||
+          (outRealUpperBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (outRealMiddleBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (void *)(outRealUpperBand) != (void *)(inReal) && TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outRealMiddleBand) != (void *)(inReal) && TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outRealLowerBand) != (void *)(inReal) && TA_RANGES_OVERLAP(outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    if( optInMAType == TA_MAType_SMA )
    {
@@ -462,8 +473,16 @@ TA_RetCode TA_S_BBANDS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outRealLowerBand )
       return TA_BAD_PARAM;
-   if( outRealUpperBand == outRealMiddleBand || outRealUpperBand == outRealLowerBand || outRealMiddleBand == outRealLowerBand )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BBANDS_Lookback(optInTimePeriod,optInNbDevUp,optInNbDevDn,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outRealUpperBand == outRealMiddleBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced))) ||
+          (outRealUpperBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealUpperBand, TA_OUT_BYTES(outRealUpperBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) ||
+          (outRealMiddleBand == outRealLowerBand || TA_RANGES_OVERLAP(outRealMiddleBand, TA_OUT_BYTES(outRealMiddleBand,taProduced), outRealLowerBand, TA_OUT_BYTES(outRealLowerBand,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    if( optInMAType == TA_MAType_SMA )
    {

--- a/src/ta_func/ta_BETA.c
+++ b/src/ta_func/ta_BETA.c
@@ -110,6 +110,15 @@ TA_LIB_API TA_RetCode TA_BETA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BETA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    S_xx = 0.0;
    S_xy = 0.0;
@@ -305,6 +314,13 @@ TA_RetCode TA_S_BETA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BETA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    S_xx = 0.0;
    S_xy = 0.0;

--- a/src/ta_func/ta_BOP.c
+++ b/src/ta_func/ta_BOP.c
@@ -90,6 +90,17 @@ TA_LIB_API TA_RetCode TA_BOP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BOP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inOpen) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inOpen, TA_IN_BYTES(inOpen)) ||
+          (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* BOP = (Close - Open)/(High - Low) */
    outIdx = 0;
@@ -138,6 +149,13 @@ TA_RetCode TA_S_BOP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_BOP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_CCI.c
+++ b/src/ta_func/ta_CCI.c
@@ -115,6 +115,16 @@ TA_LIB_API TA_RetCode TA_CCI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CCI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* This ptr will points on a circular buffer of
     * at least "optInTimePeriod" element.
@@ -256,6 +266,13 @@ TA_RetCode TA_S_CCI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CCI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL2CROWS.c
+++ b/src/ta_func/ta_CDL2CROWS.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDL2CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL2CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -204,6 +211,13 @@ TA_RetCode TA_S_CDL2CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL2CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL2CROWS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3BLACKCROWS.c
+++ b/src/ta_func/ta_CDL3BLACKCROWS.c
@@ -99,6 +99,13 @@ TA_LIB_API TA_RetCode TA_CDL3BLACKCROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3BLACKCROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -218,6 +225,13 @@ TA_RetCode TA_S_CDL3BLACKCROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3BLACKCROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3BLACKCROWS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3INSIDE.c
+++ b/src/ta_func/ta_CDL3INSIDE.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDL3INSIDE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3INSIDE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -222,6 +229,13 @@ TA_RetCode TA_S_CDL3INSIDE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3INSIDE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3INSIDE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3LINESTRIKE.c
+++ b/src/ta_func/ta_CDL3LINESTRIKE.c
@@ -99,6 +99,13 @@ TA_LIB_API TA_RetCode TA_CDL3LINESTRIKE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3LINESTRIKE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -210,6 +217,13 @@ TA_RetCode TA_S_CDL3LINESTRIKE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3LINESTRIKE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3LINESTRIKE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3OUTSIDE.c
+++ b/src/ta_func/ta_CDL3OUTSIDE.c
@@ -90,6 +90,13 @@ TA_LIB_API TA_RetCode TA_CDL3OUTSIDE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3OUTSIDE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -172,6 +179,13 @@ TA_RetCode TA_S_CDL3OUTSIDE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3OUTSIDE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3OUTSIDE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3STARSINSOUTH.c
+++ b/src/ta_func/ta_CDL3STARSINSOUTH.c
@@ -123,6 +123,13 @@ TA_LIB_API TA_RetCode TA_CDL3STARSINSOUTH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3STARSINSOUTH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -287,6 +294,13 @@ TA_RetCode TA_S_CDL3STARSINSOUTH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3STARSINSOUTH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3STARSINSOUTH_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDL3WHITESOLDIERS.c
+++ b/src/ta_func/ta_CDL3WHITESOLDIERS.c
@@ -123,6 +123,13 @@ TA_LIB_API TA_RetCode TA_CDL3WHITESOLDIERS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3WHITESOLDIERS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -299,6 +306,13 @@ TA_RetCode TA_S_CDL3WHITESOLDIERS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDL3WHITESOLDIERS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDL3WHITESOLDIERS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLABANDONEDBABY.c
+++ b/src/ta_func/ta_CDLABANDONEDBABY.c
@@ -124,6 +124,13 @@ TA_LIB_API TA_RetCode TA_CDLABANDONEDBABY( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLABANDONEDBABY_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -265,6 +272,13 @@ TA_RetCode TA_S_CDLABANDONEDBABY( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLABANDONEDBABY_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLABANDONEDBABY_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLADVANCEBLOCK.c
+++ b/src/ta_func/ta_CDLADVANCEBLOCK.c
@@ -131,6 +131,13 @@ TA_LIB_API TA_RetCode TA_CDLADVANCEBLOCK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLADVANCEBLOCK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -323,6 +330,13 @@ TA_RetCode TA_S_CDLADVANCEBLOCK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLADVANCEBLOCK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLADVANCEBLOCK_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLBELTHOLD.c
+++ b/src/ta_func/ta_CDLBELTHOLD.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLBELTHOLD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLBELTHOLD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLBELTHOLD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLBELTHOLD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLBELTHOLD_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLBREAKAWAY.c
+++ b/src/ta_func/ta_CDLBREAKAWAY.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLBREAKAWAY( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLBREAKAWAY_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -201,6 +208,13 @@ TA_RetCode TA_S_CDLBREAKAWAY( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLBREAKAWAY_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLBREAKAWAY_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLCLOSINGMARUBOZU.c
+++ b/src/ta_func/ta_CDLCLOSINGMARUBOZU.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLCLOSINGMARUBOZU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCLOSINGMARUBOZU_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLCLOSINGMARUBOZU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCLOSINGMARUBOZU_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLCLOSINGMARUBOZU_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLCONCEALBABYSWALL.c
+++ b/src/ta_func/ta_CDLCONCEALBABYSWALL.c
@@ -99,6 +99,13 @@ TA_LIB_API TA_RetCode TA_CDLCONCEALBABYSWALL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCONCEALBABYSWALL_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -217,6 +224,13 @@ TA_RetCode TA_S_CDLCONCEALBABYSWALL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCONCEALBABYSWALL_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLCONCEALBABYSWALL_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLCOUNTERATTACK.c
+++ b/src/ta_func/ta_CDLCOUNTERATTACK.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLCOUNTERATTACK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCOUNTERATTACK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -227,6 +234,13 @@ TA_RetCode TA_S_CDLCOUNTERATTACK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLCOUNTERATTACK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLCOUNTERATTACK_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLDARKCLOUDCOVER.c
+++ b/src/ta_func/ta_CDLDARKCLOUDCOVER.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLDARKCLOUDCOVER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDARKCLOUDCOVER_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLDARKCLOUDCOVER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDARKCLOUDCOVER_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLDARKCLOUDCOVER_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLDOJI.c
+++ b/src/ta_func/ta_CDLDOJI.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -192,6 +199,13 @@ TA_RetCode TA_S_CDLDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLDOJI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLDOJISTAR.c
+++ b/src/ta_func/ta_CDLDOJISTAR.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDOJISTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -220,6 +227,13 @@ TA_RetCode TA_S_CDLDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDOJISTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLDOJISTAR_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLDRAGONFLYDOJI.c
+++ b/src/ta_func/ta_CDLDRAGONFLYDOJI.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLDRAGONFLYDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDRAGONFLYDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -217,6 +224,13 @@ TA_RetCode TA_S_CDLDRAGONFLYDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLDRAGONFLYDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLDRAGONFLYDOJI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLENGULFING.c
+++ b/src/ta_func/ta_CDLENGULFING.c
@@ -92,6 +92,13 @@ TA_LIB_API TA_RetCode TA_CDLENGULFING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLENGULFING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -180,6 +187,13 @@ TA_RetCode TA_S_CDLENGULFING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLENGULFING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLENGULFING_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLEVENINGDOJISTAR.c
+++ b/src/ta_func/ta_CDLEVENINGDOJISTAR.c
@@ -123,6 +123,13 @@ TA_LIB_API TA_RetCode TA_CDLEVENINGDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLEVENINGDOJISTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -264,6 +271,13 @@ TA_RetCode TA_S_CDLEVENINGDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLEVENINGDOJISTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLEVENINGDOJISTAR_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLEVENINGSTAR.c
+++ b/src/ta_func/ta_CDLEVENINGSTAR.c
@@ -116,6 +116,13 @@ TA_LIB_API TA_RetCode TA_CDLEVENINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLEVENINGSTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -246,6 +253,13 @@ TA_RetCode TA_S_CDLEVENINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLEVENINGSTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLEVENINGSTAR_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLGAPSIDESIDEWHITE.c
+++ b/src/ta_func/ta_CDLGAPSIDESIDEWHITE.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLGAPSIDESIDEWHITE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLGAPSIDESIDEWHITE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -226,6 +233,13 @@ TA_RetCode TA_S_CDLGAPSIDESIDEWHITE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLGAPSIDESIDEWHITE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLGAPSIDESIDEWHITE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLGRAVESTONEDOJI.c
+++ b/src/ta_func/ta_CDLGRAVESTONEDOJI.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLGRAVESTONEDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLGRAVESTONEDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -217,6 +224,13 @@ TA_RetCode TA_S_CDLGRAVESTONEDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLGRAVESTONEDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLGRAVESTONEDOJI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHAMMER.c
+++ b/src/ta_func/ta_CDLHAMMER.c
@@ -122,6 +122,13 @@ TA_LIB_API TA_RetCode TA_CDLHAMMER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHAMMER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -267,6 +274,13 @@ TA_RetCode TA_S_CDLHAMMER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHAMMER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHAMMER_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHANGINGMAN.c
+++ b/src/ta_func/ta_CDLHANGINGMAN.c
@@ -122,6 +122,13 @@ TA_LIB_API TA_RetCode TA_CDLHANGINGMAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHANGINGMAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -267,6 +274,13 @@ TA_RetCode TA_S_CDLHANGINGMAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHANGINGMAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHANGINGMAN_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHARAMI.c
+++ b/src/ta_func/ta_CDLHARAMI.c
@@ -108,6 +108,13 @@ TA_LIB_API TA_RetCode TA_CDLHARAMI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHARAMI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -244,6 +251,13 @@ TA_RetCode TA_S_CDLHARAMI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHARAMI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHARAMI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHARAMICROSS.c
+++ b/src/ta_func/ta_CDLHARAMICROSS.c
@@ -108,6 +108,13 @@ TA_LIB_API TA_RetCode TA_CDLHARAMICROSS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHARAMICROSS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -239,6 +246,13 @@ TA_RetCode TA_S_CDLHARAMICROSS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHARAMICROSS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHARAMICROSS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHIGHWAVE.c
+++ b/src/ta_func/ta_CDLHIGHWAVE.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLHIGHWAVE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIGHWAVE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLHIGHWAVE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIGHWAVE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHIGHWAVE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHIKKAKE.c
+++ b/src/ta_func/ta_CDLHIKKAKE.c
@@ -100,6 +100,13 @@ TA_LIB_API TA_RetCode TA_CDLHIKKAKE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIKKAKE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Confirmation-window countdown + cached 2nd-candle high/low: the pattern
     * state carried without an absolute bar index.
@@ -227,6 +234,13 @@ TA_RetCode TA_S_CDLHIKKAKE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIKKAKE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHIKKAKE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHIKKAKEMOD.c
+++ b/src/ta_func/ta_CDLHIKKAKEMOD.c
@@ -108,6 +108,13 @@ TA_LIB_API TA_RetCode TA_CDLHIKKAKEMOD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIKKAKEMOD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Confirmation window countdown (replaces the absolute patternIdx guard)
     * and a cache of the 3rd candle's high/low (replaces inHigh/inLow
@@ -264,6 +271,13 @@ TA_RetCode TA_S_CDLHIKKAKEMOD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHIKKAKEMOD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHIKKAKEMOD_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLHOMINGPIGEON.c
+++ b/src/ta_func/ta_CDLHOMINGPIGEON.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLHOMINGPIGEON( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHOMINGPIGEON_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -222,6 +229,13 @@ TA_RetCode TA_S_CDLHOMINGPIGEON( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLHOMINGPIGEON_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLHOMINGPIGEON_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLIDENTICAL3CROWS.c
+++ b/src/ta_func/ta_CDLIDENTICAL3CROWS.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLIDENTICAL3CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLIDENTICAL3CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -245,6 +252,13 @@ TA_RetCode TA_S_CDLIDENTICAL3CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLIDENTICAL3CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLIDENTICAL3CROWS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLINNECK.c
+++ b/src/ta_func/ta_CDLINNECK.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLINNECK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLINNECK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -222,6 +229,13 @@ TA_RetCode TA_S_CDLINNECK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLINNECK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLINNECK_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLINVERTEDHAMMER.c
+++ b/src/ta_func/ta_CDLINVERTEDHAMMER.c
@@ -114,6 +114,13 @@ TA_LIB_API TA_RetCode TA_CDLINVERTEDHAMMER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLINVERTEDHAMMER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -244,6 +251,13 @@ TA_RetCode TA_S_CDLINVERTEDHAMMER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLINVERTEDHAMMER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLINVERTEDHAMMER_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLKICKING.c
+++ b/src/ta_func/ta_CDLKICKING.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLKICKING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLKICKING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -232,6 +239,13 @@ TA_RetCode TA_S_CDLKICKING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLKICKING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLKICKING_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLKICKINGBYLENGTH.c
+++ b/src/ta_func/ta_CDLKICKINGBYLENGTH.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLKICKINGBYLENGTH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLKICKINGBYLENGTH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -233,6 +240,13 @@ TA_RetCode TA_S_CDLKICKINGBYLENGTH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLKICKINGBYLENGTH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLKICKINGBYLENGTH_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLLADDERBOTTOM.c
+++ b/src/ta_func/ta_CDLLADDERBOTTOM.c
@@ -99,6 +99,13 @@ TA_LIB_API TA_RetCode TA_CDLLADDERBOTTOM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLADDERBOTTOM_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -207,6 +214,13 @@ TA_RetCode TA_S_CDLLADDERBOTTOM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLADDERBOTTOM_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLLADDERBOTTOM_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLLONGLEGGEDDOJI.c
+++ b/src/ta_func/ta_CDLLONGLEGGEDDOJI.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLLONGLEGGEDDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLONGLEGGEDDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLLONGLEGGEDDOJI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLONGLEGGEDDOJI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLLONGLEGGEDDOJI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLLONGLINE.c
+++ b/src/ta_func/ta_CDLLONGLINE.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLLONGLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLONGLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -214,6 +221,13 @@ TA_RetCode TA_S_CDLLONGLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLLONGLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLLONGLINE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLMARUBOZU.c
+++ b/src/ta_func/ta_CDLMARUBOZU.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLMARUBOZU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMARUBOZU_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -214,6 +221,13 @@ TA_RetCode TA_S_CDLMARUBOZU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMARUBOZU_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLMARUBOZU_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLMATCHINGLOW.c
+++ b/src/ta_func/ta_CDLMATCHINGLOW.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLMATCHINGLOW( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMATCHINGLOW_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -195,6 +202,13 @@ TA_RetCode TA_S_CDLMATCHINGLOW( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMATCHINGLOW_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLMATCHINGLOW_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLMATHOLD.c
+++ b/src/ta_func/ta_CDLMATHOLD.c
@@ -115,6 +115,13 @@ TA_LIB_API TA_RetCode TA_CDLMATHOLD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMATHOLD_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -260,6 +267,13 @@ TA_RetCode TA_S_CDLMATHOLD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMATHOLD_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLMATHOLD_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLMORNINGDOJISTAR.c
+++ b/src/ta_func/ta_CDLMORNINGDOJISTAR.c
@@ -124,6 +124,13 @@ TA_LIB_API TA_RetCode TA_CDLMORNINGDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMORNINGDOJISTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -266,6 +273,13 @@ TA_RetCode TA_S_CDLMORNINGDOJISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMORNINGDOJISTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLMORNINGDOJISTAR_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLMORNINGSTAR.c
+++ b/src/ta_func/ta_CDLMORNINGSTAR.c
@@ -117,6 +117,13 @@ TA_LIB_API TA_RetCode TA_CDLMORNINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMORNINGSTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -248,6 +255,13 @@ TA_RetCode TA_S_CDLMORNINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLMORNINGSTAR_Lookback(optInPenetration);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLMORNINGSTAR_Lookback(optInPenetration);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLONNECK.c
+++ b/src/ta_func/ta_CDLONNECK.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLONNECK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLONNECK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -222,6 +229,13 @@ TA_RetCode TA_S_CDLONNECK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLONNECK_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLONNECK_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLPIERCING.c
+++ b/src/ta_func/ta_CDLPIERCING.c
@@ -100,6 +100,13 @@ TA_LIB_API TA_RetCode TA_CDLPIERCING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLPIERCING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -210,6 +217,13 @@ TA_RetCode TA_S_CDLPIERCING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLPIERCING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLPIERCING_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLRICKSHAWMAN.c
+++ b/src/ta_func/ta_CDLRICKSHAWMAN.c
@@ -114,6 +114,13 @@ TA_LIB_API TA_RetCode TA_CDLRICKSHAWMAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLRICKSHAWMAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -242,6 +249,13 @@ TA_RetCode TA_S_CDLRICKSHAWMAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLRICKSHAWMAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLRICKSHAWMAN_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLRISEFALL3METHODS.c
+++ b/src/ta_func/ta_CDLRISEFALL3METHODS.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLRISEFALL3METHODS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLRISEFALL3METHODS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -247,6 +254,13 @@ TA_RetCode TA_S_CDLRISEFALL3METHODS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLRISEFALL3METHODS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLRISEFALL3METHODS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSEPARATINGLINES.c
+++ b/src/ta_func/ta_CDLSEPARATINGLINES.c
@@ -114,6 +114,13 @@ TA_LIB_API TA_RetCode TA_CDLSEPARATINGLINES( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSEPARATINGLINES_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -244,6 +251,13 @@ TA_RetCode TA_S_CDLSEPARATINGLINES( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSEPARATINGLINES_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSEPARATINGLINES_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSHOOTINGSTAR.c
+++ b/src/ta_func/ta_CDLSHOOTINGSTAR.c
@@ -114,6 +114,13 @@ TA_LIB_API TA_RetCode TA_CDLSHOOTINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSHOOTINGSTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -244,6 +251,13 @@ TA_RetCode TA_S_CDLSHOOTINGSTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSHOOTINGSTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSHOOTINGSTAR_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSHORTLINE.c
+++ b/src/ta_func/ta_CDLSHORTLINE.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLSHORTLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSHORTLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -215,6 +222,13 @@ TA_RetCode TA_S_CDLSHORTLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSHORTLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSHORTLINE_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSPINNINGTOP.c
+++ b/src/ta_func/ta_CDLSPINNINGTOP.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLSPINNINGTOP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSPINNINGTOP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -192,6 +199,13 @@ TA_RetCode TA_S_CDLSPINNINGTOP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSPINNINGTOP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSPINNINGTOP_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSTALLEDPATTERN.c
+++ b/src/ta_func/ta_CDLSTALLEDPATTERN.c
@@ -123,6 +123,13 @@ TA_LIB_API TA_RetCode TA_CDLSTALLEDPATTERN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSTALLEDPATTERN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -289,6 +296,13 @@ TA_RetCode TA_S_CDLSTALLEDPATTERN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSTALLEDPATTERN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSTALLEDPATTERN_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLSTICKSANDWICH.c
+++ b/src/ta_func/ta_CDLSTICKSANDWICH.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLSTICKSANDWICH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSTICKSANDWICH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -200,6 +207,13 @@ TA_RetCode TA_S_CDLSTICKSANDWICH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLSTICKSANDWICH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLSTICKSANDWICH_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLTAKURI.c
+++ b/src/ta_func/ta_CDLTAKURI.c
@@ -114,6 +114,13 @@ TA_LIB_API TA_RetCode TA_CDLTAKURI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTAKURI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -240,6 +247,13 @@ TA_RetCode TA_S_CDLTAKURI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTAKURI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLTAKURI_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLTASUKIGAP.c
+++ b/src/ta_func/ta_CDLTASUKIGAP.c
@@ -98,6 +98,13 @@ TA_LIB_API TA_RetCode TA_CDLTASUKIGAP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTASUKIGAP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -211,6 +218,13 @@ TA_RetCode TA_S_CDLTASUKIGAP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTASUKIGAP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLTASUKIGAP_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLTHRUSTING.c
+++ b/src/ta_func/ta_CDLTHRUSTING.c
@@ -107,6 +107,13 @@ TA_LIB_API TA_RetCode TA_CDLTHRUSTING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTHRUSTING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -226,6 +233,13 @@ TA_RetCode TA_S_CDLTHRUSTING( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTHRUSTING_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLTHRUSTING_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLTRISTAR.c
+++ b/src/ta_func/ta_CDLTRISTAR.c
@@ -99,6 +99,13 @@ TA_LIB_API TA_RetCode TA_CDLTRISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTRISTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -207,6 +214,13 @@ TA_RetCode TA_S_CDLTRISTAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLTRISTAR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLTRISTAR_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLUNIQUE3RIVER.c
+++ b/src/ta_func/ta_CDLUNIQUE3RIVER.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLUNIQUE3RIVER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLUNIQUE3RIVER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -226,6 +233,13 @@ TA_RetCode TA_S_CDLUNIQUE3RIVER( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLUNIQUE3RIVER_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLUNIQUE3RIVER_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLUPSIDEGAP2CROWS.c
+++ b/src/ta_func/ta_CDLUPSIDEGAP2CROWS.c
@@ -106,6 +106,13 @@ TA_LIB_API TA_RetCode TA_CDLUPSIDEGAP2CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLUPSIDEGAP2CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -228,6 +235,13 @@ TA_RetCode TA_S_CDLUPSIDEGAP2CROWS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLUPSIDEGAP2CROWS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLUPSIDEGAP2CROWS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CDLXSIDEGAP3METHODS.c
+++ b/src/ta_func/ta_CDLXSIDEGAP3METHODS.c
@@ -90,6 +90,13 @@ TA_LIB_API TA_RetCode TA_CDLXSIDEGAP3METHODS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLXSIDEGAP3METHODS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -178,6 +185,13 @@ TA_RetCode TA_S_CDLXSIDEGAP3METHODS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CDLXSIDEGAP3METHODS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_CDLXSIDEGAP3METHODS_Lookback();
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_CEIL.c
+++ b/src/ta_func/ta_CEIL.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_CEIL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CEIL_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_CEIL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CEIL_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_CMF.c
+++ b/src/ta_func/ta_CMF.c
@@ -113,6 +113,17 @@ TA_LIB_API TA_RetCode TA_CMF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMF_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Both the per-bar money flow volume and the volume that produced it are
     * carried in the circular buffer. Keeping the volume here rather than
@@ -290,6 +301,13 @@ TA_RetCode TA_S_CMF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMF_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_CMO.c
+++ b/src/ta_func/ta_CMO.c
@@ -107,6 +107,14 @@ TA_LIB_API TA_RetCode TA_CMO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMO_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* CMO calculation is mostly identical to RSI.
     *
@@ -355,6 +363,13 @@ TA_RetCode TA_S_CMO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMO_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_CMOU.c
+++ b/src/ta_func/ta_CMOU.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_CMOU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMOU_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* CMOU -- unsmoothed Chande Momentum Oscillator (as in TradingView ta.cmo,
     * QuantConnect, pandas-ta default). Over the trailing optInTimePeriod changes
@@ -254,6 +262,13 @@ TA_RetCode TA_S_CMOU( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CMOU_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_CORREL.c
+++ b/src/ta_func/ta_CORREL.c
@@ -106,6 +106,15 @@ TA_LIB_API TA_RetCode TA_CORREL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CORREL_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Move up the start index if there is not
     * enough initial data.
@@ -230,6 +239,13 @@ TA_RetCode TA_S_CORREL( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_CORREL_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_COS.c
+++ b/src/ta_func/ta_COS.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_COS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_COS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_COS( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_COS_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_COSH.c
+++ b/src/ta_func/ta_COSH.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_COSH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_COSH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_COSH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_COSH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_DEMA.c
+++ b/src/ta_func/ta_DEMA.c
@@ -104,6 +104,14 @@ TA_LIB_API TA_RetCode TA_DEMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DEMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* For an explanation of this function, please read
     *
@@ -290,6 +298,13 @@ TA_RetCode TA_S_DEMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DEMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outNBElement= 0;
    *outBegIdx= 0;

--- a/src/ta_func/ta_DIV.c
+++ b/src/ta_func/ta_DIV.c
@@ -82,6 +82,15 @@ TA_LIB_API TA_RetCode TA_DIV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DIV_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -114,6 +123,13 @@ TA_RetCode TA_S_DIV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DIV_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_DX.c
+++ b/src/ta_func/ta_DX.c
@@ -119,6 +119,16 @@ TA_LIB_API TA_RetCode TA_DX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -461,6 +471,13 @@ TA_RetCode TA_S_DX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_DX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod > 1 )
    {

--- a/src/ta_func/ta_EFI.c
+++ b/src/ta_func/ta_EFI.c
@@ -104,6 +104,15 @@ TA_LIB_API TA_RetCode TA_EFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EFI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    optInK_1 = 2.0 / (double)(optInTimePeriod + 1);
    /* Alexander Elder's Force Index (Trading for a Living, 1993): the one-bar
@@ -256,6 +265,13 @@ TA_RetCode TA_S_EFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EFI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    optInK_1 = 2.0 / (double)(optInTimePeriod + 1);
    lookbackTotal = TA_EFI_Lookback(optInTimePeriod);

--- a/src/ta_func/ta_EMA.c
+++ b/src/ta_func/ta_EMA.c
@@ -98,6 +98,14 @@ TA_LIB_API TA_RetCode TA_EMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    optInK_1 = 2.0 / (double)(optInTimePeriod + 1);
    /* Identify the minimum number of price bar needed
@@ -220,6 +228,13 @@ TA_RetCode TA_S_EMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    optInK_1 = 2.0 / (double)(optInTimePeriod + 1);
    lookbackTotal = TA_EMA_Lookback(optInTimePeriod);

--- a/src/ta_func/ta_EXP.c
+++ b/src/ta_func/ta_EXP.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_EXP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EXP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_EXP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_EXP_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_FLOOR.c
+++ b/src/ta_func/ta_FLOOR.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_FLOOR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_FLOOR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_FLOOR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_FLOOR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_HMA.c
+++ b/src/ta_func/ta_HMA.c
@@ -125,6 +125,14 @@ TA_LIB_API TA_RetCode TA_HMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The de-lagged series needs only its last sqrt(n) values, so the whole
     * computation runs in one pass over a single window into the input:
@@ -390,6 +398,13 @@ TA_RetCode TA_S_HMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod == 1 )
    {

--- a/src/ta_func/ta_HT_DCPERIOD.c
+++ b/src/ta_func/ta_HT_DCPERIOD.c
@@ -139,6 +139,14 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_DCPERIOD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -499,6 +507,13 @@ TA_RetCode TA_S_HT_DCPERIOD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_DCPERIOD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_HT_DCPHASE.c
+++ b/src/ta_func/ta_HT_DCPHASE.c
@@ -157,6 +157,14 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_DCPHASE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -598,6 +606,13 @@ TA_RetCode TA_S_HT_DCPHASE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_DCPHASE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_HT_PHASOR.c
+++ b/src/ta_func/ta_HT_PHASOR.c
@@ -141,8 +141,16 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outQuadrature )
       return TA_BAD_PARAM;
-   if( outInPhase == outQuadrature )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_PHASOR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outInPhase == outQuadrature || TA_RANGES_OVERLAP(outInPhase, TA_OUT_BYTES(outInPhase,taProduced), outQuadrature, TA_OUT_BYTES(outQuadrature,taProduced))) ||
+          (void *)(outInPhase) != (void *)(inReal) && TA_RANGES_OVERLAP(outInPhase, TA_OUT_BYTES(outInPhase,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outQuadrature) != (void *)(inReal) && TA_RANGES_OVERLAP(outQuadrature, TA_OUT_BYTES(outQuadrature,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -510,8 +518,14 @@ TA_RetCode TA_S_HT_PHASOR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outQuadrature )
       return TA_BAD_PARAM;
-   if( outInPhase == outQuadrature )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_PHASOR_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outInPhase == outQuadrature || TA_RANGES_OVERLAP(outInPhase, TA_OUT_BYTES(outInPhase,taProduced), outQuadrature, TA_OUT_BYTES(outQuadrature,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_HT_SINE.c
+++ b/src/ta_func/ta_HT_SINE.c
@@ -161,8 +161,16 @@ TA_LIB_API TA_RetCode TA_HT_SINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outLeadSine )
       return TA_BAD_PARAM;
-   if( outSine == outLeadSine )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_SINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outSine == outLeadSine || TA_RANGES_OVERLAP(outSine, TA_OUT_BYTES(outSine,taProduced), outLeadSine, TA_OUT_BYTES(outLeadSine,taProduced))) ||
+          (void *)(outSine) != (void *)(inReal) && TA_RANGES_OVERLAP(outSine, TA_OUT_BYTES(outSine,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outLeadSine) != (void *)(inReal) && TA_RANGES_OVERLAP(outLeadSine, TA_OUT_BYTES(outLeadSine,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -610,8 +618,14 @@ TA_RetCode TA_S_HT_SINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outLeadSine )
       return TA_BAD_PARAM;
-   if( outSine == outLeadSine )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_SINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outSine == outLeadSine || TA_RANGES_OVERLAP(outSine, TA_OUT_BYTES(outSine,taProduced), outLeadSine, TA_OUT_BYTES(outLeadSine,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_HT_TRENDLINE.c
+++ b/src/ta_func/ta_HT_TRENDLINE.c
@@ -162,6 +162,14 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_TRENDLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -565,6 +573,13 @@ TA_RetCode TA_S_HT_TRENDLINE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_TRENDLINE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_HT_TRENDMODE.c
+++ b/src/ta_func/ta_HT_TRENDMODE.c
@@ -178,6 +178,13 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_TRENDMODE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -705,6 +712,13 @@ TA_RetCode TA_S_HT_TRENDMODE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_HT_TRENDMODE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_IMI.c
+++ b/src/ta_func/ta_IMI.c
@@ -101,6 +101,15 @@ TA_LIB_API TA_RetCode TA_IMI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_IMI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inOpen) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inOpen, TA_IN_BYTES(inOpen)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    outIdx = 0;
    lookback = TA_IMI_Lookback(optInTimePeriod);
@@ -172,6 +181,13 @@ TA_RetCode TA_S_IMI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_IMI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    lookback = TA_IMI_Lookback(optInTimePeriod);

--- a/src/ta_func/ta_KAMA.c
+++ b/src/ta_func/ta_KAMA.c
@@ -114,6 +114,14 @@ TA_LIB_API TA_RetCode TA_KAMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_KAMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    constMax = 2.0 / (30.0 + 1.0);
    constDiff = 2.0 / (2.0 + 1.0) - constMax;
@@ -319,6 +327,13 @@ TA_RetCode TA_S_KAMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_KAMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    constMax = 2.0 / (30.0 + 1.0);
    constDiff = 2.0 / (2.0 + 1.0) - constMax;

--- a/src/ta_func/ta_LINEARREG.c
+++ b/src/ta_func/ta_LINEARREG.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_LINEARREG( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -222,6 +230,13 @@ TA_RetCode TA_S_LINEARREG( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_LINEARREG_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_LINEARREG_ANGLE.c
+++ b/src/ta_func/ta_LINEARREG_ANGLE.c
@@ -107,6 +107,14 @@ TA_LIB_API TA_RetCode TA_LINEARREG_ANGLE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_ANGLE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -219,6 +227,13 @@ TA_RetCode TA_S_LINEARREG_ANGLE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_ANGLE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_LINEARREG_ANGLE_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_LINEARREG_INTERCEPT.c
+++ b/src/ta_func/ta_LINEARREG_INTERCEPT.c
@@ -104,6 +104,14 @@ TA_LIB_API TA_RetCode TA_LINEARREG_INTERCEPT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_INTERCEPT_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -216,6 +224,13 @@ TA_RetCode TA_S_LINEARREG_INTERCEPT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_INTERCEPT_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_LINEARREG_INTERCEPT_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_LINEARREG_SLOPE.c
+++ b/src/ta_func/ta_LINEARREG_SLOPE.c
@@ -103,6 +103,14 @@ TA_LIB_API TA_RetCode TA_LINEARREG_SLOPE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_SLOPE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -212,6 +220,13 @@ TA_RetCode TA_S_LINEARREG_SLOPE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LINEARREG_SLOPE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_LINEARREG_SLOPE_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_LN.c
+++ b/src/ta_func/ta_LN.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_LN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_LN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_LOG10.c
+++ b/src/ta_func/ta_LOG10.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_LOG10( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LOG10_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_LOG10( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_LOG10_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_MA.c
+++ b/src/ta_func/ta_MA.c
@@ -148,6 +148,14 @@ TA_LIB_API TA_RetCode TA_MA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MA_Lookback(optInTimePeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* No-smoothing identity: period 1 (every MA type) or the explicit
     * TA_MAType_DISABLED (any period, issue #93). One copy path, lookback 0.
@@ -237,6 +245,13 @@ TA_RetCode TA_S_MA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MA_Lookback(optInTimePeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod == 1 || optInMAType == TA_MAType_DISABLED )
    {

--- a/src/ta_func/ta_MACD.c
+++ b/src/ta_func/ta_MACD.c
@@ -149,8 +149,19 @@ TA_LIB_API TA_RetCode TA_MACD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACD_Lookback(optInFastPeriod,optInSlowPeriod,optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (void *)(outMACD) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDSignal) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDHist) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Make sure slow is really slower than
     * the fast period! if not, swap...
@@ -400,8 +411,16 @@ TA_RetCode TA_S_MACD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACD_Lookback(optInFastPeriod,optInSlowPeriod,optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    if( optInSlowPeriod < optInFastPeriod )
    {

--- a/src/ta_func/ta_MACDEXT.c
+++ b/src/ta_func/ta_MACDEXT.c
@@ -164,8 +164,19 @@ TA_LIB_API TA_RetCode TA_MACDEXT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACDEXT_Lookback(optInFastPeriod,optInFastMAType,optInSlowPeriod,optInSlowMAType,optInSignalPeriod,optInSignalMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (void *)(outMACD) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDSignal) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDHist) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    if( optInFastMAType == TA_MAType_EMA && optInSlowMAType == TA_MAType_EMA && optInSignalMAType == TA_MAType_EMA && optInFastPeriod >= 2 && optInSlowPeriod >= 2 && optInSignalPeriod >= 2 )
    {
@@ -371,8 +382,16 @@ TA_RetCode TA_S_MACDEXT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACDEXT_Lookback(optInFastPeriod,optInFastMAType,optInSlowPeriod,optInSlowMAType,optInSignalPeriod,optInSignalMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    if( optInFastMAType == TA_MAType_EMA && optInSlowMAType == TA_MAType_EMA && optInSignalMAType == TA_MAType_EMA && optInFastPeriod >= 2 && optInSlowPeriod >= 2 && optInSignalPeriod >= 2 )
    {

--- a/src/ta_func/ta_MACDFIX.c
+++ b/src/ta_func/ta_MACDFIX.c
@@ -118,8 +118,19 @@ TA_LIB_API TA_RetCode TA_MACDFIX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACDFIX_Lookback(optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (void *)(outMACD) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDSignal) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMACDHist) != (void *)(inReal) && TA_RANGES_OVERLAP(outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    optInFastPeriod = 12;
    optInSlowPeriod = 26;
@@ -341,8 +352,16 @@ TA_RetCode TA_S_MACDFIX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMACDHist )
       return TA_BAD_PARAM;
-   if( outMACD == outMACDSignal || outMACD == outMACDHist || outMACDSignal == outMACDHist )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MACDFIX_Lookback(optInSignalPeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMACD == outMACDSignal || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced))) ||
+          (outMACD == outMACDHist || TA_RANGES_OVERLAP(outMACD, TA_OUT_BYTES(outMACD,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) ||
+          (outMACDSignal == outMACDHist || TA_RANGES_OVERLAP(outMACDSignal, TA_OUT_BYTES(outMACDSignal,taProduced), outMACDHist, TA_OUT_BYTES(outMACDHist,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    optInFastPeriod = 12;
    optInSlowPeriod = 26;

--- a/src/ta_func/ta_MAMA.c
+++ b/src/ta_func/ta_MAMA.c
@@ -180,8 +180,16 @@ TA_LIB_API TA_RetCode TA_MAMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMAMA )
       return TA_BAD_PARAM;
-   if( outFAMA != NULL && outMAMA == outFAMA )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAMA_Lookback(optInFastLimit,optInSlowLimit);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( outFAMA != NULL && (outMAMA == outFAMA || TA_RANGES_OVERLAP(outMAMA, TA_OUT_BYTES(outMAMA,taProduced), outFAMA, TA_OUT_BYTES(outFAMA,taProduced))) ||
+          (void *)(outMAMA) != (void *)(inReal) && TA_RANGES_OVERLAP(outMAMA, TA_OUT_BYTES(outMAMA,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          outFAMA != NULL && (void *)(outFAMA) != (void *)(inReal) && TA_RANGES_OVERLAP(outFAMA, TA_OUT_BYTES(outFAMA,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;
@@ -601,8 +609,14 @@ TA_RetCode TA_S_MAMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMAMA )
       return TA_BAD_PARAM;
-   if( outFAMA != NULL && outMAMA == outFAMA )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAMA_Lookback(optInFastLimit,optInSlowLimit);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( outFAMA != NULL && (outMAMA == outFAMA || TA_RANGES_OVERLAP(outMAMA, TA_OUT_BYTES(outMAMA,taProduced), outFAMA, TA_OUT_BYTES(outFAMA,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    a = 0.0962;
    b = 0.5769;

--- a/src/ta_func/ta_MARKETFI.c
+++ b/src/ta_func/ta_MARKETFI.c
@@ -88,6 +88,16 @@ TA_LIB_API TA_RetCode TA_MARKETFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MARKETFI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Bill Williams' Market Facilitation Index: the price range a bar
     * travelled per unit of volume traded, i.e. how much movement the
@@ -154,6 +164,13 @@ TA_RetCode TA_S_MARKETFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MARKETFI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_MAVP.c
+++ b/src/ta_func/ta_MAVP.c
@@ -143,6 +143,15 @@ TA_LIB_API TA_RetCode TA_MAVP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAVP_Lookback(optInMinPeriod,optInMaxPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outReal) != (void *)(inPeriods) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inPeriods, TA_IN_BYTES(inPeriods)) )
+         return TA_BAD_PARAM;
+   }
 
    /* An inverted period window (min above max) is an invalid parameter
     * combination: the per-bar clamp below would push a period above
@@ -500,6 +509,13 @@ TA_RetCode TA_S_MAVP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAVP_Lookback(optInMinPeriod,optInMaxPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInMinPeriod > optInMaxPeriod )
    {

--- a/src/ta_func/ta_MAX.c
+++ b/src/ta_func/ta_MAX.c
@@ -104,6 +104,14 @@ TA_LIB_API TA_RetCode TA_MAX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -290,6 +298,13 @@ TA_RetCode TA_S_MAX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MAXINDEX.c
+++ b/src/ta_func/ta_MAXINDEX.c
@@ -94,6 +94,13 @@ TA_LIB_API TA_RetCode TA_MAXINDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAXINDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -188,6 +195,13 @@ TA_RetCode TA_S_MAXINDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MAXINDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MEDPRICE.c
+++ b/src/ta_func/ta_MEDPRICE.c
@@ -86,6 +86,15 @@ TA_LIB_API TA_RetCode TA_MEDPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MEDPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* MEDPRICE = (High + Low ) / 2
     * This is the high and low of the same price bar.
@@ -125,6 +134,13 @@ TA_RetCode TA_S_MEDPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MEDPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_MFI.c
+++ b/src/ta_func/ta_MFI.c
@@ -124,6 +124,17 @@ TA_LIB_API TA_RetCode TA_MFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MFI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Id, Type, Static Size */
    if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
@@ -310,6 +321,13 @@ TA_RetCode TA_S_MFI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MFI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod < 1 ) return TA_INTERNAL_ERROR(137);
    if( (int)optInTimePeriod > (int)(sizeof(local_mflow_positive)/sizeof(double)) )

--- a/src/ta_func/ta_MIDPOINT.c
+++ b/src/ta_func/ta_MIDPOINT.c
@@ -111,6 +111,14 @@ TA_LIB_API TA_RetCode TA_MIDPOINT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIDPOINT_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Find the highest and lowest value of a timeserie
     * over the period.
@@ -363,6 +371,13 @@ TA_RetCode TA_S_MIDPOINT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIDPOINT_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MIDPRICE.c
+++ b/src/ta_func/ta_MIDPRICE.c
@@ -118,6 +118,15 @@ TA_LIB_API TA_RetCode TA_MIDPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIDPRICE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* MIDPRICE = (Highest High + Lowest Low)/2
     *
@@ -374,6 +383,13 @@ TA_RetCode TA_S_MIDPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIDPRICE_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MIN.c
+++ b/src/ta_func/ta_MIN.c
@@ -104,6 +104,14 @@ TA_LIB_API TA_RetCode TA_MIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIN_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -289,6 +297,13 @@ TA_RetCode TA_S_MIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MIN_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MININDEX.c
+++ b/src/ta_func/ta_MININDEX.c
@@ -94,6 +94,13 @@ TA_LIB_API TA_RetCode TA_MININDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MININDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -188,6 +195,13 @@ TA_RetCode TA_S_MININDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outInteger )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MININDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MINMAX.c
+++ b/src/ta_func/ta_MINMAX.c
@@ -109,8 +109,16 @@ TA_LIB_API TA_RetCode TA_MINMAX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMax )
       return TA_BAD_PARAM;
-   if( outMin == outMax )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINMAX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMin == outMax || TA_RANGES_OVERLAP(outMin, TA_OUT_BYTES(outMin,taProduced), outMax, TA_OUT_BYTES(outMax,taProduced))) ||
+          (void *)(outMin) != (void *)(inReal) && TA_RANGES_OVERLAP(outMin, TA_OUT_BYTES(outMin,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outMax) != (void *)(inReal) && TA_RANGES_OVERLAP(outMax, TA_OUT_BYTES(outMax,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -363,8 +371,14 @@ TA_RetCode TA_S_MINMAX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMax )
       return TA_BAD_PARAM;
-   if( outMin == outMax )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINMAX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMin == outMax || TA_RANGES_OVERLAP(outMin, TA_OUT_BYTES(outMin,taProduced), outMax, TA_OUT_BYTES(outMax,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MINMAXINDEX.c
+++ b/src/ta_func/ta_MINMAXINDEX.c
@@ -100,8 +100,14 @@ TA_LIB_API TA_RetCode TA_MINMAXINDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMaxIdx )
       return TA_BAD_PARAM;
-   if( outMinIdx == outMaxIdx )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINMAXINDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMinIdx == outMaxIdx || TA_RANGES_OVERLAP(outMinIdx, TA_OUT_BYTES(outMinIdx,taProduced), outMaxIdx, TA_OUT_BYTES(outMaxIdx,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -227,8 +233,14 @@ TA_RetCode TA_S_MINMAXINDEX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outMaxIdx )
       return TA_BAD_PARAM;
-   if( outMinIdx == outMaxIdx )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINMAXINDEX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outMinIdx == outMaxIdx || TA_RANGES_OVERLAP(outMinIdx, TA_OUT_BYTES(outMinIdx,taProduced), outMaxIdx, TA_OUT_BYTES(outMaxIdx,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_MINUS_DI.c
+++ b/src/ta_func/ta_MINUS_DI.c
@@ -118,6 +118,16 @@ TA_LIB_API TA_RetCode TA_MINUS_DI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINUS_DI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -482,6 +492,13 @@ TA_RetCode TA_S_MINUS_DI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINUS_DI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod > 1 )
    {

--- a/src/ta_func/ta_MINUS_DM.c
+++ b/src/ta_func/ta_MINUS_DM.c
@@ -107,6 +107,15 @@ TA_LIB_API TA_RetCode TA_MINUS_DM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINUS_DM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -343,6 +352,13 @@ TA_RetCode TA_S_MINUS_DM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MINUS_DM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod > 1 )
    {

--- a/src/ta_func/ta_MOM.c
+++ b/src/ta_func/ta_MOM.c
@@ -91,6 +91,14 @@ TA_LIB_API TA_RetCode TA_MOM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MOM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The interpretation of the rate of change varies widely depending
     * which software and/or books you are refering to.
@@ -179,6 +187,13 @@ TA_RetCode TA_S_MOM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MOM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_MULT.c
+++ b/src/ta_func/ta_MULT.c
@@ -82,6 +82,15 @@ TA_LIB_API TA_RetCode TA_MULT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MULT_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    outIdx = 0;
    i = startIdx;
@@ -118,6 +127,13 @@ TA_RetCode TA_S_MULT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_MULT_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    i = startIdx;

--- a/src/ta_func/ta_NATR.c
+++ b/src/ta_func/ta_NATR.c
@@ -118,6 +118,16 @@ TA_LIB_API TA_RetCode TA_NATR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_NATR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* This function is very similar as ATR, except
     * it is being normalized as follow:
@@ -354,6 +364,13 @@ TA_RetCode TA_S_NATR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_NATR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_NVI.c
+++ b/src/ta_func/ta_NVI.c
@@ -91,6 +91,15 @@ TA_LIB_API TA_RetCode TA_NVI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_NVI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The index is a running cumulative value seeded at 1000, updated only on
     * bars whose volume decreased versus the prior bar (Negative Volume).
@@ -164,6 +173,13 @@ TA_RetCode TA_S_NVI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_NVI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    prevNVI = 1000.0;
    prevClose = (double)inClose[startIdx];

--- a/src/ta_func/ta_OBV.c
+++ b/src/ta_func/ta_OBV.c
@@ -90,6 +90,15 @@ TA_LIB_API TA_RetCode TA_OBV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_OBV_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    prevOBV = inVolume[startIdx];
    prevReal = inReal[startIdx];
@@ -137,6 +146,13 @@ TA_RetCode TA_S_OBV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_OBV_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    prevOBV = (double)inVolume[startIdx];
    prevReal = (double)inReal[startIdx];

--- a/src/ta_func/ta_PLUS_DI.c
+++ b/src/ta_func/ta_PLUS_DI.c
@@ -118,6 +118,16 @@ TA_LIB_API TA_RetCode TA_PLUS_DI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PLUS_DI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -482,6 +492,13 @@ TA_RetCode TA_S_PLUS_DI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PLUS_DI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod > 1 )
    {

--- a/src/ta_func/ta_PLUS_DM.c
+++ b/src/ta_func/ta_PLUS_DM.c
@@ -108,6 +108,15 @@ TA_LIB_API TA_RetCode TA_PLUS_DM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PLUS_DM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /*
     * The DM1 (one period) is base on the largest part of
@@ -344,6 +353,13 @@ TA_RetCode TA_S_PLUS_DM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PLUS_DM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( optInTimePeriod > 1 )
    {

--- a/src/ta_func/ta_PPO.c
+++ b/src/ta_func/ta_PPO.c
@@ -120,6 +120,14 @@ TA_LIB_API TA_RetCode TA_PPO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PPO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Allocate an intermediate buffer. */
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
@@ -212,6 +220,13 @@ TA_RetCode TA_S_PPO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PPO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
    if( !tempBuffer )

--- a/src/ta_func/ta_PVI.c
+++ b/src/ta_func/ta_PVI.c
@@ -91,6 +91,15 @@ TA_LIB_API TA_RetCode TA_PVI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PVI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The index is a running cumulative value seeded at 1000, updated only on
     * bars whose volume increased versus the prior bar (Positive Volume).
@@ -164,6 +173,13 @@ TA_RetCode TA_S_PVI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PVI_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    prevPVI = 1000.0;
    prevClose = (double)inClose[startIdx];

--- a/src/ta_func/ta_PVO.c
+++ b/src/ta_func/ta_PVO.c
@@ -114,6 +114,14 @@ TA_LIB_API TA_RetCode TA_PVO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PVO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Allocate an intermediate buffer. */
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
@@ -206,6 +214,13 @@ TA_RetCode TA_S_PVO( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_PVO_Lookback(optInFastPeriod,optInSlowPeriod,optInMAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    tempBuffer = malloc((endIdx - startIdx + 1) * sizeof(double));
    if( !tempBuffer )

--- a/src/ta_func/ta_QSTICK.c
+++ b/src/ta_func/ta_QSTICK.c
@@ -95,6 +95,15 @@ TA_LIB_API TA_RetCode TA_QSTICK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_QSTICK_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inOpen) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inOpen, TA_IN_BYTES(inOpen)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Qstick (Chande & Kroll, The New Technical Trader, 1994): a simple moving
     * average of the candle body, close minus open. Above zero means bodies
@@ -197,6 +206,13 @@ TA_RetCode TA_S_QSTICK( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_QSTICK_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = (int)(optInTimePeriod - 1);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_ROC.c
+++ b/src/ta_func/ta_ROC.c
@@ -92,6 +92,14 @@ TA_LIB_API TA_RetCode TA_ROC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROC_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The interpretation of the rate of change varies widely depending
     * which software and/or books you are refering to.
@@ -186,6 +194,13 @@ TA_RetCode TA_S_ROC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROC_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_ROCP.c
+++ b/src/ta_func/ta_ROCP.c
@@ -92,6 +92,14 @@ TA_LIB_API TA_RetCode TA_ROCP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCP_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The interpretation of the rate of change varies widely depending
     * which software and/or books you are refering to.
@@ -186,6 +194,13 @@ TA_RetCode TA_S_ROCP( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCP_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_ROCR.c
+++ b/src/ta_func/ta_ROCR.c
@@ -92,6 +92,14 @@ TA_LIB_API TA_RetCode TA_ROCR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The interpretation of the rate of change varies widely depending
     * which software and/or books you are refering to.
@@ -186,6 +194,13 @@ TA_RetCode TA_S_ROCR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_ROCR100.c
+++ b/src/ta_func/ta_ROCR100.c
@@ -92,6 +92,14 @@ TA_LIB_API TA_RetCode TA_ROCR100( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCR100_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The interpretation of the rate of change varies widely depending
     * which software and/or books you are refering to.
@@ -186,6 +194,13 @@ TA_RetCode TA_S_ROCR100( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ROCR100_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < optInTimePeriod )
    {

--- a/src/ta_func/ta_RSI.c
+++ b/src/ta_func/ta_RSI.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_RSI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_RSI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The following algorithm is base on the original
     * work from Wilder's and shall represent the
@@ -363,6 +371,13 @@ TA_RetCode TA_S_RSI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_RSI_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_SAR.c
+++ b/src/ta_func/ta_SAR.c
@@ -118,6 +118,15 @@ TA_LIB_API TA_RetCode TA_SAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SAR_Lookback(optInAcceleration,optInMaximum);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* > 0 indicates long. == 0 indicates short */
    /* Implementation of the SAR has been a little bit open to interpretation
@@ -410,6 +419,13 @@ TA_RetCode TA_S_SAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SAR_Lookback(optInAcceleration,optInMaximum);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < 1 )
    {

--- a/src/ta_func/ta_SAREXT.c
+++ b/src/ta_func/ta_SAREXT.c
@@ -176,6 +176,15 @@ TA_LIB_API TA_RetCode TA_SAREXT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SAREXT_Lookback(optInStartValue,optInOffsetOnReverse,optInAccelerationInitLong,optInAccelerationLong,optInAccelerationMaxLong,optInAccelerationInitShort,optInAccelerationShort,optInAccelerationMaxShort);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) )
+         return TA_BAD_PARAM;
+   }
 
    /* > 0 indicates long. == 0 indicates short */
    /* This function is the same as TA_SAR, except that the caller has
@@ -567,6 +576,13 @@ TA_RetCode TA_S_SAREXT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SAREXT_Lookback(optInStartValue,optInOffsetOnReverse,optInAccelerationInitLong,optInAccelerationLong,optInAccelerationMaxLong,optInAccelerationInitShort,optInAccelerationShort,optInAccelerationMaxShort);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < 1 )
    {

--- a/src/ta_func/ta_SIN.c
+++ b/src/ta_func/ta_SIN.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_SIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SIN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_SIN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SIN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_SINH.c
+++ b/src/ta_func/ta_SINH.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_SINH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SINH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_SINH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SINH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_SMA.c
+++ b/src/ta_func/ta_SMA.c
@@ -94,6 +94,14 @@ TA_LIB_API TA_RetCode TA_SMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -175,6 +183,13 @@ TA_RetCode TA_S_SMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = (int)(optInTimePeriod - 1);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_SQRT.c
+++ b/src/ta_func/ta_SQRT.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_SQRT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SQRT_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_SQRT( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SQRT_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_STDDEV.c
+++ b/src/ta_func/ta_STDDEV.c
@@ -103,6 +103,14 @@ TA_LIB_API TA_RetCode TA_STDDEV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STDDEV_Lookback(optInTimePeriod,optInNbDev);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Calculate the variance. */
    retCode = TA_VAR(startIdx,endIdx,inReal,optInTimePeriod,1.0,outBegIdx,outNBElement,outReal);
@@ -175,6 +183,13 @@ TA_RetCode TA_S_STDDEV( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STDDEV_Lookback(optInTimePeriod,optInNbDev);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    retCode = TA_S_VAR(startIdx,endIdx,inReal,optInTimePeriod,1.0,outBegIdx,outNBElement,outReal);
    if( retCode != TA_SUCCESS )

--- a/src/ta_func/ta_STOCH.c
+++ b/src/ta_func/ta_STOCH.c
@@ -162,8 +162,20 @@ TA_LIB_API TA_RetCode TA_STOCH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outSlowD )
       return TA_BAD_PARAM;
-   if( outSlowK == outSlowD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCH_Lookback(optInFastK_Period,optInSlowK_Period,optInSlowK_MAType,optInSlowD_Period,optInSlowD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outSlowK == outSlowD || TA_RANGES_OVERLAP(outSlowK, TA_OUT_BYTES(outSlowK,taProduced), outSlowD, TA_OUT_BYTES(outSlowD,taProduced))) ||
+          (void *)(outSlowK) != (void *)(inHigh) && TA_RANGES_OVERLAP(outSlowK, TA_OUT_BYTES(outSlowK,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outSlowK) != (void *)(inLow) && TA_RANGES_OVERLAP(outSlowK, TA_OUT_BYTES(outSlowK,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outSlowK) != (void *)(inClose) && TA_RANGES_OVERLAP(outSlowK, TA_OUT_BYTES(outSlowK,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outSlowD) != (void *)(inHigh) && TA_RANGES_OVERLAP(outSlowD, TA_OUT_BYTES(outSlowD,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outSlowD) != (void *)(inLow) && TA_RANGES_OVERLAP(outSlowD, TA_OUT_BYTES(outSlowD,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outSlowD) != (void *)(inClose) && TA_RANGES_OVERLAP(outSlowD, TA_OUT_BYTES(outSlowD,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* With stochastic, there is a total of 4 different lines that
     * are defined: FASTK, FASTD, SLOWK and SLOWD.
@@ -442,8 +454,14 @@ TA_RetCode TA_S_STOCH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outSlowD )
       return TA_BAD_PARAM;
-   if( outSlowK == outSlowD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCH_Lookback(optInFastK_Period,optInSlowK_Period,optInSlowK_MAType,optInSlowD_Period,optInSlowD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outSlowK == outSlowD || TA_RANGES_OVERLAP(outSlowK, TA_OUT_BYTES(outSlowK,taProduced), outSlowD, TA_OUT_BYTES(outSlowD,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    lookbackK = optInFastK_Period - 1;
    lookbackKSlow = TA_MA_Lookback(optInSlowK_Period,optInSlowK_MAType);

--- a/src/ta_func/ta_STOCHF.c
+++ b/src/ta_func/ta_STOCHF.c
@@ -143,8 +143,20 @@ TA_LIB_API TA_RetCode TA_STOCHF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outFastD )
       return TA_BAD_PARAM;
-   if( outFastK == outFastD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCHF_Lookback(optInFastK_Period,optInFastD_Period,optInFastD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outFastK == outFastD || TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), outFastD, TA_OUT_BYTES(outFastD,taProduced))) ||
+          (void *)(outFastK) != (void *)(inHigh) && TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outFastK) != (void *)(inLow) && TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outFastK) != (void *)(inClose) && TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), inClose, TA_IN_BYTES(inClose)) ||
+          (void *)(outFastD) != (void *)(inHigh) && TA_RANGES_OVERLAP(outFastD, TA_OUT_BYTES(outFastD,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outFastD) != (void *)(inLow) && TA_RANGES_OVERLAP(outFastD, TA_OUT_BYTES(outFastD,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outFastD) != (void *)(inClose) && TA_RANGES_OVERLAP(outFastD, TA_OUT_BYTES(outFastD,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* With stochastic, there is a total of 4 different lines that
     * are defined: FASTK, FASTD, SLOWK and SLOWD.
@@ -405,8 +417,14 @@ TA_RetCode TA_S_STOCHF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outFastD )
       return TA_BAD_PARAM;
-   if( outFastK == outFastD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCHF_Lookback(optInFastK_Period,optInFastD_Period,optInFastD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outFastK == outFastD || TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), outFastD, TA_OUT_BYTES(outFastD,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    lookbackK = optInFastK_Period - 1;
    lookbackFastD = TA_MA_Lookback(optInFastD_Period,optInFastD_MAType);

--- a/src/ta_func/ta_STOCHRSI.c
+++ b/src/ta_func/ta_STOCHRSI.c
@@ -131,8 +131,16 @@ TA_LIB_API TA_RetCode TA_STOCHRSI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outFastD )
       return TA_BAD_PARAM;
-   if( outFastK == outFastD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCHRSI_Lookback(optInTimePeriod,optInFastK_Period,optInFastD_Period,optInFastD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outFastK == outFastD || TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), outFastD, TA_OUT_BYTES(outFastD,taProduced))) ||
+          (void *)(outFastK) != (void *)(inReal) && TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outFastD) != (void *)(inReal) && TA_RANGES_OVERLAP(outFastD, TA_OUT_BYTES(outFastD,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Stochastic RSI
     *
@@ -250,8 +258,14 @@ TA_RetCode TA_S_STOCHRSI( int    startIdx,
       return TA_BAD_PARAM;
    if( !outFastD )
       return TA_BAD_PARAM;
-   if( outFastK == outFastD )
-      return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_STOCHRSI_Lookback(optInTimePeriod,optInFastK_Period,optInFastD_Period,optInFastD_MAType);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (outFastK == outFastD || TA_RANGES_OVERLAP(outFastK, TA_OUT_BYTES(outFastK,taProduced), outFastD, TA_OUT_BYTES(outFastD,taProduced))) )
+         return TA_BAD_PARAM;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_SUB.c
+++ b/src/ta_func/ta_SUB.c
@@ -82,6 +82,15 @@ TA_LIB_API TA_RetCode TA_SUB( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SUB_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal0) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal0, TA_IN_BYTES(inReal0)) ||
+          (void *)(outReal) != (void *)(inReal1) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal1, TA_IN_BYTES(inReal1)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Default return values */
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
@@ -115,6 +124,13 @@ TA_RetCode TA_S_SUB( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SUB_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_SUM.c
+++ b/src/ta_func/ta_SUM.c
@@ -93,6 +93,14 @@ TA_LIB_API TA_RetCode TA_SUM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SUM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -170,6 +178,13 @@ TA_RetCode TA_S_SUM( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_SUM_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_T3.c
+++ b/src/ta_func/ta_T3.c
@@ -125,6 +125,14 @@ TA_LIB_API TA_RetCode TA_T3( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_T3_Lookback(optInTimePeriod,optInVFactor);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* For an explanation of this function, please read:
     *
@@ -315,6 +323,13 @@ TA_RetCode TA_S_T3( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_T3_Lookback(optInTimePeriod,optInVFactor);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = 6 * (optInTimePeriod - 1) + TA_GLOBALS_UNSTABLE_PERIOD(TA_FUNC_UNST_T3,T3);
    if( startIdx <= lookbackTotal )

--- a/src/ta_func/ta_TAN.c
+++ b/src/ta_func/ta_TAN.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_TAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_TAN( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TAN_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_TANH.c
+++ b/src/ta_func/ta_TANH.c
@@ -79,6 +79,14 @@ TA_LIB_API TA_RetCode TA_TANH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TANH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {
@@ -108,6 +116,13 @@ TA_RetCode TA_S_TANH( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TANH_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    for( i = startIdx, outIdx = 0; i <= endIdx; i += 1, outIdx += 1 )
    {

--- a/src/ta_func/ta_TEMA.c
+++ b/src/ta_func/ta_TEMA.c
@@ -109,6 +109,14 @@ TA_LIB_API TA_RetCode TA_TEMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TEMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* For an explanation of this function, please read:
     *
@@ -324,6 +332,13 @@ TA_RetCode TA_S_TEMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TEMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outNBElement= 0;
    *outBegIdx= 0;

--- a/src/ta_func/ta_TRANGE.c
+++ b/src/ta_func/ta_TRANGE.c
@@ -93,6 +93,16 @@ TA_LIB_API TA_RetCode TA_TRANGE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRANGE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* True Range is the greatest of the following:
     *
@@ -180,6 +190,13 @@ TA_RetCode TA_S_TRANGE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRANGE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    if( startIdx < 1 )
    {

--- a/src/ta_func/ta_TRIMA.c
+++ b/src/ta_func/ta_TRIMA.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_TRIMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRIMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -402,6 +410,13 @@ TA_RetCode TA_S_TRIMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRIMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_TRIX.c
+++ b/src/ta_func/ta_TRIX.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_TRIX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRIX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* TRIX = 1-day percent rate-of-change of a triple EMA. */
    /* Will change only on success. */
@@ -275,6 +283,13 @@ TA_RetCode TA_S_TRIX( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TRIX_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outNBElement= 0;
    *outBegIdx= 0;

--- a/src/ta_func/ta_TSF.c
+++ b/src/ta_func/ta_TSF.c
@@ -106,6 +106,14 @@ TA_LIB_API TA_RetCode TA_TSF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TSF_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Linear Regression is a concept also known as the
     * "least squares method" or "best fit." Linear
@@ -222,6 +230,13 @@ TA_RetCode TA_S_TSF( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TSF_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = TA_TSF_Lookback(optInTimePeriod);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_TYPPRICE.c
+++ b/src/ta_func/ta_TYPPRICE.c
@@ -89,6 +89,16 @@ TA_LIB_API TA_RetCode TA_TYPPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TYPPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Typical price = (High + Low + Close ) / 3 */
    outIdx = 0;
@@ -126,6 +136,13 @@ TA_RetCode TA_S_TYPPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_TYPPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_ULTOSC.c
+++ b/src/ta_func/ta_ULTOSC.c
@@ -151,6 +151,16 @@ TA_LIB_API TA_RetCode TA_ULTOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ULTOSC_Lookback(optInTimePeriod1,optInTimePeriod2,optInTimePeriod3);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* The two per-bar terms the three moving sums are built from. Both are a
     * pure function of the bar, so each bar is evaluated once on entry and read
@@ -438,6 +448,13 @@ TA_RetCode TA_S_ULTOSC( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_ULTOSC_Lookback(optInTimePeriod1,optInTimePeriod2,optInTimePeriod3);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    *outBegIdx= 0;
    *outNBElement= 0;

--- a/src/ta_func/ta_VAR.c
+++ b/src/ta_func/ta_VAR.c
@@ -114,6 +114,14 @@ TA_LIB_API TA_RetCode TA_VAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_VAR_Lookback(optInTimePeriod,optInNbDev);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed to calculate
     * at least one output.
@@ -283,6 +291,13 @@ TA_RetCode TA_S_VAR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_VAR_Lookback(optInTimePeriod,optInNbDev);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_VWMA.c
+++ b/src/ta_func/ta_VWMA.c
@@ -101,6 +101,15 @@ TA_LIB_API TA_RetCode TA_VWMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_VWMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) ||
+          (void *)(outReal) != (void *)(inVolume) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inVolume, TA_IN_BYTES(inVolume)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to calculate at least one output.
@@ -225,6 +234,13 @@ TA_RetCode TA_S_VWMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_VWMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = (int)(optInTimePeriod - 1);
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_WAD.c
+++ b/src/ta_func/ta_WAD.c
@@ -95,6 +95,16 @@ TA_LIB_API TA_RetCode TA_WAD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WAD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Williams' Accumulation/Distribution, in the form Steven Achelis
     * published (Technical Analysis from A to Z, 2nd ed., p.368) and the form
@@ -191,6 +201,13 @@ TA_RetCode TA_S_WAD( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WAD_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    sum = 0.0;
    outIdx = 0;

--- a/src/ta_func/ta_WCLPRICE.c
+++ b/src/ta_func/ta_WCLPRICE.c
@@ -90,6 +90,16 @@ TA_LIB_API TA_RetCode TA_WCLPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WCLPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Weighted Close Price = (High + Low + (Close*2) ) / 4 */
    outIdx = 0;
@@ -128,6 +138,13 @@ TA_RetCode TA_S_WCLPRICE( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WCLPRICE_Lookback();
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    outIdx = 0;
    for( i = startIdx; i <= endIdx; i += 1 )

--- a/src/ta_func/ta_WILLR.c
+++ b/src/ta_func/ta_WILLR.c
@@ -115,6 +115,16 @@ TA_LIB_API TA_RetCode TA_WILLR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WILLR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inHigh) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inHigh, TA_IN_BYTES(inHigh)) ||
+          (void *)(outReal) != (void *)(inLow) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inLow, TA_IN_BYTES(inLow)) ||
+          (void *)(outReal) != (void *)(inClose) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inClose, TA_IN_BYTES(inClose)) )
+         return TA_BAD_PARAM;
+   }
 
    /* Identify the minimum number of price bar needed
     * to identify at least one output over the specified
@@ -389,6 +399,13 @@ TA_RetCode TA_S_WILLR( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WILLR_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    nbInitialElementNeeded = optInTimePeriod - 1;
    if( startIdx < nbInitialElementNeeded )

--- a/src/ta_func/ta_WMA.c
+++ b/src/ta_func/ta_WMA.c
@@ -98,6 +98,14 @@ TA_LIB_API TA_RetCode TA_WMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      if( (void *)(outReal) != (void *)(inReal) && TA_RANGES_OVERLAP(outReal, TA_OUT_BYTES(outReal,taProduced), inReal, TA_IN_BYTES(inReal)) )
+         return TA_BAD_PARAM;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    /* Move up the start index if there is not
@@ -239,6 +247,13 @@ TA_RetCode TA_S_WMA( int    startIdx,
       return TA_BAD_PARAM;
    if( !outReal )
       return TA_BAD_PARAM;
+   {
+      int taFirst = (int)TA_WMA_Lookback(optInTimePeriod);
+      int taProduced;
+      if( taFirst < startIdx ) taFirst = startIdx;
+      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;
+      (void)taProduced;
+   }
 
    lookbackTotal = optInTimePeriod - 1;
    if( startIdx < lookbackTotal )

--- a/src/ta_func/ta_utility.h
+++ b/src/ta_func/ta_utility.h
@@ -15,6 +15,53 @@
    #include "ta_global.h"
 #endif
 
+/* uintptr_t for TA_RANGES_OVERLAP below. No conditional fallback: a platform
+ * without the type should fail to compile rather than silently fall back to a
+ * pointer-equality guard, which would restore the weaker check that #225 is
+ * about while still reporting success. */
+#include <stdint.h>
+
+/* Do the byte ranges [a, a+an) and [b, b+bn) intersect?  (issue #225)
+ *
+ * Comparing pointers into DIFFERENT objects with < is undefined in C11 6.5.8p5,
+ * so this casts to uintptr_t. The standards gap costs an answer only where
+ * either answer is correct:
+ *   - two pointers into the SAME object -- the case the guard must catch --
+ *     order consistently under the cast, so a real overlap is never missed;
+ *   - pointers into distinct live objects occupy disjoint address ranges, so
+ *     for correctly sized buffers the test cannot report a false overlap.
+ *
+ * A ZERO extent short-circuits to "no overlap". The two-term half-open test is
+ * only equivalent to max(a,b) < min(a+eA,b+eB) when both extents are positive,
+ * and a zero produced count is both reachable and common -- without this,
+ * TA_SMA(0, 5, buf, 30, ..., out = buf + 2) flips from TA_SUCCESS/nb=0 to
+ * TA_BAD_PARAM.
+ *
+ * Byte extents rather than element counts keep it type-agnostic: MINMAXINDEX's
+ * int outputs against a double input need no special case. Strictly `<` on both
+ * sides: a closed interval would reject touching-but-disjoint buffers, which is
+ * the layout the documented Exact Allocation recipe produces. */
+#define TA_RANGES_OVERLAP(a,an,b,bn) \
+   ( (an) != 0 && (bn) != 0 && \
+     (uintptr_t)(a) < (uintptr_t)(b) + (bn) && (uintptr_t)(b) < (uintptr_t)(a) + (an) )
+
+/* Byte extents of an output and an input buffer.
+ *
+ * An output holds the elements actually WRITTEN, not the requested range:
+ * `endIdx - max(startIdx, lookback) + 1`, clamped at zero. That is method 3
+ * ("Exact Allocation") in website/src/api/README.md 3.3, so it is the size a
+ * caller following our own documentation provides -- using the range instead
+ * over-states by max(0, lookback - startIdx) and rejects that caller. The
+ * clamp must happen before the byte multiply: a negative count would wrap the
+ * extent to ~2^64 and make the predicate answer "no overlap", the one
+ * fail-open path in the scheme.
+ *
+ * An input is read at ABSOLUTE indices up to endIdx, so its extent from the
+ * base is endIdx+1 elements -- measuring from `in + startIdx`, or at the
+ * narrower range extent, silently reopens the hole. */
+#define TA_OUT_BYTES(p,produced)  ( (size_t)(produced) * sizeof((p)[0]) )
+#define TA_IN_BYTES(p)            ( (size_t)(endIdx + 1) * sizeof((p)[0]) )
+
 /* FMA runtime CPU dispatch (PR #96): mark fused indicators with target_clones so
  * a portable baseline build (e.g. a manylinux wheel) dispatches to a hardware-fma
  * clone at load — no -mfma, no SIGILL on pre-2013 CPUs. glibc-only: target_clones

--- a/src/tools/ta_regtest/test_codegen.c
+++ b/src/tools/ta_regtest/test_codegen.c
@@ -6900,6 +6900,94 @@ static ErrorNumber verify_fuzz_zerosum_nonvacuous(void)
  * directly — each of the 3 outputs aliased onto each of the 3 inputs must
  * reproduce the separate-buffer result BIT-FOR-BIT (all 3 bands, to catch an
  * aliased write corrupting a still-needed read of another band's input). */
+/* #225: buffer-overlap rejects, batch tier.
+ *
+ * Four shapes. Three must be REJECTED once the guard lands; the fourth must
+ * stay ACCEPTED and bit-identical, because a false reject is this change's
+ * only real failure mode.
+ *
+ * The startIdx > 0 shape is the one no fill-tier probe can reach:
+ * TA_*_OpenAndFill passes startIdx = 0 internally, where the write-extent and
+ * read-extent rules coincide exactly. Only a batch call with startIdx > 0
+ * separates `endIdx - startIdx + 1` (wrong for an input, short by startIdx)
+ * from `endIdx + 1`.
+ */
+static ErrorNumber verify_buffer_overlap_rejects(void)
+{
+    enum { ON = 300, OPER = 30 };
+    static double src[ON], buf[ON + 8], sep1[ON + 8], sep2[ON + 8];
+    static double ref[ON], got[ON];
+    int bi, nb, i, bad = 0, accepted = 0;
+    TA_RetCode rc;
+
+    for( i = 0; i < ON; i++ )
+        src[i] = 100.0 + (i % 17) * 1.5 + (i % 7) * 0.25;
+
+    /* ---- must stay ACCEPTED: whole-buffer in place, value-identical ------ */
+    if( TA_SMA(0, ON - 1, src, OPER, &bi, &nb, ref) != TA_SUCCESS )
+    {
+        printf("overlap probe: reference SMA failed\n");
+        return TA_TSTCDL_PREDICATE_VACUOUS;
+    }
+    memcpy(buf, src, sizeof(double) * ON);
+    rc = TA_SMA(0, ON - 1, buf, OPER, &bi, &nb, buf);
+    if( rc != TA_SUCCESS )
+    {
+        printf("OVERLAP PROBE: whole-buffer in-place SMA was REJECTED (rc=%d) -- "
+               "false reject\n", (int)rc);
+        bad++;
+    }
+    else
+    {
+        for( i = 0; i < nb; i++ )
+            if( memcmp(&buf[i], &ref[i], sizeof(double)) != 0 ) { bad++; break; }
+        if( i < nb )
+            printf("OVERLAP PROBE: in-place SMA differs from the disjoint result "
+                   "at %d\n", i);
+    }
+
+    /* ---- must stay ACCEPTED: a range that produces nothing --------------
+     * The two-term half-open test is only equivalent to the max/min form when
+     * both extents are positive, so a zero produced count has to short-circuit
+     * to "no overlap". Without that this flips from TA_SUCCESS/nb=0 to
+     * TA_BAD_PARAM. */
+    memcpy(buf, src, sizeof(double) * ON);
+    rc = TA_SMA(0, 5, buf, 30, &bi, &nb, buf + 2);
+    if( rc != TA_SUCCESS || nb != 0 )
+    {
+        printf("OVERLAP PROBE: empty-range SMA (lookback past endIdx) rc=%d nb=%d, "
+               "expected TA_SUCCESS/0\n", (int)rc, nb);
+        bad++;
+    }
+
+    /* ---- must be REJECTED: two outputs one element apart ---------------- */
+    rc = TA_BBANDS(0, ON - 1, src, 5, 2.0, 2.0, TA_MAType_SMA, &bi, &nb,
+                   buf, buf + 1, sep1);
+    if( rc != TA_BAD_PARAM ) { printf("OVERLAP PROBE: out/out overlap accepted (rc=%d)\n", (int)rc); accepted++; }
+
+    /* ---- must be REJECTED: input and output one element apart ----------- */
+    memcpy(buf, src, sizeof(double) * ON);
+    rc = TA_BBANDS(0, ON - 1, buf, 5, 2.0, 2.0, TA_MAType_SMA, &bi, &nb,
+                   buf + 1, sep1, sep2);
+    if( rc != TA_BAD_PARAM ) { printf("OVERLAP PROBE: in/out overlap accepted (rc=%d)\n", (int)rc); accepted++; }
+
+    /* ---- must be REJECTED: out = in + startIdx, the extent-rule case ---- */
+    memcpy(buf, src, sizeof(double) * ON);
+    rc = TA_SMA(100, ON - 1, buf, OPER, &bi, &nb, buf + 100);
+    if( rc != TA_BAD_PARAM ) { printf("OVERLAP PROBE: out = in + startIdx accepted (rc=%d) -- "
+                                      "reads [71..%d], writes [100..%d]\n", (int)rc, ON - 1, ON - 1); accepted++; }
+
+    if( bad || accepted )
+    {
+        printf("  Buffer-overlap rejects: %d false reject(s)/value change(s), "
+               "%d colliding call(s) still accepted\n", bad, accepted);
+        return TA_CODEGEN_STREAM_MISMATCH;
+    }
+    printf("  Buffer-overlap rejects: 3 colliding shapes refused, whole-buffer "
+           "in place accepted and bit-identical\n");
+    return TA_TEST_PASS;
+}
+
 static ErrorNumber verify_accbands_inplace_aliasing(void)
 {
     enum { AN = 300, AP = 14 };
@@ -6997,6 +7085,9 @@ ErrorNumber test_codegen(const TA_History *history,
     if( errNb != TA_TEST_PASS )
         return errNb;
     errNb = verify_accbands_inplace_aliasing();
+    if( errNb != TA_TEST_PASS )
+        return errNb;
+    errNb = verify_buffer_overlap_rejects();
     if( errNb != TA_TEST_PASS )
         return errNb;
 

--- a/ta_codegen/generator/src/backends/c.rs
+++ b/ta_codegen/generator/src/backends/c.rs
@@ -900,12 +900,49 @@ fn gen_func_inner(
             out.push_str(&format!("   if( !{} )\n", output.name));
             out.push_str("      return TA_BAD_PARAM;\n");
         }
-        // Output-distinctness check: aliasing two different output buffers has no
-        // correct result (each would clobber the other), so reject it. Input ==
-        // output in-place aliasing is deliberately left allowed. See issue #108.
-        // A nullable operand is guarded non-NULL first (a dropped output aliases
-        // nothing; two NULLs would otherwise compare equal and spuriously reject).
-        if func.outputs.len() >= 2 {
+        // Buffer-overlap rejects (issue #225, and #108 for the identity case
+        // the first of them subsumes). BOTH rules ship together and are NOT
+        // independent: out x out alone at the produced extent is fail-open,
+        // because `outA = in, outB = in + produced` passes it and then overruns
+        // outB. Deleting either as redundant reopens that.
+        //
+        // The extent is the number of elements actually WRITTEN --
+        // `endIdx - max(startIdx, lookback) + 1`, clamped at zero -- not the
+        // requested range. That is the size the documented Exact Allocation
+        // recipe yields (website/src/api/README.md 3.3), so the range extent
+        // would reject callers following our own documentation, and does:
+        // three same-size mallocs land inside it. Inputs are read at absolute
+        // indices, so they keep `endIdx + 1` from the base.
+        //
+        // This is also what the Rust backend has always asserted
+        // (rust_lang.rs, `endIdx - max(startIdx, lookback) + 1`); C is adopting
+        // its sibling's contract rather than inventing one.
+        //
+        // Self-consistent under composition, which is why internal composed
+        // calls need no exemption: a composed call extends the inner range by
+        // exactly the lookback the callee then consumes, so the callee's
+        // produced count equals the caller's and the inner check sees the
+        // extent the outer check already accepted.
+        if func.outputs.len() >= 2 || !func.outputs.is_empty() && !func.inputs.is_empty() {
+            let lb_args: Vec<String> = func
+                .optional_inputs
+                .iter()
+                .map(|p| p.name.clone())
+                .collect();
+            let uname = name_override.map_or_else(
+                || func.name.to_uppercase(),
+                |n| n.trim_start_matches("TA_").to_string(),
+            );
+            out.push_str("   {\n");
+            out.push_str(&format!(
+                "      int taFirst = (int)TA_{uname}_Lookback({});\n",
+                lb_args.join(",")
+            ));
+            out.push_str("      int taProduced;\n");
+            out.push_str("      if( taFirst < startIdx ) taFirst = startIdx;\n");
+            out.push_str(
+                "      taProduced = ( taFirst > endIdx ) ? 0 : endIdx - taFirst + 1;\n",
+            );
             let mut pairs: Vec<String> = Vec::new();
             for i in 0..func.outputs.len() {
                 for j in (i + 1)..func.outputs.len() {
@@ -918,11 +955,42 @@ fn gen_func_inner(
                     if b.is_nullable() {
                         guard.push_str(&format!("{} != NULL && ", b.name));
                     }
-                    pairs.push(format!("{guard}{} == {}", a.name, b.name));
+                    pairs.push(format!(
+                        "{guard}({0} == {1} || TA_RANGES_OVERLAP({0}, TA_OUT_BYTES({0},taProduced), {1}, TA_OUT_BYTES({1},taProduced)))",
+                        a.name, b.name
+                    ));
                 }
             }
-            out.push_str(&format!("   if( {} )\n", pairs.join(" || ")));
-            out.push_str("      return TA_BAD_PARAM;\n");
+            for o in &func.outputs {
+                let o_int = o.param_type == ParamType::Integer;
+                for i in &func.inputs {
+                    let i_int = i.param_type == ParamType::Integer;
+                    // The float variant widens on read, so its inputs are a
+                    // different element type from the double outputs and cannot
+                    // share memory.
+                    if single_precision && !i_int {
+                        continue;
+                    }
+                    if o_int != i_int {
+                        continue;
+                    }
+                    let mut guard = String::new();
+                    if o.is_nullable() {
+                        guard.push_str(&format!("{} != NULL && ", o.name));
+                    }
+                    pairs.push(format!(
+                        "{guard}(void *)({0}) != (void *)({1}) && TA_RANGES_OVERLAP({0}, TA_OUT_BYTES({0},taProduced), {1}, TA_IN_BYTES({1}))",
+                        o.name, i.name
+                    ));
+                }
+            }
+            if pairs.is_empty() {
+                out.push_str("      (void)taProduced;\n");
+            } else {
+                out.push_str(&format!("      if( {} )\n", pairs.join(" ||\n          ")));
+                out.push_str("         return TA_BAD_PARAM;\n");
+            }
+            out.push_str("   }\n");
         }
         out.push('\n');
     }

--- a/website/src/api/README.md
+++ b/website/src/api/README.md
@@ -170,13 +170,15 @@ it is TA_SMA_Lookback.</p>
 ### 3.4 Return Codes {#retcode}
 
 <p>Every TA function returns a <b>TA_RetCode</b>. <b>TA_SUCCESS</b> (zero) means the call completed and wrote its outputs; on anything else, treat outBegIdx and outNBElement as undefined and the output buffers as untouched.</p>
+
+<p>Computing <b>wholly in place</b> is allowed and stays supported — passing the same buffer as both an input and an output is how several indicators are meant to be used. What is rejected is <i>partial</i> overlap: two views of the same memory at different offsets make a function write through what it is still reading, and the result would be silently wrong rather than merely surprising. The extents compared are the elements actually written for an output (<a href="#output_size">Exact Allocation</a>, method 3 above) and <code>endIdx + 1</code> from the base for an input, which is where the highest index read reaches.</p>
 <p>The codes a caller normally encounters:</p>
 
 | Code | Meaning |
 |------|---------|
 | `TA_SUCCESS` | No error. |
 | `TA_LIB_NOT_INITIALIZE` | [TA_Initialize](#init) was not called, or did not succeed. |
-| `TA_BAD_PARAM` | A parameter is out of range, or a required pointer is NULL. |
+| `TA_BAD_PARAM` | A parameter is out of range, a required pointer is NULL, or two output buffers overlap / an output *partially* overlaps an input. |
 | `TA_ALLOC_ERR` | Allocation failed, most likely out of memory. |
 | `TA_OUT_OF_RANGE_START_INDEX` | startIdx is negative or above [TA_MAX_INDEX](#index_range). |
 | `TA_OUT_OF_RANGE_END_INDEX` | endIdx is negative, above [TA_MAX_INDEX](#index_range), or below startIdx. |

--- a/website/src/api/stream/README.md
+++ b/website/src/api/stream/README.md
@@ -89,6 +89,8 @@ TA_MACD_Update( s, close, &macd, &signal, &hist );
 | `TA_<NAME>_Update` / `TA_<NAME>_Peek` | `TA_BAD_PARAM` on NULL arguments, and on a non-finite bar value — in which case the handle is left exactly as it was |
 | `TA_<NAME>_Close`  | `TA_SUCCESS`; `TA_<NAME>_Close(NULL)` is a no-op |
 
+**Buffer overlap is the caller's responsibility outside `OpenAndFill`.** `OpenAndFill` carries the same reject as the batch entries, and is stricter: it refuses an output that aliases an input at all, not only partially. `Open`, `Update` and `Peek` do not check. `Update` and `Peek` take scalar `double *` outputs, where two of them either coincide or are disjoint — a partial overlap needs a misaligned cast, which is undefined before the call is made — so the only reachable mistake is passing the same pointer for two outputs, e.g. `TA_MACD_Update(s, x, &a, &a, &b)`, which returns `TA_SUCCESS` with one output clobbered. `Open` writes one element per output and is the same story. These are the hottest paths in the library and are deliberately left unchecked; pass distinct outputs.
+
 **Non-finite input is rejected.** NaN and ±Inf are not supported as inputs anywhere in TA-Lib, but the streaming tier is the one that *enforces* it: every public streaming entry point checks, and rejects without touching the handle. The batch API does not filter — it computes on whatever it is given.
 
 The difference is the retained state. Batch computes and forgets, so a NaN reaches the outputs depending on that bar and no others; a stream handle carries state forward, so a single non-finite bar would poison every value it produces afterwards, long after the feed recovers. Rejecting the bar and leaving the handle usable is more useful than accepting it and going permanently NaN.


### PR DESCRIPTION
Implements the ruling. Two rejects from the single site at `c.rs`, measured at the produced extent.

## The extent

```
first    = max(startIdx, TA_<NAME>_Lookback(<validated optIns>))
produced = (first > endIdx) ? 0 : endIdx - first + 1
outExt   = produced * sizeof(out elem)
inExt    = (endIdx + 1) * sizeof(in elem)
```

Emitted as one block after the optIn validation, so the lookback sees validated values. All four amendments are in, and the emitter comment records each one with the failure it prevents — a later reader has to actively decide to reopen them rather than tidy them away.

## Evidence

Red half first, on `dev` before any fix — the probe sits beside `verify_accbands_inplace_aliasing()`, no new file:

```
OVERLAP PROBE: out/out overlap accepted (rc=0)
OVERLAP PROBE: in/out overlap accepted (rc=0)
OVERLAP PROBE: out = in + startIdx accepted (rc=0) -- reads [71..299], writes [100..299]
```

With the fix:

```
Buffer-overlap rejects: 3 colliding shapes refused, whole-buffer in place
                        accepted and bit-identical
Stream verify: 174 functions, 20200 legs bit-exact vs batch
C: 161 passed, 0 failed
```

The probe pins the accepted side as hard as the rejected one: whole-buffer in place must stay `TA_SUCCESS` **and** bit-identical to the disjoint result, and the empty range (`TA_SMA(0, 5, buf, 30, ..., buf + 2)`) must stay `TA_SUCCESS`/nb=0. Those are the amendment-2 and false-reject cases.

**Reverting sabotage**, the red half of record: dropping the in/out rule from the emitter and regenerating reopens 2 of the 3 shapes, including `out = in + startIdx`. That is the coupling in amendment 4 demonstrated rather than asserted.

`git diff` shows the Rust, Java and C# outputs unchanged and the `TA_S_` bodies unchanged; the float variant carries no reject, since a `const float *` input cannot alias a `double *` output.

## What I got wrong on the way, since it shaped the patch

I applied your §2 "do not couple to `TA_X_Lookback()`" to the output side as well, which is where it is load-bearing, and then read the resulting false rejects as a property of internal composed calls. I built a census of those calls — 40 sites, 22 passing the caller's own output inward, 8 false-rejectable — and offered you four structural options, all of which the correct extent dissolves. The census was real work aimed at the wrong question.

Two of the four options I offered were also unsound on their own terms, and I withdrew them in-thread: "land out x out first" was based on an isolation run I had not repeated after the build drifted, and is dead anyway under amendment 4.

## Not in this PR

- **`stoch.c`'s error path**, reported separately in-thread: the `memmove` at line 363 runs before the `retCode` check at 369, so a failing inner call copies through a stale `*outNBElement`. Measured — a sentinel past the caller's buffer is overwritten. Unreachable today because that inner `TA_MA` has never failed; my first attempt made it fail and that is how it surfaced. It is a transcribed body and you ruled those off-limits here, so it is untouched and awaiting your call on whether it belongs to this issue, and whether the fix is moving the copy or zeroing the out-params in the reject preamble.
- **Open / Update / Peek** carry no reject, per your §3. The streaming page now states that explicitly instead of leaving it to be inferred from `OpenAndFill` being stricter.
