### PR TITLE
perf(rust): a stream handle carries only the candle settings its step reads (#274)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -29,7 +29,7 @@
 //!   requires the rest to match that length (`Err(BadParam)` otherwise).
 
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 
 use crate::helper_registry::HelperRegistry;
@@ -760,6 +760,71 @@ fn scale_by_stride(idx: Expr) -> Expr {
 }
 
 // ---------------------------------------------------------------------------
+// The handle's candlestick settings (issue #274)
+// ---------------------------------------------------------------------------
+//
+// A handle used to embed a whole `Core` by value — 280 bytes, of which a step
+// can reach only the `CandleSetting`s it names: the unstable period and the
+// compatibility mode are consumed at `Open`, where they set the lookback, and
+// nothing post-open consults them. 119 of the 176 generated steps read no
+// setting at all, so they were carrying 280 bytes to read none of them.
+//
+// The handle now carries exactly the settings its own step reads, one
+// `cs_<snake>: CandleSetting` field each, and nothing when it reads none. The
+// step drops its `&self` receiver and takes those settings as parameters, so
+// `Core` is a namespace for it rather than state it reads through.
+//
+// The set is derived from the whole stream source rather than from one tier's
+// steady statements: a superset can never leave a step naming a field the
+// handle does not have, and the two coincide for every shipped candlestick
+// (the batch prologue averages exactly the settings the steady state tests).
+
+/// The candlestick settings this function's handle must carry.
+fn handle_candle_settings(func: &FuncDef) -> BTreeSet<String> {
+    crate::candle_settings::detect_candle_settings(func.stream_source())
+}
+
+/// The handle field, step parameter and unpacking source for one setting:
+/// `"Near"` -> `"cs_near"`.
+fn cs_binding(setting: &str) -> String {
+    format!("cs_{}", crate::candle_settings::pascal_to_snake_case(setting))
+}
+
+/// `, cs_near: &CandleSetting, …` — the step signature's settings parameters.
+fn cs_step_params(settings: &BTreeSet<String>) -> String {
+    let mut s = String::new();
+    for setting in settings {
+        let _ = write!(s, ", {}: &CandleSetting", cs_binding(setting));
+    }
+    s
+}
+
+/// `&self.cs_near, …` — the step call's settings arguments, as a handle reads
+/// them. Distinct field places, so they borrow alongside `&mut self.state`.
+fn cs_step_args(settings: &BTreeSet<String>) -> String {
+    let mut s = String::new();
+    for setting in settings {
+        let _ = write!(s, "&self.{}, ", cs_binding(setting));
+    }
+    s
+}
+
+/// `cs_near: self.candle_settings.near, …` — the handle's settings at every
+/// construction site, where `self` is the opening `Core`.
+fn cs_ctor_fields(func: &FuncDef) -> String {
+    let mut s = String::new();
+    for setting in handle_candle_settings(func) {
+        let _ = write!(
+            s,
+            "{}: self.candle_settings.{}, ",
+            cs_binding(&setting),
+            crate::candle_settings::pascal_to_snake_case(&setting)
+        );
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
 // Structs
 // ---------------------------------------------------------------------------
 
@@ -779,6 +844,21 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
     let state = state_type_name(func);
     let sn = snake(func);
     let n = func.name.to_uppercase();
+    let settings = handle_candle_settings(func);
+    // Exactly the settings this function's step reads, and nothing where it
+    // reads none (issue #274). Ahead of `state`, so the fields a step touches
+    // every bar sit together at the front of the handle.
+    let mut cs_fields = String::new();
+    let mut cs_restore = String::new();
+    for setting in &settings {
+        let field = cs_binding(setting);
+        let _ = write!(
+            cs_fields,
+            "    /// The `{setting}` setting this stream was opened with.\n\
+             \x20   {field}: CandleSetting,\n"
+        );
+        let _ = writeln!(cs_restore, "        self.{field} = src.{field};");
+    }
     let _ = writeln!(
         o,
         "/// Live {n} stream: one value per closed bar, bit-identical to [`Core::{sn}`]\n\
@@ -789,7 +869,7 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
          #[must_use = \"a stream does nothing unless updated; dropping it closes the stream\"]\n\
          #[derive(Debug, Clone)]\n\
          #[doc(alias = \"TA_{n}_Stream\")]\n\
-         pub struct {handle} {{\n    core: Core,\n    state: {state},\n\
+         pub struct {handle} {{\n{cs_fields}    state: {state},\n\
          \x20   /// The bars this handle has produced a value for — see [`Self::out_range`].\n\
          \x20   out: OutRange,\n}}\n"
     );
@@ -802,7 +882,7 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
          \x20   /// Overwrite from `src`, reusing this handle's buffers instead of\n\
          \x20   /// allocating new ones. See `{state}::restore_from`.\n\
          \x20   pub(crate) fn restore_from(&mut self, src: &Self) {{\n\
-         \x20       self.core.clone_from(&src.core);\n\
+         {cs_restore}\
          \x20       self.state.restore_from(&src.state);\n\
          \x20       self.out = src.out;\n\
          \x20   }}\n}}\n"
@@ -1113,6 +1193,9 @@ fn emit_step(
 fn emit_step_sig(o: &mut String, func: &FuncDef, fallible: bool) {
     let sn = snake(func);
     let state = state_type_name(func);
+    // No `&self`: a step reads nothing from `Core` but the candlestick settings
+    // it names, and those arrive as parameters from the handle (issue #274).
+    let cs_params = cs_step_params(&handle_candle_settings(func));
     let mut params = String::new();
     for bar in streaming::input_array_names(func) {
         let _ = write!(params, ", {bar}: f64");
@@ -1128,7 +1211,7 @@ fn emit_step_sig(o: &mut String, func: &FuncDef, fallible: bool) {
     let ret = if fallible { " -> Result<(), RetCode>" } else { "" };
     let _ = writeln!(
         o,
-        "    fn {sn}_step_impl(&self, sp: &mut {state}{params}){ret} {{"
+        "    fn {sn}_step_impl(sp: &mut {state}{cs_params}{params}){ret} {{"
     );
 }
 
@@ -1206,11 +1289,16 @@ fn emit_step_body(
             helpers, counter,
         ));
     }
-    // Candle settings are read where batch reads them (from the immutable Core
-    // snapshot in the handle — `self` here is that Core).
+    // Candle settings unpack into the same locals batch uses, from the step's
+    // own `cs_<snake>` parameters — the handle's copy of what it was opened
+    // with, which is what the embedded `Core` used to be read for (issue #274).
     let step_settings = crate::candle_settings::detect_candle_settings(&model.steady_stmts);
     if !step_settings.is_empty() {
-        o.push_str(&crate::candle_settings::emit_rust_unpacking(&step_settings, indent));
+        o.push_str(&crate::candle_settings::emit_rust_unpacking_from(
+            &step_settings,
+            indent,
+            &|s| cs_binding(s),
+        ));
     }
     o.push_str(&body);
 }
@@ -1684,9 +1772,10 @@ fn emit_capture_and_publish(
 ) {
     let handle = stream_type_name(func);
     let _ = writeln!(o, "\n        // Capture the live batch state into the handle.");
+    let cs_ctor = cs_ctor_fields(func);
     emit_capture(o, func, model, scalars, typing, registry, helpers, counter, extra_fields);
     // The core publishes only the handle; the scalar wrapper reads its sink.
-    let _ = writeln!(o, "        Ok({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+    let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
 }
 
 
@@ -1833,6 +1922,7 @@ fn emit_identity_fast_path(
 ) {
     let Some(idp) = &model.identity else { return };
     let handle = stream_type_name(func);
+    let cs_ctor = cs_ctor_fields(func);
     let state = state_type_name(func);
     let sn = snake(func);
     let opt_real_params: Vec<String> = func
@@ -1884,7 +1974,7 @@ fn emit_identity_fast_path(
     let _ = writeln!(o, "            }}");
     let _ = writeln!(
         o,
-        "            return Ok({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});"
+        "            return Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});"
     );
     let _ = writeln!(o, "        }}");
 }
@@ -2321,6 +2411,7 @@ fn stream_doctest(
 #[allow(clippy::too_many_lines)]
 fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_fallible: bool) {
     let sn = snake(func);
+    let cs_args = cs_step_args(&handle_candle_settings(func));
     let n = func.name.to_uppercase();
     let handle = stream_type_name(func);
     let state = state_type_name(func);
@@ -2402,7 +2493,7 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     o.push_str(&out_decls);
     let _ = writeln!(
         o,
-        "        self.core.{sn}_step_impl(&mut self.state, {fwd_bars}{out_refs}){step_try};"
+        "        Core::{sn}_step_impl(&mut self.state, {cs_args}{fwd_bars}{out_refs}){step_try};"
     );
     // After the step, so a rejected bar (non-finite here, or a sub-stream's
     // reject through `?`) leaves the range exactly where it was. `peek` runs the
@@ -2548,7 +2639,7 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     }
     let _ = writeln!(
         o,
-        "            self.core.{sn}_step_impl(&mut self.state, {step_args}){step_try};"
+        "            Core::{sn}_step_impl(&mut self.state, {cs_args}{step_args}){step_try};"
     );
     let _ = writeln!(
         o,
@@ -2979,6 +3070,7 @@ fn emit_dispatch(
     let _ = counter;
     let sn = snake(func);
     let handle = stream_type_name(func);
+    let cs_ctor = cs_ctor_fields(func);
     let state = state_type_name(func);
     let sub_enum = sub_enum_name(func);
     let inputs = streaming::input_array_names(func);
@@ -3170,17 +3262,17 @@ fn emit_dispatch(
                     };
                     let _ = writeln!(
                         o,
-                        "            return Ok(({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, {value}));"
+                        "            return Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, {value}));"
                     );
                 }
                 OutMode::Fill => {
                     let _ = writeln!(
                         o,
-                        "            return Ok(({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }}));"
+                        "            return Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }}));"
                     );
                 }
                 OutMode::FillInternal => {
-                    let _ = writeln!(o, "            return Ok({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});");
+                    let _ = writeln!(o, "            return Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});");
                 }
             }
             let _ = writeln!(o, "        }}");
@@ -3313,13 +3405,13 @@ fn emit_dispatch(
         match mode {
             OutMode::Core => unreachable!("dispatch tier is exempt from the merge"),
             OutMode::Scalar => {
-                let _ = writeln!(o, "        Ok(({handle} {{ core: self.clone(), state, out: subRange }}, value))");
+                let _ = writeln!(o, "        Ok(({handle} {{ {cs_ctor}state, out: subRange }}, value))");
             }
             OutMode::Fill => {
-                let _ = writeln!(o, "        Ok(({handle} {{ core: self.clone(), state, out: fillRange }}, fillRange))");
+                let _ = writeln!(o, "        Ok(({handle} {{ {cs_ctor}state, out: fillRange }}, fillRange))");
             }
             OutMode::FillInternal => {
-                let _ = writeln!(o, "        Ok({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+                let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
             }
         }
         let _ = writeln!(o, "    }}\n");
@@ -3355,6 +3447,7 @@ fn emit_period_bank(
 ) {
     let _ = (registry, helpers);
     let handle = stream_type_name(func);
+    let cs_ctor = cs_ctor_fields(func);
     let state = state_type_name(func);
     let callee = plan.callee.to_uppercase();
     let callee = callee.as_str();
@@ -3465,7 +3558,7 @@ fn emit_period_bank(
     let _ = writeln!(o, "        let state = {state} {{ {params_join}, bank }};");
     let _ = writeln!(
         o,
-        "        Ok(({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: subStart, count: historyLen - subStart }} }}, lastValue_{out}))"
+        "        Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: subStart, count: historyLen - subStart }} }}, lastValue_{out}))"
     );
     let _ = writeln!(o, "    }}\n");
 
@@ -3515,7 +3608,7 @@ fn emit_period_bank(
     let _ = writeln!(o, "        let state = {state} {{ {params_join}, bank }};");
     let _ = writeln!(
         o,
-        "        Ok(({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }} }}, OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }}))"
+        "        Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }} }}, OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }}))"
     );
     let _ = writeln!(o, "    }}\n");
     let _ = writeln!(o, "}}\n");
@@ -3821,7 +3914,13 @@ fn emit_composed_step(
         }
         let step_settings = crate::candle_settings::detect_candle_settings(&model.steady_stmts);
         if !step_settings.is_empty() {
-            o.push_str(&crate::candle_settings::emit_rust_unpacking(&step_settings, 8));
+            // A step's settings come from its own parameters, never a `Core`
+            // receiver it no longer has (issue #274).
+            o.push_str(&crate::candle_settings::emit_rust_unpacking_from(
+                &step_settings,
+                8,
+                &|s| cs_binding(s),
+            ));
         }
         o.push_str(&body);
         let series = cp.series.clone().expect("producer plan carries a series");
@@ -3974,6 +4073,7 @@ fn emit_composed_open(
 ) {
     // The composed fill/scratch path hardcodes f64 Vecs (mirrors C's assert).
     let handle = stream_type_name(func);
+    let cs_ctor = cs_ctor_fields(func);
     let state = state_type_name(func);
     let sn = snake(func);
     let opt_real_params: Vec<String> = func
@@ -4203,7 +4303,7 @@ fn emit_composed_open(
                     let _ = writeln!(o, "        }}");
                 }
             }
-            let _ = writeln!(o, "        Ok({handle} {{ core: self.clone(), state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+            let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
         }
     }
     let _ = writeln!(o, "    }}\n");

--- a/ta_codegen/generator/src/candle_settings.rs
+++ b/ta_codegen/generator/src/candle_settings.rs
@@ -214,21 +214,40 @@ pub fn emit_c_unpacking(settings: &BTreeSet<String>, indent: usize) -> String {
 /// generated candle-range comparisons run on — the same shape as Java's
 /// `.ordinal()` and C#'s `(int)` cast below.
 pub fn emit_rust_unpacking(settings: &BTreeSet<String>, indent: usize) -> String {
+    emit_rust_unpacking_from(settings, indent, &|setting| {
+        format!("self.candle_settings.{}", pascal_to_snake_case(setting))
+    })
+}
+
+/// `emit_rust_unpacking`, with the caller choosing where each `CandleSetting`
+/// is read from.
+///
+/// The batch and `Open` tiers run on a `Core` receiver and read
+/// `self.candle_settings.<snake>`. A streaming *step* has no `Core` — a handle
+/// carries only the settings its own step reads (issue #274) — so it reads its
+/// `cs_<snake>` parameter instead. Both spellings unpack into the identical
+/// `<Setting>_rangeType` / `_avgPeriod` / `_factor` locals the transcribed
+/// candle bodies are written against, so only the source moves.
+pub fn emit_rust_unpacking_from(
+    settings: &BTreeSet<String>,
+    indent: usize,
+    source: &dyn Fn(&str) -> String,
+) -> String {
     let pad = " ".repeat(indent);
     let mut out = String::new();
     for setting in settings {
-        let snake = pascal_to_snake_case(setting);
+        let src = source(setting);
         out.push_str(&format!(
             "{pad}#[allow(non_snake_case)]\n\
-             {pad}let {setting}_rangeType: i32 = self.candle_settings.{snake}.range_type as i32;\n"
+             {pad}let {setting}_rangeType: i32 = {src}.range_type as i32;\n"
         ));
         out.push_str(&format!(
             "{pad}#[allow(non_snake_case)]\n\
-             {pad}let {setting}_avgPeriod: i32 = self.candle_settings.{snake}.avg_period;\n"
+             {pad}let {setting}_avgPeriod: i32 = {src}.avg_period;\n"
         ));
         out.push_str(&format!(
             "{pad}#[allow(non_snake_case)]\n\
-             {pad}let {setting}_factor: f64 = self.candle_settings.{snake}.factor;\n"
+             {pad}let {setting}_factor: f64 = {src}.factor;\n"
         ));
     }
     out
@@ -297,7 +316,7 @@ pub fn emit_csharp_unpacking(settings: &BTreeSet<String>, indent: usize) -> Stri
 /// Convert `PascalCase` to `snake_case`.
 ///
 /// `"BodyLong"` -> `"body_long"`, `"ShadowVeryShort"` -> `"shadow_very_short"`
-fn pascal_to_snake_case(s: &str) -> String {
+pub fn pascal_to_snake_case(s: &str) -> String {
     let mut result = String::new();
     for (i, ch) in s.chars().enumerate() {
         if ch.is_uppercase() && i > 0 {

--- a/ta_codegen/generator/templates/rust/types.rs
+++ b/ta_codegen/generator/templates/rust/types.rs
@@ -279,9 +279,12 @@ pub enum CandleSettingType {
 /// # Ok::<(), ta_lib::RetCode>(())
 /// ```
 ///
-/// To change a setting, build a new `Core` — cloning is cheap (it is a small
-/// `[i32; N]` array plus two small fields). [`Core::to_builder`] seeds a builder
-/// from an existing `Core` for clone-and-modify.
+/// To change a setting, build a new `Core` — cloning it copies bytes and never
+/// allocates, but there are 280 of them on x86-64 (an `[i32; N]` array, eleven
+/// `CandleSetting`s and the compatibility mode), so it is a memcpy rather than
+/// a free operation. [`Core::to_builder`] seeds a builder from an existing
+/// `Core` for clone-and-modify. Stream handles do not hold one: each carries
+/// only the `CandleSetting`s its own step reads.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Core {
     /// Unstable period for each function identified by [`FuncUnstId`].

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -9535,8 +9535,11 @@ fn the_transition_tier_is_step_impl_in_every_backend() {
         (
             "rust",
             &rust,
-            "fn SMA_step_impl(&self, sp: &mut SMA_StreamState,",
-            &["self.core.SMA_step_impl(&mut self.state,"],
+            // No `&self`: SMA's step reads nothing from `Core`, and a step that
+            // does reads only the `cs_<setting>` parameters its handle carries
+            // (issue #274).
+            "fn SMA_step_impl(sp: &mut SMA_StreamState,",
+            &["Core::SMA_step_impl(&mut self.state,"],
             "step_internal",
         ),
         (
@@ -13136,3 +13139,113 @@ fn every_declared_input_is_checked_in_every_backend() {
     assert_eq!(pairs, 7, "the seven never-indexed legs of #260");
 }
 
+
+/// A stream handle carries exactly the candlestick settings its own step reads,
+/// and no `Core` (issue #274).
+///
+/// The three rows are the three cases, and each is a control on the others: a
+/// step that reads one setting, a step that reads five, and a step that reads
+/// none. A handle that went back to embedding `Core` fails all three; one that
+/// widened to "every setting" fails the first two on the count; one that
+/// narrowed to nothing fails them on the field itself.
+#[test]
+fn a_stream_handle_carries_only_the_settings_its_step_reads() {
+    let registry = make_registry();
+    let helpers = HelperRegistry::empty();
+
+    // (indicator, handle, the settings its step reads, in field order)
+    let cases: [(&str, &str, &[&str]); 3] = [
+        ("cdldoji", "CDLDOJI_Stream", &["cs_body_doji"]),
+        (
+            "cdladvanceblock",
+            "CDLADVANCEBLOCK_Stream",
+            &[
+                "cs_body_long",
+                "cs_far",
+                "cs_near",
+                "cs_shadow_long",
+                "cs_shadow_short",
+            ],
+        ),
+        ("sma", "SMA_Stream", &[]),
+    ];
+
+    for (name, handle, settings) in cases {
+        let (func, enums) = load_indicator(name);
+        assert!(func.streaming, "{name} must carry the `stream` flag");
+        let rust = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+
+        let start = rust
+            .find(&format!("pub struct {handle} {{"))
+            .unwrap_or_else(|| panic!("{name}: no {handle} definition"));
+        let body = &rust[start..start + rust[start..].find("\n}").expect("struct end")];
+
+        assert!(
+            !body.contains("core: Core,"),
+            "{name}: {handle} still embeds a whole Core"
+        );
+        assert_eq!(
+            body.matches(": CandleSetting,").count(),
+            settings.len(),
+            "{name}: {handle} carries the wrong number of settings\n{body}"
+        );
+        for field in settings {
+            assert!(
+                body.contains(&format!("{field}: CandleSetting,")),
+                "{name}: {handle} is missing {field}"
+            );
+        }
+
+        // The step takes them as parameters — it has no receiver to read them
+        // through — and the call site hands over the handle's own fields.
+        let params: String = settings
+            .iter()
+            .map(|f| format!(", {f}: &CandleSetting"))
+            .collect();
+        let args: String = settings.iter().map(|f| format!("&self.{f}, ")).collect();
+        let upper = name.to_uppercase();
+        assert!(
+            rust.contains(&format!(
+                "fn {upper}_step_impl(sp: &mut {upper}_StreamState{params},"
+            )),
+            "{name}: step signature does not take exactly its settings"
+        );
+        assert!(
+            rust.contains(&format!(
+                "Core::{upper}_step_impl(&mut self.state, {args}"
+            )),
+            "{name}: `update` does not hand the step its settings"
+        );
+    }
+}
+
+/// A step unpacks its candle settings from its own parameters; only the batch
+/// and `Open` tiers, which run on a `Core` receiver, read `self.candle_settings`
+/// (issue #274).
+#[test]
+fn a_stream_step_reads_candle_settings_from_its_parameters() {
+    let registry = make_registry();
+    let helpers = HelperRegistry::empty();
+    let (func, enums) = load_indicator("cdldoji");
+    let rust = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+
+    let step = rust
+        .find("fn CDLDOJI_step_impl(")
+        .expect("cdldoji renders a step");
+    let step_body = &rust[step..step + rust[step..].find("\n    }").expect("step end")];
+
+    assert!(
+        step_body.contains("let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;"),
+        "the step must unpack from its parameter\n{step_body}"
+    );
+    assert!(
+        !step_body.contains("self.candle_settings"),
+        "the step has no Core receiver to read through\n{step_body}"
+    );
+    // The control: the batch tier still does, and is the reason the unpacking
+    // emitter keeps both spellings.
+    assert!(
+        rust.contains("let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;"),
+        "the batch tier must still read the Core it runs on"
+    );
+}

--- a/ta_codegen/generator/tests/rust_stream_suite.rs
+++ b/ta_codegen/generator/tests/rust_stream_suite.rs
@@ -71,7 +71,10 @@ fn test_rust_sma_ring_stream_section() {
     let s = rust_stream_section("sma");
     // Handle + state struct shapes.
     assert!(s.contains("pub struct SMA_Stream {"));
-    assert!(s.contains("core: Core,"));
+    // No `Core` on the handle: SMA's step reads no candle setting, so it
+    // carries none (#274). `backend_suite`'s handle gate owns that claim
+    // across the tiers that do read one.
+    assert!(!s.contains("core: Core,"));
     assert!(s.contains("state: SMA_StreamState,"));
     assert!(s.contains("struct SMA_StreamState {"));
     assert!(s.contains("ring_trailingIdx_inReal: Vec<f64>,"));
@@ -81,7 +84,7 @@ fn test_rust_sma_ring_stream_section() {
     assert!(!s.contains("peekMode"), "no peekMode in the Rust tier");
     assert!(!s.contains("unsafe"), "stream sections are safe Rust");
     // Step: ring read-old-then-push order, `(*outReal)` write.
-    assert!(s.contains("fn SMA_step_impl(&self, sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64)"));
+    assert!(s.contains("fn SMA_step_impl(sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64)"));
     // `tempReal` is step-local scratch, not a handle field (#252).
     assert!(s.contains("(*outReal) = tempReal / (sp.optInTimePeriod as f64);"));
     assert!(!s.contains("tempReal: f64,"), "no scratch field on the state struct");
@@ -425,7 +428,7 @@ fn rust_dispatch_open_modes_differ_only_where_intended() {
     assert!(!scalar.contains("outBegIdx"), "the scalar open has no out-meta:\n{scalar}");
     assert!(!fill.contains("outBegIdx"), "the public fill carries no out-meta pair:\n{fill}");
     assert!(
-        fill.contains("Ok((MA_Stream { core: self.clone(), state, out: fillRange }, fillRange))"),
+        fill.contains("Ok((MA_Stream { state, out: fillRange }, fillRange))"),
         "the public fill returns the arm's own range beside the handle, and keeps it \
          on the handle too (#241):\n{fill}"
     );

--- a/ta_codegen/output/rust/library/src/ta_func/ac.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ac.rs
@@ -453,7 +453,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AC_Stream")]
 pub struct AC_Stream {
-    core: Core,
     state: AC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -464,7 +463,6 @@ impl AC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -522,7 +520,7 @@ impl AC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AC_step_impl(&self, sp: &mut AC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AC_step_impl(sp: &mut AC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         let mut osc: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -804,7 +802,7 @@ impl Core {
             cbSize_oscBuffer: cbSize_oscBuffer,
             cb_oscBuffer: oscBuffer,
         };
-        Ok(AC_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AC_Open`] (composition seam).
@@ -921,7 +919,7 @@ impl AC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -954,7 +952,7 @@ impl AC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/accbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/accbands.rs
@@ -391,7 +391,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ACCBANDS_Stream")]
 pub struct ACCBANDS_Stream {
-    core: Core,
     state: ACCBANDS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -402,7 +401,6 @@ impl ACCBANDS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ACCBANDS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -446,7 +444,7 @@ impl ACCBANDS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ACCBANDS_step_impl(&self, sp: &mut ACCBANDS_StreamState, inHigh: f64, inLow: f64, inClose: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) {
+    fn ACCBANDS_step_impl(sp: &mut ACCBANDS_StreamState, inHigh: f64, inLow: f64, inClose: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) {
         let mut tempUpper: f64 = 0.0_f64;
         let mut tempMiddle: f64 = 0.0_f64;
         let mut tempLower: f64 = 0.0_f64;
@@ -656,7 +654,7 @@ impl Core {
             ring_trailingIdx_inLow,
             ring_trailingIdx_inClose,
         };
-        Ok(ACCBANDS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ACCBANDS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ACCBANDS_Open`] (composition seam).
@@ -797,7 +795,7 @@ impl ACCBANDS_Stream {
         let mut outRealUpperBand: f64 = 0.0_f64;
         let mut outRealMiddleBand: f64 = 0.0_f64;
         let mut outRealLowerBand: f64 = 0.0_f64;
-        self.core.ACCBANDS_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
+        Core::ACCBANDS_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -830,7 +828,7 @@ impl ACCBANDS_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ACCBANDS_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i]);
+            Core::ACCBANDS_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/acos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/acos.rs
@@ -221,7 +221,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ACOS_Stream")]
 pub struct ACOS_Stream {
-    core: Core,
     state: ACOS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -232,7 +231,6 @@ impl ACOS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ACOS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -258,7 +256,7 @@ impl ACOS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ACOS_step_impl(&self, sp: &mut ACOS_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ACOS_step_impl(sp: &mut ACOS_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).acos();
     }
 
@@ -299,7 +297,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = ACOS_StreamState {
         };
-        Ok(ACOS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ACOS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ACOS_Open`] (composition seam).
@@ -404,7 +402,7 @@ impl ACOS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ACOS_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ACOS_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -437,7 +435,7 @@ impl ACOS_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ACOS_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ACOS_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ad.rs
@@ -277,7 +277,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AD_Stream")]
 pub struct AD_Stream {
-    core: Core,
     state: AD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -288,7 +287,6 @@ impl AD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -316,7 +314,7 @@ impl AD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AD_step_impl(&self, sp: &mut AD_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn AD_step_impl(sp: &mut AD_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut high: f64 = 0.0_f64;
         let mut low: f64 = 0.0_f64;
         let mut close: f64 = 0.0_f64;
@@ -400,7 +398,7 @@ impl Core {
         let state = AD_StreamState {
             ad,
         };
-        Ok(AD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AD_Open`] (composition seam).
@@ -515,7 +513,7 @@ impl AD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AD_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::AD_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -548,7 +546,7 @@ impl AD_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AD_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::AD_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/add.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/add.rs
@@ -221,7 +221,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADD_Stream")]
 pub struct ADD_Stream {
-    core: Core,
     state: ADD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -232,7 +231,6 @@ impl ADD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -258,7 +256,7 @@ impl ADD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADD_step_impl(&self, sp: &mut ADD_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn ADD_step_impl(sp: &mut ADD_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         (*outReal) = inReal0 + inReal1;
     }
 
@@ -302,7 +300,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = ADD_StreamState {
         };
-        Ok(ADD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADD_Open`] (composition seam).
@@ -413,7 +411,7 @@ impl ADD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ADD_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::ADD_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -446,7 +444,7 @@ impl ADD_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ADD_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::ADD_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/adosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adosc.rs
@@ -442,7 +442,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADOSC_Stream")]
 pub struct ADOSC_Stream {
-    core: Core,
     state: ADOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -453,7 +452,6 @@ impl ADOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -497,7 +495,7 @@ impl ADOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADOSC_step_impl(&self, sp: &mut ADOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn ADOSC_step_impl(sp: &mut ADOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut high: f64 = 0.0_f64;
         let mut low: f64 = 0.0_f64;
         let mut close: f64 = 0.0_f64;
@@ -671,7 +669,7 @@ impl Core {
             one_minus_fastk,
             ad,
         };
-        Ok(ADOSC_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADOSC_Open`] (composition seam).
@@ -786,7 +784,7 @@ impl ADOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ADOSC_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::ADOSC_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -819,7 +817,7 @@ impl ADOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ADOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::ADOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/adx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adx.rs
@@ -622,7 +622,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADX_Stream")]
 pub struct ADX_Stream {
-    core: Core,
     state: ADX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -633,7 +632,6 @@ impl ADX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -675,7 +673,7 @@ impl ADX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADX_step_impl(&self, sp: &mut ADX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ADX_step_impl(sp: &mut ADX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut diffP: f64 = 0.0_f64;
         let mut diffM: f64 = 0.0_f64;
@@ -1120,7 +1118,7 @@ impl Core {
             prevTR,
             prevADX,
         };
-        Ok(ADX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADX_Open`] (composition seam).
@@ -1232,7 +1230,7 @@ impl ADX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ADX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ADX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1265,7 +1263,7 @@ impl ADX_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ADX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ADX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/adxr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adxr.rs
@@ -317,7 +317,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADXR_Stream")]
 pub struct ADXR_Stream {
-    core: Core,
     state: ADXR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -328,7 +327,6 @@ impl ADXR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADXR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -364,7 +362,7 @@ impl ADXR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADXR_step_impl(&self, sp: &mut ADXR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn ADXR_step_impl(sp: &mut ADXR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_adx: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
 
@@ -484,7 +482,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(ADXR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADXR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADXR_Open`] (composition seam).
@@ -596,7 +594,7 @@ impl ADXR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ADXR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal)?;
+        Core::ADXR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -629,7 +627,7 @@ impl ADXR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ADXR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i])?;
+            Core::ADXR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ao.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ao.rs
@@ -379,7 +379,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AO_Stream")]
 pub struct AO_Stream {
-    core: Core,
     state: AO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -390,7 +389,6 @@ impl AO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -436,7 +434,7 @@ impl AO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AO_step_impl(&self, sp: &mut AO_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AO_step_impl(sp: &mut AO_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingFastIdx == 0 {
@@ -643,7 +641,7 @@ impl Core {
             ringCap_trailingSlowIdx: cap_trailingSlowIdx as usize,
             ring_trailingSlowIdx_derived,
         };
-        Ok(AO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AO_Open`] (composition seam).
@@ -760,7 +758,7 @@ impl AO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AO_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AO_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -793,7 +791,7 @@ impl AO_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AO_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AO_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/apo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/apo.rs
@@ -334,7 +334,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_APO_Stream")]
 pub struct APO_Stream {
-    core: Core,
     state: APO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -345,7 +344,6 @@ impl APO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `APO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -381,7 +379,7 @@ impl APO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn APO_step_impl(&self, sp: &mut APO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn APO_step_impl(sp: &mut APO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
 
@@ -502,7 +500,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(APO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(APO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::APO_Open`] (composition seam).
@@ -615,7 +613,7 @@ impl APO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.APO_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::APO_step_impl(&mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -648,7 +646,7 @@ impl APO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.APO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::APO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -343,7 +343,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AROON_Stream")]
 pub struct AROON_Stream {
-    core: Core,
     state: AROON_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -354,7 +353,6 @@ impl AROON_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AROON_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -404,7 +402,7 @@ impl AROON_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AROON_step_impl(&self, sp: &mut AROON_StreamState, inHigh: f64, inLow: f64, outAroonDown: &mut f64, outAroonUp: &mut f64) {
+    fn AROON_step_impl(sp: &mut AROON_StreamState, inHigh: f64, inLow: f64, outAroonDown: &mut f64, outAroonUp: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -605,7 +603,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(AROON_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AROON_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AROON_Open`] (composition seam).
@@ -731,7 +729,7 @@ impl AROON_Stream {
         }
         let mut outAroonDown: f64 = 0.0_f64;
         let mut outAroonUp: f64 = 0.0_f64;
-        self.core.AROON_step_impl(&mut self.state, inHigh, inLow, &mut outAroonDown, &mut outAroonUp);
+        Core::AROON_step_impl(&mut self.state, inHigh, inLow, &mut outAroonDown, &mut outAroonUp);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -764,7 +762,7 @@ impl AROON_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AROON_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outAroonDown[i], &mut outAroonUp[i]);
+            Core::AROON_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outAroonDown[i], &mut outAroonUp[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
@@ -346,7 +346,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AROONOSC_Stream")]
 pub struct AROONOSC_Stream {
-    core: Core,
     state: AROONOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -357,7 +356,6 @@ impl AROONOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AROONOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -407,7 +405,7 @@ impl AROONOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AROONOSC_step_impl(&self, sp: &mut AROONOSC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AROONOSC_step_impl(sp: &mut AROONOSC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         let mut aroon: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -629,7 +627,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(AROONOSC_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AROONOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AROONOSC_Open`] (composition seam).
@@ -746,7 +744,7 @@ impl AROONOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AROONOSC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AROONOSC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -779,7 +777,7 @@ impl AROONOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AROONOSC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AROONOSC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/asin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/asin.rs
@@ -220,7 +220,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ASIN_Stream")]
 pub struct ASIN_Stream {
-    core: Core,
     state: ASIN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -231,7 +230,6 @@ impl ASIN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ASIN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -257,7 +255,7 @@ impl ASIN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ASIN_step_impl(&self, sp: &mut ASIN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ASIN_step_impl(sp: &mut ASIN_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).asin();
     }
 
@@ -298,7 +296,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = ASIN_StreamState {
         };
-        Ok(ASIN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ASIN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ASIN_Open`] (composition seam).
@@ -403,7 +401,7 @@ impl ASIN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ASIN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ASIN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -436,7 +434,7 @@ impl ASIN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ASIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ASIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/atan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atan.rs
@@ -217,7 +217,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ATAN_Stream")]
 pub struct ATAN_Stream {
-    core: Core,
     state: ATAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -228,7 +227,6 @@ impl ATAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ATAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -254,7 +252,7 @@ impl ATAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ATAN_step_impl(&self, sp: &mut ATAN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ATAN_step_impl(sp: &mut ATAN_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).atan();
     }
 
@@ -296,7 +294,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = ATAN_StreamState {
         };
-        Ok(ATAN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ATAN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ATAN_Open`] (composition seam).
@@ -401,7 +399,7 @@ impl ATAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ATAN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ATAN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -434,7 +432,7 @@ impl ATAN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ATAN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ATAN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/atr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atr.rs
@@ -399,7 +399,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ATR_Stream")]
 pub struct ATR_Stream {
-    core: Core,
     state: ATR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -410,7 +409,6 @@ impl ATR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ATR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -442,7 +440,7 @@ impl ATR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ATR_step_impl(&self, sp: &mut ATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ATR_step_impl(sp: &mut ATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut val2: f64 = 0.0_f64;
         let mut val3: f64 = 0.0_f64;
         let mut greatest: f64 = 0.0_f64;
@@ -642,7 +640,7 @@ impl Core {
             prevATR,
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(ATR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ATR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ATR_Open`] (composition seam).
@@ -754,7 +752,7 @@ impl ATR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -787,7 +785,7 @@ impl ATR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
@@ -268,7 +268,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AVGDEV_Stream")]
 pub struct AVGDEV_Stream {
-    core: Core,
     state: AVGDEV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -279,7 +278,6 @@ impl AVGDEV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AVGDEV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -313,7 +311,7 @@ impl AVGDEV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AVGDEV_step_impl(&self, sp: &mut AVGDEV_StreamState, inReal: f64, outReal: &mut f64) {
+    fn AVGDEV_step_impl(sp: &mut AVGDEV_StreamState, inReal: f64, outReal: &mut f64) {
         let mut todaySum: f64 = 0.0_f64;
         let mut todayDev: f64 = 0.0_f64;
         let mut i: usize = 0_usize;
@@ -419,7 +417,7 @@ impl Core {
             winCap_i: cap_i as usize,
             win_i_inReal,
         };
-        Ok(AVGDEV_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AVGDEV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AVGDEV_Open`] (composition seam).
@@ -524,7 +522,7 @@ impl AVGDEV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AVGDEV_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::AVGDEV_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -557,7 +555,7 @@ impl AVGDEV_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AVGDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::AVGDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
@@ -244,7 +244,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AVGPRICE_Stream")]
 pub struct AVGPRICE_Stream {
-    core: Core,
     state: AVGPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -255,7 +254,6 @@ impl AVGPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AVGPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -281,7 +279,7 @@ impl AVGPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AVGPRICE_step_impl(&self, sp: &mut AVGPRICE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn AVGPRICE_step_impl(sp: &mut AVGPRICE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         (*outReal) = (inHigh + inLow + inClose + inOpen) / 4_f64;
     }
 
@@ -323,7 +321,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = AVGPRICE_StreamState {
         };
-        Ok(AVGPRICE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AVGPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AVGPRICE_Open`] (composition seam).
@@ -438,7 +436,7 @@ impl AVGPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.AVGPRICE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outReal);
+        Core::AVGPRICE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -471,7 +469,7 @@ impl AVGPRICE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.AVGPRICE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::AVGPRICE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -643,7 +643,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_BBANDS_Stream")]
 pub struct BBANDS_Stream {
-    core: Core,
     state: BBANDS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -654,7 +653,6 @@ impl BBANDS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `BBANDS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -692,7 +690,7 @@ impl BBANDS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn BBANDS_step_impl(&self, sp: &mut BBANDS_StreamState, inReal: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) -> Result<(), RetCode> {
+    fn BBANDS_step_impl(sp: &mut BBANDS_StreamState, inReal: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut cur_tempBuffer1: f64 = 0.0_f64;
@@ -885,7 +883,7 @@ impl Core {
             let last_sc_outRealLowerBand = sc_outRealLowerBand[*outNBElement - 1];
             outRealLowerBand[0] = last_sc_outRealLowerBand;
         }
-        Ok(BBANDS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(BBANDS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::BBANDS_Open`] (composition seam).
@@ -1019,7 +1017,7 @@ impl BBANDS_Stream {
         let mut outRealUpperBand: f64 = 0.0_f64;
         let mut outRealMiddleBand: f64 = 0.0_f64;
         let mut outRealLowerBand: f64 = 0.0_f64;
-        self.core.BBANDS_step_impl(&mut self.state, inReal, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand)?;
+        Core::BBANDS_step_impl(&mut self.state, inReal, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1052,7 +1050,7 @@ impl BBANDS_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.BBANDS_step_impl(&mut self.state, inReal[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i])?;
+            Core::BBANDS_step_impl(&mut self.state, inReal[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/beta.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/beta.rs
@@ -580,7 +580,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_BETA_Stream")]
 pub struct BETA_Stream {
-    core: Core,
     state: BETA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -591,7 +590,6 @@ impl BETA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `BETA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -661,7 +659,7 @@ impl BETA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn BETA_step_impl(&self, sp: &mut BETA_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn BETA_step_impl(sp: &mut BETA_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         let mut tmp_real: f64 = 0.0_f64;
         let mut denom: f64 = 0.0_f64;
         let mut denom_scale: f64 = 0.0_f64;
@@ -1252,7 +1250,7 @@ impl Core {
             x_inReal0,
             x_inReal1,
         };
-        Ok(BETA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(BETA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::BETA_Open`] (composition seam).
@@ -1371,7 +1369,7 @@ impl BETA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.BETA_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::BETA_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1404,7 +1402,7 @@ impl BETA_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.BETA_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::BETA_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/bop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bop.rs
@@ -253,7 +253,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_BOP_Stream")]
 pub struct BOP_Stream {
-    core: Core,
     state: BOP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -264,7 +263,6 @@ impl BOP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `BOP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -290,7 +288,7 @@ impl BOP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn BOP_step_impl(&self, sp: &mut BOP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn BOP_step_impl(sp: &mut BOP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         // BOP is a fraction of the bar's own range, so it is scale-free and the
         // divisor only has to be positive. An exact test, not the fixed
@@ -354,7 +352,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = BOP_StreamState {
         };
-        Ok(BOP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(BOP_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::BOP_Open`] (composition seam).
@@ -469,7 +467,7 @@ impl BOP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.BOP_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outReal);
+        Core::BOP_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -502,7 +500,7 @@ impl BOP_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.BOP_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::BOP_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cci.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cci.rs
@@ -376,7 +376,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CCI_Stream")]
 pub struct CCI_Stream {
-    core: Core,
     state: CCI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -387,7 +386,6 @@ impl CCI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CCI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -423,7 +421,7 @@ impl CCI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CCI_step_impl(&self, sp: &mut CCI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn CCI_step_impl(sp: &mut CCI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut tempReal3: f64 = 0.0_f64;
@@ -614,7 +612,7 @@ impl Core {
             cbSize_circBuffer: cbSize_circBuffer,
             cb_circBuffer: circBuffer,
         };
-        Ok(CCI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CCI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CCI_Open`] (composition seam).
@@ -726,7 +724,7 @@ impl CCI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CCI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::CCI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -759,7 +757,7 @@ impl CCI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CCI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::CCI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
@@ -358,7 +358,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL2CROWS_Stream")]
 pub struct CDL2CROWS_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDL2CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -369,7 +370,7 @@ impl CDL2CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL2CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -419,13 +420,13 @@ impl CDL2CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL2CROWS_step_impl(&self, sp: &mut CDL2CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL2CROWS_step_impl(sp: &mut CDL2CROWS_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -675,7 +676,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDL2CROWS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL2CROWS_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL2CROWS_Open`] (composition seam).
@@ -790,7 +791,7 @@ impl CDL2CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL2CROWS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL2CROWS_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -823,7 +824,7 @@ impl CDL2CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL2CROWS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL2CROWS_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
@@ -403,7 +403,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3BLACKCROWS_Stream")]
 pub struct CDL3BLACKCROWS_Stream {
-    core: Core,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDL3BLACKCROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -414,7 +415,7 @@ impl CDL3BLACKCROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3BLACKCROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -472,14 +473,14 @@ impl CDL3BLACKCROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3BLACKCROWS_step_impl(&self, sp: &mut CDL3BLACKCROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3BLACKCROWS_step_impl(sp: &mut CDL3BLACKCROWS_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -761,7 +762,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3BLACKCROWS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3BLACKCROWS_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3BLACKCROWS_Open`] (composition seam).
@@ -876,7 +877,7 @@ impl CDL3BLACKCROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3BLACKCROWS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3BLACKCROWS_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -909,7 +910,7 @@ impl CDL3BLACKCROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3BLACKCROWS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3BLACKCROWS_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
@@ -426,7 +426,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3INSIDE_Stream")]
 pub struct CDL3INSIDE_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDL3INSIDE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -437,7 +440,8 @@ impl CDL3INSIDE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3INSIDE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -495,19 +499,19 @@ impl CDL3INSIDE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3INSIDE_step_impl(&self, sp: &mut CDL3INSIDE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3INSIDE_step_impl(sp: &mut CDL3INSIDE_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -881,7 +885,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDL3INSIDE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3INSIDE_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3INSIDE_Open`] (composition seam).
@@ -1004,7 +1008,7 @@ impl CDL3INSIDE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3INSIDE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3INSIDE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1037,7 +1041,7 @@ impl CDL3INSIDE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3INSIDE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3INSIDE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
@@ -389,7 +389,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3LINESTRIKE_Stream")]
 pub struct CDL3LINESTRIKE_Stream {
-    core: Core,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
     state: CDL3LINESTRIKE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -400,7 +401,7 @@ impl CDL3LINESTRIKE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3LINESTRIKE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_near = src.cs_near;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -460,14 +461,14 @@ impl CDL3LINESTRIKE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3LINESTRIKE_step_impl(&self, sp: &mut CDL3LINESTRIKE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3LINESTRIKE_step_impl(sp: &mut CDL3LINESTRIKE_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -722,7 +723,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDL3LINESTRIKE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3LINESTRIKE_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3LINESTRIKE_Open`] (composition seam).
@@ -837,7 +838,7 @@ impl CDL3LINESTRIKE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3LINESTRIKE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3LINESTRIKE_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -870,7 +871,7 @@ impl CDL3LINESTRIKE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3LINESTRIKE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3LINESTRIKE_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
@@ -284,7 +284,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3OUTSIDE_Stream")]
 pub struct CDL3OUTSIDE_Stream {
-    core: Core,
     state: CDL3OUTSIDE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -295,7 +294,6 @@ impl CDL3OUTSIDE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3OUTSIDE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -329,7 +327,7 @@ impl CDL3OUTSIDE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3OUTSIDE_step_impl(&self, sp: &mut CDL3OUTSIDE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3OUTSIDE_step_impl(sp: &mut CDL3OUTSIDE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         if (if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 }) == 1 && (((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && sp.lag1_inClose > sp.lag2_inOpen && sp.lag1_inOpen < sp.lag2_inClose && inClose > sp.lag1_inClose || (((if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && (if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == 1 && sp.lag1_inOpen > sp.lag2_inClose && sp.lag1_inClose < sp.lag2_inOpen && inClose < sp.lag1_inClose {
             // white engulfs black
             // third candle higher
@@ -422,7 +420,7 @@ impl Core {
             lag1_inClose: inClose[historyLen - 1],
             lag2_inClose: inClose[historyLen - 2],
         };
-        Ok(CDL3OUTSIDE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3OUTSIDE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3OUTSIDE_Open`] (composition seam).
@@ -537,7 +535,7 @@ impl CDL3OUTSIDE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3OUTSIDE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3OUTSIDE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -570,7 +568,7 @@ impl CDL3OUTSIDE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3OUTSIDE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3OUTSIDE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
@@ -599,7 +599,14 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3STARSINSOUTH_Stream")]
 pub struct CDL3STARSINSOUTH_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDL3STARSINSOUTH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -610,7 +617,10 @@ impl CDL3STARSINSOUTH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3STARSINSOUTH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -690,32 +700,32 @@ impl CDL3STARSINSOUTH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3STARSINSOUTH_step_impl(&self, sp: &mut CDL3STARSINSOUTH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3STARSINSOUTH_step_impl(sp: &mut CDL3STARSINSOUTH_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1345,7 +1355,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3STARSINSOUTH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3STARSINSOUTH_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3STARSINSOUTH_Open`] (composition seam).
@@ -1468,7 +1478,7 @@ impl CDL3STARSINSOUTH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3STARSINSOUTH_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3STARSINSOUTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1501,7 +1511,7 @@ impl CDL3STARSINSOUTH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3STARSINSOUTH_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3STARSINSOUTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
@@ -657,7 +657,14 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3WHITESOLDIERS_Stream")]
 pub struct CDL3WHITESOLDIERS_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Far` setting this stream was opened with.
+    cs_far: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDL3WHITESOLDIERS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -668,7 +675,10 @@ impl CDL3WHITESOLDIERS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3WHITESOLDIERS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_far = src.cs_far;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -748,32 +758,32 @@ impl CDL3WHITESOLDIERS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3WHITESOLDIERS_step_impl(&self, sp: &mut CDL3WHITESOLDIERS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3WHITESOLDIERS_step_impl(sp: &mut CDL3WHITESOLDIERS_StreamState, cs_body_short: &CandleSetting, cs_far: &CandleSetting, cs_near: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Far_rangeType: i32 = self.candle_settings.far.range_type as i32;
+        let Far_rangeType: i32 = cs_far.range_type as i32;
         #[allow(non_snake_case)]
-        let Far_avgPeriod: i32 = self.candle_settings.far.avg_period;
+        let Far_avgPeriod: i32 = cs_far.avg_period;
         #[allow(non_snake_case)]
-        let Far_factor: f64 = self.candle_settings.far.factor;
+        let Far_factor: f64 = cs_far.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyShortTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1438,7 +1448,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3WHITESOLDIERS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3WHITESOLDIERS_Stream { cs_body_short: self.candle_settings.body_short, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3WHITESOLDIERS_Open`] (composition seam).
@@ -1561,7 +1571,7 @@ impl CDL3WHITESOLDIERS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDL3WHITESOLDIERS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3WHITESOLDIERS_step_impl(&mut self.state, &self.cs_body_short, &self.cs_far, &self.cs_near, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1594,7 +1604,7 @@ impl CDL3WHITESOLDIERS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDL3WHITESOLDIERS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3WHITESOLDIERS_step_impl(&mut self.state, &self.cs_body_short, &self.cs_far, &self.cs_near, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -563,7 +563,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLABANDONEDBABY_Stream")]
 pub struct CDLABANDONEDBABY_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLABANDONEDBABY_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -574,7 +579,9 @@ impl CDLABANDONEDBABY_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLABANDONEDBABY_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -642,25 +649,25 @@ impl CDLABANDONEDBABY_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLABANDONEDBABY_step_impl(&self, sp: &mut CDLABANDONEDBABY_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLABANDONEDBABY_step_impl(sp: &mut CDLABANDONEDBABY_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1176,7 +1183,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLABANDONEDBABY_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLABANDONEDBABY_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLABANDONEDBABY_Open`] (composition seam).
@@ -1299,7 +1306,7 @@ impl CDLABANDONEDBABY_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLABANDONEDBABY_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLABANDONEDBABY_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1332,7 +1339,7 @@ impl CDLABANDONEDBABY_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLABANDONEDBABY_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLABANDONEDBABY_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
@@ -743,7 +743,16 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLADVANCEBLOCK_Stream")]
 pub struct CDLADVANCEBLOCK_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Far` setting this stream was opened with.
+    cs_far: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowShort` setting this stream was opened with.
+    cs_shadow_short: CandleSetting,
     state: CDLADVANCEBLOCK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -754,7 +763,11 @@ impl CDLADVANCEBLOCK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLADVANCEBLOCK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_far = src.cs_far;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_short = src.cs_shadow_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -846,38 +859,38 @@ impl CDLADVANCEBLOCK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLADVANCEBLOCK_step_impl(&self, sp: &mut CDLADVANCEBLOCK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLADVANCEBLOCK_step_impl(sp: &mut CDLADVANCEBLOCK_StreamState, cs_body_long: &CandleSetting, cs_far: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Far_rangeType: i32 = self.candle_settings.far.range_type as i32;
+        let Far_rangeType: i32 = cs_far.range_type as i32;
         #[allow(non_snake_case)]
-        let Far_avgPeriod: i32 = self.candle_settings.far.avg_period;
+        let Far_avgPeriod: i32 = cs_far.avg_period;
         #[allow(non_snake_case)]
-        let Far_factor: f64 = self.candle_settings.far.factor;
+        let Far_factor: f64 = cs_far.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = self.candle_settings.shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = self.candle_settings.shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = self.candle_settings.shadow_short.factor;
+        let ShadowShort_factor: f64 = cs_shadow_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1650,7 +1663,7 @@ impl Core {
             ringLag_ShadowShortTrailingIdx: capLag_ShadowShortTrailingIdx as usize,
             ring_ShadowShortTrailingIdx_derived,
         };
-        Ok(CDLADVANCEBLOCK_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLADVANCEBLOCK_Stream { cs_body_long: self.candle_settings.body_long, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLADVANCEBLOCK_Open`] (composition seam).
@@ -1773,7 +1786,7 @@ impl CDLADVANCEBLOCK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLADVANCEBLOCK_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLADVANCEBLOCK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_far, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1806,7 +1819,7 @@ impl CDLADVANCEBLOCK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLADVANCEBLOCK_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLADVANCEBLOCK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_far, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
@@ -423,7 +423,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLBELTHOLD_Stream")]
 pub struct CDLBELTHOLD_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLBELTHOLD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -434,7 +437,8 @@ impl CDLBELTHOLD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLBELTHOLD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -476,19 +480,19 @@ impl CDLBELTHOLD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLBELTHOLD_step_impl(&self, sp: &mut CDLBELTHOLD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLBELTHOLD_step_impl(sp: &mut CDLBELTHOLD_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -836,7 +840,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLBELTHOLD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLBELTHOLD_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLBELTHOLD_Open`] (composition seam).
@@ -959,7 +963,7 @@ impl CDLBELTHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLBELTHOLD_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLBELTHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -992,7 +996,7 @@ impl CDLBELTHOLD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLBELTHOLD_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLBELTHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
@@ -357,7 +357,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLBREAKAWAY_Stream")]
 pub struct CDLBREAKAWAY_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDLBREAKAWAY_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -368,7 +369,7 @@ impl CDLBREAKAWAY_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLBREAKAWAY_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -436,13 +437,13 @@ impl CDLBREAKAWAY_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLBREAKAWAY_step_impl(&self, sp: &mut CDLBREAKAWAY_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLBREAKAWAY_step_impl(sp: &mut CDLBREAKAWAY_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -685,7 +686,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLBREAKAWAY_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLBREAKAWAY_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLBREAKAWAY_Open`] (composition seam).
@@ -800,7 +801,7 @@ impl CDLBREAKAWAY_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLBREAKAWAY_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLBREAKAWAY_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -833,7 +834,7 @@ impl CDLBREAKAWAY_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLBREAKAWAY_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLBREAKAWAY_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
@@ -421,7 +421,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCLOSINGMARUBOZU_Stream")]
 pub struct CDLCLOSINGMARUBOZU_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLCLOSINGMARUBOZU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -432,7 +435,8 @@ impl CDLCLOSINGMARUBOZU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCLOSINGMARUBOZU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -474,19 +478,19 @@ impl CDLCLOSINGMARUBOZU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCLOSINGMARUBOZU_step_impl(&self, sp: &mut CDLCLOSINGMARUBOZU_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCLOSINGMARUBOZU_step_impl(sp: &mut CDLCLOSINGMARUBOZU_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -834,7 +838,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLCLOSINGMARUBOZU_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCLOSINGMARUBOZU_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCLOSINGMARUBOZU_Open`] (composition seam).
@@ -957,7 +961,7 @@ impl CDLCLOSINGMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLCLOSINGMARUBOZU_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCLOSINGMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -990,7 +994,7 @@ impl CDLCLOSINGMARUBOZU_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLCLOSINGMARUBOZU_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCLOSINGMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
@@ -406,7 +406,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCONCEALBABYSWALL_Stream")]
 pub struct CDLCONCEALBABYSWALL_Stream {
-    core: Core,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLCONCEALBABYSWALL_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -417,7 +418,7 @@ impl CDLCONCEALBABYSWALL_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCONCEALBABYSWALL_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -477,14 +478,14 @@ impl CDLCONCEALBABYSWALL_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCONCEALBABYSWALL_step_impl(&self, sp: &mut CDLCONCEALBABYSWALL_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCONCEALBABYSWALL_step_impl(sp: &mut CDLCONCEALBABYSWALL_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -766,7 +767,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLCONCEALBABYSWALL_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCONCEALBABYSWALL_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCONCEALBABYSWALL_Open`] (composition seam).
@@ -881,7 +882,7 @@ impl CDLCONCEALBABYSWALL_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLCONCEALBABYSWALL_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCONCEALBABYSWALL_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -914,7 +915,7 @@ impl CDLCONCEALBABYSWALL_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLCONCEALBABYSWALL_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCONCEALBABYSWALL_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
@@ -448,7 +448,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCOUNTERATTACK_Stream")]
 pub struct CDLCOUNTERATTACK_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLCOUNTERATTACK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -459,7 +462,8 @@ impl CDLCOUNTERATTACK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCOUNTERATTACK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -513,20 +517,20 @@ impl CDLCOUNTERATTACK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCOUNTERATTACK_step_impl(&self, sp: &mut CDLCOUNTERATTACK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCOUNTERATTACK_step_impl(sp: &mut CDLCOUNTERATTACK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -873,7 +877,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLCOUNTERATTACK_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCOUNTERATTACK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCOUNTERATTACK_Open`] (composition seam).
@@ -996,7 +1000,7 @@ impl CDLCOUNTERATTACK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLCOUNTERATTACK_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCOUNTERATTACK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1029,7 +1033,7 @@ impl CDLCOUNTERATTACK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLCOUNTERATTACK_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCOUNTERATTACK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -386,7 +386,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDARKCLOUDCOVER_Stream")]
 pub struct CDLDARKCLOUDCOVER_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDLDARKCLOUDCOVER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -397,7 +398,7 @@ impl CDLDARKCLOUDCOVER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDARKCLOUDCOVER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -443,13 +444,13 @@ impl CDLDARKCLOUDCOVER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDARKCLOUDCOVER_step_impl(&self, sp: &mut CDLDARKCLOUDCOVER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDARKCLOUDCOVER_step_impl(sp: &mut CDLDARKCLOUDCOVER_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -675,7 +676,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLDARKCLOUDCOVER_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDARKCLOUDCOVER_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDARKCLOUDCOVER_Open`] (composition seam).
@@ -790,7 +791,7 @@ impl CDLDARKCLOUDCOVER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLDARKCLOUDCOVER_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDARKCLOUDCOVER_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -823,7 +824,7 @@ impl CDLDARKCLOUDCOVER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLDARKCLOUDCOVER_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDARKCLOUDCOVER_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
@@ -341,7 +341,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDOJI_Stream")]
 pub struct CDLDOJI_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
     state: CDLDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -352,7 +353,7 @@ impl CDLDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -386,13 +387,13 @@ impl CDLDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDOJI_step_impl(&self, sp: &mut CDLDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDOJI_step_impl(sp: &mut CDLDOJI_StreamState, cs_body_doji: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -604,7 +605,7 @@ impl Core {
             ringCap_BodyDojiTrailingIdx: cap_BodyDojiTrailingIdx as usize,
             ring_BodyDojiTrailingIdx_derived,
         };
-        Ok(CDLDOJI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDOJI_Open`] (composition seam).
@@ -719,7 +720,7 @@ impl CDLDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLDOJI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDOJI_step_impl(&mut self.state, &self.cs_body_doji, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -752,7 +753,7 @@ impl CDLDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLDOJI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDOJI_step_impl(&mut self.state, &self.cs_body_doji, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
@@ -430,7 +430,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDOJISTAR_Stream")]
 pub struct CDLDOJISTAR_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDLDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -441,7 +444,8 @@ impl CDLDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -491,19 +495,19 @@ impl CDLDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDOJISTAR_step_impl(&self, sp: &mut CDLDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDOJISTAR_step_impl(sp: &mut CDLDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -865,7 +869,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLDOJISTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDOJISTAR_Open`] (composition seam).
@@ -988,7 +992,7 @@ impl CDLDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLDOJISTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1021,7 +1025,7 @@ impl CDLDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLDOJISTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
@@ -427,7 +427,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDRAGONFLYDOJI_Stream")]
 pub struct CDLDRAGONFLYDOJI_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLDRAGONFLYDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -438,7 +441,8 @@ impl CDLDRAGONFLYDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDRAGONFLYDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -480,19 +484,19 @@ impl CDLDRAGONFLYDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDRAGONFLYDOJI_step_impl(&self, sp: &mut CDLDRAGONFLYDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDRAGONFLYDOJI_step_impl(sp: &mut CDLDRAGONFLYDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -839,7 +843,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLDRAGONFLYDOJI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDRAGONFLYDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDRAGONFLYDOJI_Open`] (composition seam).
@@ -962,7 +966,7 @@ impl CDLDRAGONFLYDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLDRAGONFLYDOJI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDRAGONFLYDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -995,7 +999,7 @@ impl CDLDRAGONFLYDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLDRAGONFLYDOJI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDRAGONFLYDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
@@ -294,7 +294,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLENGULFING_Stream")]
 pub struct CDLENGULFING_Stream {
-    core: Core,
     state: CDLENGULFING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -305,7 +304,6 @@ impl CDLENGULFING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLENGULFING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -335,7 +333,7 @@ impl CDLENGULFING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLENGULFING_step_impl(&self, sp: &mut CDLENGULFING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLENGULFING_step_impl(sp: &mut CDLENGULFING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         if (if inClose >= inOpen { 1 } else { 0 - 1 }) == 1 && (((if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && (inClose >= sp.lag1_inOpen && inOpen < sp.lag1_inClose || inClose > sp.lag1_inOpen && inOpen <= sp.lag1_inClose) || (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && (if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 }) == 1 && (inOpen >= sp.lag1_inClose && inClose < sp.lag1_inOpen || inOpen > sp.lag1_inClose && inClose <= sp.lag1_inOpen) {
             // white engulfs black
             // black engulfs white
@@ -430,7 +428,7 @@ impl Core {
             lag1_inOpen: inOpen[historyLen - 1],
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(CDLENGULFING_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLENGULFING_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLENGULFING_Open`] (composition seam).
@@ -545,7 +543,7 @@ impl CDLENGULFING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLENGULFING_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLENGULFING_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -578,7 +576,7 @@ impl CDLENGULFING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLENGULFING_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLENGULFING_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -523,7 +523,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLEVENINGDOJISTAR_Stream")]
 pub struct CDLEVENINGDOJISTAR_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLEVENINGDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -534,7 +539,9 @@ impl CDLEVENINGDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLEVENINGDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -602,25 +609,25 @@ impl CDLEVENINGDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLEVENINGDOJISTAR_step_impl(&self, sp: &mut CDLEVENINGDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLEVENINGDOJISTAR_step_impl(sp: &mut CDLEVENINGDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1140,7 +1147,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLEVENINGDOJISTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLEVENINGDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLEVENINGDOJISTAR_Open`] (composition seam).
@@ -1263,7 +1270,7 @@ impl CDLEVENINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLEVENINGDOJISTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLEVENINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1296,7 +1303,7 @@ impl CDLEVENINGDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLEVENINGDOJISTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLEVENINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -505,7 +505,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLEVENINGSTAR_Stream")]
 pub struct CDLEVENINGSTAR_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLEVENINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -516,7 +519,8 @@ impl CDLEVENINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLEVENINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -580,19 +584,19 @@ impl CDLEVENINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLEVENINGSTAR_step_impl(&self, sp: &mut CDLEVENINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLEVENINGSTAR_step_impl(sp: &mut CDLEVENINGSTAR_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -1029,7 +1033,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLEVENINGSTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLEVENINGSTAR_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLEVENINGSTAR_Open`] (composition seam).
@@ -1152,7 +1156,7 @@ impl CDLEVENINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLEVENINGSTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLEVENINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1185,7 +1189,7 @@ impl CDLEVENINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLEVENINGSTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLEVENINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
@@ -432,7 +432,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLGAPSIDESIDEWHITE_Stream")]
 pub struct CDLGAPSIDESIDEWHITE_Stream {
-    core: Core,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
     state: CDLGAPSIDESIDEWHITE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -443,7 +446,8 @@ impl CDLGAPSIDESIDEWHITE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLGAPSIDESIDEWHITE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_equal = src.cs_equal;
+        self.cs_near = src.cs_near;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -501,19 +505,19 @@ impl CDLGAPSIDESIDEWHITE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLGAPSIDESIDEWHITE_step_impl(&self, sp: &mut CDLGAPSIDESIDEWHITE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLGAPSIDESIDEWHITE_step_impl(sp: &mut CDLGAPSIDESIDEWHITE_StreamState, cs_equal: &CandleSetting, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -857,7 +861,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLGAPSIDESIDEWHITE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLGAPSIDESIDEWHITE_Stream { cs_equal: self.candle_settings.equal, cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLGAPSIDESIDEWHITE_Open`] (composition seam).
@@ -980,7 +984,7 @@ impl CDLGAPSIDESIDEWHITE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, &self.cs_equal, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1013,7 +1017,7 @@ impl CDLGAPSIDESIDEWHITE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, &self.cs_equal, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
@@ -426,7 +426,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLGRAVESTONEDOJI_Stream")]
 pub struct CDLGRAVESTONEDOJI_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLGRAVESTONEDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -437,7 +440,8 @@ impl CDLGRAVESTONEDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLGRAVESTONEDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -479,19 +483,19 @@ impl CDLGRAVESTONEDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLGRAVESTONEDOJI_step_impl(&self, sp: &mut CDLGRAVESTONEDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLGRAVESTONEDOJI_step_impl(sp: &mut CDLGRAVESTONEDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -838,7 +842,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLGRAVESTONEDOJI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLGRAVESTONEDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLGRAVESTONEDOJI_Open`] (composition seam).
@@ -961,7 +965,7 @@ impl CDLGRAVESTONEDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLGRAVESTONEDOJI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLGRAVESTONEDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -994,7 +998,7 @@ impl CDLGRAVESTONEDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLGRAVESTONEDOJI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLGRAVESTONEDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
@@ -556,7 +556,14 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHAMMER_Stream")]
 pub struct CDLHAMMER_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLHAMMER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -567,7 +574,10 @@ impl CDLHAMMER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHAMMER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -633,31 +643,31 @@ impl CDLHAMMER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHAMMER_step_impl(&self, sp: &mut CDLHAMMER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHAMMER_step_impl(sp: &mut CDLHAMMER_StreamState, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1287,7 +1297,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLHAMMER_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHAMMER_Stream { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHAMMER_Open`] (composition seam).
@@ -1410,7 +1420,7 @@ impl CDLHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHAMMER_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1443,7 +1453,7 @@ impl CDLHAMMER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHAMMER_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
@@ -560,7 +560,14 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHANGINGMAN_Stream")]
 pub struct CDLHANGINGMAN_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLHANGINGMAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -571,7 +578,10 @@ impl CDLHANGINGMAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHANGINGMAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -637,31 +647,31 @@ impl CDLHANGINGMAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHANGINGMAN_step_impl(&self, sp: &mut CDLHANGINGMAN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHANGINGMAN_step_impl(sp: &mut CDLHANGINGMAN_StreamState, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1291,7 +1301,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLHANGINGMAN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHANGINGMAN_Stream { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHANGINGMAN_Open`] (composition seam).
@@ -1414,7 +1424,7 @@ impl CDLHANGINGMAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHANGINGMAN_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHANGINGMAN_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1447,7 +1457,7 @@ impl CDLHANGINGMAN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHANGINGMAN_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHANGINGMAN_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
@@ -441,7 +441,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHARAMI_Stream")]
 pub struct CDLHARAMI_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLHARAMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -452,7 +455,8 @@ impl CDLHARAMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHARAMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -502,19 +506,19 @@ impl CDLHARAMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHARAMI_step_impl(&self, sp: &mut CDLHARAMI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHARAMI_step_impl(sp: &mut CDLHARAMI_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -904,7 +908,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLHARAMI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHARAMI_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHARAMI_Open`] (composition seam).
@@ -1027,7 +1031,7 @@ impl CDLHARAMI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHARAMI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHARAMI_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1060,7 +1064,7 @@ impl CDLHARAMI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHARAMI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHARAMI_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
@@ -443,7 +443,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHARAMICROSS_Stream")]
 pub struct CDLHARAMICROSS_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDLHARAMICROSS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -454,7 +457,8 @@ impl CDLHARAMICROSS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHARAMICROSS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -504,19 +508,19 @@ impl CDLHARAMICROSS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHARAMICROSS_step_impl(&self, sp: &mut CDLHARAMICROSS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHARAMICROSS_step_impl(sp: &mut CDLHARAMICROSS_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -905,7 +909,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLHARAMICROSS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHARAMICROSS_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHARAMICROSS_Open`] (composition seam).
@@ -1028,7 +1032,7 @@ impl CDLHARAMICROSS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHARAMICROSS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHARAMICROSS_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1061,7 +1065,7 @@ impl CDLHARAMICROSS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHARAMICROSS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHARAMICROSS_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
@@ -421,7 +421,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHIGHWAVE_Stream")]
 pub struct CDLHIGHWAVE_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowVeryLong` setting this stream was opened with.
+    cs_shadow_very_long: CandleSetting,
     state: CDLHIGHWAVE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -432,7 +435,8 @@ impl CDLHIGHWAVE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHIGHWAVE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_shadow_very_long = src.cs_shadow_very_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -474,19 +478,19 @@ impl CDLHIGHWAVE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHIGHWAVE_step_impl(&self, sp: &mut CDLHIGHWAVE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHIGHWAVE_step_impl(sp: &mut CDLHIGHWAVE_StreamState, cs_body_short: &CandleSetting, cs_shadow_very_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_rangeType: i32 = self.candle_settings.shadow_very_long.range_type as i32;
+        let ShadowVeryLong_rangeType: i32 = cs_shadow_very_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_avgPeriod: i32 = self.candle_settings.shadow_very_long.avg_period;
+        let ShadowVeryLong_avgPeriod: i32 = cs_shadow_very_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_factor: f64 = self.candle_settings.shadow_very_long.factor;
+        let ShadowVeryLong_factor: f64 = cs_shadow_very_long.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -831,7 +835,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLHIGHWAVE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHIGHWAVE_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_very_long: self.candle_settings.shadow_very_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHIGHWAVE_Open`] (composition seam).
@@ -954,7 +958,7 @@ impl CDLHIGHWAVE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHIGHWAVE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHIGHWAVE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_very_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -987,7 +991,7 @@ impl CDLHIGHWAVE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHIGHWAVE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHIGHWAVE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_very_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
@@ -332,7 +332,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHIKKAKE_Stream")]
 pub struct CDLHIKKAKE_Stream {
-    core: Core,
     state: CDLHIKKAKE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -343,7 +342,6 @@ impl CDLHIKKAKE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHIKKAKE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -385,7 +383,7 @@ impl CDLHIKKAKE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHIKKAKE_step_impl(&self, sp: &mut CDLHIKKAKE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHIKKAKE_step_impl(sp: &mut CDLHIKKAKE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         if sp.lag1_inHigh < sp.lag2_inHigh &&
            sp.lag1_inLow > sp.lag2_inLow &&   // 1st + 2nd: lower high and higher low
            (inHigh < sp.lag1_inHigh && inLow < sp.lag1_inLow || inHigh > sp.lag1_inHigh && inLow > sp.lag1_inLow) // (bull) 3rd: lower high and lower low (bear) 3rd: higher high and higher low
@@ -535,7 +533,7 @@ impl Core {
             lag1_inLow: inLow[historyLen - 1],
             lag2_inLow: inLow[historyLen - 2],
         };
-        Ok(CDLHIKKAKE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHIKKAKE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHIKKAKE_Open`] (composition seam).
@@ -650,7 +648,7 @@ impl CDLHIKKAKE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHIKKAKE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHIKKAKE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -683,7 +681,7 @@ impl CDLHIKKAKE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHIKKAKE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHIKKAKE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
@@ -444,7 +444,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHIKKAKEMOD_Stream")]
 pub struct CDLHIKKAKEMOD_Stream {
-    core: Core,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
     state: CDLHIKKAKEMOD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -455,7 +456,7 @@ impl CDLHIKKAKEMOD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHIKKAKEMOD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_near = src.cs_near;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -519,13 +520,13 @@ impl CDLHIKKAKEMOD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHIKKAKEMOD_step_impl(&self, sp: &mut CDLHIKKAKEMOD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHIKKAKEMOD_step_impl(sp: &mut CDLHIKKAKEMOD_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -850,7 +851,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLHIKKAKEMOD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHIKKAKEMOD_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHIKKAKEMOD_Open`] (composition seam).
@@ -965,7 +966,7 @@ impl CDLHIKKAKEMOD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHIKKAKEMOD_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHIKKAKEMOD_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -998,7 +999,7 @@ impl CDLHIKKAKEMOD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHIKKAKEMOD_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHIKKAKEMOD_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
@@ -430,7 +430,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHOMINGPIGEON_Stream")]
 pub struct CDLHOMINGPIGEON_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLHOMINGPIGEON_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -441,7 +444,8 @@ impl CDLHOMINGPIGEON_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHOMINGPIGEON_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -493,19 +497,19 @@ impl CDLHOMINGPIGEON_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHOMINGPIGEON_step_impl(&self, sp: &mut CDLHOMINGPIGEON_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHOMINGPIGEON_step_impl(sp: &mut CDLHOMINGPIGEON_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -856,7 +860,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLHOMINGPIGEON_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHOMINGPIGEON_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHOMINGPIGEON_Open`] (composition seam).
@@ -979,7 +983,7 @@ impl CDLHOMINGPIGEON_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLHOMINGPIGEON_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHOMINGPIGEON_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1012,7 +1016,7 @@ impl CDLHOMINGPIGEON_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLHOMINGPIGEON_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHOMINGPIGEON_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
@@ -495,7 +495,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLIDENTICAL3CROWS_Stream")]
 pub struct CDLIDENTICAL3CROWS_Stream {
-    core: Core,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLIDENTICAL3CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -506,7 +509,8 @@ impl CDLIDENTICAL3CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLIDENTICAL3CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_equal = src.cs_equal;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -568,20 +572,20 @@ impl CDLIDENTICAL3CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLIDENTICAL3CROWS_step_impl(&self, sp: &mut CDLIDENTICAL3CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLIDENTICAL3CROWS_step_impl(sp: &mut CDLIDENTICAL3CROWS_StreamState, cs_equal: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -985,7 +989,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLIDENTICAL3CROWS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLIDENTICAL3CROWS_Stream { cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLIDENTICAL3CROWS_Open`] (composition seam).
@@ -1108,7 +1112,7 @@ impl CDLIDENTICAL3CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLIDENTICAL3CROWS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLIDENTICAL3CROWS_step_impl(&mut self.state, &self.cs_equal, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1141,7 +1145,7 @@ impl CDLIDENTICAL3CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLIDENTICAL3CROWS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLIDENTICAL3CROWS_step_impl(&mut self.state, &self.cs_equal, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
@@ -427,7 +427,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLINNECK_Stream")]
 pub struct CDLINNECK_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLINNECK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -438,7 +441,8 @@ impl CDLINNECK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLINNECK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -492,19 +496,19 @@ impl CDLINNECK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLINNECK_step_impl(&self, sp: &mut CDLINNECK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLINNECK_step_impl(sp: &mut CDLINNECK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -839,7 +843,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLINNECK_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLINNECK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLINNECK_Open`] (composition seam).
@@ -962,7 +966,7 @@ impl CDLINNECK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLINNECK_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLINNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -995,7 +999,7 @@ impl CDLINNECK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLINNECK_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLINNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
@@ -491,7 +491,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLINVERTEDHAMMER_Stream")]
 pub struct CDLINVERTEDHAMMER_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLINVERTEDHAMMER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -502,7 +507,9 @@ impl CDLINVERTEDHAMMER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLINVERTEDHAMMER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -556,25 +563,25 @@ impl CDLINVERTEDHAMMER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLINVERTEDHAMMER_step_impl(&self, sp: &mut CDLINVERTEDHAMMER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLINVERTEDHAMMER_step_impl(sp: &mut CDLINVERTEDHAMMER_StreamState, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1068,7 +1075,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLINVERTEDHAMMER_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLINVERTEDHAMMER_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLINVERTEDHAMMER_Open`] (composition seam).
@@ -1191,7 +1198,7 @@ impl CDLINVERTEDHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLINVERTEDHAMMER_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLINVERTEDHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1224,7 +1231,7 @@ impl CDLINVERTEDHAMMER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLINVERTEDHAMMER_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLINVERTEDHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
@@ -461,7 +461,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLKICKING_Stream")]
 pub struct CDLKICKING_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLKICKING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -472,7 +475,8 @@ impl CDLKICKING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLKICKING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -526,20 +530,20 @@ impl CDLKICKING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLKICKING_step_impl(&self, sp: &mut CDLKICKING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLKICKING_step_impl(sp: &mut CDLKICKING_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -894,7 +898,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLKICKING_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLKICKING_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLKICKING_Open`] (composition seam).
@@ -1017,7 +1021,7 @@ impl CDLKICKING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLKICKING_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLKICKING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1050,7 +1054,7 @@ impl CDLKICKING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLKICKING_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLKICKING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
@@ -461,7 +461,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLKICKINGBYLENGTH_Stream")]
 pub struct CDLKICKINGBYLENGTH_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLKICKINGBYLENGTH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -472,7 +475,8 @@ impl CDLKICKINGBYLENGTH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLKICKINGBYLENGTH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -526,20 +530,20 @@ impl CDLKICKINGBYLENGTH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLKICKINGBYLENGTH_step_impl(&self, sp: &mut CDLKICKINGBYLENGTH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLKICKINGBYLENGTH_step_impl(sp: &mut CDLKICKINGBYLENGTH_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -895,7 +899,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLKICKINGBYLENGTH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLKICKINGBYLENGTH_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLKICKINGBYLENGTH_Open`] (composition seam).
@@ -1018,7 +1022,7 @@ impl CDLKICKINGBYLENGTH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLKICKINGBYLENGTH_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLKICKINGBYLENGTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1051,7 +1055,7 @@ impl CDLKICKINGBYLENGTH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLKICKINGBYLENGTH_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLKICKINGBYLENGTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
@@ -365,7 +365,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLADDERBOTTOM_Stream")]
 pub struct CDLLADDERBOTTOM_Stream {
-    core: Core,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLLADDERBOTTOM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -376,7 +377,7 @@ impl CDLLADDERBOTTOM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLADDERBOTTOM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -432,13 +433,13 @@ impl CDLLADDERBOTTOM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLADDERBOTTOM_step_impl(&self, sp: &mut CDLLADDERBOTTOM_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLADDERBOTTOM_step_impl(sp: &mut CDLLADDERBOTTOM_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -681,7 +682,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLLADDERBOTTOM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLADDERBOTTOM_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLADDERBOTTOM_Open`] (composition seam).
@@ -796,7 +797,7 @@ impl CDLLADDERBOTTOM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLLADDERBOTTOM_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLADDERBOTTOM_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -829,7 +830,7 @@ impl CDLLADDERBOTTOM_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLLADDERBOTTOM_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLADDERBOTTOM_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
@@ -424,7 +424,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLONGLEGGEDDOJI_Stream")]
 pub struct CDLLONGLEGGEDDOJI_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
     state: CDLLONGLEGGEDDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -435,7 +438,8 @@ impl CDLLONGLEGGEDDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLONGLEGGEDDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_shadow_long = src.cs_shadow_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -477,19 +481,19 @@ impl CDLLONGLEGGEDDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLONGLEGGEDDOJI_step_impl(&self, sp: &mut CDLLONGLEGGEDDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLONGLEGGEDDOJI_step_impl(sp: &mut CDLLONGLEGGEDDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -834,7 +838,7 @@ impl Core {
             ringCap_ShadowLongTrailingIdx: cap_ShadowLongTrailingIdx as usize,
             ring_ShadowLongTrailingIdx_derived,
         };
-        Ok(CDLLONGLEGGEDDOJI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLONGLEGGEDDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_long: self.candle_settings.shadow_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLONGLEGGEDDOJI_Open`] (composition seam).
@@ -957,7 +961,7 @@ impl CDLLONGLEGGEDDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLLONGLEGGEDDOJI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLONGLEGGEDDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -990,7 +994,7 @@ impl CDLLONGLEGGEDDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLLONGLEGGEDDOJI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLONGLEGGEDDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
@@ -407,7 +407,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLONGLINE_Stream")]
 pub struct CDLLONGLINE_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowShort` setting this stream was opened with.
+    cs_shadow_short: CandleSetting,
     state: CDLLONGLINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -418,7 +421,8 @@ impl CDLLONGLINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLONGLINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_short = src.cs_shadow_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -460,19 +464,19 @@ impl CDLLONGLINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLONGLINE_step_impl(&self, sp: &mut CDLLONGLINE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLONGLINE_step_impl(sp: &mut CDLLONGLINE_StreamState, cs_body_long: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = self.candle_settings.shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = self.candle_settings.shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = self.candle_settings.shadow_short.factor;
+        let ShadowShort_factor: f64 = cs_shadow_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -816,7 +820,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLLONGLINE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLONGLINE_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLONGLINE_Open`] (composition seam).
@@ -939,7 +943,7 @@ impl CDLLONGLINE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLLONGLINE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLONGLINE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -972,7 +976,7 @@ impl CDLLONGLINE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLLONGLINE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLONGLINE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
@@ -417,7 +417,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMARUBOZU_Stream")]
 pub struct CDLMARUBOZU_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLMARUBOZU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -428,7 +431,8 @@ impl CDLMARUBOZU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMARUBOZU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -470,19 +474,19 @@ impl CDLMARUBOZU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMARUBOZU_step_impl(&self, sp: &mut CDLMARUBOZU_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMARUBOZU_step_impl(sp: &mut CDLMARUBOZU_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -826,7 +830,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLMARUBOZU_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMARUBOZU_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMARUBOZU_Open`] (composition seam).
@@ -949,7 +953,7 @@ impl CDLMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLMARUBOZU_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -982,7 +986,7 @@ impl CDLMARUBOZU_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLMARUBOZU_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
@@ -358,7 +358,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMATCHINGLOW_Stream")]
 pub struct CDLMATCHINGLOW_Stream {
-    core: Core,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLMATCHINGLOW_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -369,7 +370,7 @@ impl CDLMATCHINGLOW_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMATCHINGLOW_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -413,13 +414,13 @@ impl CDLMATCHINGLOW_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMATCHINGLOW_step_impl(&self, sp: &mut CDLMATCHINGLOW_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMATCHINGLOW_step_impl(sp: &mut CDLMATCHINGLOW_StreamState, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -631,7 +632,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLMATCHINGLOW_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMATCHINGLOW_Stream { cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMATCHINGLOW_Open`] (composition seam).
@@ -746,7 +747,7 @@ impl CDLMATCHINGLOW_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLMATCHINGLOW_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMATCHINGLOW_step_impl(&mut self.state, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -779,7 +780,7 @@ impl CDLMATCHINGLOW_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLMATCHINGLOW_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMATCHINGLOW_step_impl(&mut self.state, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -512,7 +512,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMATHOLD_Stream")]
 pub struct CDLMATHOLD_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLMATHOLD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -523,7 +526,8 @@ impl CDLMATHOLD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMATHOLD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -601,20 +605,20 @@ impl CDLMATHOLD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMATHOLD_step_impl(&self, sp: &mut CDLMATHOLD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMATHOLD_step_impl(sp: &mut CDLMATHOLD_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1036,7 +1040,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMATHOLD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMATHOLD_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMATHOLD_Open`] (composition seam).
@@ -1159,7 +1163,7 @@ impl CDLMATHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLMATHOLD_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMATHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1192,7 +1196,7 @@ impl CDLMATHOLD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLMATHOLD_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMATHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -564,7 +564,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMORNINGDOJISTAR_Stream")]
 pub struct CDLMORNINGDOJISTAR_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLMORNINGDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -575,7 +580,9 @@ impl CDLMORNINGDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMORNINGDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -643,25 +650,25 @@ impl CDLMORNINGDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMORNINGDOJISTAR_step_impl(&self, sp: &mut CDLMORNINGDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMORNINGDOJISTAR_step_impl(sp: &mut CDLMORNINGDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1181,7 +1188,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMORNINGDOJISTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMORNINGDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMORNINGDOJISTAR_Open`] (composition seam).
@@ -1304,7 +1311,7 @@ impl CDLMORNINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLMORNINGDOJISTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMORNINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1337,7 +1344,7 @@ impl CDLMORNINGDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLMORNINGDOJISTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMORNINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -547,7 +547,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMORNINGSTAR_Stream")]
 pub struct CDLMORNINGSTAR_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLMORNINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -558,7 +561,8 @@ impl CDLMORNINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMORNINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -622,19 +626,19 @@ impl CDLMORNINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMORNINGSTAR_step_impl(&self, sp: &mut CDLMORNINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMORNINGSTAR_step_impl(sp: &mut CDLMORNINGSTAR_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -1071,7 +1075,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMORNINGSTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMORNINGSTAR_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMORNINGSTAR_Open`] (composition seam).
@@ -1194,7 +1198,7 @@ impl CDLMORNINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLMORNINGSTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMORNINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1227,7 +1231,7 @@ impl CDLMORNINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLMORNINGSTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMORNINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
@@ -426,7 +426,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLONNECK_Stream")]
 pub struct CDLONNECK_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLONNECK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -437,7 +440,8 @@ impl CDLONNECK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLONNECK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -491,19 +495,19 @@ impl CDLONNECK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLONNECK_step_impl(&self, sp: &mut CDLONNECK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLONNECK_step_impl(sp: &mut CDLONNECK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -838,7 +842,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLONNECK_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLONNECK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLONNECK_Open`] (composition seam).
@@ -961,7 +965,7 @@ impl CDLONNECK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLONNECK_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLONNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -994,7 +998,7 @@ impl CDLONNECK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLONNECK_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLONNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
@@ -410,7 +410,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLPIERCING_Stream")]
 pub struct CDLPIERCING_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
     state: CDLPIERCING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -421,7 +422,7 @@ impl CDLPIERCING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLPIERCING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -465,14 +466,14 @@ impl CDLPIERCING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLPIERCING_step_impl(&self, sp: &mut CDLPIERCING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLPIERCING_step_impl(sp: &mut CDLPIERCING_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -708,7 +709,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLPIERCING_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLPIERCING_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLPIERCING_Open`] (composition seam).
@@ -823,7 +824,7 @@ impl CDLPIERCING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLPIERCING_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLPIERCING_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -856,7 +857,7 @@ impl CDLPIERCING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLPIERCING_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLPIERCING_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
@@ -488,7 +488,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLRICKSHAWMAN_Stream")]
 pub struct CDLRICKSHAWMAN_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
     state: CDLRICKSHAWMAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -499,7 +504,9 @@ impl CDLRICKSHAWMAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLRICKSHAWMAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_long = src.cs_shadow_long;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -549,25 +556,25 @@ impl CDLRICKSHAWMAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLRICKSHAWMAN_step_impl(&self, sp: &mut CDLRICKSHAWMAN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLRICKSHAWMAN_step_impl(sp: &mut CDLRICKSHAWMAN_StreamState, cs_body_doji: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1054,7 +1061,7 @@ impl Core {
             ringCap_ShadowLongTrailingIdx: cap_ShadowLongTrailingIdx as usize,
             ring_ShadowLongTrailingIdx_derived,
         };
-        Ok(CDLRICKSHAWMAN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLRICKSHAWMAN_Stream { cs_body_doji: self.candle_settings.body_doji, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLRICKSHAWMAN_Open`] (composition seam).
@@ -1177,7 +1184,7 @@ impl CDLRICKSHAWMAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLRICKSHAWMAN_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLRICKSHAWMAN_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_near, &self.cs_shadow_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1210,7 +1217,7 @@ impl CDLRICKSHAWMAN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLRICKSHAWMAN_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLRICKSHAWMAN_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_near, &self.cs_shadow_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
@@ -535,7 +535,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLRISEFALL3METHODS_Stream")]
 pub struct CDLRISEFALL3METHODS_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLRISEFALL3METHODS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -546,7 +549,8 @@ impl CDLRISEFALL3METHODS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLRISEFALL3METHODS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -622,20 +626,20 @@ impl CDLRISEFALL3METHODS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLRISEFALL3METHODS_step_impl(&self, sp: &mut CDLRISEFALL3METHODS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLRISEFALL3METHODS_step_impl(sp: &mut CDLRISEFALL3METHODS_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1116,7 +1120,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLRISEFALL3METHODS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLRISEFALL3METHODS_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLRISEFALL3METHODS_Open`] (composition seam).
@@ -1239,7 +1243,7 @@ impl CDLRISEFALL3METHODS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLRISEFALL3METHODS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLRISEFALL3METHODS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1272,7 +1276,7 @@ impl CDLRISEFALL3METHODS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLRISEFALL3METHODS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLRISEFALL3METHODS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
@@ -493,7 +493,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSEPARATINGLINES_Stream")]
 pub struct CDLSEPARATINGLINES_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLSEPARATINGLINES_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -504,7 +509,9 @@ impl CDLSEPARATINGLINES_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSEPARATINGLINES_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_equal = src.cs_equal;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -564,25 +571,25 @@ impl CDLSEPARATINGLINES_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSEPARATINGLINES_step_impl(&self, sp: &mut CDLSEPARATINGLINES_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSEPARATINGLINES_step_impl(sp: &mut CDLSEPARATINGLINES_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -1064,7 +1071,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSEPARATINGLINES_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSEPARATINGLINES_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSEPARATINGLINES_Open`] (composition seam).
@@ -1187,7 +1194,7 @@ impl CDLSEPARATINGLINES_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSEPARATINGLINES_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSEPARATINGLINES_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1220,7 +1227,7 @@ impl CDLSEPARATINGLINES_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSEPARATINGLINES_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSEPARATINGLINES_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
@@ -491,7 +491,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSHOOTINGSTAR_Stream")]
 pub struct CDLSHOOTINGSTAR_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLSHOOTINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -502,7 +507,9 @@ impl CDLSHOOTINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSHOOTINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_shadow_long = src.cs_shadow_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -556,25 +563,25 @@ impl CDLSHOOTINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSHOOTINGSTAR_step_impl(&self, sp: &mut CDLSHOOTINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSHOOTINGSTAR_step_impl(sp: &mut CDLSHOOTINGSTAR_StreamState, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = self.candle_settings.shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = self.candle_settings.shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = self.candle_settings.shadow_long.factor;
+        let ShadowLong_factor: f64 = cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1068,7 +1075,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSHOOTINGSTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSHOOTINGSTAR_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSHOOTINGSTAR_Open`] (composition seam).
@@ -1191,7 +1198,7 @@ impl CDLSHOOTINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSHOOTINGSTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSHOOTINGSTAR_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1224,7 +1231,7 @@ impl CDLSHOOTINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSHOOTINGSTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSHOOTINGSTAR_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
@@ -416,7 +416,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSHORTLINE_Stream")]
 pub struct CDLSHORTLINE_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowShort` setting this stream was opened with.
+    cs_shadow_short: CandleSetting,
     state: CDLSHORTLINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -427,7 +430,8 @@ impl CDLSHORTLINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSHORTLINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
+        self.cs_shadow_short = src.cs_shadow_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -469,19 +473,19 @@ impl CDLSHORTLINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSHORTLINE_step_impl(&self, sp: &mut CDLSHORTLINE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSHORTLINE_step_impl(sp: &mut CDLSHORTLINE_StreamState, cs_body_short: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = self.candle_settings.shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = self.candle_settings.shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = self.candle_settings.shadow_short.factor;
+        let ShadowShort_factor: f64 = cs_shadow_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -826,7 +830,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLSHORTLINE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSHORTLINE_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSHORTLINE_Open`] (composition seam).
@@ -949,7 +953,7 @@ impl CDLSHORTLINE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSHORTLINE_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSHORTLINE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -982,7 +986,7 @@ impl CDLSHORTLINE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSHORTLINE_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSHORTLINE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
@@ -345,7 +345,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSPINNINGTOP_Stream")]
 pub struct CDLSPINNINGTOP_Stream {
-    core: Core,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLSPINNINGTOP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -356,7 +357,7 @@ impl CDLSPINNINGTOP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSPINNINGTOP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -390,13 +391,13 @@ impl CDLSPINNINGTOP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSPINNINGTOP_step_impl(&self, sp: &mut CDLSPINNINGTOP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSPINNINGTOP_step_impl(sp: &mut CDLSPINNINGTOP_StreamState, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -608,7 +609,7 @@ impl Core {
             ringCap_BodyTrailingIdx: cap_BodyTrailingIdx as usize,
             ring_BodyTrailingIdx_derived,
         };
-        Ok(CDLSPINNINGTOP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSPINNINGTOP_Stream { cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSPINNINGTOP_Open`] (composition seam).
@@ -723,7 +724,7 @@ impl CDLSPINNINGTOP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSPINNINGTOP_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSPINNINGTOP_step_impl(&mut self.state, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -756,7 +757,7 @@ impl CDLSPINNINGTOP_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSPINNINGTOP_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSPINNINGTOP_step_impl(&mut self.state, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
@@ -616,7 +616,14 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSTALLEDPATTERN_Stream")]
 pub struct CDLSTALLEDPATTERN_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLSTALLEDPATTERN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -627,7 +634,10 @@ impl CDLSTALLEDPATTERN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSTALLEDPATTERN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
+        self.cs_near = src.cs_near;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -707,32 +717,32 @@ impl CDLSTALLEDPATTERN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSTALLEDPATTERN_step_impl(&self, sp: &mut CDLSTALLEDPATTERN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSTALLEDPATTERN_step_impl(sp: &mut CDLSTALLEDPATTERN_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1360,7 +1370,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSTALLEDPATTERN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSTALLEDPATTERN_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSTALLEDPATTERN_Open`] (composition seam).
@@ -1483,7 +1493,7 @@ impl CDLSTALLEDPATTERN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSTALLEDPATTERN_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSTALLEDPATTERN_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_near, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1516,7 +1526,7 @@ impl CDLSTALLEDPATTERN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSTALLEDPATTERN_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSTALLEDPATTERN_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_near, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
@@ -357,7 +357,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSTICKSANDWICH_Stream")]
 pub struct CDLSTICKSANDWICH_Stream {
-    core: Core,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLSTICKSANDWICH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -368,7 +369,7 @@ impl CDLSTICKSANDWICH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSTICKSANDWICH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -420,13 +421,13 @@ impl CDLSTICKSANDWICH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSTICKSANDWICH_step_impl(&self, sp: &mut CDLSTICKSANDWICH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSTICKSANDWICH_step_impl(sp: &mut CDLSTICKSANDWICH_StreamState, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -653,7 +654,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLSTICKSANDWICH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSTICKSANDWICH_Stream { cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSTICKSANDWICH_Open`] (composition seam).
@@ -768,7 +769,7 @@ impl CDLSTICKSANDWICH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLSTICKSANDWICH_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSTICKSANDWICH_step_impl(&mut self.state, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -801,7 +802,7 @@ impl CDLSTICKSANDWICH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLSTICKSANDWICH_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSTICKSANDWICH_step_impl(&mut self.state, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
@@ -479,7 +479,12 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTAKURI_Stream")]
 pub struct CDLTAKURI_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryLong` setting this stream was opened with.
+    cs_shadow_very_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
     state: CDLTAKURI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -490,7 +495,9 @@ impl CDLTAKURI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTAKURI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
+        self.cs_shadow_very_long = src.cs_shadow_very_long;
+        self.cs_shadow_very_short = src.cs_shadow_very_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -540,25 +547,25 @@ impl CDLTAKURI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTAKURI_step_impl(&self, sp: &mut CDLTAKURI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTAKURI_step_impl(sp: &mut CDLTAKURI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_rangeType: i32 = self.candle_settings.shadow_very_long.range_type as i32;
+        let ShadowVeryLong_rangeType: i32 = cs_shadow_very_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_avgPeriod: i32 = self.candle_settings.shadow_very_long.avg_period;
+        let ShadowVeryLong_avgPeriod: i32 = cs_shadow_very_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_factor: f64 = self.candle_settings.shadow_very_long.factor;
+        let ShadowVeryLong_factor: f64 = cs_shadow_very_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = self.candle_settings.shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = self.candle_settings.shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = self.candle_settings.shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1038,7 +1045,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLTAKURI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTAKURI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_long: self.candle_settings.shadow_very_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTAKURI_Open`] (composition seam).
@@ -1161,7 +1168,7 @@ impl CDLTAKURI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLTAKURI_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTAKURI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1194,7 +1201,7 @@ impl CDLTAKURI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLTAKURI_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTAKURI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
@@ -367,7 +367,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTASUKIGAP_Stream")]
 pub struct CDLTASUKIGAP_Stream {
-    core: Core,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
     state: CDLTASUKIGAP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -378,7 +379,7 @@ impl CDLTASUKIGAP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTASUKIGAP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_near = src.cs_near;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -426,13 +427,13 @@ impl CDLTASUKIGAP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTASUKIGAP_step_impl(&self, sp: &mut CDLTASUKIGAP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTASUKIGAP_step_impl(sp: &mut CDLTASUKIGAP_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = self.candle_settings.near.range_type as i32;
+        let Near_rangeType: i32 = cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = self.candle_settings.near.avg_period;
+        let Near_avgPeriod: i32 = cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = self.candle_settings.near.factor;
+        let Near_factor: f64 = cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -673,7 +674,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLTASUKIGAP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTASUKIGAP_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTASUKIGAP_Open`] (composition seam).
@@ -788,7 +789,7 @@ impl CDLTASUKIGAP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLTASUKIGAP_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTASUKIGAP_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -821,7 +822,7 @@ impl CDLTASUKIGAP_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLTASUKIGAP_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTASUKIGAP_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
@@ -462,7 +462,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTHRUSTING_Stream")]
 pub struct CDLTHRUSTING_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
     state: CDLTHRUSTING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -473,7 +476,8 @@ impl CDLTHRUSTING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTHRUSTING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_equal = src.cs_equal;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -527,19 +531,19 @@ impl CDLTHRUSTING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTHRUSTING_step_impl(&self, sp: &mut CDLTHRUSTING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTHRUSTING_step_impl(sp: &mut CDLTHRUSTING_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = self.candle_settings.equal.range_type as i32;
+        let Equal_rangeType: i32 = cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = self.candle_settings.equal.avg_period;
+        let Equal_avgPeriod: i32 = cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = self.candle_settings.equal.factor;
+        let Equal_factor: f64 = cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -876,7 +880,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLTHRUSTING_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTHRUSTING_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTHRUSTING_Open`] (composition seam).
@@ -999,7 +1003,7 @@ impl CDLTHRUSTING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLTHRUSTING_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTHRUSTING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1032,7 +1036,7 @@ impl CDLTHRUSTING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLTHRUSTING_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTHRUSTING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
@@ -361,7 +361,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTRISTAR_Stream")]
 pub struct CDLTRISTAR_Stream {
-    core: Core,
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
     state: CDLTRISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -372,7 +373,7 @@ impl CDLTRISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTRISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_doji = src.cs_body_doji;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -422,13 +423,13 @@ impl CDLTRISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTRISTAR_step_impl(&self, sp: &mut CDLTRISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTRISTAR_step_impl(sp: &mut CDLTRISTAR_StreamState, cs_body_doji: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = self.candle_settings.body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;
+        let BodyDoji_factor: f64 = cs_body_doji.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -685,7 +686,7 @@ impl Core {
             ringCap_BodyTrailingIdx: cap_BodyTrailingIdx as usize,
             ring_BodyTrailingIdx_derived,
         };
-        Ok(CDLTRISTAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTRISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTRISTAR_Open`] (composition seam).
@@ -800,7 +801,7 @@ impl CDLTRISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLTRISTAR_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTRISTAR_step_impl(&mut self.state, &self.cs_body_doji, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -833,7 +834,7 @@ impl CDLTRISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLTRISTAR_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTRISTAR_step_impl(&mut self.state, &self.cs_body_doji, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
@@ -429,7 +429,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLUNIQUE3RIVER_Stream")]
 pub struct CDLUNIQUE3RIVER_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLUNIQUE3RIVER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -440,7 +443,8 @@ impl CDLUNIQUE3RIVER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLUNIQUE3RIVER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -498,19 +502,19 @@ impl CDLUNIQUE3RIVER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLUNIQUE3RIVER_step_impl(&self, sp: &mut CDLUNIQUE3RIVER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLUNIQUE3RIVER_step_impl(sp: &mut CDLUNIQUE3RIVER_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -892,7 +896,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLUNIQUE3RIVER_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLUNIQUE3RIVER_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLUNIQUE3RIVER_Open`] (composition seam).
@@ -1015,7 +1019,7 @@ impl CDLUNIQUE3RIVER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLUNIQUE3RIVER_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLUNIQUE3RIVER_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1048,7 +1052,7 @@ impl CDLUNIQUE3RIVER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLUNIQUE3RIVER_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLUNIQUE3RIVER_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
@@ -431,7 +431,10 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLUPSIDEGAP2CROWS_Stream")]
 pub struct CDLUPSIDEGAP2CROWS_Stream {
-    core: Core,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
     state: CDLUPSIDEGAP2CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -442,7 +445,8 @@ impl CDLUPSIDEGAP2CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLUPSIDEGAP2CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
+        self.cs_body_long = src.cs_body_long;
+        self.cs_body_short = src.cs_body_short;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -500,19 +504,19 @@ impl CDLUPSIDEGAP2CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLUPSIDEGAP2CROWS_step_impl(&self, sp: &mut CDLUPSIDEGAP2CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLUPSIDEGAP2CROWS_step_impl(sp: &mut CDLUPSIDEGAP2CROWS_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = self.candle_settings.body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = self.candle_settings.body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = self.candle_settings.body_long.factor;
+        let BodyLong_factor: f64 = cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = self.candle_settings.body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = self.candle_settings.body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = self.candle_settings.body_short.factor;
+        let BodyShort_factor: f64 = cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -896,7 +900,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLUPSIDEGAP2CROWS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLUPSIDEGAP2CROWS_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLUPSIDEGAP2CROWS_Open`] (composition seam).
@@ -1019,7 +1023,7 @@ impl CDLUPSIDEGAP2CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1052,7 +1056,7 @@ impl CDLUPSIDEGAP2CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
@@ -294,7 +294,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLXSIDEGAP3METHODS_Stream")]
 pub struct CDLXSIDEGAP3METHODS_Stream {
-    core: Core,
     state: CDLXSIDEGAP3METHODS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -305,7 +304,6 @@ impl CDLXSIDEGAP3METHODS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLXSIDEGAP3METHODS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -339,7 +337,7 @@ impl CDLXSIDEGAP3METHODS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLXSIDEGAP3METHODS_step_impl(&self, sp: &mut CDLXSIDEGAP3METHODS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLXSIDEGAP3METHODS_step_impl(sp: &mut CDLXSIDEGAP3METHODS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         if (if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == (if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 }) && // 1st and 2nd of same color
            (if sp.lag1_inClose >= sp.lag1_inOpen { 1 } else { 0 - 1 }) == 0 - (if inClose >= inOpen { 1 } else { 0 - 1 }) && // 3rd opposite color
            inOpen < (sp.lag1_inClose).max(sp.lag1_inOpen) &&  // 3rd opens within 2nd rb
@@ -443,7 +441,7 @@ impl Core {
             lag1_inClose: inClose[historyLen - 1],
             lag2_inClose: inClose[historyLen - 2],
         };
-        Ok(CDLXSIDEGAP3METHODS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLXSIDEGAP3METHODS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLXSIDEGAP3METHODS_Open`] (composition seam).
@@ -558,7 +556,7 @@ impl CDLXSIDEGAP3METHODS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.CDLXSIDEGAP3METHODS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLXSIDEGAP3METHODS_step_impl(&mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -591,7 +589,7 @@ impl CDLXSIDEGAP3METHODS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CDLXSIDEGAP3METHODS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLXSIDEGAP3METHODS_step_impl(&mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ceil.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ceil.rs
@@ -215,7 +215,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CEIL_Stream")]
 pub struct CEIL_Stream {
-    core: Core,
     state: CEIL_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -226,7 +225,6 @@ impl CEIL_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CEIL_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -252,7 +250,7 @@ impl CEIL_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CEIL_step_impl(&self, sp: &mut CEIL_StreamState, inReal: f64, outReal: &mut f64) {
+    fn CEIL_step_impl(sp: &mut CEIL_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).ceil();
     }
 
@@ -293,7 +291,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = CEIL_StreamState {
         };
-        Ok(CEIL_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CEIL_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CEIL_Open`] (composition seam).
@@ -398,7 +396,7 @@ impl CEIL_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CEIL_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::CEIL_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -431,7 +429,7 @@ impl CEIL_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CEIL_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::CEIL_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cmf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmf.rs
@@ -423,7 +423,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMF_Stream")]
 pub struct CMF_Stream {
-    core: Core,
     state: CMF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -434,7 +433,6 @@ impl CMF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -476,7 +474,7 @@ impl CMF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMF_step_impl(&self, sp: &mut CMF_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn CMF_step_impl(sp: &mut CMF_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut high: f64 = 0.0_f64;
         let mut low: f64 = 0.0_f64;
         let mut close: f64 = 0.0_f64;
@@ -660,7 +658,7 @@ impl Core {
             cb_mfv_flow: mfv_flow,
             cb_mfv_volume: mfv_volume,
         };
-        Ok(CMF_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMF_Open`] (composition seam).
@@ -783,7 +781,7 @@ impl CMF_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CMF_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::CMF_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -816,7 +814,7 @@ impl CMF_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CMF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::CMF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cmo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmo.rs
@@ -455,7 +455,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMO_Stream")]
 pub struct CMO_Stream {
-    core: Core,
     state: CMO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -466,7 +465,6 @@ impl CMO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -500,7 +498,7 @@ impl CMO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMO_step_impl(&self, sp: &mut CMO_StreamState, inReal: f64, outReal: &mut f64) {
+    fn CMO_step_impl(sp: &mut CMO_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
         if sp.optInTimePeriod == 1 {
@@ -576,7 +574,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(CMO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(CMO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut today: usize = 0_usize;
@@ -768,7 +766,7 @@ impl Core {
             prevLoss,
             prevValue,
         };
-        Ok(CMO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMO_Open`] (composition seam).
@@ -873,7 +871,7 @@ impl CMO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CMO_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::CMO_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -906,7 +904,7 @@ impl CMO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CMO_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::CMO_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cmou.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmou.rs
@@ -384,7 +384,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMOU_Stream")]
 pub struct CMOU_Stream {
-    core: Core,
     state: CMOU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -395,7 +394,6 @@ impl CMOU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMOU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -439,7 +437,7 @@ impl CMOU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMOU_step_impl(&self, sp: &mut CMOU_StreamState, inReal: f64, outReal: &mut f64) {
+    fn CMOU_step_impl(sp: &mut CMOU_StreamState, inReal: f64, outReal: &mut f64) {
         let mut sum: f64 = 0.0_f64;
         let mut diff: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -674,7 +672,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(CMOU_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMOU_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMOU_Open`] (composition seam).
@@ -779,7 +777,7 @@ impl CMOU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CMOU_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::CMOU_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -812,7 +810,7 @@ impl CMOU_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CMOU_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::CMOU_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -482,7 +482,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CORREL_Stream")]
 pub struct CORREL_Stream {
-    core: Core,
     state: CORREL_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -493,7 +492,6 @@ impl CORREL_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CORREL_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -557,7 +555,7 @@ impl CORREL_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CORREL_step_impl(&self, sp: &mut CORREL_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn CORREL_step_impl(sp: &mut CORREL_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         let mut x: f64 = 0.0_f64;
         let mut y: f64 = 0.0_f64;
         let mut trailingX: f64 = 0.0_f64;
@@ -1020,7 +1018,7 @@ impl Core {
             x_inReal0,
             x_inReal1,
         };
-        Ok(CORREL_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CORREL_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CORREL_Open`] (composition seam).
@@ -1139,7 +1137,7 @@ impl CORREL_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.CORREL_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::CORREL_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1172,7 +1170,7 @@ impl CORREL_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.CORREL_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::CORREL_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cos.rs
@@ -215,7 +215,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_COS_Stream")]
 pub struct COS_Stream {
-    core: Core,
     state: COS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -226,7 +225,6 @@ impl COS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `COS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -252,7 +250,7 @@ impl COS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn COS_step_impl(&self, sp: &mut COS_StreamState, inReal: f64, outReal: &mut f64) {
+    fn COS_step_impl(sp: &mut COS_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).cos();
     }
 
@@ -293,7 +291,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = COS_StreamState {
         };
-        Ok(COS_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(COS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::COS_Open`] (composition seam).
@@ -398,7 +396,7 @@ impl COS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.COS_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::COS_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -431,7 +429,7 @@ impl COS_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.COS_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::COS_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cosh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cosh.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_COSH_Stream")]
 pub struct COSH_Stream {
-    core: Core,
     state: COSH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl COSH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `COSH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl COSH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn COSH_step_impl(&self, sp: &mut COSH_StreamState, inReal: f64, outReal: &mut f64) {
+    fn COSH_step_impl(sp: &mut COSH_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).cosh();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = COSH_StreamState {
         };
-        Ok(COSH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(COSH_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::COSH_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl COSH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.COSH_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::COSH_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl COSH_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.COSH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::COSH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/dema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dema.rs
@@ -411,7 +411,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_DEMA_Stream")]
 pub struct DEMA_Stream {
-    core: Core,
     state: DEMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -422,7 +421,6 @@ impl DEMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `DEMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -456,7 +454,7 @@ impl DEMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn DEMA_step_impl(&self, sp: &mut DEMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn DEMA_step_impl(sp: &mut DEMA_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
@@ -515,7 +513,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(DEMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(DEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut prevEMA1: f64 = 0.0_f64;
         let mut prevEMA2: f64 = 0.0_f64;
@@ -643,7 +641,7 @@ impl Core {
             prevEMA2,
             optInK_1,
         };
-        Ok(DEMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(DEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::DEMA_Open`] (composition seam).
@@ -748,7 +746,7 @@ impl DEMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.DEMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::DEMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -781,7 +779,7 @@ impl DEMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.DEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::DEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/div.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/div.rs
@@ -226,7 +226,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_DIV_Stream")]
 pub struct DIV_Stream {
-    core: Core,
     state: DIV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -237,7 +236,6 @@ impl DIV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `DIV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -263,7 +261,7 @@ impl DIV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn DIV_step_impl(&self, sp: &mut DIV_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn DIV_step_impl(sp: &mut DIV_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         (*outReal) = inReal0 / inReal1;
     }
 
@@ -307,7 +305,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = DIV_StreamState {
         };
-        Ok(DIV_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(DIV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::DIV_Open`] (composition seam).
@@ -418,7 +416,7 @@ impl DIV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.DIV_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::DIV_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -451,7 +449,7 @@ impl DIV_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.DIV_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::DIV_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/dx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dx.rs
@@ -563,7 +563,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_DX_Stream")]
 pub struct DX_Stream {
-    core: Core,
     state: DX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -574,7 +573,6 @@ impl DX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `DX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -616,7 +614,7 @@ impl DX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn DX_step_impl(&self, sp: &mut DX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn DX_step_impl(sp: &mut DX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut diffP: f64 = 0.0_f64;
         let mut diffM: f64 = 0.0_f64;
@@ -1001,7 +999,7 @@ impl Core {
             prevTR,
             lastOut_outReal: outReal[(*outNBElement - 1) * outStride],
         };
-        Ok(DX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(DX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::DX_Open`] (composition seam).
@@ -1113,7 +1111,7 @@ impl DX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.DX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::DX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1146,7 +1144,7 @@ impl DX_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.DX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::DX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/efi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/efi.rs
@@ -404,7 +404,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_EFI_Stream")]
 pub struct EFI_Stream {
-    core: Core,
     state: EFI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -415,7 +414,6 @@ impl EFI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `EFI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -449,7 +447,7 @@ impl EFI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn EFI_step_impl(&self, sp: &mut EFI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn EFI_step_impl(sp: &mut EFI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             let mut force: f64 = 0.0_f64;
             force = (inClose - sp.prevClose) * inVolume;
@@ -569,7 +567,7 @@ impl Core {
                 optInK_1,
                 prevMA,
             };
-            Ok(EFI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(EFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut optInK_1: f64 = 0.0_f64;
             let mut tempReal: f64 = 0.0_f64;
@@ -674,7 +672,7 @@ impl Core {
                 optInK_1,
                 prevMA,
             };
-            Ok(EFI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(EFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -788,7 +786,7 @@ impl EFI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.EFI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
+        Core::EFI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -821,7 +819,7 @@ impl EFI_Stream {
             if !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.EFI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
+            Core::EFI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ema.rs
@@ -354,7 +354,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_EMA_Stream")]
 pub struct EMA_Stream {
-    core: Core,
     state: EMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -365,7 +364,6 @@ impl EMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `EMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -397,7 +395,7 @@ impl EMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn EMA_step_impl(&self, sp: &mut EMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn EMA_step_impl(sp: &mut EMA_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
@@ -454,7 +452,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(EMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(EMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut optInK_1: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -528,7 +526,7 @@ impl Core {
             optInK_1,
             prevMA,
         };
-        Ok(EMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(EMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::EMA_Open`] (composition seam).
@@ -633,7 +631,7 @@ impl EMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.EMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::EMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -666,7 +664,7 @@ impl EMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.EMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::EMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/exp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/exp.rs
@@ -215,7 +215,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_EXP_Stream")]
 pub struct EXP_Stream {
-    core: Core,
     state: EXP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -226,7 +225,6 @@ impl EXP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `EXP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -252,7 +250,7 @@ impl EXP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn EXP_step_impl(&self, sp: &mut EXP_StreamState, inReal: f64, outReal: &mut f64) {
+    fn EXP_step_impl(sp: &mut EXP_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).exp();
     }
 
@@ -293,7 +291,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = EXP_StreamState {
         };
-        Ok(EXP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(EXP_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::EXP_Open`] (composition seam).
@@ -398,7 +396,7 @@ impl EXP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.EXP_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::EXP_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -431,7 +429,7 @@ impl EXP_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.EXP_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::EXP_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/floor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/floor.rs
@@ -213,7 +213,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_FLOOR_Stream")]
 pub struct FLOOR_Stream {
-    core: Core,
     state: FLOOR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -224,7 +223,6 @@ impl FLOOR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `FLOOR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -250,7 +248,7 @@ impl FLOOR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn FLOOR_step_impl(&self, sp: &mut FLOOR_StreamState, inReal: f64, outReal: &mut f64) {
+    fn FLOOR_step_impl(sp: &mut FLOOR_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).floor();
     }
 
@@ -291,7 +289,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = FLOOR_StreamState {
         };
-        Ok(FLOOR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(FLOOR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::FLOOR_Open`] (composition seam).
@@ -396,7 +394,7 @@ impl FLOOR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.FLOOR_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::FLOOR_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -429,7 +427,7 @@ impl FLOOR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.FLOOR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::FLOOR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/hma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/hma.rs
@@ -603,7 +603,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HMA_Stream")]
 pub struct HMA_Stream {
-    core: Core,
     state: HMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -614,7 +613,6 @@ impl HMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -714,7 +712,7 @@ impl HMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HMA_step_impl(&self, sp: &mut HMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn HMA_step_impl(sp: &mut HMA_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
@@ -972,7 +970,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(HMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         if optInTimePeriod == 2 || optInTimePeriod == 3 {
             let mut lookbackTotal: usize = 0_usize;
@@ -1164,7 +1162,7 @@ impl Core {
                 cbSize_dRing: 0_usize,
                 cb_dRing: Vec::new(),
             };
-            Ok(HMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut lookbackTotal: usize = 0_usize;
             let mut lookbackSqrt: usize = 0_usize;
@@ -1518,7 +1516,7 @@ impl Core {
                 cbSize_dRing: cbSize_dRing,
                 cb_dRing: dRing,
             };
-            Ok(HMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1632,7 +1630,7 @@ impl HMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.HMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::HMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1665,7 +1663,7 @@ impl HMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::HMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
@@ -550,7 +550,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_DCPERIOD_Stream")]
 pub struct HT_DCPERIOD_Stream {
-    core: Core,
     state: HT_DCPERIOD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -561,7 +560,6 @@ impl HT_DCPERIOD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_DCPERIOD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -677,7 +675,7 @@ impl HT_DCPERIOD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_DCPERIOD_step_impl(&self, sp: &mut HT_DCPERIOD_StreamState, inReal: f64, outReal: &mut f64) {
+    fn HT_DCPERIOD_step_impl(sp: &mut HT_DCPERIOD_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut adjustedPrevPeriod: f64 = 0.0_f64;
@@ -1228,7 +1226,7 @@ impl Core {
             ringCap_trailingWMAIdx: cap_trailingWMAIdx as usize,
             ring_trailingWMAIdx_inReal,
         };
-        Ok(HT_DCPERIOD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_DCPERIOD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_DCPERIOD_Open`] (composition seam).
@@ -1333,7 +1331,7 @@ impl HT_DCPERIOD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.HT_DCPERIOD_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::HT_DCPERIOD_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1366,7 +1364,7 @@ impl HT_DCPERIOD_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_DCPERIOD_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::HT_DCPERIOD_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
@@ -628,7 +628,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_DCPHASE_Stream")]
 pub struct HT_DCPHASE_Stream {
-    core: Core,
     state: HT_DCPHASE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -639,7 +638,6 @@ impl HT_DCPHASE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_DCPHASE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -767,7 +765,7 @@ impl HT_DCPHASE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_DCPHASE_step_impl(&self, sp: &mut HT_DCPHASE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn HT_DCPHASE_step_impl(sp: &mut HT_DCPHASE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut i: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
@@ -1454,7 +1452,7 @@ impl Core {
             cbSize_smoothPrice: cbSize_smoothPrice,
             cb_smoothPrice: smoothPrice,
         };
-        Ok(HT_DCPHASE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_DCPHASE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_DCPHASE_Open`] (composition seam).
@@ -1567,7 +1565,7 @@ impl HT_DCPHASE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.HT_DCPHASE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::HT_DCPHASE_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1600,7 +1598,7 @@ impl HT_DCPHASE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_DCPHASE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::HT_DCPHASE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
@@ -574,7 +574,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_PHASOR_Stream")]
 pub struct HT_PHASOR_Stream {
-    core: Core,
     state: HT_PHASOR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -585,7 +584,6 @@ impl HT_PHASOR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_PHASOR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -699,7 +697,7 @@ impl HT_PHASOR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_PHASOR_step_impl(&self, sp: &mut HT_PHASOR_StreamState, inReal: f64, outInPhase: &mut f64, outQuadrature: &mut f64) {
+    fn HT_PHASOR_step_impl(sp: &mut HT_PHASOR_StreamState, inReal: f64, outInPhase: &mut f64, outQuadrature: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut adjustedPrevPeriod: f64 = 0.0_f64;
@@ -1254,7 +1252,7 @@ impl Core {
             ringCap_trailingWMAIdx: cap_trailingWMAIdx as usize,
             ring_trailingWMAIdx_inReal,
         };
-        Ok(HT_PHASOR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_PHASOR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_PHASOR_Open`] (composition seam).
@@ -1368,7 +1366,7 @@ impl HT_PHASOR_Stream {
         }
         let mut outInPhase: f64 = 0.0_f64;
         let mut outQuadrature: f64 = 0.0_f64;
-        self.core.HT_PHASOR_step_impl(&mut self.state, inReal, &mut outInPhase, &mut outQuadrature);
+        Core::HT_PHASOR_step_impl(&mut self.state, inReal, &mut outInPhase, &mut outQuadrature);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1401,7 +1399,7 @@ impl HT_PHASOR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_PHASOR_step_impl(&mut self.state, inReal[i], &mut outInPhase[i], &mut outQuadrature[i]);
+            Core::HT_PHASOR_step_impl(&mut self.state, inReal[i], &mut outInPhase[i], &mut outQuadrature[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -646,7 +646,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_SINE_Stream")]
 pub struct HT_SINE_Stream {
-    core: Core,
     state: HT_SINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -657,7 +656,6 @@ impl HT_SINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_SINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -787,7 +785,7 @@ impl HT_SINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_SINE_step_impl(&self, sp: &mut HT_SINE_StreamState, inReal: f64, outSine: &mut f64, outLeadSine: &mut f64) {
+    fn HT_SINE_step_impl(sp: &mut HT_SINE_StreamState, inReal: f64, outSine: &mut f64, outLeadSine: &mut f64) {
         let mut i: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
@@ -1479,7 +1477,7 @@ impl Core {
             cbSize_smoothPrice: cbSize_smoothPrice,
             cb_smoothPrice: smoothPrice,
         };
-        Ok(HT_SINE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_SINE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_SINE_Open`] (composition seam).
@@ -1601,7 +1599,7 @@ impl HT_SINE_Stream {
         }
         let mut outSine: f64 = 0.0_f64;
         let mut outLeadSine: f64 = 0.0_f64;
-        self.core.HT_SINE_step_impl(&mut self.state, inReal, &mut outSine, &mut outLeadSine);
+        Core::HT_SINE_step_impl(&mut self.state, inReal, &mut outSine, &mut outLeadSine);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1634,7 +1632,7 @@ impl HT_SINE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_SINE_step_impl(&mut self.state, inReal[i], &mut outSine[i], &mut outLeadSine[i]);
+            Core::HT_SINE_step_impl(&mut self.state, inReal[i], &mut outSine[i], &mut outLeadSine[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
@@ -607,7 +607,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_TRENDLINE_Stream")]
 pub struct HT_TRENDLINE_Stream {
-    core: Core,
     state: HT_TRENDLINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -618,7 +617,6 @@ impl HT_TRENDLINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_TRENDLINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -746,7 +744,7 @@ impl HT_TRENDLINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_TRENDLINE_step_impl(&self, sp: &mut HT_TRENDLINE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn HT_TRENDLINE_step_impl(sp: &mut HT_TRENDLINE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut i: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
@@ -1387,7 +1385,7 @@ impl Core {
             winCap_i: cap_i as usize,
             win_i_inReal,
         };
-        Ok(HT_TRENDLINE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_TRENDLINE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_TRENDLINE_Open`] (composition seam).
@@ -1500,7 +1498,7 @@ impl HT_TRENDLINE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.HT_TRENDLINE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::HT_TRENDLINE_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1533,7 +1531,7 @@ impl HT_TRENDLINE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_TRENDLINE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::HT_TRENDLINE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -716,7 +716,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HT_TRENDMODE_Stream")]
 pub struct HT_TRENDMODE_Stream {
-    core: Core,
     state: HT_TRENDMODE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -727,7 +726,6 @@ impl HT_TRENDMODE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HT_TRENDMODE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -875,7 +873,7 @@ impl HT_TRENDMODE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HT_TRENDMODE_step_impl(&self, sp: &mut HT_TRENDMODE_StreamState, inReal: f64, outInteger: &mut i32) {
+    fn HT_TRENDMODE_step_impl(sp: &mut HT_TRENDMODE_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut i: usize = 0_usize;
         let mut j: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
@@ -1723,7 +1721,7 @@ impl Core {
             cbSize_smoothPrice: cbSize_smoothPrice,
             cb_smoothPrice: smoothPrice,
         };
-        Ok(HT_TRENDMODE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(HT_TRENDMODE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::HT_TRENDMODE_Open`] (composition seam).
@@ -1836,7 +1834,7 @@ impl HT_TRENDMODE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.HT_TRENDMODE_step_impl(&mut self.state, inReal, &mut outInteger);
+        Core::HT_TRENDMODE_step_impl(&mut self.state, inReal, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1869,7 +1867,7 @@ impl HT_TRENDMODE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.HT_TRENDMODE_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
+            Core::HT_TRENDMODE_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/imi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/imi.rs
@@ -287,7 +287,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_IMI_Stream")]
 pub struct IMI_Stream {
-    core: Core,
     state: IMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -298,7 +297,6 @@ impl IMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `IMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -334,7 +332,7 @@ impl IMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn IMI_step_impl(&self, sp: &mut IMI_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
+    fn IMI_step_impl(sp: &mut IMI_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
         let mut upsum: f64 = 0.0_f64;
         let mut downsum: f64 = 0.0_f64;
         let mut i: usize = 0_usize;
@@ -449,7 +447,7 @@ impl Core {
             win_i_inOpen,
             win_i_inClose,
         };
-        Ok(IMI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(IMI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::IMI_Open`] (composition seam).
@@ -570,7 +568,7 @@ impl IMI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.IMI_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
+        Core::IMI_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -603,7 +601,7 @@ impl IMI_Stream {
             if !inOpen[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.IMI_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
+            Core::IMI_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -489,7 +489,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_KAMA_Stream")]
 pub struct KAMA_Stream {
-    core: Core,
     state: KAMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -500,7 +499,6 @@ impl KAMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `KAMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -548,7 +546,7 @@ impl KAMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn KAMA_step_impl(&self, sp: &mut KAMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn KAMA_step_impl(sp: &mut KAMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut periodROC: f64 = 0.0_f64;
@@ -661,7 +659,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(KAMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(KAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut constMax: f64 = 0.0_f64;
         let mut constDiff: f64 = 0.0_f64;
@@ -862,7 +860,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(KAMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(KAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::KAMA_Open`] (composition seam).
@@ -967,7 +965,7 @@ impl KAMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.KAMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::KAMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1000,7 +998,7 @@ impl KAMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.KAMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::KAMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
@@ -435,7 +435,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_Stream")]
 pub struct LINEARREG_Stream {
-    core: Core,
     state: LINEARREG_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -446,7 +445,6 @@ impl LINEARREG_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -500,7 +498,7 @@ impl LINEARREG_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_step_impl(&self, sp: &mut LINEARREG_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_step_impl(sp: &mut LINEARREG_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut b: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
@@ -835,7 +833,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_Open`] (composition seam).
@@ -940,7 +938,7 @@ impl LINEARREG_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LINEARREG_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -973,7 +971,7 @@ impl LINEARREG_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LINEARREG_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
@@ -412,7 +412,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_ANGLE_Stream")]
 pub struct LINEARREG_ANGLE_Stream {
-    core: Core,
     state: LINEARREG_ANGLE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -423,7 +422,6 @@ impl LINEARREG_ANGLE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_ANGLE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -477,7 +475,7 @@ impl LINEARREG_ANGLE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_ANGLE_step_impl(&self, sp: &mut LINEARREG_ANGLE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_ANGLE_step_impl(sp: &mut LINEARREG_ANGLE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
@@ -807,7 +805,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_ANGLE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_ANGLE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_ANGLE_Open`] (composition seam).
@@ -912,7 +910,7 @@ impl LINEARREG_ANGLE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LINEARREG_ANGLE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_ANGLE_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -945,7 +943,7 @@ impl LINEARREG_ANGLE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LINEARREG_ANGLE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_ANGLE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
@@ -407,7 +407,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_INTERCEPT_Stream")]
 pub struct LINEARREG_INTERCEPT_Stream {
-    core: Core,
     state: LINEARREG_INTERCEPT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -418,7 +417,6 @@ impl LINEARREG_INTERCEPT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_INTERCEPT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -472,7 +470,7 @@ impl LINEARREG_INTERCEPT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_INTERCEPT_step_impl(&self, sp: &mut LINEARREG_INTERCEPT_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_INTERCEPT_step_impl(sp: &mut LINEARREG_INTERCEPT_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
@@ -802,7 +800,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_INTERCEPT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_INTERCEPT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_INTERCEPT_Open`] (composition seam).
@@ -907,7 +905,7 @@ impl LINEARREG_INTERCEPT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -940,7 +938,7 @@ impl LINEARREG_INTERCEPT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
@@ -409,7 +409,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_SLOPE_Stream")]
 pub struct LINEARREG_SLOPE_Stream {
-    core: Core,
     state: LINEARREG_SLOPE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -420,7 +419,6 @@ impl LINEARREG_SLOPE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_SLOPE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -474,7 +472,7 @@ impl LINEARREG_SLOPE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_SLOPE_step_impl(&self, sp: &mut LINEARREG_SLOPE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_SLOPE_step_impl(sp: &mut LINEARREG_SLOPE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
@@ -799,7 +797,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_SLOPE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_SLOPE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_SLOPE_Open`] (composition seam).
@@ -904,7 +902,7 @@ impl LINEARREG_SLOPE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LINEARREG_SLOPE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_SLOPE_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -937,7 +935,7 @@ impl LINEARREG_SLOPE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LINEARREG_SLOPE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_SLOPE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ln.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ln.rs
@@ -221,7 +221,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LN_Stream")]
 pub struct LN_Stream {
-    core: Core,
     state: LN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -232,7 +231,6 @@ impl LN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -258,7 +256,7 @@ impl LN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LN_step_impl(&self, sp: &mut LN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LN_step_impl(sp: &mut LN_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).ln();
     }
 
@@ -299,7 +297,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = LN_StreamState {
         };
-        Ok(LN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LN_Open`] (composition seam).
@@ -404,7 +402,7 @@ impl LN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -437,7 +435,7 @@ impl LN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/log10.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/log10.rs
@@ -220,7 +220,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LOG10_Stream")]
 pub struct LOG10_Stream {
-    core: Core,
     state: LOG10_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -231,7 +230,6 @@ impl LOG10_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LOG10_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -257,7 +255,7 @@ impl LOG10_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LOG10_step_impl(&self, sp: &mut LOG10_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LOG10_step_impl(sp: &mut LOG10_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).log10();
     }
 
@@ -298,7 +296,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = LOG10_StreamState {
         };
-        Ok(LOG10_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LOG10_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LOG10_Open`] (composition seam).
@@ -403,7 +401,7 @@ impl LOG10_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.LOG10_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LOG10_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -436,7 +434,7 @@ impl LOG10_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.LOG10_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LOG10_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ma.rs
@@ -415,7 +415,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MA_Stream")]
 pub struct MA_Stream {
-    core: Core,
     state: MA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -426,7 +425,6 @@ impl MA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -498,7 +496,7 @@ impl MA_Sub {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MA_step_impl(&self, sp: &mut MA_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn MA_step_impl(sp: &mut MA_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         if sp.optInTimePeriod == 1 || sp.optInMAType == MAType::DISABLED {
             (*outReal) = inReal;
             return Ok(());
@@ -571,7 +569,7 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok((MA_Stream { core: self.clone(), state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, inReal[historyLen - 1]));
+            return Ok((MA_Stream { state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, inReal[historyLen - 1]));
         }
         let (sub, value, subRange) = match optInMAType {
             MAType::SMA => {
@@ -627,7 +625,7 @@ impl Core {
             _ => return Err(RetCode::BadParam),
         };
         let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok((MA_Stream { core: self.clone(), state, out: subRange }, value))
+        Ok((MA_Stream { state, out: subRange }, value))
     }
 
     /// Open a live MA stream over the warm-up history; returns the handle and
@@ -705,7 +703,7 @@ impl Core {
                 fillIdx += 1;
             }
             let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok((MA_Stream { core: self.clone(), state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, OutRange { beg_idx: fillLb, count: historyLen - fillLb }));
+            return Ok((MA_Stream { state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, OutRange { beg_idx: fillLb, count: historyLen - fillLb }));
         }
         let (sub, fillRange) = match optInMAType {
             MAType::SMA => {
@@ -751,7 +749,7 @@ impl Core {
             _ => return Err(RetCode::BadParam),
         };
         let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok((MA_Stream { core: self.clone(), state, out: fillRange }, fillRange))
+        Ok((MA_Stream { state, out: fillRange }, fillRange))
     }
 
     /// [`Core::MA_OpenAndFill`] anchored at `startIdx` — the composed-open
@@ -791,7 +789,7 @@ impl Core {
                 fillIdx += 1;
             }
             let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok(MA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(MA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let sub = match optInMAType {
             MAType::SMA => MA_Sub::SMA(
@@ -827,7 +825,7 @@ impl Core {
             _ => return Err(RetCode::BadParam),
         };
         let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok(MA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
 }
@@ -852,7 +850,7 @@ impl MA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MA_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::MA_step_impl(&mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -885,7 +883,7 @@ impl MA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MA_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::MA_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/macd.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macd.rs
@@ -526,7 +526,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACD_Stream")]
 pub struct MACD_Stream {
-    core: Core,
     state: MACD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -537,7 +536,6 @@ impl MACD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -581,7 +579,7 @@ impl MACD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACD_step_impl(&self, sp: &mut MACD_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
+    fn MACD_step_impl(sp: &mut MACD_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
         let mut macdValue: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         tempReal = inReal;
@@ -822,7 +820,7 @@ impl Core {
             fastK,
             signalK,
         };
-        Ok(MACD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACD_Open`] (composition seam).
@@ -948,7 +946,7 @@ impl MACD_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        self.core.MACD_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
+        Core::MACD_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -981,7 +979,7 @@ impl MACD_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MACD_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
+            Core::MACD_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/macdext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdext.rs
@@ -473,7 +473,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACDEXT_Stream")]
 pub struct MACDEXT_Stream {
-    core: Core,
     state: MACDEXT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -484,7 +483,6 @@ impl MACDEXT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACDEXT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -528,7 +526,7 @@ impl MACDEXT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACDEXT_step_impl(&self, sp: &mut MACDEXT_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) -> Result<(), RetCode> {
+    fn MACDEXT_step_impl(sp: &mut MACDEXT_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) -> Result<(), RetCode> {
         let mut cur_slowMABuffer: f64 = 0.0_f64;
         let mut cur_fastMABuffer: f64 = 0.0_f64;
         let mut cur_outMACDSignal: f64 = 0.0_f64;
@@ -735,7 +733,7 @@ impl Core {
             let last_sc_outMACDHist = sc_outMACDHist[*outNBElement - 1];
             outMACDHist[0] = last_sc_outMACDHist;
         }
-        Ok(MACDEXT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACDEXT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACDEXT_Open`] (composition seam).
@@ -869,7 +867,7 @@ impl MACDEXT_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        self.core.MACDEXT_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist)?;
+        Core::MACDEXT_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -902,7 +900,7 @@ impl MACDEXT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MACDEXT_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i])?;
+            Core::MACDEXT_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
@@ -464,7 +464,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACDFIX_Stream")]
 pub struct MACDFIX_Stream {
-    core: Core,
     state: MACDFIX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -475,7 +474,6 @@ impl MACDFIX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACDFIX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -515,7 +513,7 @@ impl MACDFIX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACDFIX_step_impl(&self, sp: &mut MACDFIX_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
+    fn MACDFIX_step_impl(sp: &mut MACDFIX_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
         let mut macdValue: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         tempReal = inReal;
@@ -732,7 +730,7 @@ impl Core {
             fastK,
             signalK,
         };
-        Ok(MACDFIX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACDFIX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACDFIX_Open`] (composition seam).
@@ -858,7 +856,7 @@ impl MACDFIX_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        self.core.MACDFIX_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
+        Core::MACDFIX_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -891,7 +889,7 @@ impl MACDFIX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MACDFIX_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
+            Core::MACDFIX_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -681,7 +681,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAMA_Stream")]
 pub struct MAMA_Stream {
-    core: Core,
     state: MAMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -692,7 +691,6 @@ impl MAMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -816,7 +814,7 @@ impl MAMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAMA_step_impl(&self, sp: &mut MAMA_StreamState, inReal: f64, outMAMA: &mut f64, outFAMA: &mut f64) {
+    fn MAMA_step_impl(sp: &mut MAMA_StreamState, inReal: f64, outMAMA: &mut f64, outFAMA: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut adjustedPrevPeriod: f64 = 0.0_f64;
@@ -1454,7 +1452,7 @@ impl Core {
             ringCap_trailingWMAIdx: cap_trailingWMAIdx as usize,
             ring_trailingWMAIdx_inReal,
         };
-        Ok(MAMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAMA_Open`] (composition seam).
@@ -1570,7 +1568,7 @@ impl MAMA_Stream {
         }
         let mut outMAMA: f64 = 0.0_f64;
         let mut outFAMA: f64 = 0.0_f64;
-        self.core.MAMA_step_impl(&mut self.state, inReal, &mut outMAMA, &mut outFAMA);
+        Core::MAMA_step_impl(&mut self.state, inReal, &mut outMAMA, &mut outFAMA);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1609,7 +1607,7 @@ impl MAMA_Stream {
                 return Err(RetCode::BadParam);
             }
             let slot_outFAMA = match outFAMA.as_deref_mut() { Some(_s) => &mut _s[i], None => &mut sink_outFAMA };
-            self.core.MAMA_step_impl(&mut self.state, inReal[i], &mut outMAMA[i], slot_outFAMA);
+            Core::MAMA_step_impl(&mut self.state, inReal[i], &mut outMAMA[i], slot_outFAMA);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
@@ -275,7 +275,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MARKETFI_Stream")]
 pub struct MARKETFI_Stream {
-    core: Core,
     state: MARKETFI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -286,7 +285,6 @@ impl MARKETFI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MARKETFI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -312,7 +310,7 @@ impl MARKETFI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MARKETFI_step_impl(&self, sp: &mut MARKETFI_StreamState, inHigh: f64, inLow: f64, inVolume: f64, outReal: &mut f64) {
+    fn MARKETFI_step_impl(sp: &mut MARKETFI_StreamState, inHigh: f64, inLow: f64, inVolume: f64, outReal: &mut f64) {
         // A zero-volume bar would divide by zero. Neither reference guards
         // it -- they emit +/-Inf, or NaN when the range is zero too -- but
         // issue #112 settled that a successful call never emits NaN or Inf,
@@ -392,7 +390,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = MARKETFI_StreamState {
         };
-        Ok(MARKETFI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MARKETFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MARKETFI_Open`] (composition seam).
@@ -504,7 +502,7 @@ impl MARKETFI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MARKETFI_step_impl(&mut self.state, inHigh, inLow, inVolume, &mut outReal);
+        Core::MARKETFI_step_impl(&mut self.state, inHigh, inLow, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -537,7 +535,7 @@ impl MARKETFI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MARKETFI_step_impl(&mut self.state, inHigh[i], inLow[i], inVolume[i], &mut outReal[i]);
+            Core::MARKETFI_step_impl(&mut self.state, inHigh[i], inLow[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mavp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mavp.rs
@@ -539,7 +539,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAVP_Stream")]
 pub struct MAVP_Stream {
-    core: Core,
     state: MAVP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -550,7 +549,6 @@ impl MAVP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAVP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -591,7 +589,7 @@ impl MAVP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAVP_step_impl(&self, sp: &mut MAVP_StreamState, inReal: f64, inPeriods: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn MAVP_step_impl(sp: &mut MAVP_StreamState, inReal: f64, inPeriods: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cp: i32 = inPeriods as i32;
         if cp < sp.optInMinPeriod {
             cp = sp.optInMinPeriod;
@@ -666,7 +664,7 @@ impl Core {
         }
         let lastValue_outReal: f64 = scratch[(cp - optInMinPeriod) as usize];
         let state = MAVP_StreamState { optInMinPeriod, optInMaxPeriod, optInMAType, bank };
-        Ok((MAVP_Stream { core: self.clone(), state, out: OutRange { beg_idx: subStart, count: historyLen - subStart } }, lastValue_outReal))
+        Ok((MAVP_Stream { state, out: OutRange { beg_idx: subStart, count: historyLen - subStart } }, lastValue_outReal))
     }
 
     /// Open a live MAVP stream over the warm-up history; returns the handle and
@@ -782,7 +780,7 @@ impl Core {
             t += 1;
         }
         let state = MAVP_StreamState { optInMinPeriod, optInMaxPeriod, optInMAType, bank };
-        Ok((MAVP_Stream { core: self.clone(), state, out: OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal } }, OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal }))
+        Ok((MAVP_Stream { state, out: OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal } }, OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal }))
     }
 
 }
@@ -815,7 +813,7 @@ impl MAVP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MAVP_step_impl(&mut self.state, inReal, inPeriods, &mut outReal)?;
+        Core::MAVP_step_impl(&mut self.state, inReal, inPeriods, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -848,7 +846,7 @@ impl MAVP_Stream {
             if !inReal[i].is_finite() || !inPeriods[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MAVP_step_impl(&mut self.state, inReal[i], inPeriods[i], &mut outReal[i])?;
+            Core::MAVP_step_impl(&mut self.state, inReal[i], inPeriods[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -369,7 +369,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAX_Stream")]
 pub struct MAX_Stream {
-    core: Core,
     state: MAX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -380,7 +379,6 @@ impl MAX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -422,7 +420,7 @@ impl MAX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAX_step_impl(&self, sp: &mut MAX_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MAX_step_impl(sp: &mut MAX_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -573,7 +571,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MAX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAX_Open`] (composition seam).
@@ -678,7 +676,7 @@ impl MAX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MAX_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MAX_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -711,7 +709,7 @@ impl MAX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MAX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MAX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -290,7 +290,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAXINDEX_Stream")]
 pub struct MAXINDEX_Stream {
-    core: Core,
     state: MAXINDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -301,7 +300,6 @@ impl MAXINDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAXINDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -343,7 +341,7 @@ impl MAXINDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAXINDEX_step_impl(&self, sp: &mut MAXINDEX_StreamState, inReal: f64, outInteger: &mut i32) {
+    fn MAXINDEX_step_impl(sp: &mut MAXINDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -484,7 +482,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MAXINDEX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAXINDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAXINDEX_Open`] (composition seam).
@@ -589,7 +587,7 @@ impl MAXINDEX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.MAXINDEX_step_impl(&mut self.state, inReal, &mut outInteger);
+        Core::MAXINDEX_step_impl(&mut self.state, inReal, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -622,7 +620,7 @@ impl MAXINDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MAXINDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
+            Core::MAXINDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/medprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/medprice.rs
@@ -225,7 +225,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MEDPRICE_Stream")]
 pub struct MEDPRICE_Stream {
-    core: Core,
     state: MEDPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -236,7 +235,6 @@ impl MEDPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MEDPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -262,7 +260,7 @@ impl MEDPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MEDPRICE_step_impl(&self, sp: &mut MEDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn MEDPRICE_step_impl(sp: &mut MEDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         (*outReal) = (inHigh + inLow) / 2.0;
     }
 
@@ -308,7 +306,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = MEDPRICE_StreamState {
         };
-        Ok(MEDPRICE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MEDPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MEDPRICE_Open`] (composition seam).
@@ -417,7 +415,7 @@ impl MEDPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MEDPRICE_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::MEDPRICE_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -450,7 +448,7 @@ impl MEDPRICE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MEDPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::MEDPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mfi.rs
@@ -460,7 +460,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MFI_Stream")]
 pub struct MFI_Stream {
-    core: Core,
     state: MFI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -471,7 +470,6 @@ impl MFI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MFI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -517,7 +515,7 @@ impl MFI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MFI_step_impl(&self, sp: &mut MFI_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn MFI_step_impl(sp: &mut MFI_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
         let mut tempValue3: f64 = 0.0_f64;
@@ -763,7 +761,7 @@ impl Core {
             cb_mflow_positive: mflow_positive,
             cb_mflow_negative: mflow_negative,
         };
-        Ok(MFI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MFI_Open`] (composition seam).
@@ -886,7 +884,7 @@ impl MFI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MFI_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::MFI_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -919,7 +917,7 @@ impl MFI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MFI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::MFI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -421,7 +421,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIDPOINT_Stream")]
 pub struct MIDPOINT_Stream {
-    core: Core,
     state: MIDPOINT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -432,7 +431,6 @@ impl MIDPOINT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIDPOINT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -478,7 +476,7 @@ impl MIDPOINT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIDPOINT_step_impl(&self, sp: &mut MIDPOINT_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MIDPOINT_step_impl(sp: &mut MIDPOINT_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmpLow: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -683,7 +681,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MIDPOINT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIDPOINT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIDPOINT_Open`] (composition seam).
@@ -788,7 +786,7 @@ impl MIDPOINT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MIDPOINT_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MIDPOINT_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -821,7 +819,7 @@ impl MIDPOINT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MIDPOINT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MIDPOINT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -436,7 +436,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIDPRICE_Stream")]
 pub struct MIDPRICE_Stream {
-    core: Core,
     state: MIDPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -447,7 +446,6 @@ impl MIDPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIDPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -495,7 +493,7 @@ impl MIDPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIDPRICE_step_impl(&self, sp: &mut MIDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn MIDPRICE_step_impl(sp: &mut MIDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut tmpLow: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -705,7 +703,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(MIDPRICE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIDPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIDPRICE_Open`] (composition seam).
@@ -822,7 +820,7 @@ impl MIDPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MIDPRICE_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::MIDPRICE_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -855,7 +853,7 @@ impl MIDPRICE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MIDPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::MIDPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -367,7 +367,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIN_Stream")]
 pub struct MIN_Stream {
-    core: Core,
     state: MIN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -378,7 +377,6 @@ impl MIN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -420,7 +418,7 @@ impl MIN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIN_step_impl(&self, sp: &mut MIN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MIN_step_impl(sp: &mut MIN_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -569,7 +567,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MIN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIN_Open`] (composition seam).
@@ -674,7 +672,7 @@ impl MIN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MIN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MIN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -707,7 +705,7 @@ impl MIN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -290,7 +290,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MININDEX_Stream")]
 pub struct MININDEX_Stream {
-    core: Core,
     state: MININDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -301,7 +300,6 @@ impl MININDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MININDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -343,7 +341,7 @@ impl MININDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MININDEX_step_impl(&self, sp: &mut MININDEX_StreamState, inReal: f64, outInteger: &mut i32) {
+    fn MININDEX_step_impl(sp: &mut MININDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -484,7 +482,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MININDEX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MININDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MININDEX_Open`] (composition seam).
@@ -589,7 +587,7 @@ impl MININDEX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        self.core.MININDEX_step_impl(&mut self.state, inReal, &mut outInteger);
+        Core::MININDEX_step_impl(&mut self.state, inReal, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -622,7 +620,7 @@ impl MININDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MININDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
+            Core::MININDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -427,7 +427,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINMAX_Stream")]
 pub struct MINMAX_Stream {
-    core: Core,
     state: MINMAX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -438,7 +437,6 @@ impl MINMAX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINMAX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -484,7 +482,7 @@ impl MINMAX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINMAX_step_impl(&self, sp: &mut MINMAX_StreamState, inReal: f64, outMin: &mut f64, outMax: &mut f64) {
+    fn MINMAX_step_impl(sp: &mut MINMAX_StreamState, inReal: f64, outMin: &mut f64, outMax: &mut f64) {
         let mut tmpHigh: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -686,7 +684,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MINMAX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MINMAX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MINMAX_Open`] (composition seam).
@@ -800,7 +798,7 @@ impl MINMAX_Stream {
         }
         let mut outMin: f64 = 0.0_f64;
         let mut outMax: f64 = 0.0_f64;
-        self.core.MINMAX_step_impl(&mut self.state, inReal, &mut outMin, &mut outMax);
+        Core::MINMAX_step_impl(&mut self.state, inReal, &mut outMin, &mut outMax);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -833,7 +831,7 @@ impl MINMAX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MINMAX_step_impl(&mut self.state, inReal[i], &mut outMin[i], &mut outMax[i]);
+            Core::MINMAX_step_impl(&mut self.state, inReal[i], &mut outMin[i], &mut outMax[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -323,7 +323,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINMAXINDEX_Stream")]
 pub struct MINMAXINDEX_Stream {
-    core: Core,
     state: MINMAXINDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -334,7 +333,6 @@ impl MINMAXINDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINMAXINDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -380,7 +378,7 @@ impl MINMAXINDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINMAXINDEX_step_impl(&self, sp: &mut MINMAXINDEX_StreamState, inReal: f64, outMinIdx: &mut i32, outMaxIdx: &mut i32) {
+    fn MINMAXINDEX_step_impl(sp: &mut MINMAXINDEX_StreamState, inReal: f64, outMinIdx: &mut i32, outMaxIdx: &mut i32) {
         let mut tmpHigh: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -565,7 +563,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MINMAXINDEX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MINMAXINDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MINMAXINDEX_Open`] (composition seam).
@@ -679,7 +677,7 @@ impl MINMAXINDEX_Stream {
         }
         let mut outMinIdx: i32 = 0_i32;
         let mut outMaxIdx: i32 = 0_i32;
-        self.core.MINMAXINDEX_step_impl(&mut self.state, inReal, &mut outMinIdx, &mut outMaxIdx);
+        Core::MINMAXINDEX_step_impl(&mut self.state, inReal, &mut outMinIdx, &mut outMaxIdx);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -712,7 +710,7 @@ impl MINMAXINDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MINMAXINDEX_step_impl(&mut self.state, inReal[i], &mut outMinIdx[i], &mut outMaxIdx[i]);
+            Core::MINMAXINDEX_step_impl(&mut self.state, inReal[i], &mut outMinIdx[i], &mut outMaxIdx[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
@@ -583,7 +583,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINUS_DI_Stream")]
 pub struct MINUS_DI_Stream {
-    core: Core,
     state: MINUS_DI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -594,7 +593,6 @@ impl MINUS_DI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINUS_DI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -632,7 +630,7 @@ impl MINUS_DI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINUS_DI_step_impl(&self, sp: &mut MINUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn MINUS_DI_step_impl(sp: &mut MINUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         if sp.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
@@ -919,7 +917,7 @@ impl Core {
                 prevMinusDM,
                 prevTR,
             };
-            Ok(MINUS_DI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -1185,7 +1183,7 @@ impl Core {
                 prevMinusDM,
                 prevTR,
             };
-            Ok(MINUS_DI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1298,7 +1296,7 @@ impl MINUS_DI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MINUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::MINUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1331,7 +1329,7 @@ impl MINUS_DI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MINUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::MINUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
@@ -442,7 +442,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINUS_DM_Stream")]
 pub struct MINUS_DM_Stream {
-    core: Core,
     state: MINUS_DM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -453,7 +452,6 @@ impl MINUS_DM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINUS_DM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -487,7 +485,7 @@ impl MINUS_DM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINUS_DM_step_impl(&self, sp: &mut MINUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn MINUS_DM_step_impl(sp: &mut MINUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         if sp.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
@@ -684,7 +682,7 @@ impl Core {
                 prevLow,
                 prevMinusDM,
             };
-            Ok(MINUS_DM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -854,7 +852,7 @@ impl Core {
                 prevLow,
                 prevMinusDM,
             };
-            Ok(MINUS_DM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -964,7 +962,7 @@ impl MINUS_DM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MINUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::MINUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -997,7 +995,7 @@ impl MINUS_DM_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MINUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::MINUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mom.rs
@@ -285,7 +285,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MOM_Stream")]
 pub struct MOM_Stream {
-    core: Core,
     state: MOM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -296,7 +295,6 @@ impl MOM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MOM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -330,7 +328,7 @@ impl MOM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MOM_step_impl(&self, sp: &mut MOM_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MOM_step_impl(sp: &mut MOM_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
         }
@@ -440,7 +438,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(MOM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MOM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MOM_Open`] (composition seam).
@@ -545,7 +543,7 @@ impl MOM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MOM_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MOM_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -578,7 +576,7 @@ impl MOM_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MOM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MOM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mult.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mult.rs
@@ -221,7 +221,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MULT_Stream")]
 pub struct MULT_Stream {
-    core: Core,
     state: MULT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -232,7 +231,6 @@ impl MULT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MULT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -258,7 +256,7 @@ impl MULT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MULT_step_impl(&self, sp: &mut MULT_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn MULT_step_impl(sp: &mut MULT_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         (*outReal) = inReal0 * inReal1;
     }
 
@@ -301,7 +299,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = MULT_StreamState {
         };
-        Ok(MULT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MULT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MULT_Open`] (composition seam).
@@ -412,7 +410,7 @@ impl MULT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.MULT_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::MULT_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -445,7 +443,7 @@ impl MULT_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.MULT_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::MULT_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/natr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/natr.rs
@@ -448,7 +448,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_NATR_Stream")]
 pub struct NATR_Stream {
-    core: Core,
     state: NATR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -459,7 +458,6 @@ impl NATR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `NATR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -491,7 +489,7 @@ impl NATR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn NATR_step_impl(&self, sp: &mut NATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn NATR_step_impl(sp: &mut NATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempValue: f64 = 0.0_f64;
         let mut val2: f64 = 0.0_f64;
         let mut val3: f64 = 0.0_f64;
@@ -747,7 +745,7 @@ impl Core {
             prevATR,
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(NATR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(NATR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::NATR_Open`] (composition seam).
@@ -859,7 +857,7 @@ impl NATR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.NATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::NATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -892,7 +890,7 @@ impl NATR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.NATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::NATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/nvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/nvi.rs
@@ -277,7 +277,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_NVI_Stream")]
 pub struct NVI_Stream {
-    core: Core,
     state: NVI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -288,7 +287,6 @@ impl NVI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `NVI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -320,7 +318,7 @@ impl NVI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn NVI_step_impl(&self, sp: &mut NVI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn NVI_step_impl(sp: &mut NVI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempClose: f64 = 0.0_f64;
         let mut tempVolume: f64 = 0.0_f64;
         let mut tempNVI: f64 = 0.0_f64;
@@ -426,7 +424,7 @@ impl Core {
             prevClose,
             prevVolume,
         };
-        Ok(NVI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(NVI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::NVI_Open`] (composition seam).
@@ -539,7 +537,7 @@ impl NVI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.NVI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
+        Core::NVI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -572,7 +570,7 @@ impl NVI_Stream {
             if !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.NVI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
+            Core::NVI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/obv.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/obv.rs
@@ -237,7 +237,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_OBV_Stream")]
 pub struct OBV_Stream {
-    core: Core,
     state: OBV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -248,7 +247,6 @@ impl OBV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `OBV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -278,7 +276,7 @@ impl OBV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn OBV_step_impl(&self, sp: &mut OBV_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
+    fn OBV_step_impl(sp: &mut OBV_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         tempReal = inReal;
         if tempReal > sp.prevReal {
@@ -341,7 +339,7 @@ impl Core {
             prevReal,
             prevOBV,
         };
-        Ok(OBV_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(OBV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::OBV_Open`] (composition seam).
@@ -452,7 +450,7 @@ impl OBV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.OBV_step_impl(&mut self.state, inReal, inVolume, &mut outReal);
+        Core::OBV_step_impl(&mut self.state, inReal, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -485,7 +483,7 @@ impl OBV_Stream {
             if !inReal[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.OBV_step_impl(&mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
+            Core::OBV_step_impl(&mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
@@ -585,7 +585,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PLUS_DI_Stream")]
 pub struct PLUS_DI_Stream {
-    core: Core,
     state: PLUS_DI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -596,7 +595,6 @@ impl PLUS_DI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PLUS_DI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -634,7 +632,7 @@ impl PLUS_DI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PLUS_DI_step_impl(&self, sp: &mut PLUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn PLUS_DI_step_impl(sp: &mut PLUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         if sp.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
@@ -921,7 +919,7 @@ impl Core {
                 prevPlusDM,
                 prevTR,
             };
-            Ok(PLUS_DI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -1187,7 +1185,7 @@ impl Core {
                 prevPlusDM,
                 prevTR,
             };
-            Ok(PLUS_DI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1300,7 +1298,7 @@ impl PLUS_DI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.PLUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::PLUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1333,7 +1331,7 @@ impl PLUS_DI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.PLUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::PLUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
@@ -441,7 +441,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PLUS_DM_Stream")]
 pub struct PLUS_DM_Stream {
-    core: Core,
     state: PLUS_DM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -452,7 +451,6 @@ impl PLUS_DM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PLUS_DM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -486,7 +484,7 @@ impl PLUS_DM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PLUS_DM_step_impl(&self, sp: &mut PLUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn PLUS_DM_step_impl(sp: &mut PLUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         if sp.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
@@ -683,7 +681,7 @@ impl Core {
                 prevLow,
                 prevPlusDM,
             };
-            Ok(PLUS_DM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -853,7 +851,7 @@ impl Core {
                 prevLow,
                 prevPlusDM,
             };
-            Ok(PLUS_DM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -963,7 +961,7 @@ impl PLUS_DM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.PLUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::PLUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -996,7 +994,7 @@ impl PLUS_DM_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.PLUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::PLUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ppo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ppo.rs
@@ -340,7 +340,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PPO_Stream")]
 pub struct PPO_Stream {
-    core: Core,
     state: PPO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -351,7 +350,6 @@ impl PPO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PPO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -387,7 +385,7 @@ impl PPO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PPO_step_impl(&self, sp: &mut PPO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn PPO_step_impl(sp: &mut PPO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
@@ -520,7 +518,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(PPO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(PPO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::PPO_Open`] (composition seam).
@@ -633,7 +631,7 @@ impl PPO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.PPO_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::PPO_step_impl(&mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -666,7 +664,7 @@ impl PPO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.PPO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::PPO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/pvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvi.rs
@@ -277,7 +277,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PVI_Stream")]
 pub struct PVI_Stream {
-    core: Core,
     state: PVI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -288,7 +287,6 @@ impl PVI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PVI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -320,7 +318,7 @@ impl PVI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PVI_step_impl(&self, sp: &mut PVI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn PVI_step_impl(sp: &mut PVI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempClose: f64 = 0.0_f64;
         let mut tempVolume: f64 = 0.0_f64;
         let mut tempPVI: f64 = 0.0_f64;
@@ -426,7 +424,7 @@ impl Core {
             prevClose,
             prevVolume,
         };
-        Ok(PVI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(PVI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::PVI_Open`] (composition seam).
@@ -539,7 +537,7 @@ impl PVI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.PVI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
+        Core::PVI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -572,7 +570,7 @@ impl PVI_Stream {
             if !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.PVI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
+            Core::PVI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/pvo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvo.rs
@@ -340,7 +340,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PVO_Stream")]
 pub struct PVO_Stream {
-    core: Core,
     state: PVO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -351,7 +350,6 @@ impl PVO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PVO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -387,7 +385,7 @@ impl PVO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PVO_step_impl(&self, sp: &mut PVO_StreamState, inVolume: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn PVO_step_impl(sp: &mut PVO_StreamState, inVolume: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
@@ -520,7 +518,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(PVO_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(PVO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::PVO_Open`] (composition seam).
@@ -635,7 +633,7 @@ impl PVO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.PVO_step_impl(&mut self.state, inVolume, &mut outReal)?;
+        Core::PVO_step_impl(&mut self.state, inVolume, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -668,7 +666,7 @@ impl PVO_Stream {
             if !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.PVO_step_impl(&mut self.state, inVolume[i], &mut outReal[i])?;
+            Core::PVO_step_impl(&mut self.state, inVolume[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/qstick.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/qstick.rs
@@ -322,7 +322,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_QSTICK_Stream")]
 pub struct QSTICK_Stream {
-    core: Core,
     state: QSTICK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -333,7 +332,6 @@ impl QSTICK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `QSTICK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -369,7 +367,7 @@ impl QSTICK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn QSTICK_step_impl(&self, sp: &mut QSTICK_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
+    fn QSTICK_step_impl(sp: &mut QSTICK_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_derived[0] = (inClose - inOpen) as f64;
@@ -500,7 +498,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_derived,
         };
-        Ok(QSTICK_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(QSTICK_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::QSTICK_Open`] (composition seam).
@@ -613,7 +611,7 @@ impl QSTICK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.QSTICK_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
+        Core::QSTICK_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -646,7 +644,7 @@ impl QSTICK_Stream {
             if !inOpen[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.QSTICK_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
+            Core::QSTICK_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/roc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/roc.rs
@@ -292,7 +292,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROC_Stream")]
 pub struct ROC_Stream {
-    core: Core,
     state: ROC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -303,7 +302,6 @@ impl ROC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -337,7 +335,7 @@ impl ROC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROC_step_impl(&self, sp: &mut ROC_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROC_step_impl(sp: &mut ROC_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -458,7 +456,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROC_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROC_Open`] (composition seam).
@@ -563,7 +561,7 @@ impl ROC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ROC_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROC_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -596,7 +594,7 @@ impl ROC_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ROC_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROC_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocp.rs
@@ -294,7 +294,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCP_Stream")]
 pub struct ROCP_Stream {
-    core: Core,
     state: ROCP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -305,7 +304,6 @@ impl ROCP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -339,7 +337,7 @@ impl ROCP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCP_step_impl(&self, sp: &mut ROCP_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCP_step_impl(sp: &mut ROCP_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -460,7 +458,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCP_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCP_Open`] (composition seam).
@@ -565,7 +563,7 @@ impl ROCP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ROCP_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCP_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -598,7 +596,7 @@ impl ROCP_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ROCP_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCP_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr.rs
@@ -292,7 +292,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCR_Stream")]
 pub struct ROCR_Stream {
-    core: Core,
     state: ROCR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -303,7 +302,6 @@ impl ROCR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -337,7 +335,7 @@ impl ROCR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCR_step_impl(&self, sp: &mut ROCR_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCR_step_impl(sp: &mut ROCR_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -458,7 +456,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCR_Open`] (composition seam).
@@ -563,7 +561,7 @@ impl ROCR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ROCR_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCR_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -596,7 +594,7 @@ impl ROCR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ROCR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
@@ -294,7 +294,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCR100_Stream")]
 pub struct ROCR100_Stream {
-    core: Core,
     state: ROCR100_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -305,7 +304,6 @@ impl ROCR100_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCR100_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -339,7 +337,7 @@ impl ROCR100_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCR100_step_impl(&self, sp: &mut ROCR100_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCR100_step_impl(sp: &mut ROCR100_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -460,7 +458,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCR100_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCR100_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCR100_Open`] (composition seam).
@@ -565,7 +563,7 @@ impl ROCR100_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ROCR100_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCR100_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -598,7 +596,7 @@ impl ROCR100_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ROCR100_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCR100_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -468,7 +468,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_RSI_Stream")]
 pub struct RSI_Stream {
-    core: Core,
     state: RSI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -479,7 +478,6 @@ impl RSI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `RSI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -513,7 +511,7 @@ impl RSI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn RSI_step_impl(&self, sp: &mut RSI_StreamState, inReal: f64, outReal: &mut f64) {
+    fn RSI_step_impl(sp: &mut RSI_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
         if sp.optInTimePeriod == 1 {
@@ -589,7 +587,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(RSI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(RSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut today: usize = 0_usize;
@@ -789,7 +787,7 @@ impl Core {
             prevLoss,
             prevValue,
         };
-        Ok(RSI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(RSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::RSI_Open`] (composition seam).
@@ -894,7 +892,7 @@ impl RSI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.RSI_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::RSI_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -927,7 +925,7 @@ impl RSI_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.RSI_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::RSI_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sar.rs
@@ -521,7 +521,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SAR_Stream")]
 pub struct SAR_Stream {
-    core: Core,
     state: SAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -532,7 +531,6 @@ impl SAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -574,7 +572,7 @@ impl SAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SAR_step_impl(&self, sp: &mut SAR_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn SAR_step_impl(sp: &mut SAR_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut prevHigh: f64 = 0.0_f64;
         let mut prevLow: f64 = 0.0_f64;
         prevLow = sp.newLow;
@@ -946,7 +944,7 @@ impl Core {
             ep,
             sar,
         };
-        Ok(SAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SAR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SAR_Open`] (composition seam).
@@ -1055,7 +1053,7 @@ impl SAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SAR_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::SAR_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1088,7 +1086,7 @@ impl SAR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SAR_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::SAR_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sarext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sarext.rs
@@ -688,7 +688,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SAREXT_Stream")]
 pub struct SAREXT_Stream {
-    core: Core,
     state: SAREXT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -699,7 +698,6 @@ impl SAREXT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SAREXT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -755,7 +753,7 @@ impl SAREXT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SAREXT_step_impl(&self, sp: &mut SAREXT_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn SAREXT_step_impl(sp: &mut SAREXT_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut prevHigh: f64 = 0.0_f64;
         let mut prevLow: f64 = 0.0_f64;
         prevLow = sp.newLow;
@@ -1227,7 +1225,7 @@ impl Core {
             ep,
             sar,
         };
-        Ok(SAREXT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SAREXT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SAREXT_Open`] (composition seam).
@@ -1336,7 +1334,7 @@ impl SAREXT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SAREXT_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::SAREXT_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1369,7 +1367,7 @@ impl SAREXT_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SAREXT_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::SAREXT_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sin.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SIN_Stream")]
 pub struct SIN_Stream {
-    core: Core,
     state: SIN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl SIN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SIN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl SIN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SIN_step_impl(&self, sp: &mut SIN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SIN_step_impl(sp: &mut SIN_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).sin();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = SIN_StreamState {
         };
-        Ok(SIN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SIN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SIN_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl SIN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SIN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SIN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl SIN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sinh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sinh.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SINH_Stream")]
 pub struct SINH_Stream {
-    core: Core,
     state: SINH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl SINH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SINH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl SINH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SINH_step_impl(&self, sp: &mut SINH_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SINH_step_impl(sp: &mut SINH_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).sinh();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = SINH_StreamState {
         };
-        Ok(SINH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SINH_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SINH_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl SINH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SINH_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SINH_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl SINH_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SINH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SINH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sma.rs
@@ -281,7 +281,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SMA_Stream")]
 pub struct SMA_Stream {
-    core: Core,
     state: SMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -292,7 +291,6 @@ impl SMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -328,7 +326,7 @@ impl SMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SMA_step_impl(&self, sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SMA_step_impl(sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -434,7 +432,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(SMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SMA_Open`] (composition seam).
@@ -539,7 +537,7 @@ impl SMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -572,7 +570,7 @@ impl SMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/smi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/smi.rs
@@ -645,7 +645,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SMI_Stream")]
 pub struct SMI_Stream {
-    core: Core,
     state: SMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -656,7 +655,6 @@ impl SMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -728,7 +726,7 @@ impl SMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SMI_step_impl(&self, sp: &mut SMI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSMI: &mut f64, outSMISignal: &mut f64) {
+    fn SMI_step_impl(sp: &mut SMI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSMI: &mut f64, outSMISignal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         let mut num: f64 = 0.0_f64;
         let mut den: f64 = 0.0_f64;
@@ -1151,7 +1149,7 @@ impl Core {
             x_inLow,
             x_inClose,
         };
-        Ok(SMI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SMI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SMI_Open`] (composition seam).
@@ -1280,7 +1278,7 @@ impl SMI_Stream {
         }
         let mut outSMI: f64 = 0.0_f64;
         let mut outSMISignal: f64 = 0.0_f64;
-        self.core.SMI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSMI, &mut outSMISignal);
+        Core::SMI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSMI, &mut outSMISignal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1313,7 +1311,7 @@ impl SMI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SMI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSMI[i], &mut outSMISignal[i]);
+            Core::SMI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSMI[i], &mut outSMISignal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SQRT_Stream")]
 pub struct SQRT_Stream {
-    core: Core,
     state: SQRT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl SQRT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SQRT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl SQRT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SQRT_step_impl(&self, sp: &mut SQRT_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SQRT_step_impl(sp: &mut SQRT_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).sqrt();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = SQRT_StreamState {
         };
-        Ok(SQRT_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SQRT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SQRT_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl SQRT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SQRT_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SQRT_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl SQRT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SQRT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SQRT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stddev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stddev.rs
@@ -304,7 +304,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STDDEV_Stream")]
 pub struct STDDEV_Stream {
-    core: Core,
     state: STDDEV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -315,7 +314,6 @@ impl STDDEV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STDDEV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -347,7 +345,7 @@ impl STDDEV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STDDEV_step_impl(&self, sp: &mut STDDEV_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn STDDEV_step_impl(sp: &mut STDDEV_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_outReal: f64 = 0.0_f64;
 
         // Pipeline the new bar through the sub-streams (batch tail order).
@@ -460,7 +458,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(STDDEV_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STDDEV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STDDEV_Open`] (composition seam).
@@ -565,7 +563,7 @@ impl STDDEV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.STDDEV_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::STDDEV_step_impl(&mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -598,7 +596,7 @@ impl STDDEV_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.STDDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::STDDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -547,7 +547,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCH_Stream")]
 pub struct STOCH_Stream {
-    core: Core,
     state: STOCH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -558,7 +557,6 @@ impl STOCH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -622,7 +620,7 @@ impl STOCH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCH_step_impl(&self, sp: &mut STOCH_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSlowK: &mut f64, outSlowD: &mut f64) -> Result<(), RetCode> {
+    fn STOCH_step_impl(sp: &mut STOCH_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSlowK: &mut f64, outSlowD: &mut f64) -> Result<(), RetCode> {
         let mut tmp: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outSlowD: f64 = 0.0_f64;
@@ -1000,7 +998,7 @@ impl Core {
             let last_sc_outSlowD = sc_outSlowD[*outNBElement - 1];
             outSlowD[0] = last_sc_outSlowD;
         }
-        Ok(STOCH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCH_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCH_Open`] (composition seam).
@@ -1129,7 +1127,7 @@ impl STOCH_Stream {
         }
         let mut outSlowK: f64 = 0.0_f64;
         let mut outSlowD: f64 = 0.0_f64;
-        self.core.STOCH_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSlowK, &mut outSlowD)?;
+        Core::STOCH_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSlowK, &mut outSlowD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1162,7 +1160,7 @@ impl STOCH_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.STOCH_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSlowK[i], &mut outSlowD[i])?;
+            Core::STOCH_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSlowK[i], &mut outSlowD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -501,7 +501,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCHF_Stream")]
 pub struct STOCHF_Stream {
-    core: Core,
     state: STOCHF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -512,7 +511,6 @@ impl STOCHF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCHF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -570,7 +568,7 @@ impl STOCHF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCHF_step_impl(&self, sp: &mut STOCHF_StreamState, inHigh: f64, inLow: f64, inClose: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
+    fn STOCHF_step_impl(sp: &mut STOCHF_StreamState, inHigh: f64, inLow: f64, inClose: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
         let mut tmp: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outFastD: f64 = 0.0_f64;
@@ -923,7 +921,7 @@ impl Core {
             let last_sc_outFastD = sc_outFastD[*outNBElement - 1];
             outFastD[0] = last_sc_outFastD;
         }
-        Ok(STOCHF_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCHF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCHF_Open`] (composition seam).
@@ -1052,7 +1050,7 @@ impl STOCHF_Stream {
         }
         let mut outFastK: f64 = 0.0_f64;
         let mut outFastD: f64 = 0.0_f64;
-        self.core.STOCHF_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outFastK, &mut outFastD)?;
+        Core::STOCHF_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outFastK, &mut outFastD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1085,7 +1083,7 @@ impl STOCHF_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.STOCHF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outFastK[i], &mut outFastD[i])?;
+            Core::STOCHF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outFastK[i], &mut outFastD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
@@ -374,7 +374,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCHRSI_Stream")]
 pub struct STOCHRSI_Stream {
-    core: Core,
     state: STOCHRSI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -385,7 +384,6 @@ impl STOCHRSI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCHRSI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -423,7 +421,7 @@ impl STOCHRSI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCHRSI_step_impl(&self, sp: &mut STOCHRSI_StreamState, inReal: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
+    fn STOCHRSI_step_impl(sp: &mut STOCHRSI_StreamState, inReal: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
         let mut cur_tempRSIBuffer: f64 = 0.0_f64;
         let mut cur_outFastK: f64 = 0.0_f64;
         let mut cur_outFastD: f64 = 0.0_f64;
@@ -574,7 +572,7 @@ impl Core {
             let last_sc_outFastD = sc_outFastD[*outNBElement - 1];
             outFastD[0] = last_sc_outFastD;
         }
-        Ok(STOCHRSI_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCHRSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCHRSI_Open`] (composition seam).
@@ -696,7 +694,7 @@ impl STOCHRSI_Stream {
         }
         let mut outFastK: f64 = 0.0_f64;
         let mut outFastD: f64 = 0.0_f64;
-        self.core.STOCHRSI_step_impl(&mut self.state, inReal, &mut outFastK, &mut outFastD)?;
+        Core::STOCHRSI_step_impl(&mut self.state, inReal, &mut outFastK, &mut outFastD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -729,7 +727,7 @@ impl STOCHRSI_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.STOCHRSI_step_impl(&mut self.state, inReal[i], &mut outFastK[i], &mut outFastD[i])?;
+            Core::STOCHRSI_step_impl(&mut self.state, inReal[i], &mut outFastK[i], &mut outFastD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sub.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sub.rs
@@ -222,7 +222,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SUB_Stream")]
 pub struct SUB_Stream {
-    core: Core,
     state: SUB_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -233,7 +232,6 @@ impl SUB_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SUB_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -259,7 +257,7 @@ impl SUB_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SUB_step_impl(&self, sp: &mut SUB_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn SUB_step_impl(sp: &mut SUB_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         (*outReal) = inReal0 - inReal1;
     }
 
@@ -304,7 +302,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = SUB_StreamState {
         };
-        Ok(SUB_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SUB_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SUB_Open`] (composition seam).
@@ -415,7 +413,7 @@ impl SUB_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SUB_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::SUB_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -448,7 +446,7 @@ impl SUB_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SUB_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::SUB_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sum.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sum.rs
@@ -273,7 +273,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SUM_Stream")]
 pub struct SUM_Stream {
-    core: Core,
     state: SUM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -284,7 +283,6 @@ impl SUM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SUM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -320,7 +318,7 @@ impl SUM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SUM_step_impl(&self, sp: &mut SUM_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SUM_step_impl(sp: &mut SUM_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -423,7 +421,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(SUM_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SUM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SUM_Open`] (composition seam).
@@ -528,7 +526,7 @@ impl SUM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.SUM_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SUM_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -561,7 +559,7 @@ impl SUM_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.SUM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SUM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -466,7 +466,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_T3_Stream")]
 pub struct T3_Stream {
-    core: Core,
     state: T3_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -477,7 +476,6 @@ impl T3_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `T3_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -531,7 +529,7 @@ impl T3_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn T3_step_impl(&self, sp: &mut T3_StreamState, inReal: f64, outReal: &mut f64) {
+    fn T3_step_impl(sp: &mut T3_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
@@ -609,7 +607,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(T3_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(T3_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut lookbackTotal: usize = 0_usize;
@@ -776,7 +774,7 @@ impl Core {
             c3,
             c4,
         };
-        Ok(T3_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(T3_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::T3_Open`] (composition seam).
@@ -881,7 +879,7 @@ impl T3_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.T3_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::T3_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -914,7 +912,7 @@ impl T3_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.T3_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::T3_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tan.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TAN_Stream")]
 pub struct TAN_Stream {
-    core: Core,
     state: TAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl TAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl TAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TAN_step_impl(&self, sp: &mut TAN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TAN_step_impl(sp: &mut TAN_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).tan();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = TAN_StreamState {
         };
-        Ok(TAN_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TAN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TAN_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl TAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TAN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TAN_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl TAN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TAN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TAN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tanh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tanh.rs
@@ -214,7 +214,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TANH_Stream")]
 pub struct TANH_Stream {
-    core: Core,
     state: TANH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -225,7 +224,6 @@ impl TANH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TANH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -251,7 +249,7 @@ impl TANH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TANH_step_impl(&self, sp: &mut TANH_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TANH_step_impl(sp: &mut TANH_StreamState, inReal: f64, outReal: &mut f64) {
         (*outReal) = (inReal).tanh();
     }
 
@@ -292,7 +290,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = TANH_StreamState {
         };
-        Ok(TANH_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TANH_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TANH_Open`] (composition seam).
@@ -397,7 +395,7 @@ impl TANH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TANH_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TANH_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -430,7 +428,7 @@ impl TANH_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TANH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TANH_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tema.rs
@@ -439,7 +439,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TEMA_Stream")]
 pub struct TEMA_Stream {
-    core: Core,
     state: TEMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -450,7 +449,6 @@ impl TEMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TEMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -486,7 +484,7 @@ impl TEMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TEMA_step_impl(&self, sp: &mut TEMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TEMA_step_impl(sp: &mut TEMA_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
@@ -547,7 +545,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(TEMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(TEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut prevEMA1: f64 = 0.0_f64;
         let mut prevEMA2: f64 = 0.0_f64;
@@ -704,7 +702,7 @@ impl Core {
             prevEMA3,
             optInK_1,
         };
-        Ok(TEMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TEMA_Open`] (composition seam).
@@ -809,7 +807,7 @@ impl TEMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TEMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TEMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -842,7 +840,7 @@ impl TEMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/trange.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trange.rs
@@ -286,7 +286,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TRANGE_Stream")]
 pub struct TRANGE_Stream {
-    core: Core,
     state: TRANGE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -297,7 +296,6 @@ impl TRANGE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TRANGE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -325,7 +323,7 @@ impl TRANGE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TRANGE_step_impl(&self, sp: &mut TRANGE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn TRANGE_step_impl(sp: &mut TRANGE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut val2: f64 = 0.0_f64;
         let mut val3: f64 = 0.0_f64;
         let mut greatest: f64 = 0.0_f64;
@@ -432,7 +430,7 @@ impl Core {
         let state = TRANGE_StreamState {
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(TRANGE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TRANGE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TRANGE_Open`] (composition seam).
@@ -544,7 +542,7 @@ impl TRANGE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TRANGE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::TRANGE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -577,7 +575,7 @@ impl TRANGE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TRANGE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::TRANGE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/trima.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trima.rs
@@ -508,7 +508,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TRIMA_Stream")]
 pub struct TRIMA_Stream {
-    core: Core,
     state: TRIMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -519,7 +518,6 @@ impl TRIMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TRIMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -569,7 +567,7 @@ impl TRIMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TRIMA_step_impl(&self, sp: &mut TRIMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TRIMA_step_impl(sp: &mut TRIMA_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.optInTimePeriod % 2 == 1 {
             if sp.ringCap_middleIdx == 0 {
                 sp.ring_middleIdx_inReal[0] = inReal;
@@ -891,7 +889,7 @@ impl Core {
                 ringCap_trailingIdx: cap_trailingIdx as usize,
                 ring_trailingIdx_inReal,
             };
-            Ok(TRIMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(TRIMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut lookbackTotal: usize = 0_usize;
             let mut numerator: f64 = 0.0_f64;
@@ -1099,7 +1097,7 @@ impl Core {
                 ringCap_trailingIdx: cap_trailingIdx as usize,
                 ring_trailingIdx_inReal,
             };
-            Ok(TRIMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(TRIMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1213,7 +1211,7 @@ impl TRIMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TRIMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TRIMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1246,7 +1244,7 @@ impl TRIMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TRIMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TRIMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/trix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trix.rs
@@ -393,7 +393,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TRIX_Stream")]
 pub struct TRIX_Stream {
-    core: Core,
     state: TRIX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -404,7 +403,6 @@ impl TRIX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TRIX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -440,7 +438,7 @@ impl TRIX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TRIX_step_impl(&self, sp: &mut TRIX_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TRIX_step_impl(sp: &mut TRIX_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         tempReal = sp.prevEMA3;
         sp.prevEMA1 = (inReal - sp.prevEMA1 as f64).mul_add(sp.optInK_1, sp.prevEMA1);
@@ -603,7 +601,7 @@ impl Core {
             prevEMA3,
             optInK_1,
         };
-        Ok(TRIX_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TRIX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TRIX_Open`] (composition seam).
@@ -708,7 +706,7 @@ impl TRIX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TRIX_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TRIX_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -741,7 +739,7 @@ impl TRIX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TRIX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TRIX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tsf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tsf.rs
@@ -440,7 +440,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TSF_Stream")]
 pub struct TSF_Stream {
-    core: Core,
     state: TSF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -451,7 +450,6 @@ impl TSF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TSF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -505,7 +503,7 @@ impl TSF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TSF_step_impl(&self, sp: &mut TSF_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TSF_step_impl(sp: &mut TSF_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut b: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
@@ -840,7 +838,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(TSF_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TSF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TSF_Open`] (composition seam).
@@ -945,7 +943,7 @@ impl TSF_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TSF_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TSF_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -978,7 +976,7 @@ impl TSF_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TSF_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TSF_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/types.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/types.rs
@@ -279,9 +279,12 @@ pub enum CandleSettingType {
 /// # Ok::<(), ta_lib::RetCode>(())
 /// ```
 ///
-/// To change a setting, build a new `Core` — cloning is cheap (it is a small
-/// `[i32; N]` array plus two small fields). [`Core::to_builder`] seeds a builder
-/// from an existing `Core` for clone-and-modify.
+/// To change a setting, build a new `Core` — cloning it copies bytes and never
+/// allocates, but there are 280 of them on x86-64 (an `[i32; N]` array, eleven
+/// `CandleSetting`s and the compatibility mode), so it is a memcpy rather than
+/// a free operation. [`Core::to_builder`] seeds a builder from an existing
+/// `Core` for clone-and-modify. Stream handles do not hold one: each carries
+/// only the `CandleSetting`s its own step reads.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Core {
     /// Unstable period for each function identified by [`FuncUnstId`].

--- a/ta_codegen/output/rust/library/src/ta_func/typprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/typprice.rs
@@ -233,7 +233,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TYPPRICE_Stream")]
 pub struct TYPPRICE_Stream {
-    core: Core,
     state: TYPPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -244,7 +243,6 @@ impl TYPPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TYPPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -270,7 +268,7 @@ impl TYPPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TYPPRICE_step_impl(&self, sp: &mut TYPPRICE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn TYPPRICE_step_impl(sp: &mut TYPPRICE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         (*outReal) = (inHigh + inLow + inClose) / 3.0;
     }
 
@@ -312,7 +310,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = TYPPRICE_StreamState {
         };
-        Ok(TYPPRICE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TYPPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TYPPRICE_Open`] (composition seam).
@@ -424,7 +422,7 @@ impl TYPPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.TYPPRICE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::TYPPRICE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -457,7 +455,7 @@ impl TYPPRICE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.TYPPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::TYPPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -566,7 +566,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ULTOSC_Stream")]
 pub struct ULTOSC_Stream {
-    core: Core,
     state: ULTOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -577,7 +576,6 @@ impl ULTOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ULTOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -639,7 +637,7 @@ impl ULTOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ULTOSC_step_impl(&self, sp: &mut ULTOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ULTOSC_step_impl(sp: &mut ULTOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut trueLow: f64 = 0.0_f64;
         let mut trueRange: f64 = 0.0_f64;
         let mut closeMinusTrueLow: f64 = 0.0_f64;
@@ -1053,7 +1051,7 @@ impl Core {
             cb_term_closeMinusTrueLow: term_closeMinusTrueLow,
             cb_term_trueRange: term_trueRange,
         };
-        Ok(ULTOSC_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ULTOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ULTOSC_Open`] (composition seam).
@@ -1173,7 +1171,7 @@ impl ULTOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.ULTOSC_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ULTOSC_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1206,7 +1204,7 @@ impl ULTOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.ULTOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ULTOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -420,7 +420,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_VAR_Stream")]
 pub struct VAR_Stream {
-    core: Core,
     state: VAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -431,7 +430,6 @@ impl VAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `VAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -485,7 +483,7 @@ impl VAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn VAR_step_impl(&self, sp: &mut VAR_StreamState, inReal: f64, outReal: &mut f64) {
+    fn VAR_step_impl(sp: &mut VAR_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut meanValue1: f64 = 0.0_f64;
         let mut variance: f64 = 0.0_f64;
@@ -837,7 +835,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(VAR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(VAR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::VAR_Open`] (composition seam).
@@ -942,7 +940,7 @@ impl VAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.VAR_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::VAR_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -975,7 +973,7 @@ impl VAR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.VAR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::VAR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/vwap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwap.rs
@@ -387,7 +387,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_VWAP_Stream")]
 pub struct VWAP_Stream {
-    core: Core,
     state: VWAP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -398,7 +397,6 @@ impl VWAP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `VWAP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -430,7 +428,7 @@ impl VWAP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn VWAP_step_impl(&self, sp: &mut VWAP_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn VWAP_step_impl(sp: &mut VWAP_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut typPrice: f64 = 0.0_f64;
         let mut volume: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -657,7 +655,7 @@ impl Core {
             sumV,
             vwap,
         };
-        Ok(VWAP_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(VWAP_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::VWAP_Open`] (composition seam).
@@ -772,7 +770,7 @@ impl VWAP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.VWAP_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::VWAP_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -805,7 +803,7 @@ impl VWAP_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.VWAP_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::VWAP_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/vwma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwma.rs
@@ -352,7 +352,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_VWMA_Stream")]
 pub struct VWMA_Stream {
-    core: Core,
     state: VWMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -363,7 +362,6 @@ impl VWMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `VWMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -403,7 +401,7 @@ impl VWMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn VWMA_step_impl(&self, sp: &mut VWMA_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
+    fn VWMA_step_impl(sp: &mut VWMA_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempPV: f64 = 0.0_f64;
         let mut tempV: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -492,7 +490,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(VWMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(VWMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut sumPV: f64 = 0.0_f64;
         let mut sumV: f64 = 0.0_f64;
@@ -583,7 +581,7 @@ impl Core {
             ring_trailingIdx_inReal,
             ring_trailingIdx_inVolume,
         };
-        Ok(VWMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(VWMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::VWMA_Open`] (composition seam).
@@ -702,7 +700,7 @@ impl VWMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.VWMA_step_impl(&mut self.state, inReal, inVolume, &mut outReal);
+        Core::VWMA_step_impl(&mut self.state, inReal, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -735,7 +733,7 @@ impl VWMA_Stream {
             if !inReal[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.VWMA_step_impl(&mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
+            Core::VWMA_step_impl(&mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/wad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wad.rs
@@ -324,7 +324,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WAD_Stream")]
 pub struct WAD_Stream {
-    core: Core,
     state: WAD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -335,7 +334,6 @@ impl WAD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WAD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -365,7 +363,7 @@ impl WAD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WAD_step_impl(&self, sp: &mut WAD_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn WAD_step_impl(sp: &mut WAD_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut close: f64 = 0.0_f64;
         let mut trueExtreme: f64 = 0.0_f64;
         close = inClose;
@@ -483,7 +481,7 @@ impl Core {
             sum,
             prevClose,
         };
-        Ok(WAD_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WAD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WAD_Open`] (composition seam).
@@ -595,7 +593,7 @@ impl WAD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.WAD_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::WAD_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -628,7 +626,7 @@ impl WAD_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.WAD_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::WAD_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
@@ -266,7 +266,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WCLPRICE_Stream")]
 pub struct WCLPRICE_Stream {
-    core: Core,
     state: WCLPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -277,7 +276,6 @@ impl WCLPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WCLPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -303,7 +301,7 @@ impl WCLPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WCLPRICE_step_impl(&self, sp: &mut WCLPRICE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn WCLPRICE_step_impl(sp: &mut WCLPRICE_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         (*outReal) = ((inClose as f64).mul_add(2.0, inHigh + inLow)) / 4.0;
     }
 
@@ -345,7 +343,7 @@ impl Core {
         // Capture the live batch state into the handle.
         let state = WCLPRICE_StreamState {
         };
-        Ok(WCLPRICE_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WCLPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WCLPRICE_Open`] (composition seam).
@@ -457,7 +455,7 @@ impl WCLPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.WCLPRICE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::WCLPRICE_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -490,7 +488,7 @@ impl WCLPRICE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.WCLPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::WCLPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -456,7 +456,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WILLR_Stream")]
 pub struct WILLR_Stream {
-    core: Core,
     state: WILLR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -467,7 +466,6 @@ impl WILLR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WILLR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -519,7 +517,7 @@ impl WILLR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WILLR_step_impl(&self, sp: &mut WILLR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn WILLR_step_impl(sp: &mut WILLR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -752,7 +750,7 @@ impl Core {
             x_inLow,
             x_inClose,
         };
-        Ok(WILLR_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WILLR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WILLR_Open`] (composition seam).
@@ -872,7 +870,7 @@ impl WILLR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.WILLR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::WILLR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -905,7 +903,7 @@ impl WILLR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.WILLR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::WILLR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/wma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wma.rs
@@ -409,7 +409,6 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WMA_Stream")]
 pub struct WMA_Stream {
-    core: Core,
     state: WMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -420,7 +419,6 @@ impl WMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.core.clone_from(&src.core);
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -472,7 +470,7 @@ impl WMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WMA_step_impl(&self, sp: &mut WMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn WMA_step_impl(sp: &mut WMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut j: usize = 0_usize;
         let mut rw: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
@@ -627,7 +625,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(WMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(WMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut inIdx: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
@@ -811,7 +809,7 @@ impl Core {
             winCap_j: cap_j as usize,
             win_j_inReal,
         };
-        Ok(WMA_Stream { core: self.clone(), state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WMA_Open`] (composition seam).
@@ -924,7 +922,7 @@ impl WMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        self.core.WMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::WMA_step_impl(&mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -957,7 +955,7 @@ impl WMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            self.core.WMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::WMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }


### PR DESCRIPTION

Closes #274.

## What

A generated Rust stream handle embedded a whole `Core` by value. It now carries
one `cs_<snake>: CandleSetting` field per setting its own step reads, and no
field at all where it reads none; the step drops its `&self` receiver and takes
those settings as parameters, so `Core` is the namespace it is declared in
rather than state it reads through.

```rust
// before
pub struct CDLDOJI_Stream { core: Core, state: CDLDOJI_StreamState, out: OutRange }
fn CDLDOJI_step_impl(&self, sp: &mut CDLDOJI_StreamState, ...)
    let BodyDoji_factor: f64 = self.candle_settings.body_doji.factor;

// after
pub struct CDLDOJI_Stream { cs_body_doji: CandleSetting, state: CDLDOJI_StreamState, out: OutRange }
fn CDLDOJI_step_impl(sp: &mut CDLDOJI_StreamState, cs_body_doji: &CandleSetting, ...)
    let BodyDoji_factor: f64 = cs_body_doji.factor;
```

The unstable period and the compatibility mode are consumed at `Open`, where
they set the lookback; nothing post-open consults them. `Core` is immutable, so
the handle's copy was already a snapshot — the narrowed set is exactly the read
set the generator emits, which is why this is a size change and not a semantic
one.

## Where the set comes from

`candle_settings::detect_candle_settings` over the function's whole stream
source, not over one tier's steady statements. A superset can never leave a step
naming a field its handle does not have, and the two coincide for every shipped
function: the emitted field counts are **119x0, 15x1, 28x2, 8x3, 5x4, 1x5** —
exactly the read-set census in the issue — because a candlestick's batch
prologue averages exactly the settings its steady state tests.

`emit_rust_unpacking` grew a variant that lets the caller say where each
`CandleSetting` is read from. The batch and `Open` tiers, which do run on a
`Core` receiver, still read `self.candle_settings.<snake>`; only the step tier
moved.

## Size

`size_of`, x86-64, measured before and after on this tree:

| handle | before | after | | handle | before | after |
|---|---:|---:|---|---|---:|---:|
| `EMA_Stream` | 320 | **40** | | `STDDEV_Stream` | 712 | **152** |
| `ATR_Stream` | 320 | **40** | | `HT_TRENDMODE_Stream` | 960 | **680** |
| `RSI_Stream` | 328 | **48** | | `MA_Stream` | 1136 | **576** |
| `MAVP_Stream` | 336 | **56** | | `BBANDS_Stream` | 2168 | **768** |
| `SMA_Stream` | 352 | **72** | | `STOCHRSI_Stream` | 2208 | **808** |
| `CDLDOJI_Stream` | 344 | **80** | | `MACDEXT_Stream` | 3720 | **1760** |

The "before" column reproduces the issue's table exactly. Nesting is where it
compounds: `MA_Sub` is an enum over ten handle variants that each carried their
own `Core`, so a dispatch paid the largest variant's copy whichever MA type was
selected.

## Speed

`scripts/stream_ab.py --base=<upstream dev> --lang=rust --call=peek`, 6
interleaved rounds, `iters=500000`. `peek` is `self.clone()` then `update`, so
it is the call the handle's size lands on directly.

**Read the floor first.** Every one of the 176 handles changed here, so there is
no byte-identical control function inside the A/B. The substitute is the same
tool run with `--base=HEAD` against an unmodified tree — identical code in both
arms, so every row is pure build-layout and measurement noise. Over 176
functions the worst excursion there is **-7.4%**, with only 7 functions past
-5%. Nothing smaller than that is claimed below.

Against that floor, the head of the real run (worst-first, top 20 of 176):

| func | base ns | head ns | chg |
|---|---:|---:|---:|
| `MFI` | 43.18 | 16.53 | **-61.7%** |
| `MAVP` | 704.35 | 270.80 | **-61.6%** |
| `PVO` | 43.96 | 18.63 | **-57.6%** |
| `MACDEXT` | 79.52 | 34.99 | **-56.0%** |
| `PPO` | 45.57 | 20.58 | **-54.8%** |
| `APO` | 44.71 | 21.09 | **-52.8%** |
| `STOCH` | 70.04 | 35.56 | **-49.2%** |
| `STOCHRSI` | 68.66 | 35.64 | **-48.1%** |
| `CDLDOJISTAR` | 32.55 | 17.22 | **-47.1%** |
| `CDLGRAVESTONEDOJI` | 31.22 | 16.61 | **-46.8%** |
| `CDLDOJI` | 28.57 | 15.59 | **-45.4%** |
| `AO` | 31.00 | 18.18 | **-41.4%** |
| `CMF` | 47.54 | 28.57 | **-39.9%** |
| `BBANDS` | 65.11 | 39.49 | **-39.3%** |
| `STDDEV` | 26.90 | 17.43 | **-35.2%** |
| `WMA` | 31.06 | 20.54 | **-33.9%** |
| `STOCHF` | 40.35 | 27.83 | **-31.0%** |
| `WILLR` | 23.66 | 16.50 | **-30.3%** |
| `MIDPRICE` | 20.35 | 14.37 | **-29.4%** |
| `MAX` | 18.41 | 13.72 | **-25.5%** |

Two independent runs of the A/B agree on these rows to within about two points
(`MFI` -61.7 / -59.9, `MAVP` -61.6 / -61.8, `CDLDOJI` -45.4 / -46.2), and the
head-arm absolute ns match what the identical-arms run reads for the same
functions.

`--call=update` was not run: on a single stack-local handle updated in a loop,
LLVM already deleted the dead 280-byte copy before this change — the issue
measures that row flat and this does not move it. The win is where the copy
cannot be elided, which is `peek`'s `restore_from` cascade and a fleet of
handles in a `Vec`; `peek` above is the first of those, and the size table is
the direct evidence for the second.

## Gates

- `a_stream_handle_carries_only_the_settings_its_step_reads` — a one-setting
  step (`CDLDOJI`), a five-setting step (`CDLADVANCEBLOCK`) and a no-setting
  step (`SMA`), pinned against the field set, the step signature and the call
  site. Each row is the control on the others: going back to `core: Core` fails
  all three, widening to "every setting" fails the first two on the count,
  narrowing to nothing fails them on the field. Verified red by mutating
  `handle_candle_settings` to return the empty set.
- `a_stream_step_reads_candle_settings_from_its_parameters` — the step unpacks
  from its parameters and names no `self.candle_settings`; the control in the
  same test is that the batch tier still does.
- `the_transition_tier_is_step_impl_in_every_backend` updated for the Rust row's
  new signature and call site.
- `cargo test` (generator, 382 + 309 + 24), `cargo test --tests -p ta-lib`,
  `cargo test --doc -p ta-lib` (358), `cargo clippy --all-targets` clean on both.
- `ta_regtest --xlang-hash --language=rust`: **PASS**, 176 functions,
  278,274 Rust cases, 0 mismatches, bit-identical against the in-process C
  library — including the tier-agreement leg's `Open` / `OpenAndFill` compares.

## Cross-backend

Rust-only by construction: C embeds nothing in its handle (settings are
file-scope globals), Java holds a `Core` reference, C# a `Core` class reference.
A full `generate` leaves `src/ta_func`, `src/ta_abstract`, the Java, C# and C
outputs, the four servers and both benches byte-identical — the only generated
paths that move are `ta_codegen/output/rust/library/src/ta_func/*.rs`.

`Core`'s own doc comment claimed cloning is cheap because it is "a small
`[i32; N]` array plus two small fields"; it describes 280 bytes, so it is
corrected here as the issue asks.

## Environment note

This tree had no .NET SDK, so `--xlang-hash` ran for Rust (its documented
language today) and the C# server was not built. `--codegen` needs
`bin/ta_ref_serve`, which `scripts/regtest.py` builds from the pinned
`reference-pre-cutover` worktree; that was not available here either, so the
value evidence above is the `--xlang-hash` gate rather than the pre-cutover
oracle. CI covers both.

## Not done here

The issue's "cheaper fallback" (a uniform `CandleSettings` for the 57, nothing
for the 119) is not implemented — the per-function narrowing subsumes it.


---
