### PR TITLE
fix(rust): check output capacity before output aliasing (#261)

### DIFF
--- a/docs/error-handling-spec.md
+++ b/docs/error-handling-spec.md
@@ -165,7 +165,8 @@ than a rule is the defect, not which side is right — see #260.
 
 **Implementation**: `testIndexRange`, `checkOutputAliasRejected`,
 `testBatchArgumentContract` (`test_abstract.c`, `test_internals.c`);
-`c_batch_prologue_orders_parameters_before_presence` (ta_codegen's suite);
+`c_batch_prologue_orders_parameters_before_presence`,
+`rust_batch_impl_orders_capacity_before_aliasing` (ta_codegen's suite);
 `BatchApiTest` (Java, C#); `no_phantom_io` (Rust); `--xlang-hash` for
 same-code-everywhere.
 
@@ -190,7 +191,11 @@ bound goes unchecked there in Rust as it does in C.
 [6] **The condition cannot be written**: two `&mut [f64]` cannot alias, so the
 borrow checker rejects it at compile time. The `as_ptr()` guard behind the public
 entry point therefore never fires on a real alias — but it does fire on distinct
-zero-length outputs, which share a dangling pointer (Appendix F).
+zero-length outputs, which share a dangling pointer (Appendix F). It is emitted
+*after* the capacity asserts: B5 panics in Rust where B6 returns, so this is the
+one pair of batch rules whose order a caller can see in one backend and not the
+others. A call that is both undersized and "aliased" answers the panic; it used
+to answer `BadParam` — #261.
 
 [7] **A run-time error.** Two Java arrays are either the same object or
 disjoint, so reference equality catches every case this rule covers.

--- a/ta_codegen/generator/src/backends/rust_lang.rs
+++ b/ta_codegen/generator/src/backends/rust_lang.rs
@@ -836,6 +836,17 @@ fn gen_guarded_func(
         out.push_str(&gen_opt_param_validation(opt, "        ", false, enums));
     }
 
+    // The bounds-assert preamble: the LLVM proof that elides per-access bounds
+    // checks in a `#![forbid(unsafe_code)]` crate. `guard_empty_range` keeps a
+    // call that computes nothing from panicking.
+    //
+    // BEFORE the aliasing guard below, because the spec orders B5 (a buffer too
+    // short) ahead of B6 (two outputs are the same buffer) and a call that is
+    // both must report the first (#261). The two answer DIFFERENT things here --
+    // a panic against `BadParam` -- so, unlike two rules that share a code, the
+    // order is observable and owed.
+    out.push_str(&emit_bounds_asserts(func, snake, true));
+
     // Output-distinctness (issue #108): aliasing two different output buffers has
     // no correct result. The borrow checker already forbids a safe caller from
     // passing the same `&mut` slice twice, so this only guards the unsafe/FFI
@@ -855,11 +866,6 @@ fn gen_guarded_func(
         out.push_str("            return RetCode::BadParam;\n");
         out.push_str("        }\n");
     }
-
-    // The bounds-assert preamble: the LLVM proof that elides per-access bounds
-    // checks in a `#![forbid(unsafe_code)]` crate. `guard_empty_range` keeps a
-    // call that computes nothing from panicking.
-    out.push_str(&emit_bounds_asserts(func, snake, true));
 
     if func.has_explicit_private {
         // The guarded body contains the pre-computation plus the delegation call

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -691,6 +691,129 @@ fn c_batch_prologue_orders_parameters_before_presence() {
     );
 }
 
+/// The output-distinctness guard of one Rust `_Impl`, reconstructed from the
+/// function's outputs exactly as `rust_lang::gen_guarded_func` writes it.
+///
+/// Reconstructed, not searched for: a transcribed body can hold an `as_ptr()`
+/// comparison of its own — BBANDS elects its scratch with one — so a substring
+/// match would find that instead and read the order backwards.
+fn rust_alias_guard(func: &ir::FuncDef) -> String {
+    let mut pairs: Vec<String> = Vec::new();
+    for i in 0..func.outputs.len() {
+        for j in (i + 1)..func.outputs.len() {
+            pairs.push(format!(
+                "{}.as_ptr() == {}.as_ptr()",
+                func.outputs[i].name, func.outputs[j].name
+            ));
+        }
+    }
+    format!(
+        "        if {} {{\n            return RetCode::BadParam;\n        }}\n",
+        pairs.join(" || ")
+    )
+}
+
+/// `docs/error-handling-spec.md` 2.2: B1, B2, B3, then B5 — a buffer too short —
+/// and only then B6, two outputs that are the same buffer.
+///
+/// Rust is the one backend where the order between those last two is
+/// *observable*, and it had them the wrong way round (#261). Its B5 is an
+/// `assert!` rather than a returned code — footnote [5], the LLVM proof that
+/// elides the per-access bounds checks — so a call that is both undersized and
+/// aliased answered `BadParam` where the specified order makes it a panic. C,
+/// Java and C# answer `TA_BAD_PARAM` for either, so no order is owed there.
+///
+/// Structural, and it has to be: two `&mut [f64]` cannot alias, so safe code
+/// cannot build the multi-fault call this pins.
+#[test]
+fn rust_batch_impl_orders_capacity_before_aliasing() {
+    let mut scanned = 0usize;
+    let mut with_params = 0usize;
+
+    for name in discover_indicators() {
+        let Some((func, enums)) = try_load_indicator(&name) else {
+            continue;
+        };
+        // One output cannot alias a second one; the guard is not emitted.
+        if func.outputs.len() < 2 {
+            continue;
+        }
+        let Some(out) = try_generate_all(&func, &enums) else {
+            continue;
+        };
+        // Spans the FMA dispatch trio where there is one: the two wrappers carry
+        // no prologue, so the markers below still land in `_Impl_impl`.
+        let section = extract_section(
+            &out.rust,
+            &format!("pub(crate) fn {}_Impl(", func.name),
+            &format!("pub fn {}(", func.name),
+        );
+        scanned += 1;
+        let where_ = format!("{}: {section}", func.name);
+
+        let start = section
+            .find("RetCode::OutOfRangeStartIndex")
+            .unwrap_or_else(|| panic!("{where_}\nno startIdx guard"));
+        let end = section
+            .find("RetCode::OutOfRangeEndIndex")
+            .unwrap_or_else(|| panic!("{where_}\nno endIdx guard"));
+        assert!(start < end, "{where_}\nB1 must precede B2");
+
+        let preamble = section
+            .find("let _assertLb")
+            .unwrap_or_else(|| panic!("{where_}\nno bounds-assert preamble"));
+        assert!(end < preamble, "{where_}\nB2 must precede B5");
+
+        // The sentinel substitution opens each parameter's block and its range
+        // check is the arm right after, so the last one bounds all of B3.
+        // Reconstructed per parameter, like the guard below: a bare `i32::MIN`
+        // could come from a transcribed body. An enum parameter is skipped —
+        // it has no out-of-domain value, so it emits a substitution and no check.
+        let last_param = func
+            .optional_inputs
+            .iter()
+            .filter_map(|opt| {
+                let head = match opt.param_type {
+                    ir::ParamType::Integer => {
+                        format!("if (({}) as i32) == (i32::MIN) {{", opt.name)
+                    }
+                    ir::ParamType::Real => format!("if {} == Self::REAL_DEFAULT {{", opt.name),
+                    _ => return None,
+                };
+                section.find(&head)
+            })
+            .max();
+        if let Some(at) = last_param {
+            with_params += 1;
+            assert!(end < at, "{where_}\nB2 must precede B3");
+            assert!(at < preamble, "{where_}\nB3 must precede B5");
+        }
+
+        let guard_at = section
+            .find(&rust_alias_guard(&func))
+            .unwrap_or_else(|| panic!("{where_}\nthe outputs are not checked for aliasing"));
+        // Every output's capacity is B5, so the guard has to follow ALL of the
+        // asserts, not merely the first.
+        for output in &func.outputs {
+            let cap = format!(
+                "assert!(_assertStart > endIdx || endIdx - _assertStart < {}.len());",
+                output.name
+            );
+            let cap_at = section
+                .find(&cap)
+                .unwrap_or_else(|| panic!("{where_}\n{} has no capacity assert", output.name));
+            assert!(cap_at < guard_at, "{where_}\nB5 must precede B6 ({})", output.name);
+        }
+    }
+
+    // Literal floors: derived ones move with whatever the scan happens to find.
+    assert!(scanned >= 15, "only {scanned} multi-output Rust bodies scanned");
+    assert!(
+        with_params >= 12,
+        "only {with_params} carried parameter validation — B3 is barely covered"
+    );
+}
+
 #[test]
 fn test_java_sma_guarded_has_validation() {
     let (func, enums) = load_indicator("sma");

--- a/ta_codegen/output/rust/library/src/ta_func/accbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/accbands.rs
@@ -124,9 +124,6 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outRealUpperBand.as_ptr() == outRealMiddleBand.as_ptr() || outRealUpperBand.as_ptr() == outRealLowerBand.as_ptr() || outRealMiddleBand.as_ptr() == outRealLowerBand.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.ACCBANDS_Lookback(optInTimePeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inHigh.len());
@@ -135,6 +132,9 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealUpperBand.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealMiddleBand.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealLowerBand.len());
+        if outRealUpperBand.as_ptr() == outRealMiddleBand.as_ptr() || outRealUpperBand.as_ptr() == outRealLowerBand.as_ptr() || outRealMiddleBand.as_ptr() == outRealLowerBand.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut periodTotalUpper: f64 = 0.0_f64;
         let mut periodTotalMiddle: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -111,15 +111,15 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outAroonDown.as_ptr() == outAroonUp.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.AROON_Lookback(optInTimePeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inHigh.len());
         assert!(_assertStart > endIdx || endIdx < inLow.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outAroonDown.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outAroonUp.len());
+        if outAroonDown.as_ptr() == outAroonUp.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -221,15 +221,15 @@ impl Core {
         if optInMAType == MAType::DEFAULT {
             optInMAType = MAType::SMA;
         }
-        if outRealUpperBand.as_ptr() == outRealMiddleBand.as_ptr() || outRealUpperBand.as_ptr() == outRealLowerBand.as_ptr() || outRealMiddleBand.as_ptr() == outRealLowerBand.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.BBANDS_Lookback(optInTimePeriod, optInNbDevUp, optInNbDevDn, optInMAType).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealUpperBand.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealMiddleBand.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outRealLowerBand.len());
+        if outRealUpperBand.as_ptr() == outRealMiddleBand.as_ptr() || outRealUpperBand.as_ptr() == outRealLowerBand.as_ptr() || outRealMiddleBand.as_ptr() == outRealLowerBand.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut retCode: RetCode = RetCode::Success;
         let mut i: usize = 0_usize;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
@@ -119,14 +119,14 @@ impl Core {
         if endIdx > Self::MAX_INDEX || endIdx < startIdx {
             return RetCode::OutOfRangeEndIndex;
         }
-        if outInPhase.as_ptr() == outQuadrature.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.HT_PHASOR_Lookback().unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outInPhase.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outQuadrature.len());
+        if outInPhase.as_ptr() == outQuadrature.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut outIdx: usize = 0_usize;
         let mut i: usize = 0_usize;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -125,14 +125,14 @@ impl Core {
         if endIdx > Self::MAX_INDEX || endIdx < startIdx {
             return RetCode::OutOfRangeEndIndex;
         }
-        if outSine.as_ptr() == outLeadSine.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.HT_SINE_Lookback().unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outSine.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outLeadSine.len());
+        if outSine.as_ptr() == outLeadSine.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut outIdx: usize = 0_usize;
         let mut i: usize = 0_usize;

--- a/ta_codegen/output/rust/library/src/ta_func/macd.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macd.rs
@@ -191,15 +191,15 @@ impl Core {
         } else if (((optInSignalPeriod) as i32) < 1) || (((optInSignalPeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MACD_Lookback(optInFastPeriod, optInSlowPeriod, optInSignalPeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACD.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDSignal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDHist.len());
+        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut prevFast: f64 = 0.0_f64;
         let mut prevSlow: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/macdext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdext.rs
@@ -175,15 +175,15 @@ impl Core {
         if optInSignalMAType == MAType::DEFAULT {
             optInSignalMAType = MAType::SMA;
         }
-        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MACDEXT_Lookback(optInFastPeriod, optInFastMAType, optInSlowPeriod, optInSlowMAType, optInSignalPeriod, optInSignalMAType).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACD.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDSignal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDHist.len());
+        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut slowMABuffer: Vec<f64> = Vec::new();
         let mut fastMABuffer: Vec<f64> = Vec::new();

--- a/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
@@ -151,15 +151,15 @@ impl Core {
         } else if (((optInSignalPeriod) as i32) < 1) || (((optInSignalPeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MACDFIX_Lookback(optInSignalPeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACD.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDSignal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMACDHist.len());
+        if outMACD.as_ptr() == outMACDSignal.as_ptr() || outMACD.as_ptr() == outMACDHist.as_ptr() || outMACDSignal.as_ptr() == outMACDHist.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut prevFast: f64 = 0.0_f64;
         let mut prevSlow: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -176,14 +176,14 @@ impl Core {
         } else if !((optInSlowLimit >= 1e-2) && (optInSlowLimit <= 9.9e-1)) {
             return RetCode::BadParam;
         }
-        if outMAMA.as_ptr() == outFAMA.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MAMA_Lookback(optInFastLimit, optInSlowLimit).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMAMA.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outFAMA.len());
+        if outMAMA.as_ptr() == outFAMA.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut outIdx: usize = 0_usize;
         let mut i: usize = 0_usize;

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -107,14 +107,14 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outMin.as_ptr() == outMax.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MINMAX_Lookback(optInTimePeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMin.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMax.len());
+        if outMin.as_ptr() == outMax.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut local_sufHighest: [f64; 30] = [0.0_f64; 30];
         let mut heap_sufHighest: Vec<f64> = Vec::new();

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -107,14 +107,14 @@ impl Core {
         } else if (((optInTimePeriod) as i32) < 2) || (((optInTimePeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outMinIdx.as_ptr() == outMaxIdx.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.MINMAXINDEX_Lookback(optInTimePeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMinIdx.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outMaxIdx.len());
+        if outMinIdx.as_ptr() == outMaxIdx.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut highest: f64 = 0.0_f64;
         let mut lowest: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/smi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/smi.rs
@@ -198,9 +198,6 @@ impl Core {
         } else if (((optInSignalPeriod) as i32) < 2) || (((optInSignalPeriod) as i32) > 100000) {
             return RetCode::BadParam;
         }
-        if outSMI.as_ptr() == outSMISignal.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.SMI_Lookback(optInTimePeriod, optInFastPeriod, optInSlowPeriod, optInSignalPeriod).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inHigh.len());
@@ -208,6 +205,9 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inClose.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outSMI.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outSMISignal.len());
+        if outSMI.as_ptr() == outSMISignal.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut kSlow: f64 = 0.0_f64;
         let mut kFast: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -173,9 +173,6 @@ impl Core {
         if optInSlowD_MAType == MAType::DEFAULT {
             optInSlowD_MAType = MAType::SMA;
         }
-        if outSlowK.as_ptr() == outSlowD.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.STOCH_Lookback(optInFastK_Period, optInSlowK_Period, optInSlowK_MAType, optInSlowD_Period, optInSlowD_MAType).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inHigh.len());
@@ -183,6 +180,9 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inClose.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outSlowK.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outSlowD.len());
+        if outSlowK.as_ptr() == outSlowD.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut retCode: RetCode = RetCode::Success;
         let mut lowest: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -149,9 +149,6 @@ impl Core {
         if optInFastD_MAType == MAType::DEFAULT {
             optInFastD_MAType = MAType::SMA;
         }
-        if outFastK.as_ptr() == outFastD.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.STOCHF_Lookback(optInFastK_Period, optInFastD_Period, optInFastD_MAType).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inHigh.len());
@@ -159,6 +156,9 @@ impl Core {
         assert!(_assertStart > endIdx || endIdx < inClose.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outFastK.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outFastD.len());
+        if outFastK.as_ptr() == outFastD.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut retCode: RetCode = RetCode::Success;
         let mut lowest: f64 = 0.0_f64;

--- a/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
@@ -149,14 +149,14 @@ impl Core {
         if optInFastD_MAType == MAType::DEFAULT {
             optInFastD_MAType = MAType::SMA;
         }
-        if outFastK.as_ptr() == outFastD.as_ptr() {
-            return RetCode::BadParam;
-        }
         let _assertLb = self.STOCHRSI_Lookback(optInTimePeriod, optInFastK_Period, optInFastD_Period, optInFastD_MAType).unwrap_or(usize::MAX);
         let _assertStart = if startIdx > _assertLb { startIdx } else { _assertLb };
         assert!(_assertStart > endIdx || endIdx < inReal.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outFastK.len());
         assert!(_assertStart > endIdx || endIdx - _assertStart < outFastD.len());
+        if outFastK.as_ptr() == outFastD.as_ptr() {
+            return RetCode::BadParam;
+        }
         let mut startIdx = startIdx;
         let mut tempRSIBuffer: Vec<f64> = Vec::new();
         let mut retCode: RetCode = RetCode::Success;


### PR DESCRIPTION
`docs/error-handling-spec.md` 2.2 orders B5 (a buffer too short) ahead of B6
(two outputs are the same buffer), and a call that violates both must report
the first. The Rust emitter wrote the `as_ptr()` guard before the bounds-assert
preamble, so such a call answered `BadParam` where the specified order makes it
a panic — Rust's B5 deviation. C, Java and C# already agreed with the spec.

Rust is the only backend where the order between those two is observable: there
B5 panics and B6 returns, while the other three answer `TA_BAD_PARAM` either
way. Nothing else moves — 15 multi-output bodies, Rust only; C, Java and C#
regenerate byte-identical.

`rust_batch_impl_orders_capacity_before_aliasing` pins B1 < B2 < B3 < B5 < B6
over all 15 (13 of them carrying parameter validation), reconstructing each
marker from the function's own outputs so a renamed emission fails loudly
rather than matching a body's own `as_ptr()` comparison. Structural, like the C
gate beside it: two `&mut [f64]` cannot alias, so safe code cannot build the
multi-fault call. C# still has no ordering gate.

Unchanged: a sub-lookback range skips the asserts, so the empty-output
divergence of Appendix F and open item 11 still answers `BadParam` (#262).

Gates run: `scripts/build.py regen-check` clean; generator `cargo test` (all suites); `cargo build`/`clippy --all-targets`/`test --tests`/`test --doc` on the ta-lib crate; `scripts/regtest.py --no-perftest` — all four languages 161 passed, 0 failed.

The new gate was sabotage-proved: reverting the emitter hunk makes it fail with `B5 must precede B6 (outRealUpperBand)`.

Closes #261.