### PR TITLE
perf(rust): split a stream handle into config/state, and peek the state alone (#276)

### DIFF
--- a/ta_codegen/generator/src/backends/fma.rs
+++ b/ta_codegen/generator/src/backends/fma.rs
@@ -154,6 +154,7 @@ fn stream_base(name: &str) -> &str {
     let n = name
         .strip_prefix("sp->")
         .or_else(|| name.strip_prefix("sp.")) // Rust/Java stream state prefix
+        .or_else(|| name.strip_prefix("cfg.")) // Rust stream config prefix (#276)
         .unwrap_or(name);
     // Java stream output fields are `sp.cur_<out>` — both prefixes at once.
     n.strip_prefix("cur_").unwrap_or(n)

--- a/ta_codegen/generator/src/backends/rust_lang.rs
+++ b/ta_codegen/generator/src/backends/rust_lang.rs
@@ -6239,11 +6239,19 @@ fn expr_returns_usize(expr: &Expr) -> bool {
 
 /// Check if a variable name is an IntArray (i32 element array).
 /// These should NOT be wrapped with T::ta_from_i32() when assigned to.
-/// Strip the stream-state field prefix so name-keyed inference helpers see the
-/// batch-local name (`sp.optInTimePeriod` types exactly like `optInTimePeriod`).
-/// A no-op for every batch name (none contain a dot).
+/// Strip the stream-state or stream-config field prefix so name-keyed
+/// inference helpers see the batch-local name (`cfg.optInTimePeriod` types
+/// exactly like `optInTimePeriod`). A no-op for every batch name (none contain
+/// a dot).
+///
+/// Both prefixes, not just `sp.`: #276 moved the Open-time invariants into a
+/// `cfg` of their own, and a name-keyed helper that does not recognize the new
+/// spelling silently types an `optIn*` read as something it is not — which is
+/// a missing `as f64` at best and a differently-fused expression at worst.
 pub(crate) fn strip_state_prefix(name: &str) -> &str {
-    name.strip_prefix("sp.").unwrap_or(name)
+    name.strip_prefix("sp.")
+        .or_else(|| name.strip_prefix("cfg."))
+        .unwrap_or(name)
 }
 
 fn is_int_array_var(name: &str) -> bool {

--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -155,11 +155,24 @@ fn extra_param_rust_type(c_type: &str) -> &'static str {
 // `(*out)` writes against `&mut` step params.
 // ---------------------------------------------------------------------------
 
-struct RustStreamNames;
+/// Where a carried name lives in the step: the Open-time invariants through
+/// the read-only `cfg`, everything a bar can write through `sp` (issue #276).
+fn carried_path(config: &HashSet<String>, name: &str) -> String {
+    if config.contains(name) {
+        format!("cfg.{name}")
+    } else {
+        format!("sp.{name}")
+    }
+}
+
+struct RustStreamNames {
+    /// The names this function keeps in its config — see [`carried_path`].
+    config: HashSet<String>,
+}
 
 impl streaming::NameMap for RustStreamNames {
     fn state(&self, name: &str) -> String {
-        format!("sp.{name}")
+        carried_path(&self.config, name)
     }
     fn bar(&self, array: &str) -> String {
         array.to_string()
@@ -358,22 +371,10 @@ fn state_fields_from(
     typing: &Typing,
     scalars: &[(String, VarType)],
 ) -> Vec<(String, String, String)> {
+    // The optional inputs and private extra params used to lead this list.
+    // They are Open-time invariants, so they live in `<F>_StreamConfig` now
+    // (issue #276) and the state holds only what a bar can write.
     let mut fields: Vec<(String, String, String)> = Vec::new();
-    for p in &func.optional_inputs {
-        // Params are always captured (identity path included).
-        fields.push((
-            p.name.clone(),
-            opt_param_rust_type(&p.param_type),
-            p.name.clone(),
-        ));
-    }
-    for (name, c_type) in &func.private_extra_params {
-        fields.push((
-            name.clone(),
-            extra_param_rust_type(c_type).to_string(),
-            name.clone(),
-        ));
-    }
     for (name, ty) in scalars {
         let (rty, default) = field_type_and_default(typing, name, ty, true);
         let default = default.unwrap_or_else(|| {
@@ -790,38 +791,143 @@ fn cs_binding(setting: &str) -> String {
     format!("cs_{}", crate::candle_settings::pascal_to_snake_case(setting))
 }
 
-/// `, cs_near: &CandleSetting, …` — the step signature's settings parameters.
-fn cs_step_params(settings: &BTreeSet<String>) -> String {
-    let mut s = String::new();
-    for setting in settings {
-        let _ = write!(s, ", {}: &CandleSetting", cs_binding(setting));
-    }
-    s
+// ---------------------------------------------------------------------------
+// The handle's Open-time invariants: `Config` (issue #276)
+// ---------------------------------------------------------------------------
+//
+// #274 took the candlestick settings out of the embedded `Core`. What stayed
+// behind in the *state* is the same kind of value: `optInTimePeriod` and the
+// private extra params (EMA's k factor) are fixed at `Open` and read on every
+// bar, never written by a step. Sitting in the state, they were copied by
+// every `peek` — the scratch restore has to reproduce a field it can never
+// have changed — and the step reached them through the same `&mut` the rings
+// arrive by, so nothing told the compiler a bar could not move them.
+//
+// They now live in a `<F>_StreamConfig` beside the state, and the step takes
+// `cfg: &<F>_StreamConfig`. `&T` is `noalias` + `readonly` to LLVM, so a
+// config read hoists across a write through `sp` without the compiler having
+// to prove non-aliasing by inlining.
+//
+// A function whose config would be empty emits no struct, no field and no
+// parameter, exactly as #274 emits no settings field where a step reads none.
+// That is 30 of the 176, and their generated code is byte-identical across
+// this change — the control set for its own benchmark.
+
+/// `<F>_StreamConfig` — the handle's Open-time invariants.
+fn config_type_name(func: &FuncDef) -> String {
+    format!("{}_StreamConfig", func.name.to_uppercase())
 }
 
-/// `&self.cs_near, …` — the step call's settings arguments, as a handle reads
-/// them. Distinct field places, so they borrow alongside `&mut self.state`.
-fn cs_step_args(settings: &BTreeSet<String>) -> String {
-    let mut s = String::new();
-    for setting in settings {
-        let _ = write!(s, "&self.{}, ", cs_binding(setting));
+/// The config's parameter fields: (name, rust_type, identity-path default).
+/// The optional inputs, then the private extra params — the two groups that
+/// `state_fields_from` used to lead with, in that same order.
+fn config_param_fields(func: &FuncDef) -> Vec<(String, String, String)> {
+    let mut fields: Vec<(String, String, String)> = Vec::new();
+    for p in &func.optional_inputs {
+        fields.push((
+            p.name.clone(),
+            opt_param_rust_type(&p.param_type),
+            p.name.clone(),
+        ));
     }
-    s
+    for (name, c_type) in &func.private_extra_params {
+        fields.push((
+            name.clone(),
+            extra_param_rust_type(c_type).to_string(),
+            name.clone(),
+        ));
+    }
+    fields
 }
 
-/// `cs_near: self.candle_settings.near, …` — the handle's settings at every
-/// construction site, where `self` is the opening `Core`.
-fn cs_ctor_fields(func: &FuncDef) -> String {
-    let mut s = String::new();
+/// Every name the step must reach through `cfg.` rather than `sp.`.
+fn config_field_names(func: &FuncDef) -> HashSet<String> {
+    config_param_fields(func)
+        .into_iter()
+        .map(|(n, _, _)| n)
+        .collect()
+}
+
+/// Whether this function carries a config at all — a settings-reading step or
+/// a parameter counts. False for the 30 that carry neither.
+fn has_config(func: &FuncDef) -> bool {
+    !config_param_fields(func).is_empty() || !handle_candle_settings(func).is_empty()
+}
+
+/// `cfg: &<F>_StreamConfig, ` — the step signature's leading config
+/// parameter, empty where the function has no config.
+fn cfg_step_param(func: &FuncDef) -> String {
+    if has_config(func) {
+        format!("cfg: &{}, ", config_type_name(func))
+    } else {
+        String::new()
+    }
+}
+
+/// `&self.config, ` — the step call's config argument, as a handle reads it.
+/// A distinct field place, so it borrows alongside `&mut self.state`.
+fn cfg_step_arg(func: &FuncDef) -> String {
+    if has_config(func) {
+        "&self.config, ".to_string()
+    } else {
+        String::new()
+    }
+}
+
+/// `config: <F>_StreamConfig { cs_near: self.candle_settings.near, optInTimePeriod, .. }, `
+/// — the handle's config at every construction site, where `self` is the
+/// opening `Core` and each parameter is in scope under its own name.
+fn cfg_ctor_field(func: &FuncDef) -> String {
+    if !has_config(func) {
+        return String::new();
+    }
+    let cty = config_type_name(func);
+    let mut inner = String::new();
     for setting in handle_candle_settings(func) {
         let _ = write!(
-            s,
+            inner,
             "{}: self.candle_settings.{}, ",
             cs_binding(&setting),
             crate::candle_settings::pascal_to_snake_case(&setting)
         );
     }
-    s
+    for (name, _, _) in config_param_fields(func) {
+        let _ = write!(inner, "{name}, ");
+    }
+    format!("config: {cty} {{ {inner}}}, ")
+}
+
+/// The `<F>_StreamConfig` declaration and its `Clone`-based restore.
+///
+/// Every field is `Copy` — scalars, enum params and `CandleSetting` — so the
+/// struct derives `Copy` and a handle-level restore is a plain assignment.
+fn emit_config_struct(o: &mut String, func: &FuncDef) {
+    if !has_config(func) {
+        return;
+    }
+    let cty = config_type_name(func);
+    let n = func.name.to_uppercase();
+    let _ = writeln!(
+        o,
+        "/// What {n} was opened with: read on every bar, written by none of\n\
+         /// them. Held beside the state so a step takes it as `&{cty}`\n\
+         /// (`noalias` + `readonly`) and `peek`'s scratch never copies it.\n\
+         #[derive(Debug, Clone, Copy)]\n\
+         #[allow(non_snake_case, dead_code)]\n\
+         struct {cty} {{"
+    );
+    for setting in handle_candle_settings(func) {
+        let _ = writeln!(
+            o,
+            "    /// The `{setting}` setting this stream was opened with.\n\
+             \x20   {}: CandleSetting,",
+            cs_binding(&setting)
+        );
+    }
+    for (name, rty, _) in config_param_fields(func) {
+        let _ = writeln!(o, "    {name}: {rty},");
+    }
+    let _ = writeln!(o, "}}\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -844,21 +950,19 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
     let state = state_type_name(func);
     let sn = snake(func);
     let n = func.name.to_uppercase();
-    let settings = handle_candle_settings(func);
-    // Exactly the settings this function's step reads, and nothing where it
-    // reads none (issue #274). Ahead of `state`, so the fields a step touches
-    // every bar sit together at the front of the handle.
-    let mut cs_fields = String::new();
-    let mut cs_restore = String::new();
-    for setting in &settings {
-        let field = cs_binding(setting);
-        let _ = write!(
-            cs_fields,
-            "    /// The `{setting}` setting this stream was opened with.\n\
-             \x20   {field}: CandleSetting,\n"
-        );
-        let _ = writeln!(cs_restore, "        self.{field} = src.{field};");
-    }
+    // The Open-time invariants — the settings this step reads (#274) and the
+    // parameters it was opened with (#276) — in one `Copy` struct ahead of the
+    // state. A function that has neither carries no field at all.
+    emit_config_struct(o, func);
+    let (cfg_field, cfg_restore) = if has_config(func) {
+        let cty = config_type_name(func);
+        (
+            format!("    /// What this stream was opened with — see `{cty}`.\n    config: {cty},\n"),
+            "        self.config = src.config;\n".to_string(),
+        )
+    } else {
+        (String::new(), String::new())
+    };
     let _ = writeln!(
         o,
         "/// Live {n} stream: one value per closed bar, bit-identical to [`Core::{sn}`]\n\
@@ -869,7 +973,7 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
          #[must_use = \"a stream does nothing unless updated; dropping it closes the stream\"]\n\
          #[derive(Debug, Clone)]\n\
          #[doc(alias = \"TA_{n}_Stream\")]\n\
-         pub struct {handle} {{\n{cs_fields}    state: {state},\n\
+         pub struct {handle} {{\n{cfg_field}    state: {state},\n\
          \x20   /// The bars this handle has produced a value for — see [`Self::out_range`].\n\
          \x20   out: OutRange,\n}}\n"
     );
@@ -882,7 +986,7 @@ fn emit_handle_struct(o: &mut String, func: &FuncDef) {
          \x20   /// Overwrite from `src`, reusing this handle's buffers instead of\n\
          \x20   /// allocating new ones. See `{state}::restore_from`.\n\
          \x20   pub(crate) fn restore_from(&mut self, src: &Self) {{\n\
-         {cs_restore}\
+         {cfg_restore}\
          \x20       self.state.restore_from(&src.state);\n\
          \x20       self.out = src.out;\n\
          \x20   }}\n}}\n"
@@ -1072,12 +1176,17 @@ fn build_step_ctx(func: &FuncDef, models: &[&StreamModel], typing: &Typing) -> R
     for bar in streaming::input_array_names(func) {
         ctx.real_vars.insert(bar);
     }
-    // Alias every state field name under `sp.` in the same set its bare name
-    // occupies, so the cast-inference matches batch decisions on field reads.
+    // Alias every carried field name under its own path — `cfg.` for the
+    // Open-time invariants, `sp.` for everything a bar can write — in the same
+    // set its bare name occupies, so the cast-inference matches batch
+    // decisions on field reads. Both spellings are inserted for every name:
+    // the sets are keyed by spelling, not by field, so a name that is not this
+    // function's config simply never appears under `cfg.` in a rendered body.
+    let cfg_names = config_field_names(func);
     let alias = |set: &mut HashSet<String>| {
         let names: Vec<String> = set.iter().cloned().collect();
         for n in names {
-            set.insert(format!("sp.{n}"));
+            set.insert(carried_path(&cfg_names, &n));
         }
     };
     // Extrema override: cursor machinery is i32 in the handle.
@@ -1193,9 +1302,11 @@ fn emit_step(
 fn emit_step_sig(o: &mut String, func: &FuncDef, fallible: bool) {
     let sn = snake(func);
     let state = state_type_name(func);
-    // No `&self`: a step reads nothing from `Core` but the candlestick settings
-    // it names, and those arrive as parameters from the handle (issue #274).
-    let cs_params = cs_step_params(&handle_candle_settings(func));
+    // No `&self`: a step reads nothing from `Core` (issue #274). What it was
+    // opened with — the settings it names and the params it was given —
+    // arrives as one `&Config`, which is `noalias` + `readonly` and so cannot
+    // be moved by a write through `sp` (issue #276).
+    let cfg_param_lead = cfg_step_param(func);
     let mut params = String::new();
     for bar in streaming::input_array_names(func) {
         let _ = write!(params, ", {bar}: f64");
@@ -1211,7 +1322,7 @@ fn emit_step_sig(o: &mut String, func: &FuncDef, fallible: bool) {
     let ret = if fallible { " -> Result<(), RetCode>" } else { "" };
     let _ = writeln!(
         o,
-        "    fn {sn}_step_impl(sp: &mut {state}{cs_params}{params}){ret} {{"
+        "    fn {sn}_step_impl({cfg_param_lead}sp: &mut {state}{params}){ret} {{"
     );
 }
 
@@ -1247,7 +1358,7 @@ fn emit_step_body(
     }
     emit_extrema_rebase(o, model, indent);
 
-    let transition = streaming::build_transition(model, &RustStreamNames)
+    let transition = streaming::build_transition(model, &RustStreamNames { config: config_field_names(func) })
         .unwrap_or_else(|e| panic!("streaming transition: {e}"));
     // C's `*outReal = 0;` must type as f64: float integer literals written to
     // a REAL output become float literals (the renderer's ArrayAccess-target
@@ -1290,14 +1401,15 @@ fn emit_step_body(
         ));
     }
     // Candle settings unpack into the same locals batch uses, from the step's
-    // own `cs_<snake>` parameters — the handle's copy of what it was opened
-    // with, which is what the embedded `Core` used to be read for (issue #274).
+    // read-only `cfg` — the handle's copy of what it was opened with, which is
+    // what the embedded `Core` used to be read for (#274, moved into the
+    // config struct by #276).
     let step_settings = crate::candle_settings::detect_candle_settings(&model.steady_stmts);
     if !step_settings.is_empty() {
         o.push_str(&crate::candle_settings::emit_rust_unpacking_from(
             &step_settings,
             indent,
-            &|s| cs_binding(s),
+            &|s| format!("cfg.{}", cs_binding(s)),
         ));
     }
     o.push_str(&body);
@@ -1318,7 +1430,7 @@ fn emit_identity_step_branch(
     counter: &Cell<usize>,
     indent: usize,
 ) {
-    if let Some(s) = streaming::identity_step_branch(model, &RustStreamNames) {
+    if let Some(s) = streaming::identity_step_branch(model, &RustStreamNames { config: config_field_names(model.func) }) {
         let output_names: Vec<String> =
             model.func.outputs.iter().map(|out| out.name.clone()).collect();
         let var_inits: HashMap<String, &Expr> = HashMap::new();
@@ -1772,10 +1884,10 @@ fn emit_capture_and_publish(
 ) {
     let handle = stream_type_name(func);
     let _ = writeln!(o, "\n        // Capture the live batch state into the handle.");
-    let cs_ctor = cs_ctor_fields(func);
+    let cfg_ctor = cfg_ctor_field(func);
     emit_capture(o, func, model, scalars, typing, registry, helpers, counter, extra_fields);
     // The core publishes only the handle; the scalar wrapper reads its sink.
-    let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+    let _ = writeln!(o, "        Ok({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
 }
 
 
@@ -1922,7 +2034,7 @@ fn emit_identity_fast_path(
 ) {
     let Some(idp) = &model.identity else { return };
     let handle = stream_type_name(func);
-    let cs_ctor = cs_ctor_fields(func);
+    let cfg_ctor = cfg_ctor_field(func);
     let state = state_type_name(func);
     let sn = snake(func);
     let opt_real_params: Vec<String> = func
@@ -1974,7 +2086,7 @@ fn emit_identity_fast_path(
     let _ = writeln!(o, "            }}");
     let _ = writeln!(
         o,
-        "            return Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});"
+        "            return Ok({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});"
     );
     let _ = writeln!(o, "        }}");
 }
@@ -2188,13 +2300,10 @@ fn emit_capture(
     }
 
     // --- the state literal ---------------------------------------------------
+    // The optional inputs and private extra params that used to open this
+    // literal are built into the config at the publish site (`cfg_ctor_field`),
+    // where the opening `Core` is still in scope for the settings beside them.
     let _ = writeln!(o, "        let state = {state} {{");
-    for p in &func.optional_inputs {
-        let _ = writeln!(o, "            {},", p.name);
-    }
-    for (name, _) in &func.private_extra_params {
-        let _ = writeln!(o, "            {name},");
-    }
     for (name, _ty) in scalars {
         if model.parity.as_ref().is_some_and(|p| &p.field == name) {
             // Synthetic parity field: seeded to the NEXT bar's parity.
@@ -2411,7 +2520,7 @@ fn stream_doctest(
 #[allow(clippy::too_many_lines)]
 fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_fallible: bool) {
     let sn = snake(func);
-    let cs_args = cs_step_args(&handle_candle_settings(func));
+    let cfg_arg = cfg_step_arg(func);
     let n = func.name.to_uppercase();
     let handle = stream_type_name(func);
     let state = state_type_name(func);
@@ -2450,18 +2559,25 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     // peek the same handle at once, and they must not share a scratch.
     //
     // The retention that buys: one handle copy per (thread, function actually
-    // peeked), held until the thread ends, sized to the largest handle that
-    // thread peeked and keeping that handle's `Core` alive. Dropping every
-    // stream handle does not release it. Bounded and small per entry, but a
-    // long-lived pool thread that peeked a wide `MAVP` bank holds that bank.
+    // peeked), held until the thread ends, sized to the largest state that
+    // thread peeked. Dropping every stream handle does not release it.
+    // Bounded and small per entry, but a long-lived pool thread that peeked a
+    // wide `MAVP` bank holds that bank.
+    //
+    // It holds a bare `{state}`, not a whole handle: what the config says
+    // cannot change under a step, so the scratch has no business carrying a
+    // copy of it — the step reads the *live* handle's `&config` instead
+    // (issue #276). The `out: OutRange` the handle used to bring along went
+    // with it; `peek` never committed a bar, so it was bookkeeping written and
+    // then thrown away.
     if reuse {
         let _ = writeln!(
             o,
             "thread_local! {{\n\
-             \x20   /// `peek`'s reusable scratch handle (see `{state}::restore_from`).\n\
+             \x20   /// `peek`'s reusable scratch state (see `{state}::restore_from`).\n\
              \x20   /// Taken for the duration of the step and put back after, so a\n\
              \x20   /// panicking step costs the scratch, never leaves it borrowed.\n\
-             \x20   static {n}_PEEK_SCRATCH: std::cell::Cell<Option<Box<{handle}>>> =\n\x20       const {{ std::cell::Cell::new(None) }};\n\
+             \x20   static {n}_PEEK_SCRATCH: std::cell::Cell<Option<Box<{state}>>> =\n\x20       const {{ std::cell::Cell::new(None) }};\n\
              }}\n"
         );
     }
@@ -2493,7 +2609,7 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     o.push_str(&out_decls);
     let _ = writeln!(
         o,
-        "        Core::{sn}_step_impl(&mut self.state, {cs_args}{fwd_bars}{out_refs}){step_try};"
+        "        Core::{sn}_step_impl({cfg_arg}&mut self.state, {fwd_bars}{out_refs}){step_try};"
     );
     // After the step, so a rejected bar (non-finite here, or a sub-stream's
     // reject through `?`) leaves the range exactly where it was. `peek` runs the
@@ -2639,7 +2755,7 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     }
     let _ = writeln!(
         o,
-        "            Core::{sn}_step_impl(&mut self.state, {cs_args}{step_args}){step_try};"
+        "            Core::{sn}_step_impl({cfg_arg}&mut self.state, {step_args}){step_try};"
     );
     let _ = writeln!(
         o,
@@ -2680,25 +2796,48 @@ fn emit_update_and_peek(o: &mut String, func: &FuncDef, shape: StateShape, step_
     // must not pay for a handle clone.
     o.push_str(&finite_bar_check(func, "        "));
     if reuse {
-        // `update` on the copy, not the transition on a bare state — so the
-        // transition keeps the single call site it has always had. Reached
-        // through the state directly it acquires a second one, and on the
-        // larger steps that alone is enough to change what the inliner does
-        // with both: measured, it cost `update` up to 70% on the functions
-        // whose step sits near the threshold. `update` is the tier this API
-        // exists to make cheap; it does not pay for peek's business (#201).
+        // The step on a bare state, with the config read from the live handle.
+        //
+        // #201 put `update` on a scratch *handle* here instead, to keep the
+        // transition down to the one call site it had: reached through the
+        // state as well it gets a second, and on a step near the inliner's
+        // threshold that alone was enough to cost `update` up to 70%. That
+        // trade bought peek a handle copy per call — the config included,
+        // which no step can write, and the `out` bookkeeping, which peek
+        // computes and throws away.
+        //
+        // #276 takes that second call site back, on this tier only. What makes
+        // it affordable is the tier itself: `scratch_pays()` selects the 73
+        // states whose clone the optimizer was never folding, which are the
+        // largest steps in the corpus and the ones least likely to have been
+        // inlined into `update` on merit. Whether that holds is a measurement,
+        // not an argument — `stream_ab.py --call=update` is the gate, and the
+        // functions that carry no config at all are its control.
         //
         // One `with`, not a `take()` plus a `set()`: each is its own
         // thread-local lookup, and on the cheapest indicators the second one
         // is a measurable share of the call.
+        //
+        // The scratch goes back before the `?`, so a rejecting step costs the
+        // thread its scratch no more than an accepting one does.
+        let step_q = if step_fallible { "\n\x20           stepped?;" } else { "" };
+        let bind = if step_fallible { "let stepped = " } else { "" };
+        // `out_decls` is written at the method's own indent; inside the
+        // closure it sits one level deeper.
+        let mut peek_out_decls = String::new();
+        for l in out_decls.lines() {
+            let _ = writeln!(peek_out_decls, "    {l}");
+        }
+        let out_decls = peek_out_decls;
         let _ = writeln!(
             o,
             "        {n}_PEEK_SCRATCH.with(|cell| {{\n\
-             \x20           let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));\n\
-             \x20           scratch.restore_from(self);\n\
-             \x20           let value = scratch.update({fwd_bars});\n\
-             \x20           cell.set(Some(scratch));\n\
-             \x20           value\n\
+             \x20           let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));\n\
+             \x20           scratch.restore_from(&self.state);\n\
+             {out_decls}\
+             \x20           {bind}Core::{sn}_step_impl({cfg_arg}&mut scratch, {fwd_bars}{out_refs});\n\
+             \x20           cell.set(Some(scratch));{step_q}\n\
+             \x20           Ok({ret})\n\
              \x20       }})"
         );
     } else {
@@ -2769,13 +2908,13 @@ fn indent_block(s: &str, extra: usize) -> String {
     out
 }
 
-/// The caller's optional params rewritten onto the handle (`optInTimePeriod`
-/// -> `sp.optInTimePeriod`): the step re-derives its arm predicate from the
-/// stored immutable param — no mode tag is ever stored.
-fn params_on_state(func: &FuncDef, e: &Expr) -> Expr {
+/// The caller's optional params rewritten onto the handle's config
+/// (`optInTimePeriod` -> `cfg.optInTimePeriod`): the step re-derives its arm
+/// predicate from the stored immutable param — no mode tag is ever stored.
+fn params_on_config(func: &FuncDef, e: &Expr) -> Expr {
     let params: Vec<String> = func.optional_inputs.iter().map(|p| p.name.clone()).collect();
     streaming::rewrite_expr(e, &|x| match x {
-        Expr::Var(v) if params.contains(&v) => Expr::Var(format!("sp.{v}")),
+        Expr::Var(v) if params.contains(&v) => Expr::Var(format!("cfg.{v}")),
         other => other,
     })
 }
@@ -2901,7 +3040,7 @@ fn emit_dual_mode(
     // Identity (HMA period 1) short-circuits ahead of the predicate, as it does
     // in the batch and in Open: it is a property of the function, not of a mode.
     emit_identity_step_branch(o, ma, &ctx, &opt_real_params, enums, registry, helpers, counter, 8);
-    let pred_sp = params_on_state(func, &dmp.predicate);
+    let pred_sp = params_on_config(func, &dmp.predicate);
     let pred_sp = render_expr(&pred_sp, &ctx, &opt_real_params, registry, helpers);
     let _ = writeln!(o, "        if {pred_sp} {{");
     emit_step_body(o, func, ma, &typing, &ctx, enums, registry, helpers, counter, 12);
@@ -3070,7 +3209,7 @@ fn emit_dispatch(
     let _ = counter;
     let sn = snake(func);
     let handle = stream_type_name(func);
-    let cs_ctor = cs_ctor_fields(func);
+    let cfg_ctor = cfg_ctor_field(func);
     let state = state_type_name(func);
     let sub_enum = sub_enum_name(func);
     let inputs = streaming::input_array_names(func);
@@ -3088,18 +3227,11 @@ fn emit_dispatch(
 
     // --- structs + sub enum -------------------------------------------------
     emit_handle_struct(o, func);
-    let mut state_fields: Vec<(String, String, String)> = func
-        .optional_inputs
-        .iter()
-        .map(|p| {
-            (
-                p.name.clone(),
-                opt_param_rust_type(&p.param_type).clone(),
-                String::new(),
-            )
-        })
-        .collect();
-    state_fields.push(("sub".into(), sub_enum.clone(), String::new()));
+    // The params this tier used to lead its state with are Open-time
+    // invariants and live in the config now (issue #276); the sub-stream is
+    // all that is left to carry.
+    let state_fields: Vec<(String, String, String)> =
+        vec![("sub".into(), sub_enum.clone(), String::new())];
     let sub_note = format!(
         "Sub-stream, tagged by {}; `{sub_enum}::Identity` on the identity path.",
         dp.param
@@ -3147,7 +3279,7 @@ fn emit_dispatch(
     // --- step ---------------------------------------------------------------
     emit_step_sig(o, func, true);
     if let Some(idp) = &dp.identity {
-        let cond = params_on_state(func, &idp.condition);
+        let cond = params_on_config(func, &idp.condition);
         let cond = render_expr(&cond, &ctx, &[], registry, helpers);
         let _ = writeln!(o, "        if {cond} {{");
         for (out, inp) in &idp.pairs {
@@ -3245,7 +3377,7 @@ fn emit_dispatch(
             }
             let _ = writeln!(
                 o,
-                "            let state = {state} {{ {params_join}, sub: {sub_enum}::Identity }};"
+                "            let state = {state} {{ sub: {sub_enum}::Identity }};"
             );
             match mode {
                 OutMode::Core => unreachable!("dispatch tier is exempt from the merge"),
@@ -3262,17 +3394,17 @@ fn emit_dispatch(
                     };
                     let _ = writeln!(
                         o,
-                        "            return Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, {value}));"
+                        "            return Ok(({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, {value}));"
                     );
                 }
                 OutMode::Fill => {
                     let _ = writeln!(
                         o,
-                        "            return Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }}));"
+                        "            return Ok(({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }} }}, OutRange {{ beg_idx: fillLb, count: historyLen - fillLb }}));"
                     );
                 }
                 OutMode::FillInternal => {
-                    let _ = writeln!(o, "            return Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});");
+                    let _ = writeln!(o, "            return Ok({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }});");
                 }
             }
             let _ = writeln!(o, "        }}");
@@ -3401,17 +3533,17 @@ fn emit_dispatch(
         }
         let _ = writeln!(o, "            _ => return Err(RetCode::BadParam),");
         let _ = writeln!(o, "        }};");
-        let _ = writeln!(o, "        let state = {state} {{ {params_join}, sub }};");
+        let _ = writeln!(o, "        let state = {state} {{ sub }};");
         match mode {
             OutMode::Core => unreachable!("dispatch tier is exempt from the merge"),
             OutMode::Scalar => {
-                let _ = writeln!(o, "        Ok(({handle} {{ {cs_ctor}state, out: subRange }}, value))");
+                let _ = writeln!(o, "        Ok(({handle} {{ {cfg_ctor}state, out: subRange }}, value))");
             }
             OutMode::Fill => {
-                let _ = writeln!(o, "        Ok(({handle} {{ {cs_ctor}state, out: fillRange }}, fillRange))");
+                let _ = writeln!(o, "        Ok(({handle} {{ {cfg_ctor}state, out: fillRange }}, fillRange))");
             }
             OutMode::FillInternal => {
-                let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+                let _ = writeln!(o, "        Ok({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
             }
         }
         let _ = writeln!(o, "    }}\n");
@@ -3447,7 +3579,7 @@ fn emit_period_bank(
 ) {
     let _ = (registry, helpers);
     let handle = stream_type_name(func);
-    let cs_ctor = cs_ctor_fields(func);
+    let cfg_ctor = cfg_ctor_field(func);
     let state = state_type_name(func);
     let callee = plan.callee.to_uppercase();
     let callee = callee.as_str();
@@ -3457,12 +3589,6 @@ fn emit_period_bank(
     let price = plan.price_input.as_str();
     let period = plan.period_input.as_str();
     let out = plan.output.as_str();
-    let params_join = func
-        .optional_inputs
-        .iter()
-        .map(|p| p.name.clone())
-        .collect::<Vec<_>>()
-        .join(", ");
 
     // Callee opt args in the callee's signature order (from the plan; the
     // lookback binds the period slot to the MAX param — the shared anchor).
@@ -3481,18 +3607,10 @@ fn emit_period_bank(
 
     // --- structs ------------------------------------------------------------
     emit_handle_struct(o, func);
-    let mut state_fields: Vec<(String, String, String)> = func
-        .optional_inputs
-        .iter()
-        .map(|p| {
-            (
-                p.name.clone(),
-                opt_param_rust_type(&p.param_type).clone(),
-                String::new(),
-            )
-        })
-        .collect();
-    state_fields.push(("bank".into(), format!("Vec<{subty}>"), String::new()));
+    // As on the dispatch tier: the params are config (issue #276), so the bank
+    // is the whole of this tier's mutable state.
+    let state_fields: Vec<(String, String, String)> =
+        vec![("bank".into(), format!("Vec<{subty}>"), String::new())];
     let bank_note = format!(
         "One sub-{} stream per period in [{min}, {max}], advanced in lockstep.",
         callee.to_uppercase()
@@ -3505,12 +3623,12 @@ fn emit_period_bank(
     // --- step: advance ALL slots, output the clamped-period slot ------------
     emit_step_sig(o, func, true);
     let _ = writeln!(o, "        let mut cp: i32 = {period} as i32;");
-    let _ = writeln!(o, "        if cp < sp.{min} {{");
-    let _ = writeln!(o, "            cp = sp.{min};");
-    let _ = writeln!(o, "        }} else if cp > sp.{max} {{");
-    let _ = writeln!(o, "            cp = sp.{max};");
+    let _ = writeln!(o, "        if cp < cfg.{min} {{");
+    let _ = writeln!(o, "            cp = cfg.{min};");
+    let _ = writeln!(o, "        }} else if cp > cfg.{max} {{");
+    let _ = writeln!(o, "            cp = cfg.{max};");
     let _ = writeln!(o, "        }}");
-    let _ = writeln!(o, "        let slot: usize = (cp - sp.{min}) as usize;");
+    let _ = writeln!(o, "        let slot: usize = (cp - cfg.{min}) as usize;");
     let _ = writeln!(o, "        for (bankIdx, sub) in sp.bank.iter_mut().enumerate() {{");
     let _ = writeln!(o, "            let subValue = sub.update({price})?;");
     let _ = writeln!(o, "            if bankIdx == slot {{");
@@ -3555,10 +3673,10 @@ fn emit_period_bank(
     let _ = writeln!(o, "        let mut cp: i32 = {period}[historyLen - 1] as i32;");
     let _ = writeln!(o, "        if cp < {min} {{\n            cp = {min};\n        }} else if cp > {max} {{\n            cp = {max};\n        }}");
     let _ = writeln!(o, "        let lastValue_{out}: f64 = scratch[(cp - {min}) as usize];");
-    let _ = writeln!(o, "        let state = {state} {{ {params_join}, bank }};");
+    let _ = writeln!(o, "        let state = {state} {{ bank }};");
     let _ = writeln!(
         o,
-        "        Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: subStart, count: historyLen - subStart }} }}, lastValue_{out}))"
+        "        Ok(({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: subStart, count: historyLen - subStart }} }}, lastValue_{out}))"
     );
     let _ = writeln!(o, "    }}\n");
 
@@ -3605,10 +3723,10 @@ fn emit_period_bank(
     let _ = writeln!(o, "            {out}[t - lookbackTotal] = scratch[(cp - {min}) as usize];");
     let _ = writeln!(o, "            t += 1;");
     let _ = writeln!(o, "        }}");
-    let _ = writeln!(o, "        let state = {state} {{ {params_join}, bank }};");
+    let _ = writeln!(o, "        let state = {state} {{ bank }};");
     let _ = writeln!(
         o,
-        "        Ok(({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }} }}, OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }}))"
+        "        Ok(({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }} }}, OutRange {{ beg_idx: lookbackTotal, count: historyLen - lookbackTotal }}))"
     );
     let _ = writeln!(o, "    }}\n");
     let _ = writeln!(o, "}}\n");
@@ -3630,11 +3748,13 @@ fn emit_period_bank(
 /// intermediate series' "output" write lands in a `cur_<series>` scalar.
 struct RustComposedNames {
     series: String,
+    /// The names this function keeps in its config — see [`carried_path`].
+    config: HashSet<String>,
 }
 
 impl streaming::NameMap for RustComposedNames {
     fn state(&self, name: &str) -> String {
-        format!("sp.{name}")
+        carried_path(&self.config, name)
     }
     fn bar(&self, array: &str) -> String {
         array.to_string()
@@ -3783,7 +3903,7 @@ fn transform_map_step(
             Expr::ArrayAccess(name, _) if cur.contains_key(&name) => {
                 Expr::Var(cur.get(&name).expect("checked").clone())
             }
-            Expr::Var(v) if params.contains(&v) => Expr::Var(format!("sp.{v}")),
+            Expr::Var(v) if params.contains(&v) => Expr::Var(format!("cfg.{v}")),
             other => other,
         }
     };
@@ -3806,7 +3926,7 @@ fn composed_step_ctx(
         let mut c = typing.ctx.clone();
         for p in &func.optional_inputs {
             if p.param_type == ParamType::Real {
-                c.real_vars.insert(format!("sp.{}", p.name));
+                c.real_vars.insert(format!("cfg.{}", p.name));
             }
         }
         for bar in streaming::input_array_names(func) {
@@ -3902,6 +4022,7 @@ fn emit_composed_step(
         emit_extrema_rebase(o, model, 8);
         let names = RustComposedNames {
             series: cp.series.clone().expect("producer plan carries a series"),
+            config: config_field_names(func),
         };
         let transition = streaming::build_transition(model, &names)
             .unwrap_or_else(|e| panic!("streaming transition: {e}"));
@@ -3914,12 +4035,12 @@ fn emit_composed_step(
         }
         let step_settings = crate::candle_settings::detect_candle_settings(&model.steady_stmts);
         if !step_settings.is_empty() {
-            // A step's settings come from its own parameters, never a `Core`
-            // receiver it no longer has (issue #274).
+            // A step's settings come from its read-only `cfg`, never a `Core`
+            // receiver it no longer has (#274, #276).
             o.push_str(&crate::candle_settings::emit_rust_unpacking_from(
                 &step_settings,
                 8,
-                &|s| cs_binding(s),
+                &|s| format!("cfg.{}", cs_binding(s)),
             ));
         }
         o.push_str(&body);
@@ -4073,7 +4194,7 @@ fn emit_composed_open(
 ) {
     // The composed fill/scratch path hardcodes f64 Vecs (mirrors C's assert).
     let handle = stream_type_name(func);
-    let cs_ctor = cs_ctor_fields(func);
+    let cfg_ctor = cfg_ctor_field(func);
     let state = state_type_name(func);
     let sn = snake(func);
     let opt_real_params: Vec<String> = func
@@ -4262,14 +4383,10 @@ fn emit_composed_open(
             o, func, model, &model.state, typing, registry, helpers, counter, &extra,
         );
     } else {
-        // Loopless pipeline: params + extras + subs/rings only.
+        // Loopless pipeline: subs/rings only. The params and extras that used
+        // to open this literal are built into the config at the publish site
+        // (issue #276).
         let _ = writeln!(o, "        let state = {state} {{");
-        for p in &func.optional_inputs {
-            let _ = writeln!(o, "            {},", p.name);
-        }
-        for (name, _) in &func.private_extra_params {
-            let _ = writeln!(o, "            {name},");
-        }
         o.push_str(&extra);
         let _ = writeln!(o, "        }};");
     }
@@ -4303,7 +4420,7 @@ fn emit_composed_open(
                     let _ = writeln!(o, "        }}");
                 }
             }
-            let _ = writeln!(o, "        Ok({handle} {{ {cs_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
+            let _ = writeln!(o, "        Ok({handle} {{ {cfg_ctor}state, out: OutRange {{ beg_idx: *outBegIdx, count: *outNBElement }} }})");
         }
     }
     let _ = writeln!(o, "    }}\n");
@@ -4471,25 +4588,14 @@ fn emit_composed(
 
     // --- handle + state struct ---------------------------------------------
     emit_handle_struct(o, func);
-    let mut fields: Vec<(String, String, String)> = if let Some(model) = &cp.producer {
-        state_fields(func, model, &typing)
-    } else {
-        let mut f: Vec<(String, String, String)> = Vec::new();
-        for p in &func.optional_inputs {
-            f.push((
-                p.name.clone(),
-                opt_param_rust_type(&p.param_type),
-                p.name.clone(),
-            ));
-        }
-        for (name, c_type) in &func.private_extra_params {
-            f.push((
-                name.clone(),
-                extra_param_rust_type(c_type).to_string(),
-                name.clone(),
-            ));
-        }
-        f
+    // A loopless composed function has no producer model to take a field list
+    // from, and what it used to put here by hand — the optional inputs and the
+    // private extra params — are Open-time invariants that now live on the
+    // config (issue #276). So it starts empty: the subs and the lag rings
+    // below are the whole of its mutable state.
+    let mut fields: Vec<(String, String, String)> = match &cp.producer {
+        Some(model) => state_fields(func, model, &typing),
+        None => Vec::new(),
     };
     for (si, sub) in cp.subs.iter().enumerate() {
         fields.push((

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -9535,11 +9535,11 @@ fn the_transition_tier_is_step_impl_in_every_backend() {
         (
             "rust",
             &rust,
-            // No `&self`: SMA's step reads nothing from `Core`, and a step that
-            // does reads only the `cs_<setting>` parameters its handle carries
-            // (issue #274).
-            "fn SMA_step_impl(sp: &mut SMA_StreamState,",
-            &["Core::SMA_step_impl(&mut self.state,"],
+            // No `&self`: SMA's step reads nothing from `Core` (#274), and
+            // what it was opened with arrives as one read-only `&Config`
+            // ahead of the state (#276).
+            "fn SMA_step_impl(cfg: &SMA_StreamConfig, sp: &mut SMA_StreamState,",
+            &["Core::SMA_step_impl(&self.config, &mut self.state,"],
             "step_internal",
         ),
         (
@@ -13175,6 +13175,7 @@ fn a_stream_handle_carries_only_the_settings_its_step_reads() {
         assert!(func.streaming, "{name} must carry the `stream` flag");
         let rust = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
 
+        let upper = name.to_uppercase();
         let start = rust
             .find(&format!("pub struct {handle} {{"))
             .unwrap_or_else(|| panic!("{name}: no {handle} definition"));
@@ -13184,44 +13185,51 @@ fn a_stream_handle_carries_only_the_settings_its_step_reads() {
             !body.contains("core: Core,"),
             "{name}: {handle} still embeds a whole Core"
         );
+        // #276 moved the settings one level in, from the handle to its config.
+        // The handle names neither `CandleSetting` nor any `optIn*` now.
         assert_eq!(
             body.matches(": CandleSetting,").count(),
+            0,
+            "{name}: {handle} holds settings directly instead of in its config\n{body}"
+        );
+
+        let cstart = rust
+            .find(&format!("struct {upper}_StreamConfig {{"))
+            .unwrap_or_else(|| panic!("{name}: no {upper}_StreamConfig definition"));
+        let cbody = &rust[cstart..cstart + rust[cstart..].find("\n}").expect("struct end")];
+        assert_eq!(
+            cbody.matches(": CandleSetting,").count(),
             settings.len(),
-            "{name}: {handle} carries the wrong number of settings\n{body}"
+            "{name}: {upper}_StreamConfig carries the wrong number of settings\n{cbody}"
         );
         for field in settings {
             assert!(
-                body.contains(&format!("{field}: CandleSetting,")),
-                "{name}: {handle} is missing {field}"
+                cbody.contains(&format!("{field}: CandleSetting,")),
+                "{name}: {upper}_StreamConfig is missing {field}"
             );
         }
 
-        // The step takes them as parameters — it has no receiver to read them
-        // through — and the call site hands over the handle's own fields.
-        let params: String = settings
-            .iter()
-            .map(|f| format!(", {f}: &CandleSetting"))
-            .collect();
-        let args: String = settings.iter().map(|f| format!("&self.{f}, ")).collect();
-        let upper = name.to_uppercase();
+        // The step takes them through its read-only config — it has no
+        // receiver to read them through — and the call site hands over the
+        // handle's own field.
         assert!(
             rust.contains(&format!(
-                "fn {upper}_step_impl(sp: &mut {upper}_StreamState{params},"
+                "fn {upper}_step_impl(cfg: &{upper}_StreamConfig, sp: &mut {upper}_StreamState,"
             )),
-            "{name}: step signature does not take exactly its settings"
+            "{name}: step signature does not take its config by reference"
         );
         assert!(
             rust.contains(&format!(
-                "Core::{upper}_step_impl(&mut self.state, {args}"
+                "Core::{upper}_step_impl(&self.config, &mut self.state, "
             )),
-            "{name}: `update` does not hand the step its settings"
+            "{name}: `update` does not hand the step its config"
         );
     }
 }
 
-/// A step unpacks its candle settings from its own parameters; only the batch
-/// and `Open` tiers, which run on a `Core` receiver, read `self.candle_settings`
-/// (issue #274).
+/// A step unpacks its candle settings from its own read-only config; only the
+/// batch and `Open` tiers, which run on a `Core` receiver, read
+/// `self.candle_settings` (#274, moved into the config by #276).
 #[test]
 fn a_stream_step_reads_candle_settings_from_its_parameters() {
     let registry = make_registry();
@@ -13235,8 +13243,8 @@ fn a_stream_step_reads_candle_settings_from_its_parameters() {
     let step_body = &rust[step..step + rust[step..].find("\n    }").expect("step end")];
 
     assert!(
-        step_body.contains("let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;"),
-        "the step must unpack from its parameter\n{step_body}"
+        step_body.contains("let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;"),
+        "the step must unpack from its config\n{step_body}"
     );
     assert!(
         !step_body.contains("self.candle_settings"),
@@ -13248,4 +13256,142 @@ fn a_stream_step_reads_candle_settings_from_its_parameters() {
         rust.contains("let BodyDoji_rangeType: i32 = self.candle_settings.body_doji.range_type as i32;"),
         "the batch tier must still read the Core it runs on"
     );
+}
+
+/// A stream handle splits into `config` (what `Open` fixed) and `state` (what a
+/// bar writes), and the step takes the first by reference (issue #276).
+///
+/// Four rows, each a control on the others:
+///
+/// * `SMA` — one `optIn*` and no setting. Its param must be ON the config and
+///   OFF the state; asserting only the first half would pass on a generator
+///   that copied the param into both, which is the shape this change exists to
+///   remove.
+/// * `BBANDS` — four config fields AND a `peek` scratch. Pins the second half
+///   of the change: the scratch is a bare `<F>_StreamState`, the step is called
+///   on it directly with the live handle's `&config`, and neither the second
+///   `is_finite` nor the `out.count` bookkeeping that `update` would have run
+///   survives in `peek`.
+/// * `CDLCOUNTERATTACK` — settings and no param, so the config is what #274
+///   put on the handle, one level in.
+/// * `TRANGE` — neither. It must emit NO config struct, NO config field and NO
+///   `cfg` parameter. This is the row that fails a generator which emits the
+///   struct unconditionally, and it is why the 38 functions in its position are
+///   byte-identical across this change and can serve as the benchmark control.
+#[test]
+fn a_stream_handle_splits_into_open_time_config_and_per_bar_state() {
+    let registry = make_registry();
+    let helpers = HelperRegistry::empty();
+
+    // (indicator, config fields in order, has a peek scratch)
+    let cases: [(&str, &[&str], bool); 4] = [
+        ("sma", &["optInTimePeriod: i32,"], false),
+        (
+            "bbands",
+            &[
+                "optInTimePeriod: i32,",
+                "optInNbDevUp: f64,",
+                "optInNbDevDn: f64,",
+                "optInMAType: MAType,",
+            ],
+            true,
+        ),
+        (
+            "cdlcounterattack",
+            &["cs_body_long: CandleSetting,", "cs_equal: CandleSetting,"],
+            false,
+        ),
+        ("trange", &[], false),
+    ];
+
+    for (name, fields, has_scratch) in cases {
+        let (func, enums) = load_indicator(name);
+        assert!(func.streaming, "{name} must carry the `stream` flag");
+        let rust = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+        let up = name.to_uppercase();
+
+        let state_body = {
+            let at = rust
+                .find(&format!("struct {up}_StreamState {{"))
+                .unwrap_or_else(|| panic!("{name}: no {up}_StreamState"));
+            &rust[at..at + rust[at..].find("\n}").expect("struct end")]
+        };
+
+        if fields.is_empty() {
+            // The control row: nothing to carry, so nothing is emitted.
+            assert!(
+                !rust.contains(&format!("struct {up}_StreamConfig")),
+                "{name} has no Open-time invariant and must emit no config struct"
+            );
+            assert!(
+                !rust.contains("config:"),
+                "{name} must carry no config field"
+            );
+            assert!(
+                rust.contains(&format!("fn {up}_step_impl(sp: &mut {up}_StreamState")),
+                "{name}'s step must take no config parameter"
+            );
+            continue;
+        }
+
+        let cfg_body = {
+            let at = rust
+                .find(&format!("struct {up}_StreamConfig {{"))
+                .unwrap_or_else(|| panic!("{name}: no {up}_StreamConfig"));
+            &rust[at..at + rust[at..].find("\n}").expect("struct end")]
+        };
+        for f in fields {
+            assert!(cfg_body.contains(f), "{name}: config is missing `{f}`\n{cfg_body}");
+            // The half that makes it a MOVE rather than a copy.
+            let bare = f.split(':').next().expect("field name");
+            assert!(
+                !state_body.contains(bare),
+                "{name}: `{bare}` is on the state as well as the config\n{state_body}"
+            );
+        }
+        assert!(
+            rust.contains(&format!(
+                "fn {up}_step_impl(cfg: &{up}_StreamConfig, sp: &mut {up}_StreamState"
+            )),
+            "{name}: the step must take its config first, by reference"
+        );
+        assert!(
+            rust.contains(&format!("    config: {up}_StreamConfig,")),
+            "{name}: the handle must carry the config beside the state"
+        );
+
+        if has_scratch {
+            assert!(
+                rust.contains(&format!(
+                    "static {up}_PEEK_SCRATCH: std::cell::Cell<Option<Box<{up}_StreamState>>>"
+                )),
+                "{name}: the reused scratch holds a bare state, not a whole handle"
+            );
+            let peek = {
+                let at = rust
+                    .find("    pub fn peek(&self")
+                    .unwrap_or_else(|| panic!("{name}: no peek"));
+                &rust[at..at + rust[at..].find("\n    }").expect("peek end")]
+            };
+            assert!(
+                peek.contains(&format!("Core::{up}_step_impl(&self.config, &mut scratch,")),
+                "{name}: peek runs the step on the scratch with the LIVE handle's config\n{peek}"
+            );
+            // What that buys, stated as the two things `update` does that
+            // `peek` no longer repeats.
+            assert!(
+                !peek.contains("scratch.update("),
+                "{name}: peek must not re-enter `update`, which re-checks the bar\n{peek}"
+            );
+            assert!(
+                !peek.contains("out.count"),
+                "{name}: peek commits nothing, so it does no range bookkeeping\n{peek}"
+            );
+            assert_eq!(
+                peek.matches("is_finite").count(),
+                1,
+                "{name}: the bar is checked once, not twice\n{peek}"
+            );
+        }
+    }
 }

--- a/ta_codegen/generator/tests/rust_stream_suite.rs
+++ b/ta_codegen/generator/tests/rust_stream_suite.rs
@@ -73,9 +73,20 @@ fn test_rust_sma_ring_stream_section() {
     assert!(s.contains("pub struct SMA_Stream {"));
     // No `Core` on the handle: SMA's step reads no candle setting, so it
     // carries none (#274). `backend_suite`'s handle gate owns that claim
-    // across the tiers that do read one.
+    // across the tiers that do read one. What it was opened with is the
+    // config beside the state (#276).
     assert!(!s.contains("core: Core,"));
+    assert!(s.contains("config: SMA_StreamConfig,"));
     assert!(s.contains("state: SMA_StreamState,"));
+    assert!(s.contains("struct SMA_StreamConfig {"));
+    // The param is an Open-time invariant, so it is on the config and NOT on
+    // the state — the split is what #276 buys, and asserting only the first
+    // half would pass on a state that kept its own copy.
+    assert!(s.contains("optInTimePeriod: i32,"));
+    assert!(
+        !body_of(&s, "struct SMA_StreamState {").contains("optInTimePeriod"),
+        "the param must not be duplicated onto the state"
+    );
     assert!(s.contains("struct SMA_StreamState {"));
     assert!(s.contains("ring_trailingIdx_inReal: Vec<f64>,"));
     assert!(s.contains("ringPos_trailingIdx: usize,"));
@@ -84,9 +95,14 @@ fn test_rust_sma_ring_stream_section() {
     assert!(!s.contains("peekMode"), "no peekMode in the Rust tier");
     assert!(!s.contains("unsafe"), "stream sections are safe Rust");
     // Step: ring read-old-then-push order, `(*outReal)` write.
-    assert!(s.contains("fn SMA_step_impl(sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64)"));
-    // `tempReal` is step-local scratch, not a handle field (#252).
-    assert!(s.contains("(*outReal) = tempReal / (sp.optInTimePeriod as f64);"));
+    assert!(s.contains(
+        "fn SMA_step_impl(cfg: &SMA_StreamConfig, sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64)"
+    ));
+    // `tempReal` is step-local scratch, not a handle field (#252). The param
+    // reads through `cfg` and still carries its `as f64` — the name-keyed
+    // typing helpers have to recognize the new prefix, or the cast silently
+    // goes missing (#276).
+    assert!(s.contains("(*outReal) = tempReal / (cfg.optInTimePeriod as f64);"));
     assert!(!s.contains("tempReal: f64,"), "no scratch field on the state struct");
     assert!(s.contains("sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;"));
     // Open family: internal seam + thin wrapper + fill in batch param order.
@@ -428,7 +444,9 @@ fn rust_dispatch_open_modes_differ_only_where_intended() {
     assert!(!scalar.contains("outBegIdx"), "the scalar open has no out-meta:\n{scalar}");
     assert!(!fill.contains("outBegIdx"), "the public fill carries no out-meta pair:\n{fill}");
     assert!(
-        fill.contains("Ok((MA_Stream { state, out: fillRange }, fillRange))"),
+        fill.contains(
+            "Ok((MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: fillRange }, fillRange))"
+        ),
         "the public fill returns the arm's own range beside the handle, and keeps it \
          on the handle too (#241):\n{fill}"
     );

--- a/ta_codegen/output/rust/library/src/ta_func/ac.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ac.rs
@@ -444,6 +444,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What AC was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&AC_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct AC_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInSignalPeriod: i32,
+}
+
 /// Live AC stream: one value per closed bar, bit-identical to [`Core::AC`]
 /// over the same series. Open with [`Core::AC_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -453,6 +464,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AC_Stream")]
 pub struct AC_Stream {
+    /// What this stream was opened with — see `AC_StreamConfig`.
+    config: AC_StreamConfig,
     state: AC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -463,6 +476,7 @@ impl AC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -471,9 +485,6 @@ impl AC_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct AC_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInSignalPeriod: i32,
     sumFast: f64,
     sumSlow: f64,
     sumSignal: f64,
@@ -494,9 +505,6 @@ impl AC_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInSignalPeriod = src.optInSignalPeriod;
         self.sumFast = src.sumFast;
         self.sumSlow = src.sumSlow;
         self.sumSignal = src.sumSignal;
@@ -520,7 +528,7 @@ impl AC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AC_step_impl(sp: &mut AC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AC_step_impl(cfg: &AC_StreamConfig, sp: &mut AC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         let mut osc: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -535,7 +543,7 @@ impl Core {
         sp.sumSlow += medianPrice;
         // Snapshot the oscillator before either total drops its trailing bar,
         // mirroring the add-new / snapshot / subtract-old order of TA_SMA.
-        osc = sp.sumFast / (sp.optInFastPeriod as f64) - sp.sumSlow / (sp.optInSlowPeriod as f64);
+        osc = sp.sumFast / (cfg.optInFastPeriod as f64) - sp.sumSlow / (cfg.optInSlowPeriod as f64);
         sp.sumFast -= sp.ring_trailingFastIdx_derived[sp.ringPos_trailingFastIdx];
         sp.sumSlow -= sp.ring_trailingSlowIdx_derived[sp.ringPos_trailingSlowIdx];
         // Today's oscillator enters the signal window at its own slot, and the
@@ -544,7 +552,7 @@ impl Core {
         // overwrite the newest value rather than the oldest one.
         sp.cb_oscBuffer[sp.oscBuffer_Idx] = osc;
         sp.sumSignal += osc;
-        tempReal = osc - sp.sumSignal / (sp.optInSignalPeriod as f64);
+        tempReal = osc - sp.sumSignal / (cfg.optInSignalPeriod as f64);
         sp.oscBuffer_Idx = sp.oscBuffer_Idx + 1;
         if sp.oscBuffer_Idx > sp.maxIdx_oscBuffer {
             sp.oscBuffer_Idx = 0;
@@ -785,9 +793,6 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let state = AC_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInSignalPeriod,
             sumFast,
             sumSlow,
             sumSignal,
@@ -802,7 +807,7 @@ impl Core {
             cbSize_oscBuffer: cbSize_oscBuffer,
             cb_oscBuffer: oscBuffer,
         };
-        Ok(AC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AC_Stream { config: AC_StreamConfig { optInFastPeriod, optInSlowPeriod, optInSignalPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AC_Open`] (composition seam).
@@ -892,10 +897,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `AC_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `AC_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static AC_PEEK_SCRATCH: std::cell::Cell<Option<Box<AC_Stream>>> =
+    static AC_PEEK_SCRATCH: std::cell::Cell<Option<Box<AC_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -919,7 +924,7 @@ impl AC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::AC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AC_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -952,7 +957,7 @@ impl AC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::AC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AC_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -976,11 +981,12 @@ impl AC_Stream {
             return Err(RetCode::BadParam);
         }
         AC_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::AC_step_impl(&self.config, &mut scratch, inHigh, inLow, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/accbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/accbands.rs
@@ -382,6 +382,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ACCBANDS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ACCBANDS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ACCBANDS_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ACCBANDS stream: one value per closed bar, bit-identical to [`Core::ACCBANDS`]
 /// over the same series. Open with [`Core::ACCBANDS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -391,6 +400,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ACCBANDS_Stream")]
 pub struct ACCBANDS_Stream {
+    /// What this stream was opened with — see `ACCBANDS_StreamConfig`.
+    config: ACCBANDS_StreamConfig,
     state: ACCBANDS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -401,6 +412,7 @@ impl ACCBANDS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ACCBANDS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -409,7 +421,6 @@ impl ACCBANDS_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ACCBANDS_StreamState {
-    optInTimePeriod: i32,
     periodTotalUpper: f64,
     periodTotalMiddle: f64,
     periodTotalLower: f64,
@@ -425,7 +436,6 @@ impl ACCBANDS_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.periodTotalUpper = src.periodTotalUpper;
         self.periodTotalMiddle = src.periodTotalMiddle;
         self.periodTotalLower = src.periodTotalLower;
@@ -444,7 +454,7 @@ impl ACCBANDS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ACCBANDS_step_impl(sp: &mut ACCBANDS_StreamState, inHigh: f64, inLow: f64, inClose: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) {
+    fn ACCBANDS_step_impl(cfg: &ACCBANDS_StreamConfig, sp: &mut ACCBANDS_StreamState, inHigh: f64, inLow: f64, inClose: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) {
         let mut tempUpper: f64 = 0.0_f64;
         let mut tempMiddle: f64 = 0.0_f64;
         let mut tempLower: f64 = 0.0_f64;
@@ -481,9 +491,9 @@ impl Core {
         }
         sp.periodTotalMiddle -= sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx];
         // Write the three bands.
-        (*outRealUpperBand) = tempUpper / (sp.optInTimePeriod as f64);
-        (*outRealMiddleBand) = tempMiddle / (sp.optInTimePeriod as f64);
-        (*outRealLowerBand) = tempLower / (sp.optInTimePeriod as f64);
+        (*outRealUpperBand) = tempUpper / (cfg.optInTimePeriod as f64);
+        (*outRealMiddleBand) = tempMiddle / (cfg.optInTimePeriod as f64);
+        (*outRealLowerBand) = tempLower / (cfg.optInTimePeriod as f64);
         sp.ring_trailingIdx_inHigh[sp.ringPos_trailingIdx] = inHigh;
         sp.ring_trailingIdx_inLow[sp.ringPos_trailingIdx] = inLow;
         sp.ring_trailingIdx_inClose[sp.ringPos_trailingIdx] = inClose;
@@ -644,7 +654,6 @@ impl Core {
         ring_trailingIdx_inClose[..cap_trailingIdx as usize]
             .copy_from_slice(&inClose[historyLen - cap_trailingIdx as usize..]);
         let state = ACCBANDS_StreamState {
-            optInTimePeriod,
             periodTotalUpper,
             periodTotalMiddle,
             periodTotalLower,
@@ -654,7 +663,7 @@ impl Core {
             ring_trailingIdx_inLow,
             ring_trailingIdx_inClose,
         };
-        Ok(ACCBANDS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ACCBANDS_Stream { config: ACCBANDS_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ACCBANDS_Open`] (composition seam).
@@ -766,10 +775,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `ACCBANDS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `ACCBANDS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static ACCBANDS_PEEK_SCRATCH: std::cell::Cell<Option<Box<ACCBANDS_Stream>>> =
+    static ACCBANDS_PEEK_SCRATCH: std::cell::Cell<Option<Box<ACCBANDS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -795,7 +804,7 @@ impl ACCBANDS_Stream {
         let mut outRealUpperBand: f64 = 0.0_f64;
         let mut outRealMiddleBand: f64 = 0.0_f64;
         let mut outRealLowerBand: f64 = 0.0_f64;
-        Core::ACCBANDS_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
+        Core::ACCBANDS_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -828,7 +837,7 @@ impl ACCBANDS_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ACCBANDS_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i]);
+            Core::ACCBANDS_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -852,11 +861,14 @@ impl ACCBANDS_Stream {
             return Err(RetCode::BadParam);
         }
         ACCBANDS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outRealUpperBand: f64 = 0.0_f64;
+            let mut outRealMiddleBand: f64 = 0.0_f64;
+            let mut outRealLowerBand: f64 = 0.0_f64;
+            Core::ACCBANDS_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
             cell.set(Some(scratch));
-            value
+            Ok((outRealUpperBand, outRealMiddleBand, outRealLowerBand))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/adosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adosc.rs
@@ -433,6 +433,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ADOSC was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ADOSC_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ADOSC_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+}
+
 /// Live ADOSC stream: one value per closed bar, bit-identical to [`Core::ADOSC`]
 /// over the same series. Open with [`Core::ADOSC_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -442,6 +452,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADOSC_Stream")]
 pub struct ADOSC_Stream {
+    /// What this stream was opened with — see `ADOSC_StreamConfig`.
+    config: ADOSC_StreamConfig,
     state: ADOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -452,6 +464,7 @@ impl ADOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -460,8 +473,6 @@ impl ADOSC_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ADOSC_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
     slowEMA: f64,
     slowk: f64,
     one_minus_slowk: f64,
@@ -476,8 +487,6 @@ impl ADOSC_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
         self.slowEMA = src.slowEMA;
         self.slowk = src.slowk;
         self.one_minus_slowk = src.one_minus_slowk;
@@ -495,7 +504,7 @@ impl ADOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADOSC_step_impl(sp: &mut ADOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn ADOSC_step_impl(cfg: &ADOSC_StreamConfig, sp: &mut ADOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut high: f64 = 0.0_f64;
         let mut low: f64 = 0.0_f64;
         let mut close: f64 = 0.0_f64;
@@ -659,8 +668,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = ADOSC_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
             slowEMA,
             slowk,
             one_minus_slowk,
@@ -669,7 +676,7 @@ impl Core {
             one_minus_fastk,
             ad,
         };
-        Ok(ADOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADOSC_Stream { config: ADOSC_StreamConfig { optInFastPeriod, optInSlowPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADOSC_Open`] (composition seam).
@@ -784,7 +791,7 @@ impl ADOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ADOSC_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::ADOSC_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -817,7 +824,7 @@ impl ADOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ADOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::ADOSC_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/adx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adx.rs
@@ -613,6 +613,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ADX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ADX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ADX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ADX stream: one value per closed bar, bit-identical to [`Core::ADX`]
 /// over the same series. Open with [`Core::ADX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -622,6 +631,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADX_Stream")]
 pub struct ADX_Stream {
+    /// What this stream was opened with — see `ADX_StreamConfig`.
+    config: ADX_StreamConfig,
     state: ADX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -632,6 +643,7 @@ impl ADX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -640,7 +652,6 @@ impl ADX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ADX_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevClose: f64,
@@ -655,7 +666,6 @@ impl ADX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevClose = src.prevClose;
@@ -673,7 +683,7 @@ impl ADX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADX_step_impl(sp: &mut ADX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ADX_step_impl(cfg: &ADX_StreamConfig, sp: &mut ADX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut diffP: f64 = 0.0_f64;
         let mut diffM: f64 = 0.0_f64;
@@ -688,8 +698,8 @@ impl Core {
         diffM = sp.prevLow - tempReal;
         // Minus Delta
         sp.prevLow = tempReal;
-        sp.prevMinusDM -= sp.prevMinusDM / ((sp.optInTimePeriod) as f64);
-        sp.prevPlusDM -= sp.prevPlusDM / ((sp.optInTimePeriod) as f64);
+        sp.prevMinusDM -= sp.prevMinusDM / ((cfg.optInTimePeriod) as f64);
+        sp.prevPlusDM -= sp.prevPlusDM / ((cfg.optInTimePeriod) as f64);
         if diffM > 0_f64 && diffP < diffM {
             // Case 2 and 4: +DM=0,-DM=diffM
             sp.prevMinusDM += diffM;
@@ -710,7 +720,7 @@ impl Core {
         }
         _true_range_0 = range_0;
         tempReal = _true_range_0;
-        sp.prevTR = sp.prevTR - sp.prevTR / ((sp.optInTimePeriod) as f64) + tempReal;
+        sp.prevTR = sp.prevTR - sp.prevTR / ((cfg.optInTimePeriod) as f64) + tempReal;
         sp.prevClose = inClose;
         if sp.prevTR > 0.0 {
             // Calculate the DX. The value is rounded (see Wilder book).
@@ -720,7 +730,7 @@ impl Core {
             if !((tempReal).abs() < 1e-14) {
                 tempReal = (100.0 * ((minusDI - plusDI).abs() / tempReal));
                 // Calculate the ADX
-                sp.prevADX = ((sp.prevADX * (((sp.optInTimePeriod - 1)) as f64) + tempReal) / ((sp.optInTimePeriod) as f64));
+                sp.prevADX = ((sp.prevADX * (((cfg.optInTimePeriod - 1)) as f64) + tempReal) / ((cfg.optInTimePeriod) as f64));
             }
         }
         // Output the ADX
@@ -1109,7 +1119,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = ADX_StreamState {
-            optInTimePeriod,
             prevHigh,
             prevLow,
             prevClose,
@@ -1118,7 +1127,7 @@ impl Core {
             prevTR,
             prevADX,
         };
-        Ok(ADX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADX_Stream { config: ADX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADX_Open`] (composition seam).
@@ -1230,7 +1239,7 @@ impl ADX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ADX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ADX_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1263,7 +1272,7 @@ impl ADX_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ADX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ADX_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/adxr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adxr.rs
@@ -308,6 +308,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ADXR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ADXR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ADXR_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ADXR stream: one value per closed bar, bit-identical to [`Core::ADXR`]
 /// over the same series. Open with [`Core::ADXR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -317,6 +326,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ADXR_Stream")]
 pub struct ADXR_Stream {
+    /// What this stream was opened with — see `ADXR_StreamConfig`.
+    config: ADXR_StreamConfig,
     state: ADXR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -327,6 +338,7 @@ impl ADXR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ADXR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -335,7 +347,6 @@ impl ADXR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ADXR_StreamState {
-    optInTimePeriod: i32,
     sub0: ADX_Stream,
     lagRingPos_adx: usize,
     lagRingCap_adx: usize,
@@ -347,7 +358,6 @@ impl ADXR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.sub0.restore_from(&src.sub0);
         self.lagRingPos_adx = src.lagRingPos_adx;
         self.lagRingCap_adx = src.lagRingCap_adx;
@@ -362,7 +372,7 @@ impl ADXR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ADXR_step_impl(sp: &mut ADXR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn ADXR_step_impl(cfg: &ADXR_StreamConfig, sp: &mut ADXR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_adx: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
 
@@ -472,7 +482,6 @@ impl Core {
             }
         }
         let state = ADXR_StreamState {
-            optInTimePeriod,
             sub0,
             lagRingPos_adx: 0_usize,
             lagRingCap_adx: lagCap_adx,
@@ -482,7 +491,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(ADXR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ADXR_Stream { config: ADXR_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ADXR_Open`] (composition seam).
@@ -594,7 +603,7 @@ impl ADXR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ADXR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal)?;
+        Core::ADXR_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -627,7 +636,7 @@ impl ADXR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ADXR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i])?;
+            Core::ADXR_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ao.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ao.rs
@@ -370,6 +370,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What AO was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&AO_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct AO_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+}
+
 /// Live AO stream: one value per closed bar, bit-identical to [`Core::AO`]
 /// over the same series. Open with [`Core::AO_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -379,6 +389,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AO_Stream")]
 pub struct AO_Stream {
+    /// What this stream was opened with — see `AO_StreamConfig`.
+    config: AO_StreamConfig,
     state: AO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -389,6 +401,7 @@ impl AO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -397,8 +410,6 @@ impl AO_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct AO_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
     sumFast: f64,
     sumSlow: f64,
     ringPos_trailingFastIdx: usize,
@@ -414,8 +425,6 @@ impl AO_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
         self.sumFast = src.sumFast;
         self.sumSlow = src.sumSlow;
         self.ringPos_trailingFastIdx = src.ringPos_trailingFastIdx;
@@ -434,7 +443,7 @@ impl AO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AO_step_impl(sp: &mut AO_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AO_step_impl(cfg: &AO_StreamConfig, sp: &mut AO_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut medianPrice: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingFastIdx == 0 {
@@ -448,7 +457,7 @@ impl Core {
         sp.sumSlow += medianPrice;
         // Snapshot the oscillator before either total drops its trailing bar,
         // mirroring the add-new / snapshot / subtract-old order of TA_SMA.
-        tempReal = sp.sumFast / (sp.optInFastPeriod as f64) - sp.sumSlow / (sp.optInSlowPeriod as f64);
+        tempReal = sp.sumFast / (cfg.optInFastPeriod as f64) - sp.sumSlow / (cfg.optInSlowPeriod as f64);
         // Read both trailing bars before writing the output. When startIdx is
         // clamped to the lookback the longer window's trailing index equals
         // outIdx exactly, so a store hoisted above this would read back the
@@ -630,8 +639,6 @@ impl Core {
             }
         }
         let state = AO_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
             sumFast,
             sumSlow,
             ringPos_trailingFastIdx: 0_usize,
@@ -641,7 +648,7 @@ impl Core {
             ringCap_trailingSlowIdx: cap_trailingSlowIdx as usize,
             ring_trailingSlowIdx_derived,
         };
-        Ok(AO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AO_Stream { config: AO_StreamConfig { optInFastPeriod, optInSlowPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AO_Open`] (composition seam).
@@ -731,10 +738,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `AO_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `AO_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static AO_PEEK_SCRATCH: std::cell::Cell<Option<Box<AO_Stream>>> =
+    static AO_PEEK_SCRATCH: std::cell::Cell<Option<Box<AO_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -758,7 +765,7 @@ impl AO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::AO_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AO_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -791,7 +798,7 @@ impl AO_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::AO_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AO_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -815,11 +822,12 @@ impl AO_Stream {
             return Err(RetCode::BadParam);
         }
         AO_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::AO_step_impl(&self.config, &mut scratch, inHigh, inLow, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/apo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/apo.rs
@@ -325,6 +325,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What APO was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&APO_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct APO_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInMAType: MAType,
+}
+
 /// Live APO stream: one value per closed bar, bit-identical to [`Core::APO`]
 /// over the same series. Open with [`Core::APO_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -334,6 +345,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_APO_Stream")]
 pub struct APO_Stream {
+    /// What this stream was opened with — see `APO_StreamConfig`.
+    config: APO_StreamConfig,
     state: APO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -344,6 +357,7 @@ impl APO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `APO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -352,9 +366,6 @@ impl APO_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct APO_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInMAType: MAType,
     sub0: MA_Stream,
     sub1: MA_Stream,
 }
@@ -364,9 +375,6 @@ impl APO_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInMAType = src.optInMAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
     }
@@ -379,7 +387,7 @@ impl APO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn APO_step_impl(sp: &mut APO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn APO_step_impl(cfg: &APO_StreamConfig, sp: &mut APO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
 
@@ -490,9 +498,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = APO_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInMAType,
             sub0,
             sub1,
         };
@@ -500,7 +505,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(APO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(APO_Stream { config: APO_StreamConfig { optInFastPeriod, optInSlowPeriod, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::APO_Open`] (composition seam).
@@ -586,10 +591,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `APO_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `APO_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static APO_PEEK_SCRATCH: std::cell::Cell<Option<Box<APO_Stream>>> =
+    static APO_PEEK_SCRATCH: std::cell::Cell<Option<Box<APO_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -613,7 +618,7 @@ impl APO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::APO_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::APO_step_impl(&self.config, &mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -646,7 +651,7 @@ impl APO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::APO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::APO_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -670,11 +675,13 @@ impl APO_Stream {
             return Err(RetCode::BadParam);
         }
         APO_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            let stepped = Core::APO_step_impl(&self.config, &mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -334,6 +334,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What AROON was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&AROON_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct AROON_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live AROON stream: one value per closed bar, bit-identical to [`Core::AROON`]
 /// over the same series. Open with [`Core::AROON_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -343,6 +352,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AROON_Stream")]
 pub struct AROON_Stream {
+    /// What this stream was opened with — see `AROON_StreamConfig`.
+    config: AROON_StreamConfig,
     state: AROON_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -353,6 +364,7 @@ impl AROON_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AROON_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -361,7 +373,6 @@ impl AROON_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct AROON_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     highest: f64,
     factor: f64,
@@ -380,7 +391,6 @@ impl AROON_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.factor = src.factor;
@@ -402,7 +412,7 @@ impl AROON_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AROON_step_impl(sp: &mut AROON_StreamState, inHigh: f64, inLow: f64, outAroonDown: &mut f64, outAroonUp: &mut f64) {
+    fn AROON_step_impl(cfg: &AROON_StreamConfig, sp: &mut AROON_StreamState, inHigh: f64, inLow: f64, outAroonDown: &mut f64, outAroonUp: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -450,8 +460,8 @@ impl Core {
         }
         // Note: Do not forget that input and output buffer can be the same,
         //       so writing to the output is the last thing being done here.
-        (*outAroonUp) = sp.factor * (((sp.optInTimePeriod - (sp.today - sp.highestIdx))) as f64);
-        (*outAroonDown) = sp.factor * (((sp.optInTimePeriod - (sp.today - sp.lowestIdx))) as f64);
+        (*outAroonUp) = sp.factor * (((cfg.optInTimePeriod - (sp.today - sp.highestIdx))) as f64);
+        (*outAroonDown) = sp.factor * (((cfg.optInTimePeriod - (sp.today - sp.lowestIdx))) as f64);
         sp.trailingIdx += 1;
         sp.today += 1;
     }
@@ -590,7 +600,6 @@ impl Core {
             }
         }
         let state = AROON_StreamState {
-            optInTimePeriod,
             lowest,
             highest,
             factor,
@@ -603,7 +612,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(AROON_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AROON_Stream { config: AROON_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AROON_Open`] (composition seam).
@@ -701,10 +710,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `AROON_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `AROON_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static AROON_PEEK_SCRATCH: std::cell::Cell<Option<Box<AROON_Stream>>> =
+    static AROON_PEEK_SCRATCH: std::cell::Cell<Option<Box<AROON_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -729,7 +738,7 @@ impl AROON_Stream {
         }
         let mut outAroonDown: f64 = 0.0_f64;
         let mut outAroonUp: f64 = 0.0_f64;
-        Core::AROON_step_impl(&mut self.state, inHigh, inLow, &mut outAroonDown, &mut outAroonUp);
+        Core::AROON_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outAroonDown, &mut outAroonUp);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -762,7 +771,7 @@ impl AROON_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::AROON_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outAroonDown[i], &mut outAroonUp[i]);
+            Core::AROON_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outAroonDown[i], &mut outAroonUp[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -786,11 +795,13 @@ impl AROON_Stream {
             return Err(RetCode::BadParam);
         }
         AROON_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outAroonDown: f64 = 0.0_f64;
+            let mut outAroonUp: f64 = 0.0_f64;
+            Core::AROON_step_impl(&self.config, &mut scratch, inHigh, inLow, &mut outAroonDown, &mut outAroonUp);
             cell.set(Some(scratch));
-            value
+            Ok((outAroonDown, outAroonUp))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
@@ -337,6 +337,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What AROONOSC was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&AROONOSC_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct AROONOSC_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live AROONOSC stream: one value per closed bar, bit-identical to [`Core::AROONOSC`]
 /// over the same series. Open with [`Core::AROONOSC_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -346,6 +355,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AROONOSC_Stream")]
 pub struct AROONOSC_Stream {
+    /// What this stream was opened with — see `AROONOSC_StreamConfig`.
+    config: AROONOSC_StreamConfig,
     state: AROONOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -356,6 +367,7 @@ impl AROONOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AROONOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -364,7 +376,6 @@ impl AROONOSC_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct AROONOSC_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     highest: f64,
     factor: f64,
@@ -383,7 +394,6 @@ impl AROONOSC_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.factor = src.factor;
@@ -405,7 +415,7 @@ impl AROONOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AROONOSC_step_impl(sp: &mut AROONOSC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn AROONOSC_step_impl(cfg: &AROONOSC_StreamConfig, sp: &mut AROONOSC_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         let mut aroon: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -614,7 +624,6 @@ impl Core {
             }
         }
         let state = AROONOSC_StreamState {
-            optInTimePeriod,
             lowest,
             highest,
             factor,
@@ -627,7 +636,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(AROONOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AROONOSC_Stream { config: AROONOSC_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AROONOSC_Open`] (composition seam).
@@ -717,10 +726,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `AROONOSC_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `AROONOSC_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static AROONOSC_PEEK_SCRATCH: std::cell::Cell<Option<Box<AROONOSC_Stream>>> =
+    static AROONOSC_PEEK_SCRATCH: std::cell::Cell<Option<Box<AROONOSC_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -744,7 +753,7 @@ impl AROONOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::AROONOSC_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::AROONOSC_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -777,7 +786,7 @@ impl AROONOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::AROONOSC_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::AROONOSC_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -801,11 +810,12 @@ impl AROONOSC_Stream {
             return Err(RetCode::BadParam);
         }
         AROONOSC_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::AROONOSC_step_impl(&self.config, &mut scratch, inHigh, inLow, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/atr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atr.rs
@@ -390,6 +390,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ATR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ATR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ATR_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ATR stream: one value per closed bar, bit-identical to [`Core::ATR`]
 /// over the same series. Open with [`Core::ATR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -399,6 +408,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ATR_Stream")]
 pub struct ATR_Stream {
+    /// What this stream was opened with — see `ATR_StreamConfig`.
+    config: ATR_StreamConfig,
     state: ATR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -409,6 +420,7 @@ impl ATR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ATR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -417,7 +429,6 @@ impl ATR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ATR_StreamState {
-    optInTimePeriod: i32,
     prevATR: f64,
     lag1_inClose: f64,
 }
@@ -427,7 +438,6 @@ impl ATR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevATR = src.prevATR;
         self.lag1_inClose = src.lag1_inClose;
     }
@@ -440,7 +450,7 @@ impl ATR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ATR_step_impl(sp: &mut ATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ATR_step_impl(cfg: &ATR_StreamConfig, sp: &mut ATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut val2: f64 = 0.0_f64;
         let mut val3: f64 = 0.0_f64;
         let mut greatest: f64 = 0.0_f64;
@@ -461,9 +471,9 @@ impl Core {
         if val3 > greatest {
             greatest = val3;
         }
-        sp.prevATR *= ((sp.optInTimePeriod - 1) as f64);
+        sp.prevATR *= ((cfg.optInTimePeriod - 1) as f64);
         sp.prevATR += greatest;
-        sp.prevATR /= ((sp.optInTimePeriod) as f64);
+        sp.prevATR /= ((cfg.optInTimePeriod) as f64);
         (*outReal) = sp.prevATR;
         sp.lag1_inClose = inClose;
     }
@@ -636,11 +646,10 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = ATR_StreamState {
-            optInTimePeriod,
             prevATR,
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(ATR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ATR_Stream { config: ATR_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ATR_Open`] (composition seam).
@@ -752,7 +761,7 @@ impl ATR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ATR_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -785,7 +794,7 @@ impl ATR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ATR_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
@@ -259,6 +259,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What AVGDEV was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&AVGDEV_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct AVGDEV_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live AVGDEV stream: one value per closed bar, bit-identical to [`Core::AVGDEV`]
 /// over the same series. Open with [`Core::AVGDEV_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -268,6 +277,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_AVGDEV_Stream")]
 pub struct AVGDEV_Stream {
+    /// What this stream was opened with — see `AVGDEV_StreamConfig`.
+    config: AVGDEV_StreamConfig,
     state: AVGDEV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -278,6 +289,7 @@ impl AVGDEV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `AVGDEV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -286,7 +298,6 @@ impl AVGDEV_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct AVGDEV_StreamState {
-    optInTimePeriod: i32,
     winPos_i: usize,
     winCap_i: usize,
     win_i_inReal: Vec<f64>,
@@ -297,7 +308,6 @@ impl AVGDEV_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.winPos_i = src.winPos_i;
         self.winCap_i = src.winCap_i;
         self.win_i_inReal.clone_from(&src.win_i_inReal);
@@ -311,26 +321,26 @@ impl AVGDEV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn AVGDEV_step_impl(sp: &mut AVGDEV_StreamState, inReal: f64, outReal: &mut f64) {
+    fn AVGDEV_step_impl(cfg: &AVGDEV_StreamConfig, sp: &mut AVGDEV_StreamState, inReal: f64, outReal: &mut f64) {
         let mut todaySum: f64 = 0.0_f64;
         let mut todayDev: f64 = 0.0_f64;
         let mut i: usize = 0_usize;
         sp.win_i_inReal[sp.winPos_i] = inReal;
         todaySum = 0.0;
-        // for( i = 0; i < ((sp.optInTimePeriod) as usize); i += 1 )
+        // for( i = 0; i < ((cfg.optInTimePeriod) as usize); i += 1 )
         i = 0;
-        while i < ((sp.optInTimePeriod) as usize) {
+        while i < ((cfg.optInTimePeriod) as usize) {
             todaySum += sp.win_i_inReal[((if sp.winPos_i + sp.winCap_i - i >= sp.winCap_i { sp.winPos_i + sp.winCap_i - i - sp.winCap_i } else { sp.winPos_i + sp.winCap_i - i })) as usize];
             i += 1;
         }
         todayDev = 0.0;
-        // for( i = 0; i < ((sp.optInTimePeriod) as usize); i += 1 )
+        // for( i = 0; i < ((cfg.optInTimePeriod) as usize); i += 1 )
         i = 0;
-        while i < ((sp.optInTimePeriod) as usize) {
-            todayDev += (sp.win_i_inReal[((if sp.winPos_i + sp.winCap_i - i >= sp.winCap_i { sp.winPos_i + sp.winCap_i - i - sp.winCap_i } else { sp.winPos_i + sp.winCap_i - i })) as usize] - todaySum / ((sp.optInTimePeriod) as f64)).abs();
+        while i < ((cfg.optInTimePeriod) as usize) {
+            todayDev += (sp.win_i_inReal[((if sp.winPos_i + sp.winCap_i - i >= sp.winCap_i { sp.winPos_i + sp.winCap_i - i - sp.winCap_i } else { sp.winPos_i + sp.winCap_i - i })) as usize] - todaySum / ((cfg.optInTimePeriod) as f64)).abs();
             i += 1;
         }
-        (*outReal) = todayDev / ((sp.optInTimePeriod) as f64);
+        (*outReal) = todayDev / ((cfg.optInTimePeriod) as f64);
         sp.winPos_i = sp.winPos_i + 1;
         if sp.winPos_i >= sp.winCap_i {
             sp.winPos_i = 0;
@@ -412,12 +422,11 @@ impl Core {
         let mut win_i_inReal: Vec<f64> = vec![0.0_f64; cap_i as usize];
         win_i_inReal.copy_from_slice(&inReal[historyLen - cap_i as usize..]);
         let state = AVGDEV_StreamState {
-            optInTimePeriod,
             winPos_i: 0_usize,
             winCap_i: cap_i as usize,
             win_i_inReal,
         };
-        Ok(AVGDEV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(AVGDEV_Stream { config: AVGDEV_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::AVGDEV_Open`] (composition seam).
@@ -522,7 +531,7 @@ impl AVGDEV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::AVGDEV_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::AVGDEV_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -555,7 +564,7 @@ impl AVGDEV_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::AVGDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::AVGDEV_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -634,6 +634,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What BBANDS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&BBANDS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct BBANDS_StreamConfig {
+    optInTimePeriod: i32,
+    optInNbDevUp: f64,
+    optInNbDevDn: f64,
+    optInMAType: MAType,
+}
+
 /// Live BBANDS stream: one value per closed bar, bit-identical to [`Core::BBANDS`]
 /// over the same series. Open with [`Core::BBANDS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -643,6 +655,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_BBANDS_Stream")]
 pub struct BBANDS_Stream {
+    /// What this stream was opened with — see `BBANDS_StreamConfig`.
+    config: BBANDS_StreamConfig,
     state: BBANDS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -653,6 +667,7 @@ impl BBANDS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `BBANDS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -661,10 +676,6 @@ impl BBANDS_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct BBANDS_StreamState {
-    optInTimePeriod: i32,
-    optInNbDevUp: f64,
-    optInNbDevDn: f64,
-    optInMAType: MAType,
     sub0: MA_Stream,
     sub1: STDDEV_Stream,
 }
@@ -674,10 +685,6 @@ impl BBANDS_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInNbDevUp = src.optInNbDevUp;
-        self.optInNbDevDn = src.optInNbDevDn;
-        self.optInMAType = src.optInMAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
     }
@@ -690,7 +697,7 @@ impl BBANDS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn BBANDS_step_impl(sp: &mut BBANDS_StreamState, inReal: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) -> Result<(), RetCode> {
+    fn BBANDS_step_impl(cfg: &BBANDS_StreamConfig, sp: &mut BBANDS_StreamState, inReal: f64, outRealUpperBand: &mut f64, outRealMiddleBand: &mut f64, outRealLowerBand: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut cur_tempBuffer1: f64 = 0.0_f64;
@@ -702,15 +709,15 @@ impl Core {
         cur_tempBuffer1 = sp.sub0.update(inReal)?;
         cur_tempBuffer2 = sp.sub1.update(inReal)?;
         // Combine map (batch tail, per bar).
-        if sp.optInNbDevUp == sp.optInNbDevDn {
-            tempReal = cur_tempBuffer2 * sp.optInNbDevUp;
+        if cfg.optInNbDevUp == cfg.optInNbDevDn {
+            tempReal = cur_tempBuffer2 * cfg.optInNbDevUp;
             tempReal2 = cur_tempBuffer1;
             cur_outRealUpperBand = tempReal2 + tempReal;
             cur_outRealLowerBand = tempReal2 - tempReal;
         } else {
             tempReal2 = cur_tempBuffer1;
-            cur_outRealUpperBand = (cur_tempBuffer2 as f64).mul_add(sp.optInNbDevUp, tempReal2);
-            cur_outRealLowerBand = tempReal2 - cur_tempBuffer2 * sp.optInNbDevDn;
+            cur_outRealUpperBand = (cur_tempBuffer2 as f64).mul_add(cfg.optInNbDevUp, tempReal2);
+            cur_outRealLowerBand = tempReal2 - cur_tempBuffer2 * cfg.optInNbDevDn;
         }
         (*outRealUpperBand) = cur_outRealUpperBand;
         (*outRealMiddleBand) = cur_tempBuffer1;
@@ -864,10 +871,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = BBANDS_StreamState {
-            optInTimePeriod,
-            optInNbDevUp,
-            optInNbDevDn,
-            optInMAType,
             sub0,
             sub1,
         };
@@ -883,7 +886,7 @@ impl Core {
             let last_sc_outRealLowerBand = sc_outRealLowerBand[*outNBElement - 1];
             outRealLowerBand[0] = last_sc_outRealLowerBand;
         }
-        Ok(BBANDS_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(BBANDS_Stream { config: BBANDS_StreamConfig { optInTimePeriod, optInNbDevUp, optInNbDevDn, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::BBANDS_Open`] (composition seam).
@@ -988,10 +991,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `BBANDS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `BBANDS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static BBANDS_PEEK_SCRATCH: std::cell::Cell<Option<Box<BBANDS_Stream>>> =
+    static BBANDS_PEEK_SCRATCH: std::cell::Cell<Option<Box<BBANDS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1017,7 +1020,7 @@ impl BBANDS_Stream {
         let mut outRealUpperBand: f64 = 0.0_f64;
         let mut outRealMiddleBand: f64 = 0.0_f64;
         let mut outRealLowerBand: f64 = 0.0_f64;
-        Core::BBANDS_step_impl(&mut self.state, inReal, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand)?;
+        Core::BBANDS_step_impl(&self.config, &mut self.state, inReal, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1050,7 +1053,7 @@ impl BBANDS_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::BBANDS_step_impl(&mut self.state, inReal[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i])?;
+            Core::BBANDS_step_impl(&self.config, &mut self.state, inReal[i], &mut outRealUpperBand[i], &mut outRealMiddleBand[i], &mut outRealLowerBand[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1074,11 +1077,15 @@ impl BBANDS_Stream {
             return Err(RetCode::BadParam);
         }
         BBANDS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outRealUpperBand: f64 = 0.0_f64;
+            let mut outRealMiddleBand: f64 = 0.0_f64;
+            let mut outRealLowerBand: f64 = 0.0_f64;
+            let stepped = Core::BBANDS_step_impl(&self.config, &mut scratch, inReal, &mut outRealUpperBand, &mut outRealMiddleBand, &mut outRealLowerBand);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok((outRealUpperBand, outRealMiddleBand, outRealLowerBand))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/beta.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/beta.rs
@@ -571,6 +571,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What BETA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&BETA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct BETA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live BETA stream: one value per closed bar, bit-identical to [`Core::BETA`]
 /// over the same series. Open with [`Core::BETA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -580,6 +589,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_BETA_Stream")]
 pub struct BETA_Stream {
+    /// What this stream was opened with — see `BETA_StreamConfig`.
+    config: BETA_StreamConfig,
     state: BETA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -590,6 +601,7 @@ impl BETA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `BETA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -598,7 +610,6 @@ impl BETA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct BETA_StreamState {
-    optInTimePeriod: i32,
     S_xx: f64,
     S_xy: f64,
     S_x: f64,
@@ -627,7 +638,6 @@ impl BETA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.S_xx = src.S_xx;
         self.S_xy = src.S_xy;
         self.S_x = src.S_x;
@@ -659,7 +669,7 @@ impl BETA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn BETA_step_impl(sp: &mut BETA_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn BETA_step_impl(cfg: &BETA_StreamConfig, sp: &mut BETA_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         let mut tmp_real: f64 = 0.0_f64;
         let mut denom: f64 = 0.0_f64;
         let mut denom_scale: f64 = 0.0_f64;
@@ -743,7 +753,7 @@ impl Core {
         // startIdx-optInTimePeriod+outIdx, which is >= outIdx.
         sp.barsSinceReseed -= 1;
         if denom < 0.000001 * denom_scale || sp.leaving_xx > 1000.0 * sp.S_xx || sp.leaving_yy > 1000.0 * sp.S_yy || sp.barsSinceReseed <= 0 {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.trailingIdx) as usize;
             // Walk the window forward from the price the trailing cursor already
             // carries. A return needs its predecessor, and reading inReal[j-1]
@@ -1227,7 +1237,6 @@ impl Core {
             }
         }
         let state = BETA_StreamState {
-            optInTimePeriod,
             S_xx,
             S_xy,
             S_x,
@@ -1250,7 +1259,7 @@ impl Core {
             x_inReal0,
             x_inReal1,
         };
-        Ok(BETA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(BETA_Stream { config: BETA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::BETA_Open`] (composition seam).
@@ -1342,10 +1351,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `BETA_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `BETA_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static BETA_PEEK_SCRATCH: std::cell::Cell<Option<Box<BETA_Stream>>> =
+    static BETA_PEEK_SCRATCH: std::cell::Cell<Option<Box<BETA_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1369,7 +1378,7 @@ impl BETA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::BETA_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::BETA_step_impl(&self.config, &mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1402,7 +1411,7 @@ impl BETA_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::BETA_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::BETA_step_impl(&self.config, &mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1426,11 +1435,12 @@ impl BETA_Stream {
             return Err(RetCode::BadParam);
         }
         BETA_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal0, inReal1);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::BETA_step_impl(&self.config, &mut scratch, inReal0, inReal1, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cci.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cci.rs
@@ -367,6 +367,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CCI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CCI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CCI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live CCI stream: one value per closed bar, bit-identical to [`Core::CCI`]
 /// over the same series. Open with [`Core::CCI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -376,6 +385,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CCI_Stream")]
 pub struct CCI_Stream {
+    /// What this stream was opened with — see `CCI_StreamConfig`.
+    config: CCI_StreamConfig,
     state: CCI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -386,6 +397,7 @@ impl CCI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CCI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -394,7 +406,6 @@ impl CCI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CCI_StreamState {
-    optInTimePeriod: i32,
     circBuffer_Idx: usize,
     maxIdx_circBuffer: usize,
     cbSize_circBuffer: usize,
@@ -406,7 +417,6 @@ impl CCI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.circBuffer_Idx = src.circBuffer_Idx;
         self.maxIdx_circBuffer = src.maxIdx_circBuffer;
         self.cbSize_circBuffer = src.cbSize_circBuffer;
@@ -421,7 +431,7 @@ impl CCI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CCI_step_impl(sp: &mut CCI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn CCI_step_impl(cfg: &CCI_StreamConfig, sp: &mut CCI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut tempReal3: f64 = 0.0_f64;
@@ -432,23 +442,23 @@ impl Core {
         sp.cb_circBuffer[sp.circBuffer_Idx] = lastValue;
         // Calculate the average for the whole period.
         theAverage = 0.0;
-        // for( j = 0; j < ((sp.optInTimePeriod) as usize); j += 1 )
+        // for( j = 0; j < ((cfg.optInTimePeriod) as usize); j += 1 )
         j = 0;
-        while j < ((sp.optInTimePeriod) as usize) {
+        while j < ((cfg.optInTimePeriod) as usize) {
             theAverage += sp.cb_circBuffer[j];
             j += 1;
         }
-        theAverage /= ((sp.optInTimePeriod) as f64);
+        theAverage /= ((cfg.optInTimePeriod) as f64);
         // Do the summation of the ABS(TypePrice-average)
         // for the whole period, then its mean.
         tempReal2 = 0.0;
-        // for( j = 0; j < ((sp.optInTimePeriod) as usize); j += 1 )
+        // for( j = 0; j < ((cfg.optInTimePeriod) as usize); j += 1 )
         j = 0;
-        while j < ((sp.optInTimePeriod) as usize) {
+        while j < ((cfg.optInTimePeriod) as usize) {
             tempReal2 += (sp.cb_circBuffer[j] - theAverage).abs();
             j += 1;
         }
-        tempReal2 /= ((sp.optInTimePeriod) as f64);
+        tempReal2 /= ((cfg.optInTimePeriod) as f64);
         // And finally, the CCI...
         tempReal = lastValue - theAverage;
         // Both tests are relative to the window's own price level (issue #253).
@@ -606,13 +616,12 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let state = CCI_StreamState {
-            optInTimePeriod,
             circBuffer_Idx,
             maxIdx_circBuffer,
             cbSize_circBuffer: cbSize_circBuffer,
             cb_circBuffer: circBuffer,
         };
-        Ok(CCI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CCI_Stream { config: CCI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CCI_Open`] (composition seam).
@@ -724,7 +733,7 @@ impl CCI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::CCI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::CCI_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -757,7 +766,7 @@ impl CCI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CCI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::CCI_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
@@ -349,6 +349,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL2CROWS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL2CROWS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL2CROWS_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+}
+
 /// Live CDL2CROWS stream: one value per closed bar, bit-identical to [`Core::CDL2CROWS`]
 /// over the same series. Open with [`Core::CDL2CROWS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -358,8 +368,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL2CROWS_Stream")]
 pub struct CDL2CROWS_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDL2CROWS_StreamConfig`.
+    config: CDL2CROWS_StreamConfig,
     state: CDL2CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -370,7 +380,7 @@ impl CDL2CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL2CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -420,13 +430,13 @@ impl CDL2CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL2CROWS_step_impl(sp: &mut CDL2CROWS_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL2CROWS_step_impl(cfg: &CDL2CROWS_StreamConfig, sp: &mut CDL2CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -676,7 +686,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDL2CROWS_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL2CROWS_Stream { config: CDL2CROWS_StreamConfig { cs_body_long: self.candle_settings.body_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL2CROWS_Open`] (composition seam).
@@ -791,7 +801,7 @@ impl CDL2CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL2CROWS_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL2CROWS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -824,7 +834,7 @@ impl CDL2CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL2CROWS_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL2CROWS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
@@ -394,6 +394,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL3BLACKCROWS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL3BLACKCROWS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL3BLACKCROWS_StreamConfig {
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDL3BLACKCROWS stream: one value per closed bar, bit-identical to [`Core::CDL3BLACKCROWS`]
 /// over the same series. Open with [`Core::CDL3BLACKCROWS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -403,8 +413,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3BLACKCROWS_Stream")]
 pub struct CDL3BLACKCROWS_Stream {
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDL3BLACKCROWS_StreamConfig`.
+    config: CDL3BLACKCROWS_StreamConfig,
     state: CDL3BLACKCROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -415,7 +425,7 @@ impl CDL3BLACKCROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3BLACKCROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -473,14 +483,14 @@ impl CDL3BLACKCROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3BLACKCROWS_step_impl(sp: &mut CDL3BLACKCROWS_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3BLACKCROWS_step_impl(cfg: &CDL3BLACKCROWS_StreamConfig, sp: &mut CDL3BLACKCROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -762,7 +772,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3BLACKCROWS_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3BLACKCROWS_Stream { config: CDL3BLACKCROWS_StreamConfig { cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3BLACKCROWS_Open`] (composition seam).
@@ -877,7 +887,7 @@ impl CDL3BLACKCROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL3BLACKCROWS_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3BLACKCROWS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -910,7 +920,7 @@ impl CDL3BLACKCROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL3BLACKCROWS_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3BLACKCROWS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
@@ -417,6 +417,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL3INSIDE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL3INSIDE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL3INSIDE_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDL3INSIDE stream: one value per closed bar, bit-identical to [`Core::CDL3INSIDE`]
 /// over the same series. Open with [`Core::CDL3INSIDE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -426,10 +438,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3INSIDE_Stream")]
 pub struct CDL3INSIDE_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDL3INSIDE_StreamConfig`.
+    config: CDL3INSIDE_StreamConfig,
     state: CDL3INSIDE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -440,8 +450,7 @@ impl CDL3INSIDE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3INSIDE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -499,19 +508,19 @@ impl CDL3INSIDE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3INSIDE_step_impl(sp: &mut CDL3INSIDE_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3INSIDE_step_impl(cfg: &CDL3INSIDE_StreamConfig, sp: &mut CDL3INSIDE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -885,7 +894,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDL3INSIDE_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3INSIDE_Stream { config: CDL3INSIDE_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3INSIDE_Open`] (composition seam).
@@ -981,10 +990,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDL3INSIDE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDL3INSIDE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDL3INSIDE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3INSIDE_Stream>>> =
+    static CDL3INSIDE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3INSIDE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1008,7 +1017,7 @@ impl CDL3INSIDE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL3INSIDE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3INSIDE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1041,7 +1050,7 @@ impl CDL3INSIDE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL3INSIDE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3INSIDE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1065,11 +1074,12 @@ impl CDL3INSIDE_Stream {
             return Err(RetCode::BadParam);
         }
         CDL3INSIDE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDL3INSIDE_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
@@ -380,6 +380,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL3LINESTRIKE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL3LINESTRIKE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL3LINESTRIKE_StreamConfig {
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+}
+
 /// Live CDL3LINESTRIKE stream: one value per closed bar, bit-identical to [`Core::CDL3LINESTRIKE`]
 /// over the same series. Open with [`Core::CDL3LINESTRIKE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -389,8 +399,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3LINESTRIKE_Stream")]
 pub struct CDL3LINESTRIKE_Stream {
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
+    /// What this stream was opened with — see `CDL3LINESTRIKE_StreamConfig`.
+    config: CDL3LINESTRIKE_StreamConfig,
     state: CDL3LINESTRIKE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -401,7 +411,7 @@ impl CDL3LINESTRIKE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3LINESTRIKE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_near = src.cs_near;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -461,14 +471,14 @@ impl CDL3LINESTRIKE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3LINESTRIKE_step_impl(sp: &mut CDL3LINESTRIKE_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3LINESTRIKE_step_impl(cfg: &CDL3LINESTRIKE_StreamConfig, sp: &mut CDL3LINESTRIKE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -723,7 +733,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDL3LINESTRIKE_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3LINESTRIKE_Stream { config: CDL3LINESTRIKE_StreamConfig { cs_near: self.candle_settings.near, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3LINESTRIKE_Open`] (composition seam).
@@ -838,7 +848,7 @@ impl CDL3LINESTRIKE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL3LINESTRIKE_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3LINESTRIKE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -871,7 +881,7 @@ impl CDL3LINESTRIKE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL3LINESTRIKE_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3LINESTRIKE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
@@ -590,6 +590,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL3STARSINSOUTH was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL3STARSINSOUTH_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL3STARSINSOUTH_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDL3STARSINSOUTH stream: one value per closed bar, bit-identical to [`Core::CDL3STARSINSOUTH`]
 /// over the same series. Open with [`Core::CDL3STARSINSOUTH_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -599,14 +615,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3STARSINSOUTH_Stream")]
 pub struct CDL3STARSINSOUTH_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDL3STARSINSOUTH_StreamConfig`.
+    config: CDL3STARSINSOUTH_StreamConfig,
     state: CDL3STARSINSOUTH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -617,10 +627,7 @@ impl CDL3STARSINSOUTH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3STARSINSOUTH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -700,32 +707,32 @@ impl CDL3STARSINSOUTH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3STARSINSOUTH_step_impl(sp: &mut CDL3STARSINSOUTH_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3STARSINSOUTH_step_impl(cfg: &CDL3STARSINSOUTH_StreamConfig, sp: &mut CDL3STARSINSOUTH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1355,7 +1362,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3STARSINSOUTH_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3STARSINSOUTH_Stream { config: CDL3STARSINSOUTH_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3STARSINSOUTH_Open`] (composition seam).
@@ -1451,10 +1458,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDL3STARSINSOUTH_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDL3STARSINSOUTH_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDL3STARSINSOUTH_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3STARSINSOUTH_Stream>>> =
+    static CDL3STARSINSOUTH_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3STARSINSOUTH_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1478,7 +1485,7 @@ impl CDL3STARSINSOUTH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL3STARSINSOUTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3STARSINSOUTH_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1511,7 +1518,7 @@ impl CDL3STARSINSOUTH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL3STARSINSOUTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3STARSINSOUTH_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1535,11 +1542,12 @@ impl CDL3STARSINSOUTH_Stream {
             return Err(RetCode::BadParam);
         }
         CDL3STARSINSOUTH_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDL3STARSINSOUTH_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
@@ -648,6 +648,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDL3WHITESOLDIERS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDL3WHITESOLDIERS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDL3WHITESOLDIERS_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Far` setting this stream was opened with.
+    cs_far: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDL3WHITESOLDIERS stream: one value per closed bar, bit-identical to [`Core::CDL3WHITESOLDIERS`]
 /// over the same series. Open with [`Core::CDL3WHITESOLDIERS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -657,14 +673,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDL3WHITESOLDIERS_Stream")]
 pub struct CDL3WHITESOLDIERS_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `Far` setting this stream was opened with.
-    cs_far: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDL3WHITESOLDIERS_StreamConfig`.
+    config: CDL3WHITESOLDIERS_StreamConfig,
     state: CDL3WHITESOLDIERS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -675,10 +685,7 @@ impl CDL3WHITESOLDIERS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDL3WHITESOLDIERS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_far = src.cs_far;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -758,32 +765,32 @@ impl CDL3WHITESOLDIERS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDL3WHITESOLDIERS_step_impl(sp: &mut CDL3WHITESOLDIERS_StreamState, cs_body_short: &CandleSetting, cs_far: &CandleSetting, cs_near: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDL3WHITESOLDIERS_step_impl(cfg: &CDL3WHITESOLDIERS_StreamConfig, sp: &mut CDL3WHITESOLDIERS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Far_rangeType: i32 = cs_far.range_type as i32;
+        let Far_rangeType: i32 = cfg.cs_far.range_type as i32;
         #[allow(non_snake_case)]
-        let Far_avgPeriod: i32 = cs_far.avg_period;
+        let Far_avgPeriod: i32 = cfg.cs_far.avg_period;
         #[allow(non_snake_case)]
-        let Far_factor: f64 = cs_far.factor;
+        let Far_factor: f64 = cfg.cs_far.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyShortTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1448,7 +1455,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDL3WHITESOLDIERS_Stream { cs_body_short: self.candle_settings.body_short, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDL3WHITESOLDIERS_Stream { config: CDL3WHITESOLDIERS_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDL3WHITESOLDIERS_Open`] (composition seam).
@@ -1544,10 +1551,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDL3WHITESOLDIERS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDL3WHITESOLDIERS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDL3WHITESOLDIERS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3WHITESOLDIERS_Stream>>> =
+    static CDL3WHITESOLDIERS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDL3WHITESOLDIERS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1571,7 +1578,7 @@ impl CDL3WHITESOLDIERS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDL3WHITESOLDIERS_step_impl(&mut self.state, &self.cs_body_short, &self.cs_far, &self.cs_near, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDL3WHITESOLDIERS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1604,7 +1611,7 @@ impl CDL3WHITESOLDIERS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDL3WHITESOLDIERS_step_impl(&mut self.state, &self.cs_body_short, &self.cs_far, &self.cs_near, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDL3WHITESOLDIERS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1628,11 +1635,12 @@ impl CDL3WHITESOLDIERS_Stream {
             return Err(RetCode::BadParam);
         }
         CDL3WHITESOLDIERS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDL3WHITESOLDIERS_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -554,6 +554,21 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLABANDONEDBABY was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLABANDONEDBABY_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLABANDONEDBABY_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLABANDONEDBABY stream: one value per closed bar, bit-identical to [`Core::CDLABANDONEDBABY`]
 /// over the same series. Open with [`Core::CDLABANDONEDBABY_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -563,12 +578,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLABANDONEDBABY_Stream")]
 pub struct CDLABANDONEDBABY_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLABANDONEDBABY_StreamConfig`.
+    config: CDLABANDONEDBABY_StreamConfig,
     state: CDLABANDONEDBABY_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -579,9 +590,7 @@ impl CDLABANDONEDBABY_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLABANDONEDBABY_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -590,7 +599,6 @@ impl CDLABANDONEDBABY_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLABANDONEDBABY_StreamState {
-    optInPenetration: f64,
     BodyDojiPeriodTotal: f64,
     BodyLongPeriodTotal: f64,
     BodyShortPeriodTotal: f64,
@@ -618,7 +626,6 @@ impl CDLABANDONEDBABY_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyDojiPeriodTotal = src.BodyDojiPeriodTotal;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.BodyShortPeriodTotal = src.BodyShortPeriodTotal;
@@ -649,25 +656,25 @@ impl CDLABANDONEDBABY_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLABANDONEDBABY_step_impl(sp: &mut CDLABANDONEDBABY_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLABANDONEDBABY_step_impl(cfg: &CDLABANDONEDBABY_StreamConfig, sp: &mut CDLABANDONEDBABY_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -725,7 +732,7 @@ impl Core {
         if (sp.lag2_inClose - sp.lag2_inOpen).abs() > ((BodyLong_factor) * (if (BodyLong_avgPeriod) != 0 { (sp.BodyLongPeriodTotal) / (BodyLong_avgPeriod as f64) } else { match BodyLong_rangeType { 0 => ((sp.lag2_inClose) - (sp.lag2_inOpen)).abs(), 1 => (sp.lag2_inHigh) - (sp.lag2_inLow), 2 => ((sp.lag2_inHigh) - (if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inClose) } else { (sp.lag2_inOpen) })) + ((if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inOpen) } else { (sp.lag2_inClose) }) - (sp.lag2_inLow)), _ => 0.0 } }) / (if (BodyLong_rangeType) == 2 { 2.0 } else { 1.0 })) && // 1st: long
            (sp.lag1_inClose - sp.lag1_inOpen).abs() <= ((BodyDoji_factor) * (if (BodyDoji_avgPeriod) != 0 { (sp.BodyDojiPeriodTotal) / (BodyDoji_avgPeriod as f64) } else { match BodyDoji_rangeType { 0 => ((sp.lag1_inClose) - (sp.lag1_inOpen)).abs(), 1 => (sp.lag1_inHigh) - (sp.lag1_inLow), 2 => ((sp.lag1_inHigh) - (if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inClose) } else { (sp.lag1_inOpen) })) + ((if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inOpen) } else { (sp.lag1_inClose) }) - (sp.lag1_inLow)), _ => 0.0 } }) / (if (BodyDoji_rangeType) == 2 { 2.0 } else { 1.0 })) && // 2nd: doji
            (inClose - inOpen).abs() > ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((inClose) - (inOpen)).abs(), 1 => (inHigh) - (inLow), 2 => ((inHigh) - (if (inClose) >= (inOpen) { (inClose) } else { (inOpen) })) + ((if (inClose) >= (inOpen) { (inOpen) } else { (inClose) }) - (inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) && // 3rd: longer than short
-           ((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == 1 && (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * sp.optInPenetration && ((if sp.lag1_inLow > sp.lag2_inHigh { 1 } else { 0 }) != 0) && ((if inHigh < sp.lag1_inLow { 1 } else { 0 }) != 0) || (((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && (if inClose >= inOpen { 1 } else { 0 - 1 }) == 1 && inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(sp.optInPenetration, sp.lag2_inClose) && ((if sp.lag1_inHigh < sp.lag2_inLow { 1 } else { 0 }) != 0) && ((if inLow > sp.lag1_inHigh { 1 } else { 0 }) != 0)) // 1st white 3rd black 3rd closes well within 1st rb upside gap between 1st and 2nd downside gap between 2nd and 3rd 1st black 3rd white 3rd closes well within 1st rb downside gap between 1st and 2nd upside gap between 2nd and 3rd
+           ((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == 1 && (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * cfg.optInPenetration && ((if sp.lag1_inLow > sp.lag2_inHigh { 1 } else { 0 }) != 0) && ((if inHigh < sp.lag1_inLow { 1 } else { 0 }) != 0) || (((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && (if inClose >= inOpen { 1 } else { 0 - 1 }) == 1 && inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(cfg.optInPenetration, sp.lag2_inClose) && ((if sp.lag1_inHigh < sp.lag2_inLow { 1 } else { 0 }) != 0) && ((if inLow > sp.lag1_inHigh { 1 } else { 0 }) != 0)) // 1st white 3rd black 3rd closes well within 1st rb upside gap between 1st and 2nd downside gap between 2nd and 3rd 1st black 3rd white 3rd closes well within 1st rb downside gap between 1st and 2nd upside gap between 2nd and 3rd
         {
             (*outInteger) = ((if inClose >= inOpen { 1 } else { 0 - 1 }) * 100) as i32;
         } else {
@@ -1161,7 +1168,6 @@ impl Core {
             }
         }
         let state = CDLABANDONEDBABY_StreamState {
-            optInPenetration,
             BodyDojiPeriodTotal,
             BodyLongPeriodTotal,
             BodyShortPeriodTotal,
@@ -1183,7 +1189,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLABANDONEDBABY_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLABANDONEDBABY_Stream { config: CDLABANDONEDBABY_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLABANDONEDBABY_Open`] (composition seam).
@@ -1279,10 +1285,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLABANDONEDBABY_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLABANDONEDBABY_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLABANDONEDBABY_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLABANDONEDBABY_Stream>>> =
+    static CDLABANDONEDBABY_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLABANDONEDBABY_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1306,7 +1312,7 @@ impl CDLABANDONEDBABY_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLABANDONEDBABY_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLABANDONEDBABY_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1339,7 +1345,7 @@ impl CDLABANDONEDBABY_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLABANDONEDBABY_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLABANDONEDBABY_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1363,11 +1369,12 @@ impl CDLABANDONEDBABY_Stream {
             return Err(RetCode::BadParam);
         }
         CDLABANDONEDBABY_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLABANDONEDBABY_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
@@ -734,15 +734,12 @@ impl Core {
 }
 /**** Streaming API *****/
 
-/// Live CDLADVANCEBLOCK stream: one value per closed bar, bit-identical to [`Core::CDLADVANCEBLOCK`]
-/// over the same series. Open with [`Core::CDLADVANCEBLOCK_Open`]; dropping the handle
-/// closes the stream. Cloning it forks an independent stream.
-///
-/// [`Self::out_range`] reports the bars it has produced a value for.
-#[must_use = "a stream does nothing unless updated; dropping it closes the stream"]
-#[derive(Debug, Clone)]
-#[doc(alias = "TA_CDLADVANCEBLOCK_Stream")]
-pub struct CDLADVANCEBLOCK_Stream {
+/// What CDLADVANCEBLOCK was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLADVANCEBLOCK_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLADVANCEBLOCK_StreamConfig {
     /// The `BodyLong` setting this stream was opened with.
     cs_body_long: CandleSetting,
     /// The `Far` setting this stream was opened with.
@@ -753,6 +750,19 @@ pub struct CDLADVANCEBLOCK_Stream {
     cs_shadow_long: CandleSetting,
     /// The `ShadowShort` setting this stream was opened with.
     cs_shadow_short: CandleSetting,
+}
+
+/// Live CDLADVANCEBLOCK stream: one value per closed bar, bit-identical to [`Core::CDLADVANCEBLOCK`]
+/// over the same series. Open with [`Core::CDLADVANCEBLOCK_Open`]; dropping the handle
+/// closes the stream. Cloning it forks an independent stream.
+///
+/// [`Self::out_range`] reports the bars it has produced a value for.
+#[must_use = "a stream does nothing unless updated; dropping it closes the stream"]
+#[derive(Debug, Clone)]
+#[doc(alias = "TA_CDLADVANCEBLOCK_Stream")]
+pub struct CDLADVANCEBLOCK_Stream {
+    /// What this stream was opened with — see `CDLADVANCEBLOCK_StreamConfig`.
+    config: CDLADVANCEBLOCK_StreamConfig,
     state: CDLADVANCEBLOCK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -763,11 +773,7 @@ impl CDLADVANCEBLOCK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLADVANCEBLOCK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_far = src.cs_far;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_short = src.cs_shadow_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -859,38 +865,38 @@ impl CDLADVANCEBLOCK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLADVANCEBLOCK_step_impl(sp: &mut CDLADVANCEBLOCK_StreamState, cs_body_long: &CandleSetting, cs_far: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLADVANCEBLOCK_step_impl(cfg: &CDLADVANCEBLOCK_StreamConfig, sp: &mut CDLADVANCEBLOCK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Far_rangeType: i32 = cs_far.range_type as i32;
+        let Far_rangeType: i32 = cfg.cs_far.range_type as i32;
         #[allow(non_snake_case)]
-        let Far_avgPeriod: i32 = cs_far.avg_period;
+        let Far_avgPeriod: i32 = cfg.cs_far.avg_period;
         #[allow(non_snake_case)]
-        let Far_factor: f64 = cs_far.factor;
+        let Far_factor: f64 = cfg.cs_far.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cfg.cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cfg.cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = cs_shadow_short.factor;
+        let ShadowShort_factor: f64 = cfg.cs_shadow_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1663,7 +1669,7 @@ impl Core {
             ringLag_ShadowShortTrailingIdx: capLag_ShadowShortTrailingIdx as usize,
             ring_ShadowShortTrailingIdx_derived,
         };
-        Ok(CDLADVANCEBLOCK_Stream { cs_body_long: self.candle_settings.body_long, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLADVANCEBLOCK_Stream { config: CDLADVANCEBLOCK_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_far: self.candle_settings.far, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_short: self.candle_settings.shadow_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLADVANCEBLOCK_Open`] (composition seam).
@@ -1759,10 +1765,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLADVANCEBLOCK_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLADVANCEBLOCK_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLADVANCEBLOCK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLADVANCEBLOCK_Stream>>> =
+    static CDLADVANCEBLOCK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLADVANCEBLOCK_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1786,7 +1792,7 @@ impl CDLADVANCEBLOCK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLADVANCEBLOCK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_far, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLADVANCEBLOCK_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1819,7 +1825,7 @@ impl CDLADVANCEBLOCK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLADVANCEBLOCK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_far, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLADVANCEBLOCK_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1843,11 +1849,12 @@ impl CDLADVANCEBLOCK_Stream {
             return Err(RetCode::BadParam);
         }
         CDLADVANCEBLOCK_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLADVANCEBLOCK_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
@@ -414,6 +414,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLBELTHOLD was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLBELTHOLD_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLBELTHOLD_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLBELTHOLD stream: one value per closed bar, bit-identical to [`Core::CDLBELTHOLD`]
 /// over the same series. Open with [`Core::CDLBELTHOLD_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -423,10 +435,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLBELTHOLD_Stream")]
 pub struct CDLBELTHOLD_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLBELTHOLD_StreamConfig`.
+    config: CDLBELTHOLD_StreamConfig,
     state: CDLBELTHOLD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -437,8 +447,7 @@ impl CDLBELTHOLD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLBELTHOLD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -480,19 +489,19 @@ impl CDLBELTHOLD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLBELTHOLD_step_impl(sp: &mut CDLBELTHOLD_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLBELTHOLD_step_impl(cfg: &CDLBELTHOLD_StreamConfig, sp: &mut CDLBELTHOLD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -840,7 +849,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLBELTHOLD_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLBELTHOLD_Stream { config: CDLBELTHOLD_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLBELTHOLD_Open`] (composition seam).
@@ -936,10 +945,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLBELTHOLD_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLBELTHOLD_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLBELTHOLD_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLBELTHOLD_Stream>>> =
+    static CDLBELTHOLD_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLBELTHOLD_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -963,7 +972,7 @@ impl CDLBELTHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLBELTHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLBELTHOLD_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -996,7 +1005,7 @@ impl CDLBELTHOLD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLBELTHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLBELTHOLD_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1020,11 +1029,12 @@ impl CDLBELTHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         CDLBELTHOLD_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLBELTHOLD_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
@@ -348,6 +348,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLBREAKAWAY was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLBREAKAWAY_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLBREAKAWAY_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+}
+
 /// Live CDLBREAKAWAY stream: one value per closed bar, bit-identical to [`Core::CDLBREAKAWAY`]
 /// over the same series. Open with [`Core::CDLBREAKAWAY_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -357,8 +367,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLBREAKAWAY_Stream")]
 pub struct CDLBREAKAWAY_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDLBREAKAWAY_StreamConfig`.
+    config: CDLBREAKAWAY_StreamConfig,
     state: CDLBREAKAWAY_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -369,7 +379,7 @@ impl CDLBREAKAWAY_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLBREAKAWAY_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -437,13 +447,13 @@ impl CDLBREAKAWAY_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLBREAKAWAY_step_impl(sp: &mut CDLBREAKAWAY_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLBREAKAWAY_step_impl(cfg: &CDLBREAKAWAY_StreamConfig, sp: &mut CDLBREAKAWAY_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -686,7 +696,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLBREAKAWAY_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLBREAKAWAY_Stream { config: CDLBREAKAWAY_StreamConfig { cs_body_long: self.candle_settings.body_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLBREAKAWAY_Open`] (composition seam).
@@ -801,7 +811,7 @@ impl CDLBREAKAWAY_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLBREAKAWAY_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLBREAKAWAY_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -834,7 +844,7 @@ impl CDLBREAKAWAY_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLBREAKAWAY_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLBREAKAWAY_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
@@ -412,6 +412,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLCLOSINGMARUBOZU was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLCLOSINGMARUBOZU_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLCLOSINGMARUBOZU_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLCLOSINGMARUBOZU stream: one value per closed bar, bit-identical to [`Core::CDLCLOSINGMARUBOZU`]
 /// over the same series. Open with [`Core::CDLCLOSINGMARUBOZU_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -421,10 +433,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCLOSINGMARUBOZU_Stream")]
 pub struct CDLCLOSINGMARUBOZU_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLCLOSINGMARUBOZU_StreamConfig`.
+    config: CDLCLOSINGMARUBOZU_StreamConfig,
     state: CDLCLOSINGMARUBOZU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -435,8 +445,7 @@ impl CDLCLOSINGMARUBOZU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCLOSINGMARUBOZU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -478,19 +487,19 @@ impl CDLCLOSINGMARUBOZU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCLOSINGMARUBOZU_step_impl(sp: &mut CDLCLOSINGMARUBOZU_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCLOSINGMARUBOZU_step_impl(cfg: &CDLCLOSINGMARUBOZU_StreamConfig, sp: &mut CDLCLOSINGMARUBOZU_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -838,7 +847,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLCLOSINGMARUBOZU_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCLOSINGMARUBOZU_Stream { config: CDLCLOSINGMARUBOZU_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCLOSINGMARUBOZU_Open`] (composition seam).
@@ -934,10 +943,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLCLOSINGMARUBOZU_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLCLOSINGMARUBOZU_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLCLOSINGMARUBOZU_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLCLOSINGMARUBOZU_Stream>>> =
+    static CDLCLOSINGMARUBOZU_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLCLOSINGMARUBOZU_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -961,7 +970,7 @@ impl CDLCLOSINGMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLCLOSINGMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCLOSINGMARUBOZU_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -994,7 +1003,7 @@ impl CDLCLOSINGMARUBOZU_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLCLOSINGMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCLOSINGMARUBOZU_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1018,11 +1027,12 @@ impl CDLCLOSINGMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         CDLCLOSINGMARUBOZU_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLCLOSINGMARUBOZU_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
@@ -397,6 +397,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLCONCEALBABYSWALL was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLCONCEALBABYSWALL_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLCONCEALBABYSWALL_StreamConfig {
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLCONCEALBABYSWALL stream: one value per closed bar, bit-identical to [`Core::CDLCONCEALBABYSWALL`]
 /// over the same series. Open with [`Core::CDLCONCEALBABYSWALL_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -406,8 +416,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCONCEALBABYSWALL_Stream")]
 pub struct CDLCONCEALBABYSWALL_Stream {
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLCONCEALBABYSWALL_StreamConfig`.
+    config: CDLCONCEALBABYSWALL_StreamConfig,
     state: CDLCONCEALBABYSWALL_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -418,7 +428,7 @@ impl CDLCONCEALBABYSWALL_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCONCEALBABYSWALL_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -478,14 +488,14 @@ impl CDLCONCEALBABYSWALL_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCONCEALBABYSWALL_step_impl(sp: &mut CDLCONCEALBABYSWALL_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCONCEALBABYSWALL_step_impl(cfg: &CDLCONCEALBABYSWALL_StreamConfig, sp: &mut CDLCONCEALBABYSWALL_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -767,7 +777,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLCONCEALBABYSWALL_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCONCEALBABYSWALL_Stream { config: CDLCONCEALBABYSWALL_StreamConfig { cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCONCEALBABYSWALL_Open`] (composition seam).
@@ -882,7 +892,7 @@ impl CDLCONCEALBABYSWALL_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLCONCEALBABYSWALL_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCONCEALBABYSWALL_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -915,7 +925,7 @@ impl CDLCONCEALBABYSWALL_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLCONCEALBABYSWALL_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCONCEALBABYSWALL_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
@@ -439,6 +439,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLCOUNTERATTACK was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLCOUNTERATTACK_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLCOUNTERATTACK_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLCOUNTERATTACK stream: one value per closed bar, bit-identical to [`Core::CDLCOUNTERATTACK`]
 /// over the same series. Open with [`Core::CDLCOUNTERATTACK_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -448,10 +460,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLCOUNTERATTACK_Stream")]
 pub struct CDLCOUNTERATTACK_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLCOUNTERATTACK_StreamConfig`.
+    config: CDLCOUNTERATTACK_StreamConfig,
     state: CDLCOUNTERATTACK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -462,8 +472,7 @@ impl CDLCOUNTERATTACK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLCOUNTERATTACK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -517,20 +526,20 @@ impl CDLCOUNTERATTACK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLCOUNTERATTACK_step_impl(sp: &mut CDLCOUNTERATTACK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLCOUNTERATTACK_step_impl(cfg: &CDLCOUNTERATTACK_StreamConfig, sp: &mut CDLCOUNTERATTACK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -877,7 +886,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLCOUNTERATTACK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLCOUNTERATTACK_Stream { config: CDLCOUNTERATTACK_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLCOUNTERATTACK_Open`] (composition seam).
@@ -973,10 +982,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLCOUNTERATTACK_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLCOUNTERATTACK_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLCOUNTERATTACK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLCOUNTERATTACK_Stream>>> =
+    static CDLCOUNTERATTACK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLCOUNTERATTACK_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1000,7 +1009,7 @@ impl CDLCOUNTERATTACK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLCOUNTERATTACK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLCOUNTERATTACK_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1033,7 +1042,7 @@ impl CDLCOUNTERATTACK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLCOUNTERATTACK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLCOUNTERATTACK_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1057,11 +1066,12 @@ impl CDLCOUNTERATTACK_Stream {
             return Err(RetCode::BadParam);
         }
         CDLCOUNTERATTACK_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLCOUNTERATTACK_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -377,6 +377,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLDARKCLOUDCOVER was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLDARKCLOUDCOVER_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLDARKCLOUDCOVER_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLDARKCLOUDCOVER stream: one value per closed bar, bit-identical to [`Core::CDLDARKCLOUDCOVER`]
 /// over the same series. Open with [`Core::CDLDARKCLOUDCOVER_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -386,8 +397,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDARKCLOUDCOVER_Stream")]
 pub struct CDLDARKCLOUDCOVER_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDLDARKCLOUDCOVER_StreamConfig`.
+    config: CDLDARKCLOUDCOVER_StreamConfig,
     state: CDLDARKCLOUDCOVER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -398,7 +409,7 @@ impl CDLDARKCLOUDCOVER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDARKCLOUDCOVER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -407,7 +418,6 @@ impl CDLDARKCLOUDCOVER_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLDARKCLOUDCOVER_StreamState {
-    optInPenetration: f64,
     BodyLongPeriodTotal: f64,
     lag1_inOpen: f64,
     lag1_inHigh: f64,
@@ -424,7 +434,6 @@ impl CDLDARKCLOUDCOVER_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.lag1_inOpen = src.lag1_inOpen;
         self.lag1_inHigh = src.lag1_inHigh;
@@ -444,13 +453,13 @@ impl CDLDARKCLOUDCOVER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDARKCLOUDCOVER_step_impl(sp: &mut CDLDARKCLOUDCOVER_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDARKCLOUDCOVER_step_impl(cfg: &CDLDARKCLOUDCOVER_StreamConfig, sp: &mut CDLDARKCLOUDCOVER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -472,7 +481,7 @@ impl Core {
            (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 &&  // 2nd: black
            inOpen > sp.lag1_inHigh &&                                          // open above prior high
            inClose > sp.lag1_inOpen &&                                         // close within prior body
-           inClose < sp.lag1_inClose - (sp.lag1_inClose - sp.lag1_inOpen).abs() * sp.optInPenetration
+           inClose < sp.lag1_inClose - (sp.lag1_inClose - sp.lag1_inOpen).abs() * cfg.optInPenetration
         {
             (*outInteger) = (0 - 100) as i32;
         } else {
@@ -665,7 +674,6 @@ impl Core {
             }
         }
         let state = CDLDARKCLOUDCOVER_StreamState {
-            optInPenetration,
             BodyLongPeriodTotal,
             lag1_inOpen: inOpen[historyLen - 1],
             lag1_inHigh: inHigh[historyLen - 1],
@@ -676,7 +684,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLDARKCLOUDCOVER_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDARKCLOUDCOVER_Stream { config: CDLDARKCLOUDCOVER_StreamConfig { cs_body_long: self.candle_settings.body_long, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDARKCLOUDCOVER_Open`] (composition seam).
@@ -791,7 +799,7 @@ impl CDLDARKCLOUDCOVER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLDARKCLOUDCOVER_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDARKCLOUDCOVER_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -824,7 +832,7 @@ impl CDLDARKCLOUDCOVER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLDARKCLOUDCOVER_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDARKCLOUDCOVER_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
@@ -332,6 +332,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLDOJI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLDOJI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLDOJI_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+}
+
 /// Live CDLDOJI stream: one value per closed bar, bit-identical to [`Core::CDLDOJI`]
 /// over the same series. Open with [`Core::CDLDOJI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -341,8 +351,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDOJI_Stream")]
 pub struct CDLDOJI_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
+    /// What this stream was opened with — see `CDLDOJI_StreamConfig`.
+    config: CDLDOJI_StreamConfig,
     state: CDLDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -353,7 +363,7 @@ impl CDLDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -387,13 +397,13 @@ impl CDLDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDOJI_step_impl(sp: &mut CDLDOJI_StreamState, cs_body_doji: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDOJI_step_impl(cfg: &CDLDOJI_StreamConfig, sp: &mut CDLDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -605,7 +615,7 @@ impl Core {
             ringCap_BodyDojiTrailingIdx: cap_BodyDojiTrailingIdx as usize,
             ring_BodyDojiTrailingIdx_derived,
         };
-        Ok(CDLDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDOJI_Stream { config: CDLDOJI_StreamConfig { cs_body_doji: self.candle_settings.body_doji, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDOJI_Open`] (composition seam).
@@ -720,7 +730,7 @@ impl CDLDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLDOJI_step_impl(&mut self.state, &self.cs_body_doji, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDOJI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -753,7 +763,7 @@ impl CDLDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLDOJI_step_impl(&mut self.state, &self.cs_body_doji, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDOJI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
@@ -421,6 +421,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLDOJISTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLDOJISTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLDOJISTAR_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+}
+
 /// Live CDLDOJISTAR stream: one value per closed bar, bit-identical to [`Core::CDLDOJISTAR`]
 /// over the same series. Open with [`Core::CDLDOJISTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -430,10 +442,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDOJISTAR_Stream")]
 pub struct CDLDOJISTAR_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDLDOJISTAR_StreamConfig`.
+    config: CDLDOJISTAR_StreamConfig,
     state: CDLDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -444,8 +454,7 @@ impl CDLDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -495,19 +504,19 @@ impl CDLDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDOJISTAR_step_impl(sp: &mut CDLDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDOJISTAR_step_impl(cfg: &CDLDOJISTAR_StreamConfig, sp: &mut CDLDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -869,7 +878,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDOJISTAR_Stream { config: CDLDOJISTAR_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDOJISTAR_Open`] (composition seam).
@@ -965,10 +974,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLDOJISTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLDOJISTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLDOJISTAR_Stream>>> =
+    static CDLDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLDOJISTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -992,7 +1001,7 @@ impl CDLDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDOJISTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1025,7 +1034,7 @@ impl CDLDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDOJISTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1049,11 +1058,12 @@ impl CDLDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLDOJISTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLDOJISTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
@@ -418,6 +418,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLDRAGONFLYDOJI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLDRAGONFLYDOJI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLDRAGONFLYDOJI_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLDRAGONFLYDOJI stream: one value per closed bar, bit-identical to [`Core::CDLDRAGONFLYDOJI`]
 /// over the same series. Open with [`Core::CDLDRAGONFLYDOJI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -427,10 +439,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLDRAGONFLYDOJI_Stream")]
 pub struct CDLDRAGONFLYDOJI_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLDRAGONFLYDOJI_StreamConfig`.
+    config: CDLDRAGONFLYDOJI_StreamConfig,
     state: CDLDRAGONFLYDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -441,8 +451,7 @@ impl CDLDRAGONFLYDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLDRAGONFLYDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -484,19 +493,19 @@ impl CDLDRAGONFLYDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLDRAGONFLYDOJI_step_impl(sp: &mut CDLDRAGONFLYDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLDRAGONFLYDOJI_step_impl(cfg: &CDLDRAGONFLYDOJI_StreamConfig, sp: &mut CDLDRAGONFLYDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -843,7 +852,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLDRAGONFLYDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLDRAGONFLYDOJI_Stream { config: CDLDRAGONFLYDOJI_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLDRAGONFLYDOJI_Open`] (composition seam).
@@ -939,10 +948,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLDRAGONFLYDOJI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLDRAGONFLYDOJI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLDRAGONFLYDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLDRAGONFLYDOJI_Stream>>> =
+    static CDLDRAGONFLYDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLDRAGONFLYDOJI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -966,7 +975,7 @@ impl CDLDRAGONFLYDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLDRAGONFLYDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLDRAGONFLYDOJI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -999,7 +1008,7 @@ impl CDLDRAGONFLYDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLDRAGONFLYDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLDRAGONFLYDOJI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1023,11 +1032,12 @@ impl CDLDRAGONFLYDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         CDLDRAGONFLYDOJI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLDRAGONFLYDOJI_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -514,6 +514,21 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLEVENINGDOJISTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLEVENINGDOJISTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLEVENINGDOJISTAR_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLEVENINGDOJISTAR stream: one value per closed bar, bit-identical to [`Core::CDLEVENINGDOJISTAR`]
 /// over the same series. Open with [`Core::CDLEVENINGDOJISTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -523,12 +538,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLEVENINGDOJISTAR_Stream")]
 pub struct CDLEVENINGDOJISTAR_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLEVENINGDOJISTAR_StreamConfig`.
+    config: CDLEVENINGDOJISTAR_StreamConfig,
     state: CDLEVENINGDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -539,9 +550,7 @@ impl CDLEVENINGDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLEVENINGDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -550,7 +559,6 @@ impl CDLEVENINGDOJISTAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLEVENINGDOJISTAR_StreamState {
-    optInPenetration: f64,
     BodyDojiPeriodTotal: f64,
     BodyLongPeriodTotal: f64,
     BodyShortPeriodTotal: f64,
@@ -578,7 +586,6 @@ impl CDLEVENINGDOJISTAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyDojiPeriodTotal = src.BodyDojiPeriodTotal;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.BodyShortPeriodTotal = src.BodyShortPeriodTotal;
@@ -609,25 +616,25 @@ impl CDLEVENINGDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLEVENINGDOJISTAR_step_impl(sp: &mut CDLEVENINGDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLEVENINGDOJISTAR_step_impl(cfg: &CDLEVENINGDOJISTAR_StreamConfig, sp: &mut CDLEVENINGDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -685,7 +692,7 @@ impl Core {
         if (if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == 1 && // white
            (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 &&  // black real body
            ((if (sp.lag1_inOpen).min(sp.lag1_inClose) > (sp.lag2_inOpen).max(sp.lag2_inClose) { 1 } else { 0 }) != 0) && // gapping up
-           inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * sp.optInPenetration && // closing well within 1st rb
+           inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * cfg.optInPenetration && // closing well within 1st rb
            (sp.lag2_inClose - sp.lag2_inOpen).abs() > ((BodyLong_factor) * (if (BodyLong_avgPeriod) != 0 { (sp.BodyLongPeriodTotal) / (BodyLong_avgPeriod as f64) } else { match BodyLong_rangeType { 0 => ((sp.lag2_inClose) - (sp.lag2_inOpen)).abs(), 1 => (sp.lag2_inHigh) - (sp.lag2_inLow), 2 => ((sp.lag2_inHigh) - (if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inClose) } else { (sp.lag2_inOpen) })) + ((if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inOpen) } else { (sp.lag2_inClose) }) - (sp.lag2_inLow)), _ => 0.0 } }) / (if (BodyLong_rangeType) == 2 { 2.0 } else { 1.0 })) && // 1st: long
            (sp.lag1_inClose - sp.lag1_inOpen).abs() <= ((BodyDoji_factor) * (if (BodyDoji_avgPeriod) != 0 { (sp.BodyDojiPeriodTotal) / (BodyDoji_avgPeriod as f64) } else { match BodyDoji_rangeType { 0 => ((sp.lag1_inClose) - (sp.lag1_inOpen)).abs(), 1 => (sp.lag1_inHigh) - (sp.lag1_inLow), 2 => ((sp.lag1_inHigh) - (if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inClose) } else { (sp.lag1_inOpen) })) + ((if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inOpen) } else { (sp.lag1_inClose) }) - (sp.lag1_inLow)), _ => 0.0 } }) / (if (BodyDoji_rangeType) == 2 { 2.0 } else { 1.0 })) && // 2nd: doji
            (inClose - inOpen).abs() > ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((inClose) - (inOpen)).abs(), 1 => (inHigh) - (inLow), 2 => ((inHigh) - (if (inClose) >= (inOpen) { (inClose) } else { (inOpen) })) + ((if (inClose) >= (inOpen) { (inOpen) } else { (inClose) }) - (inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) // 3rd: longer than short
@@ -1125,7 +1132,6 @@ impl Core {
             }
         }
         let state = CDLEVENINGDOJISTAR_StreamState {
-            optInPenetration,
             BodyDojiPeriodTotal,
             BodyLongPeriodTotal,
             BodyShortPeriodTotal,
@@ -1147,7 +1153,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLEVENINGDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLEVENINGDOJISTAR_Stream { config: CDLEVENINGDOJISTAR_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLEVENINGDOJISTAR_Open`] (composition seam).
@@ -1243,10 +1249,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLEVENINGDOJISTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLEVENINGDOJISTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLEVENINGDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLEVENINGDOJISTAR_Stream>>> =
+    static CDLEVENINGDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLEVENINGDOJISTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1270,7 +1276,7 @@ impl CDLEVENINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLEVENINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLEVENINGDOJISTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1303,7 +1309,7 @@ impl CDLEVENINGDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLEVENINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLEVENINGDOJISTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1327,11 +1333,12 @@ impl CDLEVENINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLEVENINGDOJISTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLEVENINGDOJISTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -496,6 +496,19 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLEVENINGSTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLEVENINGSTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLEVENINGSTAR_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLEVENINGSTAR stream: one value per closed bar, bit-identical to [`Core::CDLEVENINGSTAR`]
 /// over the same series. Open with [`Core::CDLEVENINGSTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -505,10 +518,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLEVENINGSTAR_Stream")]
 pub struct CDLEVENINGSTAR_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLEVENINGSTAR_StreamConfig`.
+    config: CDLEVENINGSTAR_StreamConfig,
     state: CDLEVENINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -519,8 +530,7 @@ impl CDLEVENINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLEVENINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -529,7 +539,6 @@ impl CDLEVENINGSTAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLEVENINGSTAR_StreamState {
-    optInPenetration: f64,
     BodyShortPeriodTotal: f64,
     BodyLongPeriodTotal: f64,
     BodyShortPeriodTotal2: f64,
@@ -555,7 +564,6 @@ impl CDLEVENINGSTAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyShortPeriodTotal = src.BodyShortPeriodTotal;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.BodyShortPeriodTotal2 = src.BodyShortPeriodTotal2;
@@ -584,19 +592,19 @@ impl CDLEVENINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLEVENINGSTAR_step_impl(sp: &mut CDLEVENINGSTAR_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLEVENINGSTAR_step_impl(cfg: &CDLEVENINGSTAR_StreamConfig, sp: &mut CDLEVENINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -634,7 +642,7 @@ impl Core {
         if (if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 }) == 1 && // white
            (((if inClose >= inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 &&  // black real body
            ((if (sp.lag1_inOpen).min(sp.lag1_inClose) > (sp.lag2_inOpen).max(sp.lag2_inClose) { 1 } else { 0 }) != 0) && // gapping up
-           inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * sp.optInPenetration && // closing well within 1st rb
+           inClose < sp.lag2_inClose - (sp.lag2_inClose - sp.lag2_inOpen).abs() * cfg.optInPenetration && // closing well within 1st rb
            (sp.lag2_inClose - sp.lag2_inOpen).abs() > ((BodyLong_factor) * (if (BodyLong_avgPeriod) != 0 { (sp.BodyLongPeriodTotal) / (BodyLong_avgPeriod as f64) } else { match BodyLong_rangeType { 0 => ((sp.lag2_inClose) - (sp.lag2_inOpen)).abs(), 1 => (sp.lag2_inHigh) - (sp.lag2_inLow), 2 => ((sp.lag2_inHigh) - (if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inClose) } else { (sp.lag2_inOpen) })) + ((if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inOpen) } else { (sp.lag2_inClose) }) - (sp.lag2_inLow)), _ => 0.0 } }) / (if (BodyLong_rangeType) == 2 { 2.0 } else { 1.0 })) && // 1st: long
            (sp.lag1_inClose - sp.lag1_inOpen).abs() <= ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((sp.lag1_inClose) - (sp.lag1_inOpen)).abs(), 1 => (sp.lag1_inHigh) - (sp.lag1_inLow), 2 => ((sp.lag1_inHigh) - (if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inClose) } else { (sp.lag1_inOpen) })) + ((if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inOpen) } else { (sp.lag1_inClose) }) - (sp.lag1_inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) && // 2nd: short
            (inClose - inOpen).abs() > ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal2) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((inClose) - (inOpen)).abs(), 1 => (inHigh) - (inLow), 2 => ((inHigh) - (if (inClose) >= (inOpen) { (inClose) } else { (inOpen) })) + ((if (inClose) >= (inOpen) { (inOpen) } else { (inClose) }) - (inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) // 3rd: longer than short
@@ -1013,7 +1021,6 @@ impl Core {
             }
         }
         let state = CDLEVENINGSTAR_StreamState {
-            optInPenetration,
             BodyShortPeriodTotal,
             BodyLongPeriodTotal,
             BodyShortPeriodTotal2,
@@ -1033,7 +1040,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLEVENINGSTAR_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLEVENINGSTAR_Stream { config: CDLEVENINGSTAR_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLEVENINGSTAR_Open`] (composition seam).
@@ -1129,10 +1136,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLEVENINGSTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLEVENINGSTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLEVENINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLEVENINGSTAR_Stream>>> =
+    static CDLEVENINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLEVENINGSTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1156,7 +1163,7 @@ impl CDLEVENINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLEVENINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLEVENINGSTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1189,7 +1196,7 @@ impl CDLEVENINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLEVENINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLEVENINGSTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1213,11 +1220,12 @@ impl CDLEVENINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLEVENINGSTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLEVENINGSTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
@@ -423,6 +423,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLGAPSIDESIDEWHITE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLGAPSIDESIDEWHITE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLGAPSIDESIDEWHITE_StreamConfig {
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+}
+
 /// Live CDLGAPSIDESIDEWHITE stream: one value per closed bar, bit-identical to [`Core::CDLGAPSIDESIDEWHITE`]
 /// over the same series. Open with [`Core::CDLGAPSIDESIDEWHITE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -432,10 +444,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLGAPSIDESIDEWHITE_Stream")]
 pub struct CDLGAPSIDESIDEWHITE_Stream {
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
+    /// What this stream was opened with — see `CDLGAPSIDESIDEWHITE_StreamConfig`.
+    config: CDLGAPSIDESIDEWHITE_StreamConfig,
     state: CDLGAPSIDESIDEWHITE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -446,8 +456,7 @@ impl CDLGAPSIDESIDEWHITE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLGAPSIDESIDEWHITE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_equal = src.cs_equal;
-        self.cs_near = src.cs_near;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -505,19 +514,19 @@ impl CDLGAPSIDESIDEWHITE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLGAPSIDESIDEWHITE_step_impl(sp: &mut CDLGAPSIDESIDEWHITE_StreamState, cs_equal: &CandleSetting, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLGAPSIDESIDEWHITE_step_impl(cfg: &CDLGAPSIDESIDEWHITE_StreamConfig, sp: &mut CDLGAPSIDESIDEWHITE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -861,7 +870,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLGAPSIDESIDEWHITE_Stream { cs_equal: self.candle_settings.equal, cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLGAPSIDESIDEWHITE_Stream { config: CDLGAPSIDESIDEWHITE_StreamConfig { cs_equal: self.candle_settings.equal, cs_near: self.candle_settings.near, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLGAPSIDESIDEWHITE_Open`] (composition seam).
@@ -957,10 +966,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLGAPSIDESIDEWHITE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLGAPSIDESIDEWHITE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLGAPSIDESIDEWHITE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLGAPSIDESIDEWHITE_Stream>>> =
+    static CDLGAPSIDESIDEWHITE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLGAPSIDESIDEWHITE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -984,7 +993,7 @@ impl CDLGAPSIDESIDEWHITE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, &self.cs_equal, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLGAPSIDESIDEWHITE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1017,7 +1026,7 @@ impl CDLGAPSIDESIDEWHITE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLGAPSIDESIDEWHITE_step_impl(&mut self.state, &self.cs_equal, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLGAPSIDESIDEWHITE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1041,11 +1050,12 @@ impl CDLGAPSIDESIDEWHITE_Stream {
             return Err(RetCode::BadParam);
         }
         CDLGAPSIDESIDEWHITE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLGAPSIDESIDEWHITE_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
@@ -417,6 +417,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLGRAVESTONEDOJI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLGRAVESTONEDOJI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLGRAVESTONEDOJI_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLGRAVESTONEDOJI stream: one value per closed bar, bit-identical to [`Core::CDLGRAVESTONEDOJI`]
 /// over the same series. Open with [`Core::CDLGRAVESTONEDOJI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -426,10 +438,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLGRAVESTONEDOJI_Stream")]
 pub struct CDLGRAVESTONEDOJI_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLGRAVESTONEDOJI_StreamConfig`.
+    config: CDLGRAVESTONEDOJI_StreamConfig,
     state: CDLGRAVESTONEDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -440,8 +450,7 @@ impl CDLGRAVESTONEDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLGRAVESTONEDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -483,19 +492,19 @@ impl CDLGRAVESTONEDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLGRAVESTONEDOJI_step_impl(sp: &mut CDLGRAVESTONEDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLGRAVESTONEDOJI_step_impl(cfg: &CDLGRAVESTONEDOJI_StreamConfig, sp: &mut CDLGRAVESTONEDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -842,7 +851,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLGRAVESTONEDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLGRAVESTONEDOJI_Stream { config: CDLGRAVESTONEDOJI_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLGRAVESTONEDOJI_Open`] (composition seam).
@@ -938,10 +947,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLGRAVESTONEDOJI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLGRAVESTONEDOJI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLGRAVESTONEDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLGRAVESTONEDOJI_Stream>>> =
+    static CDLGRAVESTONEDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLGRAVESTONEDOJI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -965,7 +974,7 @@ impl CDLGRAVESTONEDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLGRAVESTONEDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLGRAVESTONEDOJI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -998,7 +1007,7 @@ impl CDLGRAVESTONEDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLGRAVESTONEDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLGRAVESTONEDOJI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1022,11 +1031,12 @@ impl CDLGRAVESTONEDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         CDLGRAVESTONEDOJI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLGRAVESTONEDOJI_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
@@ -547,6 +547,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHAMMER was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHAMMER_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHAMMER_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLHAMMER stream: one value per closed bar, bit-identical to [`Core::CDLHAMMER`]
 /// over the same series. Open with [`Core::CDLHAMMER_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -556,14 +572,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHAMMER_Stream")]
 pub struct CDLHAMMER_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLHAMMER_StreamConfig`.
+    config: CDLHAMMER_StreamConfig,
     state: CDLHAMMER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -574,10 +584,7 @@ impl CDLHAMMER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHAMMER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -643,31 +650,31 @@ impl CDLHAMMER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHAMMER_step_impl(sp: &mut CDLHAMMER_StreamState, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHAMMER_step_impl(cfg: &CDLHAMMER_StreamConfig, sp: &mut CDLHAMMER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1297,7 +1304,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLHAMMER_Stream { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHAMMER_Stream { config: CDLHAMMER_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHAMMER_Open`] (composition seam).
@@ -1393,10 +1400,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHAMMER_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHAMMER_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHAMMER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHAMMER_Stream>>> =
+    static CDLHAMMER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHAMMER_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1420,7 +1427,7 @@ impl CDLHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHAMMER_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1453,7 +1460,7 @@ impl CDLHAMMER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHAMMER_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1477,11 +1484,12 @@ impl CDLHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHAMMER_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHAMMER_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
@@ -551,6 +551,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHANGINGMAN was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHANGINGMAN_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHANGINGMAN_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLHANGINGMAN stream: one value per closed bar, bit-identical to [`Core::CDLHANGINGMAN`]
 /// over the same series. Open with [`Core::CDLHANGINGMAN_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -560,14 +576,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHANGINGMAN_Stream")]
 pub struct CDLHANGINGMAN_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLHANGINGMAN_StreamConfig`.
+    config: CDLHANGINGMAN_StreamConfig,
     state: CDLHANGINGMAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -578,10 +588,7 @@ impl CDLHANGINGMAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHANGINGMAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -647,31 +654,31 @@ impl CDLHANGINGMAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHANGINGMAN_step_impl(sp: &mut CDLHANGINGMAN_StreamState, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHANGINGMAN_step_impl(cfg: &CDLHANGINGMAN_StreamConfig, sp: &mut CDLHANGINGMAN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1301,7 +1308,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLHANGINGMAN_Stream { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHANGINGMAN_Stream { config: CDLHANGINGMAN_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHANGINGMAN_Open`] (composition seam).
@@ -1397,10 +1404,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHANGINGMAN_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHANGINGMAN_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHANGINGMAN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHANGINGMAN_Stream>>> =
+    static CDLHANGINGMAN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHANGINGMAN_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1424,7 +1431,7 @@ impl CDLHANGINGMAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHANGINGMAN_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHANGINGMAN_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1457,7 +1464,7 @@ impl CDLHANGINGMAN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHANGINGMAN_step_impl(&mut self.state, &self.cs_body_short, &self.cs_near, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHANGINGMAN_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1481,11 +1488,12 @@ impl CDLHANGINGMAN_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHANGINGMAN_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHANGINGMAN_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
@@ -432,6 +432,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHARAMI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHARAMI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHARAMI_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLHARAMI stream: one value per closed bar, bit-identical to [`Core::CDLHARAMI`]
 /// over the same series. Open with [`Core::CDLHARAMI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -441,10 +453,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHARAMI_Stream")]
 pub struct CDLHARAMI_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLHARAMI_StreamConfig`.
+    config: CDLHARAMI_StreamConfig,
     state: CDLHARAMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -455,8 +465,7 @@ impl CDLHARAMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHARAMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -506,19 +515,19 @@ impl CDLHARAMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHARAMI_step_impl(sp: &mut CDLHARAMI_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHARAMI_step_impl(cfg: &CDLHARAMI_StreamConfig, sp: &mut CDLHARAMI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -908,7 +917,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLHARAMI_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHARAMI_Stream { config: CDLHARAMI_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHARAMI_Open`] (composition seam).
@@ -1004,10 +1013,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHARAMI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHARAMI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHARAMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHARAMI_Stream>>> =
+    static CDLHARAMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHARAMI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1031,7 +1040,7 @@ impl CDLHARAMI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHARAMI_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHARAMI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1064,7 +1073,7 @@ impl CDLHARAMI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHARAMI_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHARAMI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1088,11 +1097,12 @@ impl CDLHARAMI_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHARAMI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHARAMI_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
@@ -434,6 +434,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHARAMICROSS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHARAMICROSS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHARAMICROSS_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+}
+
 /// Live CDLHARAMICROSS stream: one value per closed bar, bit-identical to [`Core::CDLHARAMICROSS`]
 /// over the same series. Open with [`Core::CDLHARAMICROSS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -443,10 +455,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHARAMICROSS_Stream")]
 pub struct CDLHARAMICROSS_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDLHARAMICROSS_StreamConfig`.
+    config: CDLHARAMICROSS_StreamConfig,
     state: CDLHARAMICROSS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -457,8 +467,7 @@ impl CDLHARAMICROSS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHARAMICROSS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -508,19 +517,19 @@ impl CDLHARAMICROSS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHARAMICROSS_step_impl(sp: &mut CDLHARAMICROSS_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHARAMICROSS_step_impl(cfg: &CDLHARAMICROSS_StreamConfig, sp: &mut CDLHARAMICROSS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -909,7 +918,7 @@ impl Core {
             ringCap_BodyLongTrailingIdx: cap_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLHARAMICROSS_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHARAMICROSS_Stream { config: CDLHARAMICROSS_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHARAMICROSS_Open`] (composition seam).
@@ -1005,10 +1014,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHARAMICROSS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHARAMICROSS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHARAMICROSS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHARAMICROSS_Stream>>> =
+    static CDLHARAMICROSS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHARAMICROSS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1032,7 +1041,7 @@ impl CDLHARAMICROSS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHARAMICROSS_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHARAMICROSS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1065,7 +1074,7 @@ impl CDLHARAMICROSS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHARAMICROSS_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHARAMICROSS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1089,11 +1098,12 @@ impl CDLHARAMICROSS_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHARAMICROSS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHARAMICROSS_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
@@ -412,6 +412,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHIGHWAVE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHIGHWAVE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHIGHWAVE_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowVeryLong` setting this stream was opened with.
+    cs_shadow_very_long: CandleSetting,
+}
+
 /// Live CDLHIGHWAVE stream: one value per closed bar, bit-identical to [`Core::CDLHIGHWAVE`]
 /// over the same series. Open with [`Core::CDLHIGHWAVE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -421,10 +433,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHIGHWAVE_Stream")]
 pub struct CDLHIGHWAVE_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `ShadowVeryLong` setting this stream was opened with.
-    cs_shadow_very_long: CandleSetting,
+    /// What this stream was opened with — see `CDLHIGHWAVE_StreamConfig`.
+    config: CDLHIGHWAVE_StreamConfig,
     state: CDLHIGHWAVE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -435,8 +445,7 @@ impl CDLHIGHWAVE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHIGHWAVE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_shadow_very_long = src.cs_shadow_very_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -478,19 +487,19 @@ impl CDLHIGHWAVE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHIGHWAVE_step_impl(sp: &mut CDLHIGHWAVE_StreamState, cs_body_short: &CandleSetting, cs_shadow_very_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHIGHWAVE_step_impl(cfg: &CDLHIGHWAVE_StreamConfig, sp: &mut CDLHIGHWAVE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_rangeType: i32 = cs_shadow_very_long.range_type as i32;
+        let ShadowVeryLong_rangeType: i32 = cfg.cs_shadow_very_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_avgPeriod: i32 = cs_shadow_very_long.avg_period;
+        let ShadowVeryLong_avgPeriod: i32 = cfg.cs_shadow_very_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_factor: f64 = cs_shadow_very_long.factor;
+        let ShadowVeryLong_factor: f64 = cfg.cs_shadow_very_long.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -835,7 +844,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLHIGHWAVE_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_very_long: self.candle_settings.shadow_very_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHIGHWAVE_Stream { config: CDLHIGHWAVE_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_shadow_very_long: self.candle_settings.shadow_very_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHIGHWAVE_Open`] (composition seam).
@@ -931,10 +940,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHIGHWAVE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHIGHWAVE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHIGHWAVE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHIGHWAVE_Stream>>> =
+    static CDLHIGHWAVE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHIGHWAVE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -958,7 +967,7 @@ impl CDLHIGHWAVE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHIGHWAVE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_very_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHIGHWAVE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -991,7 +1000,7 @@ impl CDLHIGHWAVE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHIGHWAVE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_very_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHIGHWAVE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1015,11 +1024,12 @@ impl CDLHIGHWAVE_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHIGHWAVE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHIGHWAVE_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
@@ -435,6 +435,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHIKKAKEMOD was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHIKKAKEMOD_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHIKKAKEMOD_StreamConfig {
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+}
+
 /// Live CDLHIKKAKEMOD stream: one value per closed bar, bit-identical to [`Core::CDLHIKKAKEMOD`]
 /// over the same series. Open with [`Core::CDLHIKKAKEMOD_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -444,8 +454,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHIKKAKEMOD_Stream")]
 pub struct CDLHIKKAKEMOD_Stream {
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
+    /// What this stream was opened with — see `CDLHIKKAKEMOD_StreamConfig`.
+    config: CDLHIKKAKEMOD_StreamConfig,
     state: CDLHIKKAKEMOD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -456,7 +466,7 @@ impl CDLHIKKAKEMOD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHIKKAKEMOD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_near = src.cs_near;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -520,13 +530,13 @@ impl CDLHIKKAKEMOD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHIKKAKEMOD_step_impl(sp: &mut CDLHIKKAKEMOD_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHIKKAKEMOD_step_impl(cfg: &CDLHIKKAKEMOD_StreamConfig, sp: &mut CDLHIKKAKEMOD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -851,7 +861,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLHIKKAKEMOD_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHIKKAKEMOD_Stream { config: CDLHIKKAKEMOD_StreamConfig { cs_near: self.candle_settings.near, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHIKKAKEMOD_Open`] (composition seam).
@@ -966,7 +976,7 @@ impl CDLHIKKAKEMOD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHIKKAKEMOD_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHIKKAKEMOD_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -999,7 +1009,7 @@ impl CDLHIKKAKEMOD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHIKKAKEMOD_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHIKKAKEMOD_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
@@ -421,6 +421,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLHOMINGPIGEON was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLHOMINGPIGEON_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLHOMINGPIGEON_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLHOMINGPIGEON stream: one value per closed bar, bit-identical to [`Core::CDLHOMINGPIGEON`]
 /// over the same series. Open with [`Core::CDLHOMINGPIGEON_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -430,10 +442,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLHOMINGPIGEON_Stream")]
 pub struct CDLHOMINGPIGEON_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLHOMINGPIGEON_StreamConfig`.
+    config: CDLHOMINGPIGEON_StreamConfig,
     state: CDLHOMINGPIGEON_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -444,8 +454,7 @@ impl CDLHOMINGPIGEON_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLHOMINGPIGEON_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -497,19 +506,19 @@ impl CDLHOMINGPIGEON_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLHOMINGPIGEON_step_impl(sp: &mut CDLHOMINGPIGEON_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLHOMINGPIGEON_step_impl(cfg: &CDLHOMINGPIGEON_StreamConfig, sp: &mut CDLHOMINGPIGEON_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -860,7 +869,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLHOMINGPIGEON_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLHOMINGPIGEON_Stream { config: CDLHOMINGPIGEON_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLHOMINGPIGEON_Open`] (composition seam).
@@ -956,10 +965,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLHOMINGPIGEON_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLHOMINGPIGEON_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLHOMINGPIGEON_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHOMINGPIGEON_Stream>>> =
+    static CDLHOMINGPIGEON_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLHOMINGPIGEON_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -983,7 +992,7 @@ impl CDLHOMINGPIGEON_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLHOMINGPIGEON_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLHOMINGPIGEON_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1016,7 +1025,7 @@ impl CDLHOMINGPIGEON_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLHOMINGPIGEON_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLHOMINGPIGEON_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1040,11 +1049,12 @@ impl CDLHOMINGPIGEON_Stream {
             return Err(RetCode::BadParam);
         }
         CDLHOMINGPIGEON_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLHOMINGPIGEON_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
@@ -486,6 +486,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLIDENTICAL3CROWS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLIDENTICAL3CROWS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLIDENTICAL3CROWS_StreamConfig {
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLIDENTICAL3CROWS stream: one value per closed bar, bit-identical to [`Core::CDLIDENTICAL3CROWS`]
 /// over the same series. Open with [`Core::CDLIDENTICAL3CROWS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -495,10 +507,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLIDENTICAL3CROWS_Stream")]
 pub struct CDLIDENTICAL3CROWS_Stream {
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLIDENTICAL3CROWS_StreamConfig`.
+    config: CDLIDENTICAL3CROWS_StreamConfig,
     state: CDLIDENTICAL3CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -509,8 +519,7 @@ impl CDLIDENTICAL3CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLIDENTICAL3CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_equal = src.cs_equal;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -572,20 +581,20 @@ impl CDLIDENTICAL3CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLIDENTICAL3CROWS_step_impl(sp: &mut CDLIDENTICAL3CROWS_StreamState, cs_equal: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLIDENTICAL3CROWS_step_impl(cfg: &CDLIDENTICAL3CROWS_StreamConfig, sp: &mut CDLIDENTICAL3CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -989,7 +998,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLIDENTICAL3CROWS_Stream { cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLIDENTICAL3CROWS_Stream { config: CDLIDENTICAL3CROWS_StreamConfig { cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLIDENTICAL3CROWS_Open`] (composition seam).
@@ -1085,10 +1094,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLIDENTICAL3CROWS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLIDENTICAL3CROWS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLIDENTICAL3CROWS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLIDENTICAL3CROWS_Stream>>> =
+    static CDLIDENTICAL3CROWS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLIDENTICAL3CROWS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1112,7 +1121,7 @@ impl CDLIDENTICAL3CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLIDENTICAL3CROWS_step_impl(&mut self.state, &self.cs_equal, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLIDENTICAL3CROWS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1145,7 +1154,7 @@ impl CDLIDENTICAL3CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLIDENTICAL3CROWS_step_impl(&mut self.state, &self.cs_equal, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLIDENTICAL3CROWS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1169,11 +1178,12 @@ impl CDLIDENTICAL3CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         CDLIDENTICAL3CROWS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLIDENTICAL3CROWS_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
@@ -418,6 +418,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLINNECK was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLINNECK_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLINNECK_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLINNECK stream: one value per closed bar, bit-identical to [`Core::CDLINNECK`]
 /// over the same series. Open with [`Core::CDLINNECK_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -427,10 +439,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLINNECK_Stream")]
 pub struct CDLINNECK_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLINNECK_StreamConfig`.
+    config: CDLINNECK_StreamConfig,
     state: CDLINNECK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -441,8 +451,7 @@ impl CDLINNECK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLINNECK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -496,19 +505,19 @@ impl CDLINNECK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLINNECK_step_impl(sp: &mut CDLINNECK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLINNECK_step_impl(cfg: &CDLINNECK_StreamConfig, sp: &mut CDLINNECK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -843,7 +852,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLINNECK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLINNECK_Stream { config: CDLINNECK_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLINNECK_Open`] (composition seam).
@@ -939,10 +948,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLINNECK_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLINNECK_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLINNECK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLINNECK_Stream>>> =
+    static CDLINNECK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLINNECK_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -966,7 +975,7 @@ impl CDLINNECK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLINNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLINNECK_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -999,7 +1008,7 @@ impl CDLINNECK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLINNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLINNECK_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1023,11 +1032,12 @@ impl CDLINNECK_Stream {
             return Err(RetCode::BadParam);
         }
         CDLINNECK_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLINNECK_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
@@ -482,6 +482,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLINVERTEDHAMMER was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLINVERTEDHAMMER_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLINVERTEDHAMMER_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLINVERTEDHAMMER stream: one value per closed bar, bit-identical to [`Core::CDLINVERTEDHAMMER`]
 /// over the same series. Open with [`Core::CDLINVERTEDHAMMER_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -491,12 +505,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLINVERTEDHAMMER_Stream")]
 pub struct CDLINVERTEDHAMMER_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLINVERTEDHAMMER_StreamConfig`.
+    config: CDLINVERTEDHAMMER_StreamConfig,
     state: CDLINVERTEDHAMMER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -507,9 +517,7 @@ impl CDLINVERTEDHAMMER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLINVERTEDHAMMER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -563,25 +571,25 @@ impl CDLINVERTEDHAMMER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLINVERTEDHAMMER_step_impl(sp: &mut CDLINVERTEDHAMMER_StreamState, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLINVERTEDHAMMER_step_impl(cfg: &CDLINVERTEDHAMMER_StreamConfig, sp: &mut CDLINVERTEDHAMMER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1075,7 +1083,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLINVERTEDHAMMER_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLINVERTEDHAMMER_Stream { config: CDLINVERTEDHAMMER_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLINVERTEDHAMMER_Open`] (composition seam).
@@ -1171,10 +1179,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLINVERTEDHAMMER_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLINVERTEDHAMMER_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLINVERTEDHAMMER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLINVERTEDHAMMER_Stream>>> =
+    static CDLINVERTEDHAMMER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLINVERTEDHAMMER_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1198,7 +1206,7 @@ impl CDLINVERTEDHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLINVERTEDHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLINVERTEDHAMMER_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1231,7 +1239,7 @@ impl CDLINVERTEDHAMMER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLINVERTEDHAMMER_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLINVERTEDHAMMER_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1255,11 +1263,12 @@ impl CDLINVERTEDHAMMER_Stream {
             return Err(RetCode::BadParam);
         }
         CDLINVERTEDHAMMER_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLINVERTEDHAMMER_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
@@ -452,6 +452,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLKICKING was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLKICKING_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLKICKING_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLKICKING stream: one value per closed bar, bit-identical to [`Core::CDLKICKING`]
 /// over the same series. Open with [`Core::CDLKICKING_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -461,10 +473,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLKICKING_Stream")]
 pub struct CDLKICKING_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLKICKING_StreamConfig`.
+    config: CDLKICKING_StreamConfig,
     state: CDLKICKING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -475,8 +485,7 @@ impl CDLKICKING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLKICKING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -530,20 +539,20 @@ impl CDLKICKING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLKICKING_step_impl(sp: &mut CDLKICKING_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLKICKING_step_impl(cfg: &CDLKICKING_StreamConfig, sp: &mut CDLKICKING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -898,7 +907,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLKICKING_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLKICKING_Stream { config: CDLKICKING_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLKICKING_Open`] (composition seam).
@@ -994,10 +1003,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLKICKING_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLKICKING_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLKICKING_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLKICKING_Stream>>> =
+    static CDLKICKING_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLKICKING_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1021,7 +1030,7 @@ impl CDLKICKING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLKICKING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLKICKING_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1054,7 +1063,7 @@ impl CDLKICKING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLKICKING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLKICKING_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1078,11 +1087,12 @@ impl CDLKICKING_Stream {
             return Err(RetCode::BadParam);
         }
         CDLKICKING_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLKICKING_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
@@ -452,6 +452,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLKICKINGBYLENGTH was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLKICKINGBYLENGTH_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLKICKINGBYLENGTH_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLKICKINGBYLENGTH stream: one value per closed bar, bit-identical to [`Core::CDLKICKINGBYLENGTH`]
 /// over the same series. Open with [`Core::CDLKICKINGBYLENGTH_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -461,10 +473,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLKICKINGBYLENGTH_Stream")]
 pub struct CDLKICKINGBYLENGTH_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLKICKINGBYLENGTH_StreamConfig`.
+    config: CDLKICKINGBYLENGTH_StreamConfig,
     state: CDLKICKINGBYLENGTH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -475,8 +485,7 @@ impl CDLKICKINGBYLENGTH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLKICKINGBYLENGTH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -530,20 +539,20 @@ impl CDLKICKINGBYLENGTH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLKICKINGBYLENGTH_step_impl(sp: &mut CDLKICKINGBYLENGTH_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLKICKINGBYLENGTH_step_impl(cfg: &CDLKICKINGBYLENGTH_StreamConfig, sp: &mut CDLKICKINGBYLENGTH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -899,7 +908,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLKICKINGBYLENGTH_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLKICKINGBYLENGTH_Stream { config: CDLKICKINGBYLENGTH_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLKICKINGBYLENGTH_Open`] (composition seam).
@@ -995,10 +1004,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLKICKINGBYLENGTH_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLKICKINGBYLENGTH_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLKICKINGBYLENGTH_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLKICKINGBYLENGTH_Stream>>> =
+    static CDLKICKINGBYLENGTH_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLKICKINGBYLENGTH_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1022,7 +1031,7 @@ impl CDLKICKINGBYLENGTH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLKICKINGBYLENGTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLKICKINGBYLENGTH_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1055,7 +1064,7 @@ impl CDLKICKINGBYLENGTH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLKICKINGBYLENGTH_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLKICKINGBYLENGTH_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1079,11 +1088,12 @@ impl CDLKICKINGBYLENGTH_Stream {
             return Err(RetCode::BadParam);
         }
         CDLKICKINGBYLENGTH_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLKICKINGBYLENGTH_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
@@ -356,6 +356,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLLADDERBOTTOM was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLLADDERBOTTOM_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLLADDERBOTTOM_StreamConfig {
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLLADDERBOTTOM stream: one value per closed bar, bit-identical to [`Core::CDLLADDERBOTTOM`]
 /// over the same series. Open with [`Core::CDLLADDERBOTTOM_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -365,8 +375,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLADDERBOTTOM_Stream")]
 pub struct CDLLADDERBOTTOM_Stream {
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLLADDERBOTTOM_StreamConfig`.
+    config: CDLLADDERBOTTOM_StreamConfig,
     state: CDLLADDERBOTTOM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -377,7 +387,7 @@ impl CDLLADDERBOTTOM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLADDERBOTTOM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -433,13 +443,13 @@ impl CDLLADDERBOTTOM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLADDERBOTTOM_step_impl(sp: &mut CDLLADDERBOTTOM_StreamState, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLADDERBOTTOM_step_impl(cfg: &CDLLADDERBOTTOM_StreamConfig, sp: &mut CDLLADDERBOTTOM_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match ShadowVeryShort_rangeType {
             0 => {
@@ -682,7 +692,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLLADDERBOTTOM_Stream { cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLADDERBOTTOM_Stream { config: CDLLADDERBOTTOM_StreamConfig { cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLADDERBOTTOM_Open`] (composition seam).
@@ -797,7 +807,7 @@ impl CDLLADDERBOTTOM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLLADDERBOTTOM_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLADDERBOTTOM_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -830,7 +840,7 @@ impl CDLLADDERBOTTOM_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLLADDERBOTTOM_step_impl(&mut self.state, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLADDERBOTTOM_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
@@ -415,6 +415,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLLONGLEGGEDDOJI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLLONGLEGGEDDOJI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLLONGLEGGEDDOJI_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+}
+
 /// Live CDLLONGLEGGEDDOJI stream: one value per closed bar, bit-identical to [`Core::CDLLONGLEGGEDDOJI`]
 /// over the same series. Open with [`Core::CDLLONGLEGGEDDOJI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -424,10 +436,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLONGLEGGEDDOJI_Stream")]
 pub struct CDLLONGLEGGEDDOJI_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
+    /// What this stream was opened with — see `CDLLONGLEGGEDDOJI_StreamConfig`.
+    config: CDLLONGLEGGEDDOJI_StreamConfig,
     state: CDLLONGLEGGEDDOJI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -438,8 +448,7 @@ impl CDLLONGLEGGEDDOJI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLONGLEGGEDDOJI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_shadow_long = src.cs_shadow_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -481,19 +490,19 @@ impl CDLLONGLEGGEDDOJI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLONGLEGGEDDOJI_step_impl(sp: &mut CDLLONGLEGGEDDOJI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLONGLEGGEDDOJI_step_impl(cfg: &CDLLONGLEGGEDDOJI_StreamConfig, sp: &mut CDLLONGLEGGEDDOJI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -838,7 +847,7 @@ impl Core {
             ringCap_ShadowLongTrailingIdx: cap_ShadowLongTrailingIdx as usize,
             ring_ShadowLongTrailingIdx_derived,
         };
-        Ok(CDLLONGLEGGEDDOJI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_long: self.candle_settings.shadow_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLONGLEGGEDDOJI_Stream { config: CDLLONGLEGGEDDOJI_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_shadow_long: self.candle_settings.shadow_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLONGLEGGEDDOJI_Open`] (composition seam).
@@ -934,10 +943,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLLONGLEGGEDDOJI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLLONGLEGGEDDOJI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLLONGLEGGEDDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLLONGLEGGEDDOJI_Stream>>> =
+    static CDLLONGLEGGEDDOJI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLLONGLEGGEDDOJI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -961,7 +970,7 @@ impl CDLLONGLEGGEDDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLLONGLEGGEDDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLONGLEGGEDDOJI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -994,7 +1003,7 @@ impl CDLLONGLEGGEDDOJI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLLONGLEGGEDDOJI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLONGLEGGEDDOJI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1018,11 +1027,12 @@ impl CDLLONGLEGGEDDOJI_Stream {
             return Err(RetCode::BadParam);
         }
         CDLLONGLEGGEDDOJI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLLONGLEGGEDDOJI_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
@@ -398,6 +398,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLLONGLINE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLLONGLINE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLLONGLINE_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowShort` setting this stream was opened with.
+    cs_shadow_short: CandleSetting,
+}
+
 /// Live CDLLONGLINE stream: one value per closed bar, bit-identical to [`Core::CDLLONGLINE`]
 /// over the same series. Open with [`Core::CDLLONGLINE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -407,10 +419,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLLONGLINE_Stream")]
 pub struct CDLLONGLINE_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowShort` setting this stream was opened with.
-    cs_shadow_short: CandleSetting,
+    /// What this stream was opened with — see `CDLLONGLINE_StreamConfig`.
+    config: CDLLONGLINE_StreamConfig,
     state: CDLLONGLINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -421,8 +431,7 @@ impl CDLLONGLINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLLONGLINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_short = src.cs_shadow_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -464,19 +473,19 @@ impl CDLLONGLINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLLONGLINE_step_impl(sp: &mut CDLLONGLINE_StreamState, cs_body_long: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLLONGLINE_step_impl(cfg: &CDLLONGLINE_StreamConfig, sp: &mut CDLLONGLINE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cfg.cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cfg.cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = cs_shadow_short.factor;
+        let ShadowShort_factor: f64 = cfg.cs_shadow_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -820,7 +829,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLLONGLINE_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLLONGLINE_Stream { config: CDLLONGLINE_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_short: self.candle_settings.shadow_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLLONGLINE_Open`] (composition seam).
@@ -916,10 +925,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLLONGLINE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLLONGLINE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLLONGLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLLONGLINE_Stream>>> =
+    static CDLLONGLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLLONGLINE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -943,7 +952,7 @@ impl CDLLONGLINE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLLONGLINE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLLONGLINE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -976,7 +985,7 @@ impl CDLLONGLINE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLLONGLINE_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLLONGLINE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1000,11 +1009,12 @@ impl CDLLONGLINE_Stream {
             return Err(RetCode::BadParam);
         }
         CDLLONGLINE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLLONGLINE_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
@@ -408,6 +408,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLMARUBOZU was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLMARUBOZU_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLMARUBOZU_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLMARUBOZU stream: one value per closed bar, bit-identical to [`Core::CDLMARUBOZU`]
 /// over the same series. Open with [`Core::CDLMARUBOZU_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -417,10 +429,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMARUBOZU_Stream")]
 pub struct CDLMARUBOZU_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLMARUBOZU_StreamConfig`.
+    config: CDLMARUBOZU_StreamConfig,
     state: CDLMARUBOZU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -431,8 +441,7 @@ impl CDLMARUBOZU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMARUBOZU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -474,19 +483,19 @@ impl CDLMARUBOZU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMARUBOZU_step_impl(sp: &mut CDLMARUBOZU_StreamState, cs_body_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMARUBOZU_step_impl(cfg: &CDLMARUBOZU_StreamConfig, sp: &mut CDLMARUBOZU_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -830,7 +839,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLMARUBOZU_Stream { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMARUBOZU_Stream { config: CDLMARUBOZU_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMARUBOZU_Open`] (composition seam).
@@ -926,10 +935,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLMARUBOZU_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLMARUBOZU_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLMARUBOZU_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMARUBOZU_Stream>>> =
+    static CDLMARUBOZU_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMARUBOZU_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -953,7 +962,7 @@ impl CDLMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMARUBOZU_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -986,7 +995,7 @@ impl CDLMARUBOZU_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLMARUBOZU_step_impl(&mut self.state, &self.cs_body_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMARUBOZU_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1010,11 +1019,12 @@ impl CDLMARUBOZU_Stream {
             return Err(RetCode::BadParam);
         }
         CDLMARUBOZU_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLMARUBOZU_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
@@ -349,6 +349,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLMATCHINGLOW was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLMATCHINGLOW_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLMATCHINGLOW_StreamConfig {
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLMATCHINGLOW stream: one value per closed bar, bit-identical to [`Core::CDLMATCHINGLOW`]
 /// over the same series. Open with [`Core::CDLMATCHINGLOW_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -358,8 +368,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMATCHINGLOW_Stream")]
 pub struct CDLMATCHINGLOW_Stream {
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLMATCHINGLOW_StreamConfig`.
+    config: CDLMATCHINGLOW_StreamConfig,
     state: CDLMATCHINGLOW_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -370,7 +380,7 @@ impl CDLMATCHINGLOW_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMATCHINGLOW_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -414,13 +424,13 @@ impl CDLMATCHINGLOW_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMATCHINGLOW_step_impl(sp: &mut CDLMATCHINGLOW_StreamState, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMATCHINGLOW_step_impl(cfg: &CDLMATCHINGLOW_StreamConfig, sp: &mut CDLMATCHINGLOW_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -632,7 +642,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLMATCHINGLOW_Stream { cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMATCHINGLOW_Stream { config: CDLMATCHINGLOW_StreamConfig { cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMATCHINGLOW_Open`] (composition seam).
@@ -747,7 +757,7 @@ impl CDLMATCHINGLOW_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLMATCHINGLOW_step_impl(&mut self.state, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMATCHINGLOW_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -780,7 +790,7 @@ impl CDLMATCHINGLOW_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLMATCHINGLOW_step_impl(&mut self.state, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMATCHINGLOW_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -503,6 +503,19 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLMATHOLD was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLMATHOLD_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLMATHOLD_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLMATHOLD stream: one value per closed bar, bit-identical to [`Core::CDLMATHOLD`]
 /// over the same series. Open with [`Core::CDLMATHOLD_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -512,10 +525,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMATHOLD_Stream")]
 pub struct CDLMATHOLD_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLMATHOLD_StreamConfig`.
+    config: CDLMATHOLD_StreamConfig,
     state: CDLMATHOLD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -526,8 +537,7 @@ impl CDLMATHOLD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMATHOLD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -536,7 +546,6 @@ impl CDLMATHOLD_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLMATHOLD_StreamState {
-    optInPenetration: f64,
     BodyPeriodTotal: [f64; 5 as usize],
     lag1_inOpen: f64,
     lag2_inOpen: f64,
@@ -569,7 +578,6 @@ impl CDLMATHOLD_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyPeriodTotal = src.BodyPeriodTotal;
         self.lag1_inOpen = src.lag1_inOpen;
         self.lag2_inOpen = src.lag2_inOpen;
@@ -605,20 +613,20 @@ impl CDLMATHOLD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMATHOLD_step_impl(sp: &mut CDLMATHOLD_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMATHOLD_step_impl(cfg: &CDLMATHOLD_StreamConfig, sp: &mut CDLMATHOLD_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -657,8 +665,8 @@ impl Core {
            ((if (sp.lag3_inOpen).min(sp.lag3_inClose) > (sp.lag4_inOpen).max(sp.lag4_inClose) { 1 } else { 0 }) != 0) && // upside gap 1st to 2nd
            (sp.lag2_inOpen).min(sp.lag2_inClose) < sp.lag4_inClose &&              // 3rd to 4th hold within 1st: a part of the real body must be within 1st real body
            (sp.lag1_inOpen).min(sp.lag1_inClose) < sp.lag4_inClose &&
-           (sp.lag2_inOpen).min(sp.lag2_inClose) > sp.lag4_inClose - (sp.lag4_inClose - sp.lag4_inOpen).abs() * sp.optInPenetration && // reaction days penetrate first body less than optInPenetration percent
-           (sp.lag1_inOpen).min(sp.lag1_inClose) > sp.lag4_inClose - (sp.lag4_inClose - sp.lag4_inOpen).abs() * sp.optInPenetration &&
+           (sp.lag2_inOpen).min(sp.lag2_inClose) > sp.lag4_inClose - (sp.lag4_inClose - sp.lag4_inOpen).abs() * cfg.optInPenetration && // reaction days penetrate first body less than optInPenetration percent
+           (sp.lag1_inOpen).min(sp.lag1_inClose) > sp.lag4_inClose - (sp.lag4_inClose - sp.lag4_inOpen).abs() * cfg.optInPenetration &&
            (sp.lag2_inClose).max(sp.lag2_inOpen) < sp.lag3_inOpen &&               // 2nd to 4th are falling
            (sp.lag1_inClose).max(sp.lag1_inOpen) < (sp.lag2_inClose).max(sp.lag2_inOpen) &&
            inOpen > sp.lag1_inClose &&                                             // 5th opens above the prior close
@@ -1013,7 +1021,6 @@ impl Core {
             }
         }
         let state = CDLMATHOLD_StreamState {
-            optInPenetration,
             BodyPeriodTotal,
             lag1_inOpen: inOpen[historyLen - 1],
             lag2_inOpen: inOpen[historyLen - 2],
@@ -1040,7 +1047,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMATHOLD_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMATHOLD_Stream { config: CDLMATHOLD_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMATHOLD_Open`] (composition seam).
@@ -1136,10 +1143,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLMATHOLD_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLMATHOLD_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLMATHOLD_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMATHOLD_Stream>>> =
+    static CDLMATHOLD_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMATHOLD_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1163,7 +1170,7 @@ impl CDLMATHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLMATHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMATHOLD_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1196,7 +1203,7 @@ impl CDLMATHOLD_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLMATHOLD_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMATHOLD_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1220,11 +1227,12 @@ impl CDLMATHOLD_Stream {
             return Err(RetCode::BadParam);
         }
         CDLMATHOLD_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLMATHOLD_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -555,6 +555,21 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLMORNINGDOJISTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLMORNINGDOJISTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLMORNINGDOJISTAR_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLMORNINGDOJISTAR stream: one value per closed bar, bit-identical to [`Core::CDLMORNINGDOJISTAR`]
 /// over the same series. Open with [`Core::CDLMORNINGDOJISTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -564,12 +579,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMORNINGDOJISTAR_Stream")]
 pub struct CDLMORNINGDOJISTAR_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLMORNINGDOJISTAR_StreamConfig`.
+    config: CDLMORNINGDOJISTAR_StreamConfig,
     state: CDLMORNINGDOJISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -580,9 +591,7 @@ impl CDLMORNINGDOJISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMORNINGDOJISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -591,7 +600,6 @@ impl CDLMORNINGDOJISTAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLMORNINGDOJISTAR_StreamState {
-    optInPenetration: f64,
     BodyDojiPeriodTotal: f64,
     BodyLongPeriodTotal: f64,
     BodyShortPeriodTotal: f64,
@@ -619,7 +627,6 @@ impl CDLMORNINGDOJISTAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyDojiPeriodTotal = src.BodyDojiPeriodTotal;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.BodyShortPeriodTotal = src.BodyShortPeriodTotal;
@@ -650,25 +657,25 @@ impl CDLMORNINGDOJISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMORNINGDOJISTAR_step_impl(sp: &mut CDLMORNINGDOJISTAR_StreamState, cs_body_doji: &CandleSetting, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMORNINGDOJISTAR_step_impl(cfg: &CDLMORNINGDOJISTAR_StreamConfig, sp: &mut CDLMORNINGDOJISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -726,7 +733,7 @@ impl Core {
         if (((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && // black
            (if inClose >= inOpen { 1 } else { 0 - 1 }) == 1 && // white real body
            ((if (sp.lag1_inOpen).max(sp.lag1_inClose) < (sp.lag2_inOpen).min(sp.lag2_inClose) { 1 } else { 0 }) != 0) && // gapping down
-           inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(sp.optInPenetration, sp.lag2_inClose) && // closing well within 1st rb
+           inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(cfg.optInPenetration, sp.lag2_inClose) && // closing well within 1st rb
            (sp.lag2_inClose - sp.lag2_inOpen).abs() > ((BodyLong_factor) * (if (BodyLong_avgPeriod) != 0 { (sp.BodyLongPeriodTotal) / (BodyLong_avgPeriod as f64) } else { match BodyLong_rangeType { 0 => ((sp.lag2_inClose) - (sp.lag2_inOpen)).abs(), 1 => (sp.lag2_inHigh) - (sp.lag2_inLow), 2 => ((sp.lag2_inHigh) - (if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inClose) } else { (sp.lag2_inOpen) })) + ((if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inOpen) } else { (sp.lag2_inClose) }) - (sp.lag2_inLow)), _ => 0.0 } }) / (if (BodyLong_rangeType) == 2 { 2.0 } else { 1.0 })) && // 1st: long
            (sp.lag1_inClose - sp.lag1_inOpen).abs() <= ((BodyDoji_factor) * (if (BodyDoji_avgPeriod) != 0 { (sp.BodyDojiPeriodTotal) / (BodyDoji_avgPeriod as f64) } else { match BodyDoji_rangeType { 0 => ((sp.lag1_inClose) - (sp.lag1_inOpen)).abs(), 1 => (sp.lag1_inHigh) - (sp.lag1_inLow), 2 => ((sp.lag1_inHigh) - (if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inClose) } else { (sp.lag1_inOpen) })) + ((if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inOpen) } else { (sp.lag1_inClose) }) - (sp.lag1_inLow)), _ => 0.0 } }) / (if (BodyDoji_rangeType) == 2 { 2.0 } else { 1.0 })) && // 2nd: doji
            (inClose - inOpen).abs() > ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((inClose) - (inOpen)).abs(), 1 => (inHigh) - (inLow), 2 => ((inHigh) - (if (inClose) >= (inOpen) { (inClose) } else { (inOpen) })) + ((if (inClose) >= (inOpen) { (inOpen) } else { (inClose) }) - (inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) // 3rd: longer than short
@@ -1166,7 +1173,6 @@ impl Core {
             }
         }
         let state = CDLMORNINGDOJISTAR_StreamState {
-            optInPenetration,
             BodyDojiPeriodTotal,
             BodyLongPeriodTotal,
             BodyShortPeriodTotal,
@@ -1188,7 +1194,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMORNINGDOJISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMORNINGDOJISTAR_Stream { config: CDLMORNINGDOJISTAR_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMORNINGDOJISTAR_Open`] (composition seam).
@@ -1284,10 +1290,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLMORNINGDOJISTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLMORNINGDOJISTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLMORNINGDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMORNINGDOJISTAR_Stream>>> =
+    static CDLMORNINGDOJISTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMORNINGDOJISTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1311,7 +1317,7 @@ impl CDLMORNINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLMORNINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMORNINGDOJISTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1344,7 +1350,7 @@ impl CDLMORNINGDOJISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLMORNINGDOJISTAR_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMORNINGDOJISTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1368,11 +1374,12 @@ impl CDLMORNINGDOJISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLMORNINGDOJISTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLMORNINGDOJISTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -538,6 +538,19 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLMORNINGSTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLMORNINGSTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLMORNINGSTAR_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    optInPenetration: f64,
+}
+
 /// Live CDLMORNINGSTAR stream: one value per closed bar, bit-identical to [`Core::CDLMORNINGSTAR`]
 /// over the same series. Open with [`Core::CDLMORNINGSTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -547,10 +560,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLMORNINGSTAR_Stream")]
 pub struct CDLMORNINGSTAR_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLMORNINGSTAR_StreamConfig`.
+    config: CDLMORNINGSTAR_StreamConfig,
     state: CDLMORNINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -561,8 +572,7 @@ impl CDLMORNINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLMORNINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -571,7 +581,6 @@ impl CDLMORNINGSTAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CDLMORNINGSTAR_StreamState {
-    optInPenetration: f64,
     BodyShortPeriodTotal: f64,
     BodyLongPeriodTotal: f64,
     BodyShortPeriodTotal2: f64,
@@ -597,7 +606,6 @@ impl CDLMORNINGSTAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInPenetration = src.optInPenetration;
         self.BodyShortPeriodTotal = src.BodyShortPeriodTotal;
         self.BodyLongPeriodTotal = src.BodyLongPeriodTotal;
         self.BodyShortPeriodTotal2 = src.BodyShortPeriodTotal2;
@@ -626,19 +634,19 @@ impl CDLMORNINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLMORNINGSTAR_step_impl(sp: &mut CDLMORNINGSTAR_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLMORNINGSTAR_step_impl(cfg: &CDLMORNINGSTAR_StreamConfig, sp: &mut CDLMORNINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -676,7 +684,7 @@ impl Core {
         if (((if sp.lag2_inClose >= sp.lag2_inOpen { 1 } else { 0 - 1 })) as i32) == 0 - 1 && // black
            (if inClose >= inOpen { 1 } else { 0 - 1 }) == 1 && // white real body
            ((if (sp.lag1_inOpen).max(sp.lag1_inClose) < (sp.lag2_inOpen).min(sp.lag2_inClose) { 1 } else { 0 }) != 0) && // gapping down
-           inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(sp.optInPenetration, sp.lag2_inClose) && // closing well within 1st rb
+           inClose > ((sp.lag2_inClose - sp.lag2_inOpen).abs() as f64).mul_add(cfg.optInPenetration, sp.lag2_inClose) && // closing well within 1st rb
            (sp.lag2_inClose - sp.lag2_inOpen).abs() > ((BodyLong_factor) * (if (BodyLong_avgPeriod) != 0 { (sp.BodyLongPeriodTotal) / (BodyLong_avgPeriod as f64) } else { match BodyLong_rangeType { 0 => ((sp.lag2_inClose) - (sp.lag2_inOpen)).abs(), 1 => (sp.lag2_inHigh) - (sp.lag2_inLow), 2 => ((sp.lag2_inHigh) - (if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inClose) } else { (sp.lag2_inOpen) })) + ((if (sp.lag2_inClose) >= (sp.lag2_inOpen) { (sp.lag2_inOpen) } else { (sp.lag2_inClose) }) - (sp.lag2_inLow)), _ => 0.0 } }) / (if (BodyLong_rangeType) == 2 { 2.0 } else { 1.0 })) && // 1st: long
            (sp.lag1_inClose - sp.lag1_inOpen).abs() <= ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((sp.lag1_inClose) - (sp.lag1_inOpen)).abs(), 1 => (sp.lag1_inHigh) - (sp.lag1_inLow), 2 => ((sp.lag1_inHigh) - (if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inClose) } else { (sp.lag1_inOpen) })) + ((if (sp.lag1_inClose) >= (sp.lag1_inOpen) { (sp.lag1_inOpen) } else { (sp.lag1_inClose) }) - (sp.lag1_inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) && // 2nd: short
            (inClose - inOpen).abs() > ((BodyShort_factor) * (if (BodyShort_avgPeriod) != 0 { (sp.BodyShortPeriodTotal2) / (BodyShort_avgPeriod as f64) } else { match BodyShort_rangeType { 0 => ((inClose) - (inOpen)).abs(), 1 => (inHigh) - (inLow), 2 => ((inHigh) - (if (inClose) >= (inOpen) { (inClose) } else { (inOpen) })) + ((if (inClose) >= (inOpen) { (inOpen) } else { (inClose) }) - (inLow)), _ => 0.0 } }) / (if (BodyShort_rangeType) == 2 { 2.0 } else { 1.0 })) // 3rd: longer than short
@@ -1055,7 +1063,6 @@ impl Core {
             }
         }
         let state = CDLMORNINGSTAR_StreamState {
-            optInPenetration,
             BodyShortPeriodTotal,
             BodyLongPeriodTotal,
             BodyShortPeriodTotal2,
@@ -1075,7 +1082,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLMORNINGSTAR_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLMORNINGSTAR_Stream { config: CDLMORNINGSTAR_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, optInPenetration, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLMORNINGSTAR_Open`] (composition seam).
@@ -1171,10 +1178,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLMORNINGSTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLMORNINGSTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLMORNINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMORNINGSTAR_Stream>>> =
+    static CDLMORNINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLMORNINGSTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1198,7 +1205,7 @@ impl CDLMORNINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLMORNINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLMORNINGSTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1231,7 +1238,7 @@ impl CDLMORNINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLMORNINGSTAR_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLMORNINGSTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1255,11 +1262,12 @@ impl CDLMORNINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLMORNINGSTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLMORNINGSTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
@@ -417,6 +417,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLONNECK was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLONNECK_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLONNECK_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLONNECK stream: one value per closed bar, bit-identical to [`Core::CDLONNECK`]
 /// over the same series. Open with [`Core::CDLONNECK_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -426,10 +438,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLONNECK_Stream")]
 pub struct CDLONNECK_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLONNECK_StreamConfig`.
+    config: CDLONNECK_StreamConfig,
     state: CDLONNECK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -440,8 +450,7 @@ impl CDLONNECK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLONNECK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -495,19 +504,19 @@ impl CDLONNECK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLONNECK_step_impl(sp: &mut CDLONNECK_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLONNECK_step_impl(cfg: &CDLONNECK_StreamConfig, sp: &mut CDLONNECK_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -842,7 +851,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLONNECK_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLONNECK_Stream { config: CDLONNECK_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLONNECK_Open`] (composition seam).
@@ -938,10 +947,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLONNECK_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLONNECK_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLONNECK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLONNECK_Stream>>> =
+    static CDLONNECK_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLONNECK_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -965,7 +974,7 @@ impl CDLONNECK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLONNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLONNECK_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -998,7 +1007,7 @@ impl CDLONNECK_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLONNECK_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLONNECK_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1022,11 +1031,12 @@ impl CDLONNECK_Stream {
             return Err(RetCode::BadParam);
         }
         CDLONNECK_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLONNECK_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
@@ -401,6 +401,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLPIERCING was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLPIERCING_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLPIERCING_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+}
+
 /// Live CDLPIERCING stream: one value per closed bar, bit-identical to [`Core::CDLPIERCING`]
 /// over the same series. Open with [`Core::CDLPIERCING_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -410,8 +420,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLPIERCING_Stream")]
 pub struct CDLPIERCING_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
+    /// What this stream was opened with — see `CDLPIERCING_StreamConfig`.
+    config: CDLPIERCING_StreamConfig,
     state: CDLPIERCING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -422,7 +432,7 @@ impl CDLPIERCING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLPIERCING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -466,14 +476,14 @@ impl CDLPIERCING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLPIERCING_step_impl(sp: &mut CDLPIERCING_StreamState, cs_body_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLPIERCING_step_impl(cfg: &CDLPIERCING_StreamConfig, sp: &mut CDLPIERCING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -709,7 +719,7 @@ impl Core {
             ringLag_BodyLongTrailingIdx: capLag_BodyLongTrailingIdx as usize,
             ring_BodyLongTrailingIdx_derived,
         };
-        Ok(CDLPIERCING_Stream { cs_body_long: self.candle_settings.body_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLPIERCING_Stream { config: CDLPIERCING_StreamConfig { cs_body_long: self.candle_settings.body_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLPIERCING_Open`] (composition seam).
@@ -824,7 +834,7 @@ impl CDLPIERCING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLPIERCING_step_impl(&mut self.state, &self.cs_body_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLPIERCING_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -857,7 +867,7 @@ impl CDLPIERCING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLPIERCING_step_impl(&mut self.state, &self.cs_body_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLPIERCING_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
@@ -479,6 +479,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLRICKSHAWMAN was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLRICKSHAWMAN_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLRICKSHAWMAN_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+}
+
 /// Live CDLRICKSHAWMAN stream: one value per closed bar, bit-identical to [`Core::CDLRICKSHAWMAN`]
 /// over the same series. Open with [`Core::CDLRICKSHAWMAN_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -488,12 +502,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLRICKSHAWMAN_Stream")]
 pub struct CDLRICKSHAWMAN_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
+    /// What this stream was opened with — see `CDLRICKSHAWMAN_StreamConfig`.
+    config: CDLRICKSHAWMAN_StreamConfig,
     state: CDLRICKSHAWMAN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -504,9 +514,7 @@ impl CDLRICKSHAWMAN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLRICKSHAWMAN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_long = src.cs_shadow_long;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -556,25 +564,25 @@ impl CDLRICKSHAWMAN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLRICKSHAWMAN_step_impl(sp: &mut CDLRICKSHAWMAN_StreamState, cs_body_doji: &CandleSetting, cs_near: &CandleSetting, cs_shadow_long: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLRICKSHAWMAN_step_impl(cfg: &CDLRICKSHAWMAN_StreamConfig, sp: &mut CDLRICKSHAWMAN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1061,7 +1069,7 @@ impl Core {
             ringCap_ShadowLongTrailingIdx: cap_ShadowLongTrailingIdx as usize,
             ring_ShadowLongTrailingIdx_derived,
         };
-        Ok(CDLRICKSHAWMAN_Stream { cs_body_doji: self.candle_settings.body_doji, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLRICKSHAWMAN_Stream { config: CDLRICKSHAWMAN_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_near: self.candle_settings.near, cs_shadow_long: self.candle_settings.shadow_long, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLRICKSHAWMAN_Open`] (composition seam).
@@ -1157,10 +1165,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLRICKSHAWMAN_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLRICKSHAWMAN_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLRICKSHAWMAN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLRICKSHAWMAN_Stream>>> =
+    static CDLRICKSHAWMAN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLRICKSHAWMAN_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1184,7 +1192,7 @@ impl CDLRICKSHAWMAN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLRICKSHAWMAN_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_near, &self.cs_shadow_long, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLRICKSHAWMAN_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1217,7 +1225,7 @@ impl CDLRICKSHAWMAN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLRICKSHAWMAN_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_near, &self.cs_shadow_long, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLRICKSHAWMAN_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1241,11 +1249,12 @@ impl CDLRICKSHAWMAN_Stream {
             return Err(RetCode::BadParam);
         }
         CDLRICKSHAWMAN_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLRICKSHAWMAN_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
@@ -526,6 +526,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLRISEFALL3METHODS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLRISEFALL3METHODS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLRISEFALL3METHODS_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLRISEFALL3METHODS stream: one value per closed bar, bit-identical to [`Core::CDLRISEFALL3METHODS`]
 /// over the same series. Open with [`Core::CDLRISEFALL3METHODS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -535,10 +547,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLRISEFALL3METHODS_Stream")]
 pub struct CDLRISEFALL3METHODS_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLRISEFALL3METHODS_StreamConfig`.
+    config: CDLRISEFALL3METHODS_StreamConfig,
     state: CDLRISEFALL3METHODS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -549,8 +559,7 @@ impl CDLRISEFALL3METHODS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLRISEFALL3METHODS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -626,20 +635,20 @@ impl CDLRISEFALL3METHODS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLRISEFALL3METHODS_step_impl(sp: &mut CDLRISEFALL3METHODS_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLRISEFALL3METHODS_step_impl(cfg: &CDLRISEFALL3METHODS_StreamConfig, sp: &mut CDLRISEFALL3METHODS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1120,7 +1129,7 @@ impl Core {
             ringLag_BodyShortTrailingIdx: capLag_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLRISEFALL3METHODS_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLRISEFALL3METHODS_Stream { config: CDLRISEFALL3METHODS_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLRISEFALL3METHODS_Open`] (composition seam).
@@ -1216,10 +1225,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLRISEFALL3METHODS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLRISEFALL3METHODS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLRISEFALL3METHODS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLRISEFALL3METHODS_Stream>>> =
+    static CDLRISEFALL3METHODS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLRISEFALL3METHODS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1243,7 +1252,7 @@ impl CDLRISEFALL3METHODS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLRISEFALL3METHODS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLRISEFALL3METHODS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1276,7 +1285,7 @@ impl CDLRISEFALL3METHODS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLRISEFALL3METHODS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLRISEFALL3METHODS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1300,11 +1309,12 @@ impl CDLRISEFALL3METHODS_Stream {
             return Err(RetCode::BadParam);
         }
         CDLRISEFALL3METHODS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLRISEFALL3METHODS_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
@@ -484,6 +484,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSEPARATINGLINES was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSEPARATINGLINES_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSEPARATINGLINES_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLSEPARATINGLINES stream: one value per closed bar, bit-identical to [`Core::CDLSEPARATINGLINES`]
 /// over the same series. Open with [`Core::CDLSEPARATINGLINES_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -493,12 +507,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSEPARATINGLINES_Stream")]
 pub struct CDLSEPARATINGLINES_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLSEPARATINGLINES_StreamConfig`.
+    config: CDLSEPARATINGLINES_StreamConfig,
     state: CDLSEPARATINGLINES_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -509,9 +519,7 @@ impl CDLSEPARATINGLINES_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSEPARATINGLINES_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_equal = src.cs_equal;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -571,25 +579,25 @@ impl CDLSEPARATINGLINES_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSEPARATINGLINES_step_impl(sp: &mut CDLSEPARATINGLINES_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSEPARATINGLINES_step_impl(cfg: &CDLSEPARATINGLINES_StreamConfig, sp: &mut CDLSEPARATINGLINES_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -1071,7 +1079,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSEPARATINGLINES_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSEPARATINGLINES_Stream { config: CDLSEPARATINGLINES_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSEPARATINGLINES_Open`] (composition seam).
@@ -1167,10 +1175,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLSEPARATINGLINES_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLSEPARATINGLINES_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLSEPARATINGLINES_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSEPARATINGLINES_Stream>>> =
+    static CDLSEPARATINGLINES_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSEPARATINGLINES_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1194,7 +1202,7 @@ impl CDLSEPARATINGLINES_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSEPARATINGLINES_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSEPARATINGLINES_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1227,7 +1235,7 @@ impl CDLSEPARATINGLINES_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSEPARATINGLINES_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSEPARATINGLINES_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1251,11 +1259,12 @@ impl CDLSEPARATINGLINES_Stream {
             return Err(RetCode::BadParam);
         }
         CDLSEPARATINGLINES_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLSEPARATINGLINES_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
@@ -482,6 +482,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSHOOTINGSTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSHOOTINGSTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSHOOTINGSTAR_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowLong` setting this stream was opened with.
+    cs_shadow_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLSHOOTINGSTAR stream: one value per closed bar, bit-identical to [`Core::CDLSHOOTINGSTAR`]
 /// over the same series. Open with [`Core::CDLSHOOTINGSTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -491,12 +505,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSHOOTINGSTAR_Stream")]
 pub struct CDLSHOOTINGSTAR_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `ShadowLong` setting this stream was opened with.
-    cs_shadow_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLSHOOTINGSTAR_StreamConfig`.
+    config: CDLSHOOTINGSTAR_StreamConfig,
     state: CDLSHOOTINGSTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -507,9 +517,7 @@ impl CDLSHOOTINGSTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSHOOTINGSTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_shadow_long = src.cs_shadow_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -563,25 +571,25 @@ impl CDLSHOOTINGSTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSHOOTINGSTAR_step_impl(sp: &mut CDLSHOOTINGSTAR_StreamState, cs_body_short: &CandleSetting, cs_shadow_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSHOOTINGSTAR_step_impl(cfg: &CDLSHOOTINGSTAR_StreamConfig, sp: &mut CDLSHOOTINGSTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowLong_rangeType: i32 = cs_shadow_long.range_type as i32;
+        let ShadowLong_rangeType: i32 = cfg.cs_shadow_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowLong_avgPeriod: i32 = cs_shadow_long.avg_period;
+        let ShadowLong_avgPeriod: i32 = cfg.cs_shadow_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowLong_factor: f64 = cs_shadow_long.factor;
+        let ShadowLong_factor: f64 = cfg.cs_shadow_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -1075,7 +1083,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSHOOTINGSTAR_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSHOOTINGSTAR_Stream { config: CDLSHOOTINGSTAR_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_shadow_long: self.candle_settings.shadow_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSHOOTINGSTAR_Open`] (composition seam).
@@ -1171,10 +1179,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLSHOOTINGSTAR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLSHOOTINGSTAR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLSHOOTINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSHOOTINGSTAR_Stream>>> =
+    static CDLSHOOTINGSTAR_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSHOOTINGSTAR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1198,7 +1206,7 @@ impl CDLSHOOTINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSHOOTINGSTAR_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSHOOTINGSTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1231,7 +1239,7 @@ impl CDLSHOOTINGSTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSHOOTINGSTAR_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSHOOTINGSTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1255,11 +1263,12 @@ impl CDLSHOOTINGSTAR_Stream {
             return Err(RetCode::BadParam);
         }
         CDLSHOOTINGSTAR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLSHOOTINGSTAR_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
@@ -407,6 +407,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSHORTLINE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSHORTLINE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSHORTLINE_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `ShadowShort` setting this stream was opened with.
+    cs_shadow_short: CandleSetting,
+}
+
 /// Live CDLSHORTLINE stream: one value per closed bar, bit-identical to [`Core::CDLSHORTLINE`]
 /// over the same series. Open with [`Core::CDLSHORTLINE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -416,10 +428,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSHORTLINE_Stream")]
 pub struct CDLSHORTLINE_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `ShadowShort` setting this stream was opened with.
-    cs_shadow_short: CandleSetting,
+    /// What this stream was opened with — see `CDLSHORTLINE_StreamConfig`.
+    config: CDLSHORTLINE_StreamConfig,
     state: CDLSHORTLINE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -430,8 +440,7 @@ impl CDLSHORTLINE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSHORTLINE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
-        self.cs_shadow_short = src.cs_shadow_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -473,19 +482,19 @@ impl CDLSHORTLINE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSHORTLINE_step_impl(sp: &mut CDLSHORTLINE_StreamState, cs_body_short: &CandleSetting, cs_shadow_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSHORTLINE_step_impl(cfg: &CDLSHORTLINE_StreamConfig, sp: &mut CDLSHORTLINE_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let ShadowShort_rangeType: i32 = cs_shadow_short.range_type as i32;
+        let ShadowShort_rangeType: i32 = cfg.cs_shadow_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowShort_avgPeriod: i32 = cs_shadow_short.avg_period;
+        let ShadowShort_avgPeriod: i32 = cfg.cs_shadow_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowShort_factor: f64 = cs_shadow_short.factor;
+        let ShadowShort_factor: f64 = cfg.cs_shadow_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -830,7 +839,7 @@ impl Core {
             ringCap_ShadowTrailingIdx: cap_ShadowTrailingIdx as usize,
             ring_ShadowTrailingIdx_derived,
         };
-        Ok(CDLSHORTLINE_Stream { cs_body_short: self.candle_settings.body_short, cs_shadow_short: self.candle_settings.shadow_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSHORTLINE_Stream { config: CDLSHORTLINE_StreamConfig { cs_body_short: self.candle_settings.body_short, cs_shadow_short: self.candle_settings.shadow_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSHORTLINE_Open`] (composition seam).
@@ -926,10 +935,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLSHORTLINE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLSHORTLINE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLSHORTLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSHORTLINE_Stream>>> =
+    static CDLSHORTLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSHORTLINE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -953,7 +962,7 @@ impl CDLSHORTLINE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSHORTLINE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSHORTLINE_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -986,7 +995,7 @@ impl CDLSHORTLINE_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSHORTLINE_step_impl(&mut self.state, &self.cs_body_short, &self.cs_shadow_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSHORTLINE_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1010,11 +1019,12 @@ impl CDLSHORTLINE_Stream {
             return Err(RetCode::BadParam);
         }
         CDLSHORTLINE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLSHORTLINE_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
@@ -336,6 +336,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSPINNINGTOP was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSPINNINGTOP_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSPINNINGTOP_StreamConfig {
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLSPINNINGTOP stream: one value per closed bar, bit-identical to [`Core::CDLSPINNINGTOP`]
 /// over the same series. Open with [`Core::CDLSPINNINGTOP_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -345,8 +355,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSPINNINGTOP_Stream")]
 pub struct CDLSPINNINGTOP_Stream {
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLSPINNINGTOP_StreamConfig`.
+    config: CDLSPINNINGTOP_StreamConfig,
     state: CDLSPINNINGTOP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -357,7 +367,7 @@ impl CDLSPINNINGTOP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSPINNINGTOP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -391,13 +401,13 @@ impl CDLSPINNINGTOP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSPINNINGTOP_step_impl(sp: &mut CDLSPINNINGTOP_StreamState, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSPINNINGTOP_step_impl(cfg: &CDLSPINNINGTOP_StreamConfig, sp: &mut CDLSPINNINGTOP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyShort_rangeType {
@@ -609,7 +619,7 @@ impl Core {
             ringCap_BodyTrailingIdx: cap_BodyTrailingIdx as usize,
             ring_BodyTrailingIdx_derived,
         };
-        Ok(CDLSPINNINGTOP_Stream { cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSPINNINGTOP_Stream { config: CDLSPINNINGTOP_StreamConfig { cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSPINNINGTOP_Open`] (composition seam).
@@ -724,7 +734,7 @@ impl CDLSPINNINGTOP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSPINNINGTOP_step_impl(&mut self.state, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSPINNINGTOP_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -757,7 +767,7 @@ impl CDLSPINNINGTOP_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSPINNINGTOP_step_impl(&mut self.state, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSPINNINGTOP_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
@@ -607,6 +607,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSTALLEDPATTERN was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSTALLEDPATTERN_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSTALLEDPATTERN_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLSTALLEDPATTERN stream: one value per closed bar, bit-identical to [`Core::CDLSTALLEDPATTERN`]
 /// over the same series. Open with [`Core::CDLSTALLEDPATTERN_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -616,14 +632,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSTALLEDPATTERN_Stream")]
 pub struct CDLSTALLEDPATTERN_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLSTALLEDPATTERN_StreamConfig`.
+    config: CDLSTALLEDPATTERN_StreamConfig,
     state: CDLSTALLEDPATTERN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -634,10 +644,7 @@ impl CDLSTALLEDPATTERN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSTALLEDPATTERN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
-        self.cs_near = src.cs_near;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -717,32 +724,32 @@ impl CDLSTALLEDPATTERN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSTALLEDPATTERN_step_impl(sp: &mut CDLSTALLEDPATTERN_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, cs_near: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSTALLEDPATTERN_step_impl(cfg: &CDLSTALLEDPATTERN_StreamConfig, sp: &mut CDLSTALLEDPATTERN_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         let mut totIdx: usize = 0_usize;
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -1370,7 +1377,7 @@ impl Core {
             ringLag_ShadowVeryShortTrailingIdx: capLag_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLSTALLEDPATTERN_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSTALLEDPATTERN_Stream { config: CDLSTALLEDPATTERN_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, cs_near: self.candle_settings.near, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSTALLEDPATTERN_Open`] (composition seam).
@@ -1466,10 +1473,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLSTALLEDPATTERN_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLSTALLEDPATTERN_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLSTALLEDPATTERN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSTALLEDPATTERN_Stream>>> =
+    static CDLSTALLEDPATTERN_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLSTALLEDPATTERN_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1493,7 +1500,7 @@ impl CDLSTALLEDPATTERN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSTALLEDPATTERN_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_near, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSTALLEDPATTERN_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1526,7 +1533,7 @@ impl CDLSTALLEDPATTERN_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSTALLEDPATTERN_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, &self.cs_near, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSTALLEDPATTERN_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1550,11 +1557,12 @@ impl CDLSTALLEDPATTERN_Stream {
             return Err(RetCode::BadParam);
         }
         CDLSTALLEDPATTERN_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLSTALLEDPATTERN_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
@@ -348,6 +348,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLSTICKSANDWICH was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLSTICKSANDWICH_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLSTICKSANDWICH_StreamConfig {
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLSTICKSANDWICH stream: one value per closed bar, bit-identical to [`Core::CDLSTICKSANDWICH`]
 /// over the same series. Open with [`Core::CDLSTICKSANDWICH_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -357,8 +367,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLSTICKSANDWICH_Stream")]
 pub struct CDLSTICKSANDWICH_Stream {
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLSTICKSANDWICH_StreamConfig`.
+    config: CDLSTICKSANDWICH_StreamConfig,
     state: CDLSTICKSANDWICH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -369,7 +379,7 @@ impl CDLSTICKSANDWICH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLSTICKSANDWICH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -421,13 +431,13 @@ impl CDLSTICKSANDWICH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLSTICKSANDWICH_step_impl(sp: &mut CDLSTICKSANDWICH_StreamState, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLSTICKSANDWICH_step_impl(cfg: &CDLSTICKSANDWICH_StreamConfig, sp: &mut CDLSTICKSANDWICH_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match Equal_rangeType {
             0 => {
@@ -654,7 +664,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLSTICKSANDWICH_Stream { cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLSTICKSANDWICH_Stream { config: CDLSTICKSANDWICH_StreamConfig { cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLSTICKSANDWICH_Open`] (composition seam).
@@ -769,7 +779,7 @@ impl CDLSTICKSANDWICH_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLSTICKSANDWICH_step_impl(&mut self.state, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLSTICKSANDWICH_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -802,7 +812,7 @@ impl CDLSTICKSANDWICH_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLSTICKSANDWICH_step_impl(&mut self.state, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLSTICKSANDWICH_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
@@ -470,6 +470,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLTAKURI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLTAKURI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLTAKURI_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+    /// The `ShadowVeryLong` setting this stream was opened with.
+    cs_shadow_very_long: CandleSetting,
+    /// The `ShadowVeryShort` setting this stream was opened with.
+    cs_shadow_very_short: CandleSetting,
+}
+
 /// Live CDLTAKURI stream: one value per closed bar, bit-identical to [`Core::CDLTAKURI`]
 /// over the same series. Open with [`Core::CDLTAKURI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -479,12 +493,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTAKURI_Stream")]
 pub struct CDLTAKURI_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
-    /// The `ShadowVeryLong` setting this stream was opened with.
-    cs_shadow_very_long: CandleSetting,
-    /// The `ShadowVeryShort` setting this stream was opened with.
-    cs_shadow_very_short: CandleSetting,
+    /// What this stream was opened with — see `CDLTAKURI_StreamConfig`.
+    config: CDLTAKURI_StreamConfig,
     state: CDLTAKURI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -495,9 +505,7 @@ impl CDLTAKURI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTAKURI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
-        self.cs_shadow_very_long = src.cs_shadow_very_long;
-        self.cs_shadow_very_short = src.cs_shadow_very_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -547,25 +555,25 @@ impl CDLTAKURI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTAKURI_step_impl(sp: &mut CDLTAKURI_StreamState, cs_body_doji: &CandleSetting, cs_shadow_very_long: &CandleSetting, cs_shadow_very_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTAKURI_step_impl(cfg: &CDLTAKURI_StreamConfig, sp: &mut CDLTAKURI_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_rangeType: i32 = cs_shadow_very_long.range_type as i32;
+        let ShadowVeryLong_rangeType: i32 = cfg.cs_shadow_very_long.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_avgPeriod: i32 = cs_shadow_very_long.avg_period;
+        let ShadowVeryLong_avgPeriod: i32 = cfg.cs_shadow_very_long.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryLong_factor: f64 = cs_shadow_very_long.factor;
+        let ShadowVeryLong_factor: f64 = cfg.cs_shadow_very_long.factor;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_rangeType: i32 = cs_shadow_very_short.range_type as i32;
+        let ShadowVeryShort_rangeType: i32 = cfg.cs_shadow_very_short.range_type as i32;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_avgPeriod: i32 = cs_shadow_very_short.avg_period;
+        let ShadowVeryShort_avgPeriod: i32 = cfg.cs_shadow_very_short.avg_period;
         #[allow(non_snake_case)]
-        let ShadowVeryShort_factor: f64 = cs_shadow_very_short.factor;
+        let ShadowVeryShort_factor: f64 = cfg.cs_shadow_very_short.factor;
         if sp.ringCap_BodyDojiTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -1045,7 +1053,7 @@ impl Core {
             ringCap_ShadowVeryShortTrailingIdx: cap_ShadowVeryShortTrailingIdx as usize,
             ring_ShadowVeryShortTrailingIdx_derived,
         };
-        Ok(CDLTAKURI_Stream { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_long: self.candle_settings.shadow_very_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTAKURI_Stream { config: CDLTAKURI_StreamConfig { cs_body_doji: self.candle_settings.body_doji, cs_shadow_very_long: self.candle_settings.shadow_very_long, cs_shadow_very_short: self.candle_settings.shadow_very_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTAKURI_Open`] (composition seam).
@@ -1141,10 +1149,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLTAKURI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLTAKURI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLTAKURI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLTAKURI_Stream>>> =
+    static CDLTAKURI_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLTAKURI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1168,7 +1176,7 @@ impl CDLTAKURI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLTAKURI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_long, &self.cs_shadow_very_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTAKURI_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1201,7 +1209,7 @@ impl CDLTAKURI_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLTAKURI_step_impl(&mut self.state, &self.cs_body_doji, &self.cs_shadow_very_long, &self.cs_shadow_very_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTAKURI_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1225,11 +1233,12 @@ impl CDLTAKURI_Stream {
             return Err(RetCode::BadParam);
         }
         CDLTAKURI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLTAKURI_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
@@ -358,6 +358,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLTASUKIGAP was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLTASUKIGAP_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLTASUKIGAP_StreamConfig {
+    /// The `Near` setting this stream was opened with.
+    cs_near: CandleSetting,
+}
+
 /// Live CDLTASUKIGAP stream: one value per closed bar, bit-identical to [`Core::CDLTASUKIGAP`]
 /// over the same series. Open with [`Core::CDLTASUKIGAP_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -367,8 +377,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTASUKIGAP_Stream")]
 pub struct CDLTASUKIGAP_Stream {
-    /// The `Near` setting this stream was opened with.
-    cs_near: CandleSetting,
+    /// What this stream was opened with — see `CDLTASUKIGAP_StreamConfig`.
+    config: CDLTASUKIGAP_StreamConfig,
     state: CDLTASUKIGAP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -379,7 +389,7 @@ impl CDLTASUKIGAP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTASUKIGAP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_near = src.cs_near;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -427,13 +437,13 @@ impl CDLTASUKIGAP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTASUKIGAP_step_impl(sp: &mut CDLTASUKIGAP_StreamState, cs_near: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTASUKIGAP_step_impl(cfg: &CDLTASUKIGAP_StreamConfig, sp: &mut CDLTASUKIGAP_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let Near_rangeType: i32 = cs_near.range_type as i32;
+        let Near_rangeType: i32 = cfg.cs_near.range_type as i32;
         #[allow(non_snake_case)]
-        let Near_avgPeriod: i32 = cs_near.avg_period;
+        let Near_avgPeriod: i32 = cfg.cs_near.avg_period;
         #[allow(non_snake_case)]
-        let Near_factor: f64 = cs_near.factor;
+        let Near_factor: f64 = cfg.cs_near.factor;
         let mut _candlerange_0: f64;
         match Near_rangeType {
             0 => {
@@ -674,7 +684,7 @@ impl Core {
             ringLag_NearTrailingIdx: capLag_NearTrailingIdx as usize,
             ring_NearTrailingIdx_derived,
         };
-        Ok(CDLTASUKIGAP_Stream { cs_near: self.candle_settings.near, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTASUKIGAP_Stream { config: CDLTASUKIGAP_StreamConfig { cs_near: self.candle_settings.near, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTASUKIGAP_Open`] (composition seam).
@@ -789,7 +799,7 @@ impl CDLTASUKIGAP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLTASUKIGAP_step_impl(&mut self.state, &self.cs_near, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTASUKIGAP_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -822,7 +832,7 @@ impl CDLTASUKIGAP_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLTASUKIGAP_step_impl(&mut self.state, &self.cs_near, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTASUKIGAP_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
@@ -453,6 +453,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLTHRUSTING was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLTHRUSTING_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLTHRUSTING_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `Equal` setting this stream was opened with.
+    cs_equal: CandleSetting,
+}
+
 /// Live CDLTHRUSTING stream: one value per closed bar, bit-identical to [`Core::CDLTHRUSTING`]
 /// over the same series. Open with [`Core::CDLTHRUSTING_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -462,10 +474,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTHRUSTING_Stream")]
 pub struct CDLTHRUSTING_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `Equal` setting this stream was opened with.
-    cs_equal: CandleSetting,
+    /// What this stream was opened with — see `CDLTHRUSTING_StreamConfig`.
+    config: CDLTHRUSTING_StreamConfig,
     state: CDLTHRUSTING_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -476,8 +486,7 @@ impl CDLTHRUSTING_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTHRUSTING_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_equal = src.cs_equal;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -531,19 +540,19 @@ impl CDLTHRUSTING_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTHRUSTING_step_impl(sp: &mut CDLTHRUSTING_StreamState, cs_body_long: &CandleSetting, cs_equal: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTHRUSTING_step_impl(cfg: &CDLTHRUSTING_StreamConfig, sp: &mut CDLTHRUSTING_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let Equal_rangeType: i32 = cs_equal.range_type as i32;
+        let Equal_rangeType: i32 = cfg.cs_equal.range_type as i32;
         #[allow(non_snake_case)]
-        let Equal_avgPeriod: i32 = cs_equal.avg_period;
+        let Equal_avgPeriod: i32 = cfg.cs_equal.avg_period;
         #[allow(non_snake_case)]
-        let Equal_factor: f64 = cs_equal.factor;
+        let Equal_factor: f64 = cfg.cs_equal.factor;
         let mut _candlerange_0: f64;
         match BodyLong_rangeType {
             0 => {
@@ -880,7 +889,7 @@ impl Core {
             ringLag_EqualTrailingIdx: capLag_EqualTrailingIdx as usize,
             ring_EqualTrailingIdx_derived,
         };
-        Ok(CDLTHRUSTING_Stream { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTHRUSTING_Stream { config: CDLTHRUSTING_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_equal: self.candle_settings.equal, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTHRUSTING_Open`] (composition seam).
@@ -976,10 +985,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLTHRUSTING_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLTHRUSTING_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLTHRUSTING_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLTHRUSTING_Stream>>> =
+    static CDLTHRUSTING_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLTHRUSTING_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1003,7 +1012,7 @@ impl CDLTHRUSTING_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLTHRUSTING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTHRUSTING_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1036,7 +1045,7 @@ impl CDLTHRUSTING_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLTHRUSTING_step_impl(&mut self.state, &self.cs_body_long, &self.cs_equal, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTHRUSTING_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1060,11 +1069,12 @@ impl CDLTHRUSTING_Stream {
             return Err(RetCode::BadParam);
         }
         CDLTHRUSTING_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLTHRUSTING_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
@@ -352,6 +352,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLTRISTAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLTRISTAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLTRISTAR_StreamConfig {
+    /// The `BodyDoji` setting this stream was opened with.
+    cs_body_doji: CandleSetting,
+}
+
 /// Live CDLTRISTAR stream: one value per closed bar, bit-identical to [`Core::CDLTRISTAR`]
 /// over the same series. Open with [`Core::CDLTRISTAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -361,8 +371,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLTRISTAR_Stream")]
 pub struct CDLTRISTAR_Stream {
-    /// The `BodyDoji` setting this stream was opened with.
-    cs_body_doji: CandleSetting,
+    /// What this stream was opened with — see `CDLTRISTAR_StreamConfig`.
+    config: CDLTRISTAR_StreamConfig,
     state: CDLTRISTAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -373,7 +383,7 @@ impl CDLTRISTAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLTRISTAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_doji = src.cs_body_doji;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -423,13 +433,13 @@ impl CDLTRISTAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLTRISTAR_step_impl(sp: &mut CDLTRISTAR_StreamState, cs_body_doji: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLTRISTAR_step_impl(cfg: &CDLTRISTAR_StreamConfig, sp: &mut CDLTRISTAR_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyDoji_rangeType: i32 = cs_body_doji.range_type as i32;
+        let BodyDoji_rangeType: i32 = cfg.cs_body_doji.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyDoji_avgPeriod: i32 = cs_body_doji.avg_period;
+        let BodyDoji_avgPeriod: i32 = cfg.cs_body_doji.avg_period;
         #[allow(non_snake_case)]
-        let BodyDoji_factor: f64 = cs_body_doji.factor;
+        let BodyDoji_factor: f64 = cfg.cs_body_doji.factor;
         if sp.ringCap_BodyTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyDoji_rangeType {
@@ -686,7 +696,7 @@ impl Core {
             ringCap_BodyTrailingIdx: cap_BodyTrailingIdx as usize,
             ring_BodyTrailingIdx_derived,
         };
-        Ok(CDLTRISTAR_Stream { cs_body_doji: self.candle_settings.body_doji, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLTRISTAR_Stream { config: CDLTRISTAR_StreamConfig { cs_body_doji: self.candle_settings.body_doji, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLTRISTAR_Open`] (composition seam).
@@ -801,7 +811,7 @@ impl CDLTRISTAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLTRISTAR_step_impl(&mut self.state, &self.cs_body_doji, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLTRISTAR_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -834,7 +844,7 @@ impl CDLTRISTAR_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLTRISTAR_step_impl(&mut self.state, &self.cs_body_doji, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLTRISTAR_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
@@ -420,6 +420,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLUNIQUE3RIVER was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLUNIQUE3RIVER_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLUNIQUE3RIVER_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLUNIQUE3RIVER stream: one value per closed bar, bit-identical to [`Core::CDLUNIQUE3RIVER`]
 /// over the same series. Open with [`Core::CDLUNIQUE3RIVER_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -429,10 +441,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLUNIQUE3RIVER_Stream")]
 pub struct CDLUNIQUE3RIVER_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLUNIQUE3RIVER_StreamConfig`.
+    config: CDLUNIQUE3RIVER_StreamConfig,
     state: CDLUNIQUE3RIVER_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -443,8 +453,7 @@ impl CDLUNIQUE3RIVER_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLUNIQUE3RIVER_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -502,19 +511,19 @@ impl CDLUNIQUE3RIVER_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLUNIQUE3RIVER_step_impl(sp: &mut CDLUNIQUE3RIVER_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLUNIQUE3RIVER_step_impl(cfg: &CDLUNIQUE3RIVER_StreamConfig, sp: &mut CDLUNIQUE3RIVER_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -896,7 +905,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLUNIQUE3RIVER_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLUNIQUE3RIVER_Stream { config: CDLUNIQUE3RIVER_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLUNIQUE3RIVER_Open`] (composition seam).
@@ -992,10 +1001,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLUNIQUE3RIVER_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLUNIQUE3RIVER_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLUNIQUE3RIVER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLUNIQUE3RIVER_Stream>>> =
+    static CDLUNIQUE3RIVER_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLUNIQUE3RIVER_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1019,7 +1028,7 @@ impl CDLUNIQUE3RIVER_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLUNIQUE3RIVER_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLUNIQUE3RIVER_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1052,7 +1061,7 @@ impl CDLUNIQUE3RIVER_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLUNIQUE3RIVER_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLUNIQUE3RIVER_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1076,11 +1085,12 @@ impl CDLUNIQUE3RIVER_Stream {
             return Err(RetCode::BadParam);
         }
         CDLUNIQUE3RIVER_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLUNIQUE3RIVER_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
@@ -422,6 +422,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CDLUPSIDEGAP2CROWS was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CDLUPSIDEGAP2CROWS_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CDLUPSIDEGAP2CROWS_StreamConfig {
+    /// The `BodyLong` setting this stream was opened with.
+    cs_body_long: CandleSetting,
+    /// The `BodyShort` setting this stream was opened with.
+    cs_body_short: CandleSetting,
+}
+
 /// Live CDLUPSIDEGAP2CROWS stream: one value per closed bar, bit-identical to [`Core::CDLUPSIDEGAP2CROWS`]
 /// over the same series. Open with [`Core::CDLUPSIDEGAP2CROWS_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -431,10 +443,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CDLUPSIDEGAP2CROWS_Stream")]
 pub struct CDLUPSIDEGAP2CROWS_Stream {
-    /// The `BodyLong` setting this stream was opened with.
-    cs_body_long: CandleSetting,
-    /// The `BodyShort` setting this stream was opened with.
-    cs_body_short: CandleSetting,
+    /// What this stream was opened with — see `CDLUPSIDEGAP2CROWS_StreamConfig`.
+    config: CDLUPSIDEGAP2CROWS_StreamConfig,
     state: CDLUPSIDEGAP2CROWS_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -445,8 +455,7 @@ impl CDLUPSIDEGAP2CROWS_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CDLUPSIDEGAP2CROWS_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
-        self.cs_body_long = src.cs_body_long;
-        self.cs_body_short = src.cs_body_short;
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -504,19 +513,19 @@ impl CDLUPSIDEGAP2CROWS_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CDLUPSIDEGAP2CROWS_step_impl(sp: &mut CDLUPSIDEGAP2CROWS_StreamState, cs_body_long: &CandleSetting, cs_body_short: &CandleSetting, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
+    fn CDLUPSIDEGAP2CROWS_step_impl(cfg: &CDLUPSIDEGAP2CROWS_StreamConfig, sp: &mut CDLUPSIDEGAP2CROWS_StreamState, inOpen: f64, inHigh: f64, inLow: f64, inClose: f64, outInteger: &mut i32) {
         #[allow(non_snake_case)]
-        let BodyLong_rangeType: i32 = cs_body_long.range_type as i32;
+        let BodyLong_rangeType: i32 = cfg.cs_body_long.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyLong_avgPeriod: i32 = cs_body_long.avg_period;
+        let BodyLong_avgPeriod: i32 = cfg.cs_body_long.avg_period;
         #[allow(non_snake_case)]
-        let BodyLong_factor: f64 = cs_body_long.factor;
+        let BodyLong_factor: f64 = cfg.cs_body_long.factor;
         #[allow(non_snake_case)]
-        let BodyShort_rangeType: i32 = cs_body_short.range_type as i32;
+        let BodyShort_rangeType: i32 = cfg.cs_body_short.range_type as i32;
         #[allow(non_snake_case)]
-        let BodyShort_avgPeriod: i32 = cs_body_short.avg_period;
+        let BodyShort_avgPeriod: i32 = cfg.cs_body_short.avg_period;
         #[allow(non_snake_case)]
-        let BodyShort_factor: f64 = cs_body_short.factor;
+        let BodyShort_factor: f64 = cfg.cs_body_short.factor;
         if sp.ringCap_BodyLongTrailingIdx == 0 {
             let mut _candlerange_0: f64;
             match BodyLong_rangeType {
@@ -900,7 +909,7 @@ impl Core {
             ringCap_BodyShortTrailingIdx: cap_BodyShortTrailingIdx as usize,
             ring_BodyShortTrailingIdx_derived,
         };
-        Ok(CDLUPSIDEGAP2CROWS_Stream { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CDLUPSIDEGAP2CROWS_Stream { config: CDLUPSIDEGAP2CROWS_StreamConfig { cs_body_long: self.candle_settings.body_long, cs_body_short: self.candle_settings.body_short, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CDLUPSIDEGAP2CROWS_Open`] (composition seam).
@@ -996,10 +1005,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CDLUPSIDEGAP2CROWS_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CDLUPSIDEGAP2CROWS_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CDLUPSIDEGAP2CROWS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLUPSIDEGAP2CROWS_Stream>>> =
+    static CDLUPSIDEGAP2CROWS_PEEK_SCRATCH: std::cell::Cell<Option<Box<CDLUPSIDEGAP2CROWS_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1023,7 +1032,7 @@ impl CDLUPSIDEGAP2CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen, inHigh, inLow, inClose, &mut outInteger);
+        Core::CDLUPSIDEGAP2CROWS_step_impl(&self.config, &mut self.state, inOpen, inHigh, inLow, inClose, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1056,7 +1065,7 @@ impl CDLUPSIDEGAP2CROWS_Stream {
             if !inOpen[i].is_finite() || !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CDLUPSIDEGAP2CROWS_step_impl(&mut self.state, &self.cs_body_long, &self.cs_body_short, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
+            Core::CDLUPSIDEGAP2CROWS_step_impl(&self.config, &mut self.state, inOpen[i], inHigh[i], inLow[i], inClose[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1080,11 +1089,12 @@ impl CDLUPSIDEGAP2CROWS_Stream {
             return Err(RetCode::BadParam);
         }
         CDLUPSIDEGAP2CROWS_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::CDLUPSIDEGAP2CROWS_step_impl(&self.config, &mut scratch, inOpen, inHigh, inLow, inClose, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cmf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmf.rs
@@ -414,6 +414,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CMF was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CMF_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CMF_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live CMF stream: one value per closed bar, bit-identical to [`Core::CMF`]
 /// over the same series. Open with [`Core::CMF_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -423,6 +432,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMF_Stream")]
 pub struct CMF_Stream {
+    /// What this stream was opened with — see `CMF_StreamConfig`.
+    config: CMF_StreamConfig,
     state: CMF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -433,6 +444,7 @@ impl CMF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -441,7 +453,6 @@ impl CMF_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CMF_StreamState {
-    optInTimePeriod: i32,
     sumMFV: f64,
     sumVol: f64,
     mfv_Idx: usize,
@@ -456,7 +467,6 @@ impl CMF_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.sumMFV = src.sumMFV;
         self.sumVol = src.sumVol;
         self.mfv_Idx = src.mfv_Idx;
@@ -474,7 +484,7 @@ impl CMF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMF_step_impl(sp: &mut CMF_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn CMF_step_impl(cfg: &CMF_StreamConfig, sp: &mut CMF_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut high: f64 = 0.0_f64;
         let mut low: f64 = 0.0_f64;
         let mut close: f64 = 0.0_f64;
@@ -649,7 +659,6 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let state = CMF_StreamState {
-            optInTimePeriod,
             sumMFV,
             sumVol,
             mfv_Idx,
@@ -658,7 +667,7 @@ impl Core {
             cb_mfv_flow: mfv_flow,
             cb_mfv_volume: mfv_volume,
         };
-        Ok(CMF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMF_Stream { config: CMF_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMF_Open`] (composition seam).
@@ -754,10 +763,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CMF_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CMF_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CMF_PEEK_SCRATCH: std::cell::Cell<Option<Box<CMF_Stream>>> =
+    static CMF_PEEK_SCRATCH: std::cell::Cell<Option<Box<CMF_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -781,7 +790,7 @@ impl CMF_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::CMF_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::CMF_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -814,7 +823,7 @@ impl CMF_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CMF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::CMF_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -838,11 +847,12 @@ impl CMF_Stream {
             return Err(RetCode::BadParam);
         }
         CMF_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose, inVolume);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::CMF_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, inVolume, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/cmo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmo.rs
@@ -446,6 +446,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CMO was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CMO_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CMO_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live CMO stream: one value per closed bar, bit-identical to [`Core::CMO`]
 /// over the same series. Open with [`Core::CMO_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -455,6 +464,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMO_Stream")]
 pub struct CMO_Stream {
+    /// What this stream was opened with — see `CMO_StreamConfig`.
+    config: CMO_StreamConfig,
     state: CMO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -465,6 +476,7 @@ impl CMO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -473,7 +485,6 @@ impl CMO_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CMO_StreamState {
-    optInTimePeriod: i32,
     prevGain: f64,
     prevLoss: f64,
     prevValue: f64,
@@ -484,7 +495,6 @@ impl CMO_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevGain = src.prevGain;
         self.prevLoss = src.prevLoss;
         self.prevValue = src.prevValue;
@@ -498,25 +508,25 @@ impl CMO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMO_step_impl(sp: &mut CMO_StreamState, inReal: f64, outReal: &mut f64) {
+    fn CMO_step_impl(cfg: &CMO_StreamConfig, sp: &mut CMO_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
-        if sp.optInTimePeriod == 1 {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
         tempValue1 = inReal;
         tempValue2 = tempValue1 - sp.prevValue;
         sp.prevValue = tempValue1;
-        sp.prevLoss *= ((sp.optInTimePeriod - 1) as f64);
-        sp.prevGain *= ((sp.optInTimePeriod - 1) as f64);
+        sp.prevLoss *= ((cfg.optInTimePeriod - 1) as f64);
+        sp.prevGain *= ((cfg.optInTimePeriod - 1) as f64);
         if tempValue2 < 0_f64 {
             sp.prevLoss -= tempValue2;
         } else {
             sp.prevGain += tempValue2;
         }
-        sp.prevLoss /= ((sp.optInTimePeriod) as f64);
-        sp.prevGain /= ((sp.optInTimePeriod) as f64);
+        sp.prevLoss /= ((cfg.optInTimePeriod) as f64);
+        sp.prevGain /= ((cfg.optInTimePeriod) as f64);
         tempValue1 = sp.prevGain + sp.prevLoss;
         if tempValue1 > 0.0 {
             (*outReal) = 100.0 * ((sp.prevGain - sp.prevLoss) / tempValue1);
@@ -558,7 +568,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = CMO_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 prevGain: 0.0_f64,
                 prevLoss: 0.0_f64,
                 prevValue: 0.0_f64,
@@ -574,7 +583,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(CMO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(CMO_Stream { config: CMO_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut today: usize = 0_usize;
@@ -761,12 +770,11 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = CMO_StreamState {
-            optInTimePeriod,
             prevGain,
             prevLoss,
             prevValue,
         };
-        Ok(CMO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMO_Stream { config: CMO_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMO_Open`] (composition seam).
@@ -871,7 +879,7 @@ impl CMO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::CMO_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::CMO_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -904,7 +912,7 @@ impl CMO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CMO_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::CMO_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/cmou.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmou.rs
@@ -375,6 +375,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CMOU was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CMOU_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CMOU_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live CMOU stream: one value per closed bar, bit-identical to [`Core::CMOU`]
 /// over the same series. Open with [`Core::CMOU_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -384,6 +393,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CMOU_Stream")]
 pub struct CMOU_Stream {
+    /// What this stream was opened with — see `CMOU_StreamConfig`.
+    config: CMOU_StreamConfig,
     state: CMOU_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -394,6 +405,7 @@ impl CMOU_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CMOU_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -402,7 +414,6 @@ impl CMOU_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CMOU_StreamState {
-    optInTimePeriod: i32,
     nullRun: usize,
     upSum: f64,
     downSum: f64,
@@ -418,7 +429,6 @@ impl CMOU_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.nullRun = src.nullRun;
         self.upSum = src.upSum;
         self.downSum = src.downSum;
@@ -437,7 +447,7 @@ impl CMOU_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CMOU_step_impl(sp: &mut CMOU_StreamState, inReal: f64, outReal: &mut f64) {
+    fn CMOU_step_impl(cfg: &CMOU_StreamConfig, sp: &mut CMOU_StreamState, inReal: f64, outReal: &mut f64) {
         let mut sum: f64 = 0.0_f64;
         let mut diff: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -473,8 +483,8 @@ impl Core {
         } else {
             sp.nullRun = 0;
         }
-        if sp.nullRun >= ((sp.optInTimePeriod) as usize) {
-            sp.nullRun = (sp.optInTimePeriod) as usize;
+        if sp.nullRun >= ((cfg.optInTimePeriod) as usize) {
+            sp.nullRun = (cfg.optInTimePeriod) as usize;
             sp.upSum = 0.0;
             sp.downSum = 0.0;
         }
@@ -662,7 +672,6 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = CMOU_StreamState {
-            optInTimePeriod,
             nullRun,
             upSum,
             downSum,
@@ -672,7 +681,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(CMOU_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CMOU_Stream { config: CMOU_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CMOU_Open`] (composition seam).
@@ -777,7 +786,7 @@ impl CMOU_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::CMOU_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::CMOU_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -810,7 +819,7 @@ impl CMOU_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CMOU_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::CMOU_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -473,6 +473,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What CORREL was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&CORREL_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct CORREL_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live CORREL stream: one value per closed bar, bit-identical to [`Core::CORREL`]
 /// over the same series. Open with [`Core::CORREL_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -482,6 +491,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_CORREL_Stream")]
 pub struct CORREL_Stream {
+    /// What this stream was opened with — see `CORREL_StreamConfig`.
+    config: CORREL_StreamConfig,
     state: CORREL_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -492,6 +503,7 @@ impl CORREL_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `CORREL_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -500,7 +512,6 @@ impl CORREL_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct CORREL_StreamState {
-    optInTimePeriod: i32,
     sumXY: f64,
     sumX: f64,
     sumY: f64,
@@ -526,7 +537,6 @@ impl CORREL_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.sumXY = src.sumXY;
         self.sumX = src.sumX;
         self.sumY = src.sumY;
@@ -555,7 +565,7 @@ impl CORREL_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn CORREL_step_impl(sp: &mut CORREL_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
+    fn CORREL_step_impl(cfg: &CORREL_StreamConfig, sp: &mut CORREL_StreamState, inReal0: f64, inReal1: f64, outReal: &mut f64) {
         let mut x: f64 = 0.0_f64;
         let mut y: f64 = 0.0_f64;
         let mut trailingX: f64 = 0.0_f64;
@@ -611,7 +621,7 @@ impl Core {
         // startIdx-lookbackTotal+outIdx, which is >= outIdx.
         sp.barsSinceReseed -= 1;
         if ssX < 0.000001 * sp.sumX2 || ssY < 0.000001 * sp.sumY2 || sp.leavingX > 1000000.0 * sp.sumX2 || sp.leavingY > 1000000.0 * sp.sumY2 || sp.barsSinceReseed <= 0 {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             // Both means in one pass over the window: the rebuild below is the
             // only O(period) work on this function's hot path, so it is walked
@@ -998,7 +1008,6 @@ impl Core {
             }
         }
         let state = CORREL_StreamState {
-            optInTimePeriod,
             sumXY,
             sumX,
             sumY,
@@ -1018,7 +1027,7 @@ impl Core {
             x_inReal0,
             x_inReal1,
         };
-        Ok(CORREL_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(CORREL_Stream { config: CORREL_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::CORREL_Open`] (composition seam).
@@ -1110,10 +1119,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `CORREL_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `CORREL_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static CORREL_PEEK_SCRATCH: std::cell::Cell<Option<Box<CORREL_Stream>>> =
+    static CORREL_PEEK_SCRATCH: std::cell::Cell<Option<Box<CORREL_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1137,7 +1146,7 @@ impl CORREL_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::CORREL_step_impl(&mut self.state, inReal0, inReal1, &mut outReal);
+        Core::CORREL_step_impl(&self.config, &mut self.state, inReal0, inReal1, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1170,7 +1179,7 @@ impl CORREL_Stream {
             if !inReal0[i].is_finite() || !inReal1[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::CORREL_step_impl(&mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
+            Core::CORREL_step_impl(&self.config, &mut self.state, inReal0[i], inReal1[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1194,11 +1203,12 @@ impl CORREL_Stream {
             return Err(RetCode::BadParam);
         }
         CORREL_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal0, inReal1);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::CORREL_step_impl(&self.config, &mut scratch, inReal0, inReal1, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/dema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dema.rs
@@ -402,6 +402,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What DEMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&DEMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct DEMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live DEMA stream: one value per closed bar, bit-identical to [`Core::DEMA`]
 /// over the same series. Open with [`Core::DEMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -411,6 +420,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_DEMA_Stream")]
 pub struct DEMA_Stream {
+    /// What this stream was opened with — see `DEMA_StreamConfig`.
+    config: DEMA_StreamConfig,
     state: DEMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -421,6 +432,7 @@ impl DEMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `DEMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -429,7 +441,6 @@ impl DEMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct DEMA_StreamState {
-    optInTimePeriod: i32,
     prevEMA1: f64,
     prevEMA2: f64,
     optInK_1: f64,
@@ -440,7 +451,6 @@ impl DEMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevEMA1 = src.prevEMA1;
         self.prevEMA2 = src.prevEMA2;
         self.optInK_1 = src.optInK_1;
@@ -454,8 +464,8 @@ impl DEMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn DEMA_step_impl(sp: &mut DEMA_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn DEMA_step_impl(cfg: &DEMA_StreamConfig, sp: &mut DEMA_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -497,7 +507,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = DEMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 prevEMA1: 0.0_f64,
                 prevEMA2: 0.0_f64,
                 optInK_1: 0.0_f64,
@@ -513,7 +522,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(DEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(DEMA_Stream { config: DEMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut prevEMA1: f64 = 0.0_f64;
         let mut prevEMA2: f64 = 0.0_f64;
@@ -636,12 +645,11 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = DEMA_StreamState {
-            optInTimePeriod,
             prevEMA1,
             prevEMA2,
             optInK_1,
         };
-        Ok(DEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(DEMA_Stream { config: DEMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::DEMA_Open`] (composition seam).
@@ -746,7 +754,7 @@ impl DEMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::DEMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::DEMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -779,7 +787,7 @@ impl DEMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::DEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::DEMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/dx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dx.rs
@@ -554,6 +554,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What DX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&DX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct DX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live DX stream: one value per closed bar, bit-identical to [`Core::DX`]
 /// over the same series. Open with [`Core::DX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -563,6 +572,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_DX_Stream")]
 pub struct DX_Stream {
+    /// What this stream was opened with — see `DX_StreamConfig`.
+    config: DX_StreamConfig,
     state: DX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -573,6 +584,7 @@ impl DX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `DX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -581,7 +593,6 @@ impl DX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct DX_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevClose: f64,
@@ -596,7 +607,6 @@ impl DX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevClose = src.prevClose;
@@ -614,7 +624,7 @@ impl DX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn DX_step_impl(sp: &mut DX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn DX_step_impl(cfg: &DX_StreamConfig, sp: &mut DX_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut diffP: f64 = 0.0_f64;
         let mut diffM: f64 = 0.0_f64;
@@ -629,8 +639,8 @@ impl Core {
         diffM = sp.prevLow - tempReal;
         // Minus Delta
         sp.prevLow = tempReal;
-        sp.prevMinusDM -= sp.prevMinusDM / ((sp.optInTimePeriod) as f64);
-        sp.prevPlusDM -= sp.prevPlusDM / ((sp.optInTimePeriod) as f64);
+        sp.prevMinusDM -= sp.prevMinusDM / ((cfg.optInTimePeriod) as f64);
+        sp.prevPlusDM -= sp.prevPlusDM / ((cfg.optInTimePeriod) as f64);
         if diffM > 0_f64 && diffP < diffM {
             // Case 2 and 4: +DM=0,-DM=diffM
             sp.prevMinusDM += diffM;
@@ -651,7 +661,7 @@ impl Core {
         }
         _true_range_0 = range_0;
         tempReal = _true_range_0;
-        sp.prevTR = sp.prevTR - sp.prevTR / ((sp.optInTimePeriod) as f64) + tempReal;
+        sp.prevTR = sp.prevTR - sp.prevTR / ((cfg.optInTimePeriod) as f64) + tempReal;
         sp.prevClose = inClose;
         // Calculate the DX. The value is rounded (see Wilder book).
         if sp.prevTR > 0.0 {
@@ -990,7 +1000,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = DX_StreamState {
-            optInTimePeriod,
             prevHigh,
             prevLow,
             prevClose,
@@ -999,7 +1008,7 @@ impl Core {
             prevTR,
             lastOut_outReal: outReal[(*outNBElement - 1) * outStride],
         };
-        Ok(DX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(DX_Stream { config: DX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::DX_Open`] (composition seam).
@@ -1111,7 +1120,7 @@ impl DX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::DX_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::DX_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1144,7 +1153,7 @@ impl DX_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::DX_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::DX_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/efi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/efi.rs
@@ -395,6 +395,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What EFI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&EFI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct EFI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live EFI stream: one value per closed bar, bit-identical to [`Core::EFI`]
 /// over the same series. Open with [`Core::EFI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -404,6 +413,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_EFI_Stream")]
 pub struct EFI_Stream {
+    /// What this stream was opened with — see `EFI_StreamConfig`.
+    config: EFI_StreamConfig,
     state: EFI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -414,6 +425,7 @@ impl EFI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `EFI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -422,7 +434,6 @@ impl EFI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct EFI_StreamState {
-    optInTimePeriod: i32,
     prevClose: f64,
     optInK_1: f64,
     prevMA: f64,
@@ -433,7 +444,6 @@ impl EFI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevClose = src.prevClose;
         self.optInK_1 = src.optInK_1;
         self.prevMA = src.prevMA;
@@ -447,8 +457,8 @@ impl EFI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn EFI_step_impl(sp: &mut EFI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn EFI_step_impl(cfg: &EFI_StreamConfig, sp: &mut EFI_StreamState, inClose: f64, inVolume: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             let mut force: f64 = 0.0_f64;
             force = (inClose - sp.prevClose) * inVolume;
             sp.prevClose = inClose;
@@ -562,12 +572,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = EFI_StreamState {
-                optInTimePeriod,
                 prevClose,
                 optInK_1,
                 prevMA,
             };
-            Ok(EFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(EFI_Stream { config: EFI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut optInK_1: f64 = 0.0_f64;
             let mut tempReal: f64 = 0.0_f64;
@@ -667,12 +676,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = EFI_StreamState {
-                optInTimePeriod,
                 prevClose,
                 optInK_1,
                 prevMA,
             };
-            Ok(EFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(EFI_Stream { config: EFI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -786,7 +794,7 @@ impl EFI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::EFI_step_impl(&mut self.state, inClose, inVolume, &mut outReal);
+        Core::EFI_step_impl(&self.config, &mut self.state, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -819,7 +827,7 @@ impl EFI_Stream {
             if !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::EFI_step_impl(&mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
+            Core::EFI_step_impl(&self.config, &mut self.state, inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ema.rs
@@ -345,6 +345,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What EMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&EMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct EMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live EMA stream: one value per closed bar, bit-identical to [`Core::EMA`]
 /// over the same series. Open with [`Core::EMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -354,6 +363,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_EMA_Stream")]
 pub struct EMA_Stream {
+    /// What this stream was opened with — see `EMA_StreamConfig`.
+    config: EMA_StreamConfig,
     state: EMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -364,6 +375,7 @@ impl EMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `EMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -372,7 +384,6 @@ impl EMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct EMA_StreamState {
-    optInTimePeriod: i32,
     optInK_1: f64,
     prevMA: f64,
 }
@@ -382,7 +393,6 @@ impl EMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.optInK_1 = src.optInK_1;
         self.prevMA = src.prevMA;
     }
@@ -395,8 +405,8 @@ impl EMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn EMA_step_impl(sp: &mut EMA_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn EMA_step_impl(cfg: &EMA_StreamConfig, sp: &mut EMA_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -437,7 +447,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = EMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 optInK_1: 0.0_f64,
                 prevMA: 0.0_f64,
             };
@@ -452,7 +461,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(EMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(EMA_Stream { config: EMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut optInK_1: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
@@ -522,11 +531,10 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = EMA_StreamState {
-            optInTimePeriod,
             optInK_1,
             prevMA,
         };
-        Ok(EMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(EMA_Stream { config: EMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::EMA_Open`] (composition seam).
@@ -631,7 +639,7 @@ impl EMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::EMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::EMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -664,7 +672,7 @@ impl EMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::EMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::EMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/hma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/hma.rs
@@ -594,6 +594,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What HMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&HMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct HMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live HMA stream: one value per closed bar, bit-identical to [`Core::HMA`]
 /// over the same series. Open with [`Core::HMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -603,6 +612,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_HMA_Stream")]
 pub struct HMA_Stream {
+    /// What this stream was opened with — see `HMA_StreamConfig`.
+    config: HMA_StreamConfig,
     state: HMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -613,6 +624,7 @@ impl HMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `HMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -621,7 +633,6 @@ impl HMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct HMA_StreamState {
-    optInTimePeriod: i32,
     dividerFull: f64,
     periodSubFull: f64,
     periodSumFull: f64,
@@ -665,7 +676,6 @@ impl HMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.dividerFull = src.dividerFull;
         self.periodSubFull = src.periodSubFull;
         self.periodSumFull = src.periodSumFull;
@@ -712,12 +722,12 @@ impl HMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn HMA_step_impl(sp: &mut HMA_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn HMA_step_impl(cfg: &HMA_StreamConfig, sp: &mut HMA_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
-        if sp.optInTimePeriod == 2 || sp.optInTimePeriod == 3 {
+        if cfg.optInTimePeriod == 2 || cfg.optInTimePeriod == 3 {
             let mut tempReal: f64 = 0.0_f64;
             let mut fullOut: f64 = 0.0_f64;
             let mut jFull: usize = 0_usize;
@@ -730,10 +740,10 @@ impl Core {
             tempReal = inReal;
             sp.periodSubFull += tempReal;
             sp.periodSubFull -= sp.trailingFull;
-            sp.periodSumFull += tempReal * ((sp.optInTimePeriod) as f64);
+            sp.periodSumFull += tempReal * ((cfg.optInTimePeriod) as f64);
             sp.barsSinceReseedFull -= 1;
             if sp.barsSinceReseedFull <= 0 {
-                sp.barsSinceReseedFull = (8 * sp.optInTimePeriod) as usize;
+                sp.barsSinceReseedFull = (8 * cfg.optInTimePeriod) as usize;
                 sp.periodSubFull = 0.0;
                 sp.periodSumFull = 0.0;
                 rw = 1;
@@ -783,10 +793,10 @@ impl Core {
             tempReal = inReal;
             sp.periodSubFull += tempReal;
             sp.periodSubFull -= sp.trailingFull;
-            sp.periodSumFull += tempReal * ((sp.optInTimePeriod) as f64);
+            sp.periodSumFull += tempReal * ((cfg.optInTimePeriod) as f64);
             sp.barsSinceReseedFull -= 1;
             if sp.barsSinceReseedFull <= 0 {
-                sp.barsSinceReseedFull = (8 * sp.optInTimePeriod) as usize;
+                sp.barsSinceReseedFull = (8 * cfg.optInTimePeriod) as usize;
                 sp.periodSubFull = 0.0;
                 sp.periodSumFull = 0.0;
                 rw = 1;
@@ -921,7 +931,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = HMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 dividerFull: 0.0_f64,
                 periodSubFull: 0.0_f64,
                 periodSumFull: 0.0_f64,
@@ -970,7 +979,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(HMA_Stream { config: HMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         if optInTimePeriod == 2 || optInTimePeriod == 3 {
             let mut lookbackTotal: usize = 0_usize;
@@ -1124,7 +1133,6 @@ impl Core {
             let mut win_jFull_inReal: Vec<f64> = vec![0.0_f64; cap_jFull as usize];
             win_jFull_inReal.copy_from_slice(&inReal[historyLen - cap_jFull as usize..]);
             let state = HMA_StreamState {
-                optInTimePeriod,
                 dividerFull,
                 periodSubFull,
                 periodSumFull,
@@ -1162,7 +1170,7 @@ impl Core {
                 cbSize_dRing: 0_usize,
                 cb_dRing: Vec::new(),
             };
-            Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(HMA_Stream { config: HMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut lookbackTotal: usize = 0_usize;
             let mut lookbackSqrt: usize = 0_usize;
@@ -1478,7 +1486,6 @@ impl Core {
                 return Err(RetCode::InternalError);
             }
             let state = HMA_StreamState {
-                optInTimePeriod,
                 dividerFull,
                 periodSubFull,
                 periodSumFull,
@@ -1516,7 +1523,7 @@ impl Core {
                 cbSize_dRing: cbSize_dRing,
                 cb_dRing: dRing,
             };
-            Ok(HMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(HMA_Stream { config: HMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1603,10 +1610,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `HMA_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `HMA_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static HMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<HMA_Stream>>> =
+    static HMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<HMA_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1630,7 +1637,7 @@ impl HMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::HMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::HMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1663,7 +1670,7 @@ impl HMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::HMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::HMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1687,11 +1694,12 @@ impl HMA_Stream {
             return Err(RetCode::BadParam);
         }
         HMA_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::HMA_step_impl(&self.config, &mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
@@ -1538,10 +1538,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `HT_DCPHASE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `HT_DCPHASE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static HT_DCPHASE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_DCPHASE_Stream>>> =
+    static HT_DCPHASE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_DCPHASE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1622,11 +1622,12 @@ impl HT_DCPHASE_Stream {
             return Err(RetCode::BadParam);
         }
         HT_DCPHASE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::HT_DCPHASE_step_impl(&mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -1571,10 +1571,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `HT_SINE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `HT_SINE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static HT_SINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_SINE_Stream>>> =
+    static HT_SINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_SINE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1656,11 +1656,13 @@ impl HT_SINE_Stream {
             return Err(RetCode::BadParam);
         }
         HT_SINE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outSine: f64 = 0.0_f64;
+            let mut outLeadSine: f64 = 0.0_f64;
+            Core::HT_SINE_step_impl(&mut scratch, inReal, &mut outSine, &mut outLeadSine);
             cell.set(Some(scratch));
-            value
+            Ok((outSine, outLeadSine))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
@@ -1471,10 +1471,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `HT_TRENDLINE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `HT_TRENDLINE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static HT_TRENDLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_TRENDLINE_Stream>>> =
+    static HT_TRENDLINE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_TRENDLINE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1555,11 +1555,12 @@ impl HT_TRENDLINE_Stream {
             return Err(RetCode::BadParam);
         }
         HT_TRENDLINE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::HT_TRENDLINE_step_impl(&mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -1807,10 +1807,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `HT_TRENDMODE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `HT_TRENDMODE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static HT_TRENDMODE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_TRENDMODE_Stream>>> =
+    static HT_TRENDMODE_PEEK_SCRATCH: std::cell::Cell<Option<Box<HT_TRENDMODE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1891,11 +1891,12 @@ impl HT_TRENDMODE_Stream {
             return Err(RetCode::BadParam);
         }
         HT_TRENDMODE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outInteger: i32 = 0_i32;
+            Core::HT_TRENDMODE_step_impl(&mut scratch, inReal, &mut outInteger);
             cell.set(Some(scratch));
-            value
+            Ok(outInteger)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/imi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/imi.rs
@@ -278,6 +278,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What IMI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&IMI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct IMI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live IMI stream: one value per closed bar, bit-identical to [`Core::IMI`]
 /// over the same series. Open with [`Core::IMI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -287,6 +296,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_IMI_Stream")]
 pub struct IMI_Stream {
+    /// What this stream was opened with — see `IMI_StreamConfig`.
+    config: IMI_StreamConfig,
     state: IMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -297,6 +308,7 @@ impl IMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `IMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -305,7 +317,6 @@ impl IMI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct IMI_StreamState {
-    optInTimePeriod: i32,
     winPos_i: usize,
     winCap_i: usize,
     win_i_inOpen: Vec<f64>,
@@ -317,7 +328,6 @@ impl IMI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.winPos_i = src.winPos_i;
         self.winCap_i = src.winCap_i;
         self.win_i_inOpen.clone_from(&src.win_i_inOpen);
@@ -332,7 +342,7 @@ impl IMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn IMI_step_impl(sp: &mut IMI_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
+    fn IMI_step_impl(cfg: &IMI_StreamConfig, sp: &mut IMI_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
         let mut upsum: f64 = 0.0_f64;
         let mut downsum: f64 = 0.0_f64;
         let mut i: usize = 0_usize;
@@ -342,8 +352,8 @@ impl Core {
         sp.win_i_inClose[sp.winPos_i] = inClose;
         upsum = 0.0;
         downsum = 0.0;
-        // for( i = sp.optInTimePeriod - 1; i >= 0; i -= 1 )
-        i = (sp.optInTimePeriod - 1) as usize;
+        // for( i = cfg.optInTimePeriod - 1; i >= 0; i -= 1 )
+        i = (cfg.optInTimePeriod - 1) as usize;
         loop {
             close = sp.win_i_inClose[((if sp.winPos_i + sp.winCap_i - i >= sp.winCap_i { sp.winPos_i + sp.winCap_i - i - sp.winCap_i } else { sp.winPos_i + sp.winCap_i - i })) as usize];
             open = sp.win_i_inOpen[((if sp.winPos_i + sp.winCap_i - i >= sp.winCap_i { sp.winPos_i + sp.winCap_i - i - sp.winCap_i } else { sp.winPos_i + sp.winCap_i - i })) as usize];
@@ -441,13 +451,12 @@ impl Core {
         let mut win_i_inClose: Vec<f64> = vec![0.0_f64; cap_i as usize];
         win_i_inClose.copy_from_slice(&inClose[historyLen - cap_i as usize..]);
         let state = IMI_StreamState {
-            optInTimePeriod,
             winPos_i: 0_usize,
             winCap_i: cap_i as usize,
             win_i_inOpen,
             win_i_inClose,
         };
-        Ok(IMI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(IMI_Stream { config: IMI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::IMI_Open`] (composition seam).
@@ -541,10 +550,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `IMI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `IMI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static IMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<IMI_Stream>>> =
+    static IMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<IMI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -568,7 +577,7 @@ impl IMI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::IMI_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
+        Core::IMI_step_impl(&self.config, &mut self.state, inOpen, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -601,7 +610,7 @@ impl IMI_Stream {
             if !inOpen[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::IMI_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
+            Core::IMI_step_impl(&self.config, &mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -625,11 +634,12 @@ impl IMI_Stream {
             return Err(RetCode::BadParam);
         }
         IMI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inOpen, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::IMI_step_impl(&self.config, &mut scratch, inOpen, inClose, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -480,6 +480,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What KAMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&KAMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct KAMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live KAMA stream: one value per closed bar, bit-identical to [`Core::KAMA`]
 /// over the same series. Open with [`Core::KAMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -489,6 +498,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_KAMA_Stream")]
 pub struct KAMA_Stream {
+    /// What this stream was opened with — see `KAMA_StreamConfig`.
+    config: KAMA_StreamConfig,
     state: KAMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -499,6 +510,7 @@ impl KAMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `KAMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -507,7 +519,6 @@ impl KAMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct KAMA_StreamState {
-    optInTimePeriod: i32,
     constMax: f64,
     constDiff: f64,
     sumROC1: f64,
@@ -525,7 +536,6 @@ impl KAMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.constMax = src.constMax;
         self.constDiff = src.constDiff;
         self.sumROC1 = src.sumROC1;
@@ -546,11 +556,11 @@ impl KAMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn KAMA_step_impl(sp: &mut KAMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn KAMA_step_impl(cfg: &KAMA_StreamConfig, sp: &mut KAMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut periodROC: f64 = 0.0_f64;
-        if sp.optInTimePeriod == 1 {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -575,8 +585,8 @@ impl Core {
         } else {
             sp.nullRun = 0;
         }
-        if sp.nullRun >= ((sp.optInTimePeriod) as usize) {
-            sp.nullRun = (sp.optInTimePeriod) as usize;
+        if sp.nullRun >= ((cfg.optInTimePeriod) as usize) {
+            sp.nullRun = (cfg.optInTimePeriod) as usize;
             sp.sumROC1 = 0.0;
         }
         // Save the trailing value. Do this because inReal
@@ -636,7 +646,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = KAMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 constMax: 0.0_f64,
                 constDiff: 0.0_f64,
                 sumROC1: 0.0_f64,
@@ -659,7 +668,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(KAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(KAMA_Stream { config: KAMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut constMax: f64 = 0.0_f64;
         let mut constDiff: f64 = 0.0_f64;
@@ -848,7 +857,6 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = KAMA_StreamState {
-            optInTimePeriod,
             constMax,
             constDiff,
             sumROC1,
@@ -860,7 +868,7 @@ impl Core {
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(KAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(KAMA_Stream { config: KAMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::KAMA_Open`] (composition seam).
@@ -965,7 +973,7 @@ impl KAMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::KAMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::KAMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -998,7 +1006,7 @@ impl KAMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::KAMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::KAMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
@@ -426,6 +426,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What LINEARREG was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&LINEARREG_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct LINEARREG_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live LINEARREG stream: one value per closed bar, bit-identical to [`Core::LINEARREG`]
 /// over the same series. Open with [`Core::LINEARREG_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -435,6 +444,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_Stream")]
 pub struct LINEARREG_Stream {
+    /// What this stream was opened with — see `LINEARREG_StreamConfig`.
+    config: LINEARREG_StreamConfig,
     state: LINEARREG_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -445,6 +456,7 @@ impl LINEARREG_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -453,7 +465,6 @@ impl LINEARREG_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct LINEARREG_StreamState {
-    optInTimePeriod: i32,
     lookbackTotal: usize,
     trailingIdx: i32,
     SumX: f64,
@@ -474,7 +485,6 @@ impl LINEARREG_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackTotal = src.lookbackTotal;
         self.trailingIdx = src.trailingIdx;
         self.SumX = src.SumX;
@@ -498,7 +508,7 @@ impl LINEARREG_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_step_impl(sp: &mut LINEARREG_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_step_impl(cfg: &LINEARREG_StreamConfig, sp: &mut LINEARREG_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut b: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
@@ -512,7 +522,7 @@ impl Core {
             sp.j -= rebaseShift;
         }
         sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
-        weightedTrailing = (sp.optInTimePeriod as f64) * sp.trailingValue;
+        weightedTrailing = (cfg.optInTimePeriod as f64) * sp.trailingValue;
         sp.SumXY = sp.SumXY + sp.SumY - weightedTrailing;
         sp.SumY = sp.SumY - sp.trailingValue + sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.sumAbs = sp.sumAbs - (sp.trailingValue).abs() + (sp.x_inReal[(sp.today & sp.xMask) as usize]).abs();
@@ -576,7 +586,7 @@ impl Core {
         // to at least lookbackTotal.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 || (weightedTrailing).abs() > 100.0 * sp.sumAbs {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             sp.SumY = 0.0;
             sp.SumXY = 0.0;
@@ -593,11 +603,11 @@ impl Core {
                 sp.j += 1;
             }
         }
-        m = (((sp.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
-        b = (sp.SumY - m * sp.SumX) / (sp.optInTimePeriod as f64);
+        m = (((cfg.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
+        b = (sp.SumY - m * sp.SumX) / (cfg.optInTimePeriod as f64);
         sp.trailingValue = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize];
         sp.trailingIdx += 1;
-        (*outReal) = (m as f64).mul_add((sp.optInTimePeriod - 1) as f64, b);
+        (*outReal) = (m as f64).mul_add((cfg.optInTimePeriod - 1) as f64, b);
         sp.today += 1;
     }
 
@@ -818,7 +828,6 @@ impl Core {
             }
         }
         let state = LINEARREG_StreamState {
-            optInTimePeriod,
             lookbackTotal,
             trailingIdx: (trailingIdx) as i32,
             SumX,
@@ -833,7 +842,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_Stream { config: LINEARREG_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_Open`] (composition seam).
@@ -938,7 +947,7 @@ impl LINEARREG_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::LINEARREG_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -971,7 +980,7 @@ impl LINEARREG_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::LINEARREG_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
@@ -403,6 +403,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What LINEARREG_ANGLE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&LINEARREG_ANGLE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct LINEARREG_ANGLE_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live LINEARREG_ANGLE stream: one value per closed bar, bit-identical to [`Core::LINEARREG_ANGLE`]
 /// over the same series. Open with [`Core::LINEARREG_ANGLE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -412,6 +421,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_ANGLE_Stream")]
 pub struct LINEARREG_ANGLE_Stream {
+    /// What this stream was opened with — see `LINEARREG_ANGLE_StreamConfig`.
+    config: LINEARREG_ANGLE_StreamConfig,
     state: LINEARREG_ANGLE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -422,6 +433,7 @@ impl LINEARREG_ANGLE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_ANGLE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -430,7 +442,6 @@ impl LINEARREG_ANGLE_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct LINEARREG_ANGLE_StreamState {
-    optInTimePeriod: i32,
     lookbackTotal: usize,
     trailingIdx: i32,
     SumX: f64,
@@ -451,7 +462,6 @@ impl LINEARREG_ANGLE_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackTotal = src.lookbackTotal;
         self.trailingIdx = src.trailingIdx;
         self.SumX = src.SumX;
@@ -475,7 +485,7 @@ impl LINEARREG_ANGLE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_ANGLE_step_impl(sp: &mut LINEARREG_ANGLE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_ANGLE_step_impl(cfg: &LINEARREG_ANGLE_StreamConfig, sp: &mut LINEARREG_ANGLE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
@@ -488,7 +498,7 @@ impl Core {
             sp.j -= rebaseShift;
         }
         sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
-        weightedTrailing = (sp.optInTimePeriod as f64) * sp.trailingValue;
+        weightedTrailing = (cfg.optInTimePeriod as f64) * sp.trailingValue;
         sp.SumXY = sp.SumXY + sp.SumY - weightedTrailing;
         sp.SumY = sp.SumY - sp.trailingValue + sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.sumAbs = sp.sumAbs - (sp.trailingValue).abs() + (sp.x_inReal[(sp.today & sp.xMask) as usize]).abs();
@@ -552,7 +562,7 @@ impl Core {
         // to at least lookbackTotal.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 || (weightedTrailing).abs() > 100.0 * sp.sumAbs {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             sp.SumY = 0.0;
             sp.SumXY = 0.0;
@@ -569,7 +579,7 @@ impl Core {
                 sp.j += 1;
             }
         }
-        m = (((sp.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
+        m = (((cfg.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
         sp.trailingValue = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize];
         sp.trailingIdx += 1;
         (*outReal) = (m).atan() * (180.0 / 3.141592653589793);
@@ -790,7 +800,6 @@ impl Core {
             }
         }
         let state = LINEARREG_ANGLE_StreamState {
-            optInTimePeriod,
             lookbackTotal,
             trailingIdx: (trailingIdx) as i32,
             SumX,
@@ -805,7 +814,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_ANGLE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_ANGLE_Stream { config: LINEARREG_ANGLE_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_ANGLE_Open`] (composition seam).
@@ -910,7 +919,7 @@ impl LINEARREG_ANGLE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::LINEARREG_ANGLE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_ANGLE_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -943,7 +952,7 @@ impl LINEARREG_ANGLE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::LINEARREG_ANGLE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_ANGLE_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
@@ -398,6 +398,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What LINEARREG_INTERCEPT was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&LINEARREG_INTERCEPT_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct LINEARREG_INTERCEPT_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live LINEARREG_INTERCEPT stream: one value per closed bar, bit-identical to [`Core::LINEARREG_INTERCEPT`]
 /// over the same series. Open with [`Core::LINEARREG_INTERCEPT_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -407,6 +416,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_INTERCEPT_Stream")]
 pub struct LINEARREG_INTERCEPT_Stream {
+    /// What this stream was opened with — see `LINEARREG_INTERCEPT_StreamConfig`.
+    config: LINEARREG_INTERCEPT_StreamConfig,
     state: LINEARREG_INTERCEPT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -417,6 +428,7 @@ impl LINEARREG_INTERCEPT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_INTERCEPT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -425,7 +437,6 @@ impl LINEARREG_INTERCEPT_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct LINEARREG_INTERCEPT_StreamState {
-    optInTimePeriod: i32,
     lookbackTotal: usize,
     trailingIdx: i32,
     SumX: f64,
@@ -446,7 +457,6 @@ impl LINEARREG_INTERCEPT_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackTotal = src.lookbackTotal;
         self.trailingIdx = src.trailingIdx;
         self.SumX = src.SumX;
@@ -470,7 +480,7 @@ impl LINEARREG_INTERCEPT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_INTERCEPT_step_impl(sp: &mut LINEARREG_INTERCEPT_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_INTERCEPT_step_impl(cfg: &LINEARREG_INTERCEPT_StreamConfig, sp: &mut LINEARREG_INTERCEPT_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
@@ -483,7 +493,7 @@ impl Core {
             sp.j -= rebaseShift;
         }
         sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
-        weightedTrailing = (sp.optInTimePeriod as f64) * sp.trailingValue;
+        weightedTrailing = (cfg.optInTimePeriod as f64) * sp.trailingValue;
         sp.SumXY = sp.SumXY + sp.SumY - weightedTrailing;
         sp.SumY = sp.SumY - sp.trailingValue + sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.sumAbs = sp.sumAbs - (sp.trailingValue).abs() + (sp.x_inReal[(sp.today & sp.xMask) as usize]).abs();
@@ -547,7 +557,7 @@ impl Core {
         // to at least lookbackTotal.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 || (weightedTrailing).abs() > 100.0 * sp.sumAbs {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             sp.SumY = 0.0;
             sp.SumXY = 0.0;
@@ -564,10 +574,10 @@ impl Core {
                 sp.j += 1;
             }
         }
-        m = (((sp.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
+        m = (((cfg.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
         sp.trailingValue = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize];
         sp.trailingIdx += 1;
-        (*outReal) = (sp.SumY - m * sp.SumX) / (sp.optInTimePeriod as f64);
+        (*outReal) = (sp.SumY - m * sp.SumX) / (cfg.optInTimePeriod as f64);
         sp.today += 1;
     }
 
@@ -785,7 +795,6 @@ impl Core {
             }
         }
         let state = LINEARREG_INTERCEPT_StreamState {
-            optInTimePeriod,
             lookbackTotal,
             trailingIdx: (trailingIdx) as i32,
             SumX,
@@ -800,7 +809,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_INTERCEPT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_INTERCEPT_Stream { config: LINEARREG_INTERCEPT_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_INTERCEPT_Open`] (composition seam).
@@ -905,7 +914,7 @@ impl LINEARREG_INTERCEPT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_INTERCEPT_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -938,7 +947,7 @@ impl LINEARREG_INTERCEPT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::LINEARREG_INTERCEPT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_INTERCEPT_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
@@ -400,6 +400,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What LINEARREG_SLOPE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&LINEARREG_SLOPE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct LINEARREG_SLOPE_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live LINEARREG_SLOPE stream: one value per closed bar, bit-identical to [`Core::LINEARREG_SLOPE`]
 /// over the same series. Open with [`Core::LINEARREG_SLOPE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -409,6 +418,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_LINEARREG_SLOPE_Stream")]
 pub struct LINEARREG_SLOPE_Stream {
+    /// What this stream was opened with — see `LINEARREG_SLOPE_StreamConfig`.
+    config: LINEARREG_SLOPE_StreamConfig,
     state: LINEARREG_SLOPE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -419,6 +430,7 @@ impl LINEARREG_SLOPE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `LINEARREG_SLOPE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -427,7 +439,6 @@ impl LINEARREG_SLOPE_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct LINEARREG_SLOPE_StreamState {
-    optInTimePeriod: i32,
     lookbackTotal: usize,
     trailingIdx: i32,
     SumX: f64,
@@ -448,7 +459,6 @@ impl LINEARREG_SLOPE_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackTotal = src.lookbackTotal;
         self.trailingIdx = src.trailingIdx;
         self.SumX = src.SumX;
@@ -472,7 +482,7 @@ impl LINEARREG_SLOPE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn LINEARREG_SLOPE_step_impl(sp: &mut LINEARREG_SLOPE_StreamState, inReal: f64, outReal: &mut f64) {
+    fn LINEARREG_SLOPE_step_impl(cfg: &LINEARREG_SLOPE_StreamConfig, sp: &mut LINEARREG_SLOPE_StreamState, inReal: f64, outReal: &mut f64) {
         let mut windowStart: usize = 0_usize;
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
@@ -484,7 +494,7 @@ impl Core {
             sp.j -= rebaseShift;
         }
         sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
-        weightedTrailing = (sp.optInTimePeriod as f64) * sp.trailingValue;
+        weightedTrailing = (cfg.optInTimePeriod as f64) * sp.trailingValue;
         sp.SumXY = sp.SumXY + sp.SumY - weightedTrailing;
         sp.SumY = sp.SumY - sp.trailingValue + sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.sumAbs = sp.sumAbs - (sp.trailingValue).abs() + (sp.x_inReal[(sp.today & sp.xMask) as usize]).abs();
@@ -548,7 +558,7 @@ impl Core {
         // to at least lookbackTotal.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 || (weightedTrailing).abs() > 100.0 * sp.sumAbs {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             sp.SumY = 0.0;
             sp.SumXY = 0.0;
@@ -567,7 +577,7 @@ impl Core {
         }
         sp.trailingValue = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize];
         sp.trailingIdx += 1;
-        (*outReal) = (((sp.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
+        (*outReal) = (((cfg.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
         sp.today += 1;
     }
 
@@ -782,7 +792,6 @@ impl Core {
             }
         }
         let state = LINEARREG_SLOPE_StreamState {
-            optInTimePeriod,
             lookbackTotal,
             trailingIdx: (trailingIdx) as i32,
             SumX,
@@ -797,7 +806,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(LINEARREG_SLOPE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(LINEARREG_SLOPE_Stream { config: LINEARREG_SLOPE_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::LINEARREG_SLOPE_Open`] (composition seam).
@@ -902,7 +911,7 @@ impl LINEARREG_SLOPE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::LINEARREG_SLOPE_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::LINEARREG_SLOPE_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -935,7 +944,7 @@ impl LINEARREG_SLOPE_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::LINEARREG_SLOPE_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::LINEARREG_SLOPE_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ma.rs
@@ -406,6 +406,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MA_StreamConfig {
+    optInTimePeriod: i32,
+    optInMAType: MAType,
+}
+
 /// Live MA stream: one value per closed bar, bit-identical to [`Core::MA`]
 /// over the same series. Open with [`Core::MA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -415,6 +425,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MA_Stream")]
 pub struct MA_Stream {
+    /// What this stream was opened with — see `MA_StreamConfig`.
+    config: MA_StreamConfig,
     state: MA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -425,6 +437,7 @@ impl MA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -433,8 +446,6 @@ impl MA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MA_StreamState {
-    optInTimePeriod: i32,
-    optInMAType: MAType,
     // Sub-stream, tagged by optInMAType; `MA_Sub::Identity` on the identity path.
     sub: MA_Sub,
 }
@@ -444,8 +455,6 @@ impl MA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInMAType = src.optInMAType;
         self.sub.restore_from(&src.sub);
     }
 }
@@ -496,8 +505,8 @@ impl MA_Sub {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MA_step_impl(sp: &mut MA_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
-        if sp.optInTimePeriod == 1 || sp.optInMAType == MAType::DISABLED {
+    fn MA_step_impl(cfg: &MA_StreamConfig, sp: &mut MA_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+        if cfg.optInTimePeriod == 1 || cfg.optInMAType == MAType::DISABLED {
             (*outReal) = inReal;
             return Ok(());
         }
@@ -568,8 +577,8 @@ impl Core {
             if historyLen < fillLb + 1 {
                 return Err(RetCode::InsufficientHistory);
             }
-            let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok((MA_Stream { state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, inReal[historyLen - 1]));
+            let state = MA_StreamState { sub: MA_Sub::Identity };
+            return Ok((MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, inReal[historyLen - 1]));
         }
         let (sub, value, subRange) = match optInMAType {
             MAType::SMA => {
@@ -624,8 +633,8 @@ impl Core {
             }
             _ => return Err(RetCode::BadParam),
         };
-        let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok((MA_Stream { state, out: subRange }, value))
+        let state = MA_StreamState { sub };
+        Ok((MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: subRange }, value))
     }
 
     /// Open a live MA stream over the warm-up history; returns the handle and
@@ -702,8 +711,8 @@ impl Core {
                 outReal[fillIdx] = inReal[fillLb + fillIdx];
                 fillIdx += 1;
             }
-            let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok((MA_Stream { state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, OutRange { beg_idx: fillLb, count: historyLen - fillLb }));
+            let state = MA_StreamState { sub: MA_Sub::Identity };
+            return Ok((MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: OutRange { beg_idx: fillLb, count: historyLen - fillLb } }, OutRange { beg_idx: fillLb, count: historyLen - fillLb }));
         }
         let (sub, fillRange) = match optInMAType {
             MAType::SMA => {
@@ -748,8 +757,8 @@ impl Core {
             }
             _ => return Err(RetCode::BadParam),
         };
-        let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok((MA_Stream { state, out: fillRange }, fillRange))
+        let state = MA_StreamState { sub };
+        Ok((MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: fillRange }, fillRange))
     }
 
     /// [`Core::MA_OpenAndFill`] anchored at `startIdx` — the composed-open
@@ -788,8 +797,8 @@ impl Core {
                 outReal[fillIdx] = inReal[fillLb + fillIdx];
                 fillIdx += 1;
             }
-            let state = MA_StreamState { optInTimePeriod, optInMAType, sub: MA_Sub::Identity };
-            return Ok(MA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            let state = MA_StreamState { sub: MA_Sub::Identity };
+            return Ok(MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let sub = match optInMAType {
             MAType::SMA => MA_Sub::SMA(
@@ -824,8 +833,8 @@ impl Core {
             ),
             _ => return Err(RetCode::BadParam),
         };
-        let state = MA_StreamState { optInTimePeriod, optInMAType, sub };
-        Ok(MA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        let state = MA_StreamState { sub };
+        Ok(MA_Stream { config: MA_StreamConfig { optInTimePeriod, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
 }
@@ -850,7 +859,7 @@ impl MA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MA_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::MA_step_impl(&self.config, &mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -883,7 +892,7 @@ impl MA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MA_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::MA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/macd.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macd.rs
@@ -517,6 +517,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MACD was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MACD_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MACD_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInSignalPeriod: i32,
+}
+
 /// Live MACD stream: one value per closed bar, bit-identical to [`Core::MACD`]
 /// over the same series. Open with [`Core::MACD_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -526,6 +537,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACD_Stream")]
 pub struct MACD_Stream {
+    /// What this stream was opened with — see `MACD_StreamConfig`.
+    config: MACD_StreamConfig,
     state: MACD_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -536,6 +549,7 @@ impl MACD_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACD_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -544,9 +558,6 @@ impl MACD_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MACD_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInSignalPeriod: i32,
     prevFast: f64,
     prevSlow: f64,
     prevSignal: f64,
@@ -560,9 +571,6 @@ impl MACD_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInSignalPeriod = src.optInSignalPeriod;
         self.prevFast = src.prevFast;
         self.prevSlow = src.prevSlow;
         self.prevSignal = src.prevSignal;
@@ -579,14 +587,14 @@ impl MACD_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACD_step_impl(sp: &mut MACD_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
+    fn MACD_step_impl(cfg: &MACD_StreamConfig, sp: &mut MACD_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
         let mut macdValue: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         tempReal = inReal;
         sp.prevFast = (tempReal - sp.prevFast as f64).mul_add(sp.fastK, sp.prevFast);
         sp.prevSlow = (tempReal - sp.prevSlow as f64).mul_add(sp.slowK, sp.prevSlow);
         macdValue = sp.prevFast - sp.prevSlow;
-        if sp.optInSignalPeriod == 1 {
+        if cfg.optInSignalPeriod == 1 {
             sp.prevSignal = macdValue;
         } else {
             sp.prevSignal = (macdValue - sp.prevSignal as f64).mul_add(sp.signalK, sp.prevSignal);
@@ -810,9 +818,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = MACD_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInSignalPeriod,
             prevFast,
             prevSlow,
             prevSignal,
@@ -820,7 +825,7 @@ impl Core {
             fastK,
             signalK,
         };
-        Ok(MACD_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACD_Stream { config: MACD_StreamConfig { optInFastPeriod, optInSlowPeriod, optInSignalPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACD_Open`] (composition seam).
@@ -946,7 +951,7 @@ impl MACD_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        Core::MACD_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
+        Core::MACD_step_impl(&self.config, &mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -979,7 +984,7 @@ impl MACD_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MACD_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
+            Core::MACD_step_impl(&self.config, &mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/macdext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdext.rs
@@ -464,6 +464,20 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MACDEXT was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MACDEXT_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MACDEXT_StreamConfig {
+    optInFastPeriod: i32,
+    optInFastMAType: MAType,
+    optInSlowPeriod: i32,
+    optInSlowMAType: MAType,
+    optInSignalPeriod: i32,
+    optInSignalMAType: MAType,
+}
+
 /// Live MACDEXT stream: one value per closed bar, bit-identical to [`Core::MACDEXT`]
 /// over the same series. Open with [`Core::MACDEXT_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -473,6 +487,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACDEXT_Stream")]
 pub struct MACDEXT_Stream {
+    /// What this stream was opened with — see `MACDEXT_StreamConfig`.
+    config: MACDEXT_StreamConfig,
     state: MACDEXT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -483,6 +499,7 @@ impl MACDEXT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACDEXT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -491,12 +508,6 @@ impl MACDEXT_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MACDEXT_StreamState {
-    optInFastPeriod: i32,
-    optInFastMAType: MAType,
-    optInSlowPeriod: i32,
-    optInSlowMAType: MAType,
-    optInSignalPeriod: i32,
-    optInSignalMAType: MAType,
     sub0: MA_Stream,
     sub1: MA_Stream,
     sub2: MA_Stream,
@@ -507,12 +518,6 @@ impl MACDEXT_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInFastMAType = src.optInFastMAType;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInSlowMAType = src.optInSlowMAType;
-        self.optInSignalPeriod = src.optInSignalPeriod;
-        self.optInSignalMAType = src.optInSignalMAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
         self.sub2.restore_from(&src.sub2);
@@ -526,7 +531,7 @@ impl MACDEXT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACDEXT_step_impl(sp: &mut MACDEXT_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) -> Result<(), RetCode> {
+    fn MACDEXT_step_impl(cfg: &MACDEXT_StreamConfig, sp: &mut MACDEXT_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) -> Result<(), RetCode> {
         let mut cur_slowMABuffer: f64 = 0.0_f64;
         let mut cur_fastMABuffer: f64 = 0.0_f64;
         let mut cur_outMACDSignal: f64 = 0.0_f64;
@@ -711,12 +716,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = MACDEXT_StreamState {
-            optInFastPeriod,
-            optInFastMAType,
-            optInSlowPeriod,
-            optInSlowMAType,
-            optInSignalPeriod,
-            optInSignalMAType,
             sub0,
             sub1,
             sub2,
@@ -733,7 +732,7 @@ impl Core {
             let last_sc_outMACDHist = sc_outMACDHist[*outNBElement - 1];
             outMACDHist[0] = last_sc_outMACDHist;
         }
-        Ok(MACDEXT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACDEXT_Stream { config: MACDEXT_StreamConfig { optInFastPeriod, optInFastMAType, optInSlowPeriod, optInSlowMAType, optInSignalPeriod, optInSignalMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACDEXT_Open`] (composition seam).
@@ -838,10 +837,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `MACDEXT_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `MACDEXT_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static MACDEXT_PEEK_SCRATCH: std::cell::Cell<Option<Box<MACDEXT_Stream>>> =
+    static MACDEXT_PEEK_SCRATCH: std::cell::Cell<Option<Box<MACDEXT_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -867,7 +866,7 @@ impl MACDEXT_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        Core::MACDEXT_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist)?;
+        Core::MACDEXT_step_impl(&self.config, &mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -900,7 +899,7 @@ impl MACDEXT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MACDEXT_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i])?;
+            Core::MACDEXT_step_impl(&self.config, &mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -924,11 +923,15 @@ impl MACDEXT_Stream {
             return Err(RetCode::BadParam);
         }
         MACDEXT_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outMACD: f64 = 0.0_f64;
+            let mut outMACDSignal: f64 = 0.0_f64;
+            let mut outMACDHist: f64 = 0.0_f64;
+            let stepped = Core::MACDEXT_step_impl(&self.config, &mut scratch, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok((outMACD, outMACDSignal, outMACDHist))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
@@ -455,6 +455,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MACDFIX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MACDFIX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MACDFIX_StreamConfig {
+    optInSignalPeriod: i32,
+}
+
 /// Live MACDFIX stream: one value per closed bar, bit-identical to [`Core::MACDFIX`]
 /// over the same series. Open with [`Core::MACDFIX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -464,6 +473,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MACDFIX_Stream")]
 pub struct MACDFIX_Stream {
+    /// What this stream was opened with — see `MACDFIX_StreamConfig`.
+    config: MACDFIX_StreamConfig,
     state: MACDFIX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -474,6 +485,7 @@ impl MACDFIX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MACDFIX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -482,7 +494,6 @@ impl MACDFIX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MACDFIX_StreamState {
-    optInSignalPeriod: i32,
     prevFast: f64,
     prevSlow: f64,
     prevSignal: f64,
@@ -496,7 +507,6 @@ impl MACDFIX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInSignalPeriod = src.optInSignalPeriod;
         self.prevFast = src.prevFast;
         self.prevSlow = src.prevSlow;
         self.prevSignal = src.prevSignal;
@@ -513,14 +523,14 @@ impl MACDFIX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MACDFIX_step_impl(sp: &mut MACDFIX_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
+    fn MACDFIX_step_impl(cfg: &MACDFIX_StreamConfig, sp: &mut MACDFIX_StreamState, inReal: f64, outMACD: &mut f64, outMACDSignal: &mut f64, outMACDHist: &mut f64) {
         let mut macdValue: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
         tempReal = inReal;
         sp.prevFast = (tempReal - sp.prevFast as f64).mul_add(sp.fastK, sp.prevFast);
         sp.prevSlow = (tempReal - sp.prevSlow as f64).mul_add(sp.slowK, sp.prevSlow);
         macdValue = sp.prevFast - sp.prevSlow;
-        if sp.optInSignalPeriod == 1 {
+        if cfg.optInSignalPeriod == 1 {
             sp.prevSignal = macdValue;
         } else {
             sp.prevSignal = (macdValue - sp.prevSignal as f64).mul_add(sp.signalK, sp.prevSignal);
@@ -722,7 +732,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = MACDFIX_StreamState {
-            optInSignalPeriod,
             prevFast,
             prevSlow,
             prevSignal,
@@ -730,7 +739,7 @@ impl Core {
             fastK,
             signalK,
         };
-        Ok(MACDFIX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MACDFIX_Stream { config: MACDFIX_StreamConfig { optInSignalPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MACDFIX_Open`] (composition seam).
@@ -856,7 +865,7 @@ impl MACDFIX_Stream {
         let mut outMACD: f64 = 0.0_f64;
         let mut outMACDSignal: f64 = 0.0_f64;
         let mut outMACDHist: f64 = 0.0_f64;
-        Core::MACDFIX_step_impl(&mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
+        Core::MACDFIX_step_impl(&self.config, &mut self.state, inReal, &mut outMACD, &mut outMACDSignal, &mut outMACDHist);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -889,7 +898,7 @@ impl MACDFIX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MACDFIX_step_impl(&mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
+            Core::MACDFIX_step_impl(&self.config, &mut self.state, inReal[i], &mut outMACD[i], &mut outMACDSignal[i], &mut outMACDHist[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -672,6 +672,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MAMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MAMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MAMA_StreamConfig {
+    optInFastLimit: f64,
+    optInSlowLimit: f64,
+}
+
 /// Live MAMA stream: one value per closed bar, bit-identical to [`Core::MAMA`]
 /// over the same series. Open with [`Core::MAMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -681,6 +691,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAMA_Stream")]
 pub struct MAMA_Stream {
+    /// What this stream was opened with — see `MAMA_StreamConfig`.
+    config: MAMA_StreamConfig,
     state: MAMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -691,6 +703,7 @@ impl MAMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -699,8 +712,6 @@ impl MAMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MAMA_StreamState {
-    optInFastLimit: f64,
-    optInSlowLimit: f64,
     period: f64,
     periodWMASum: f64,
     periodWMASub: f64,
@@ -755,8 +766,6 @@ impl MAMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastLimit = src.optInFastLimit;
-        self.optInSlowLimit = src.optInSlowLimit;
         self.period = src.period;
         self.periodWMASum = src.periodWMASum;
         self.periodWMASub = src.periodWMASub;
@@ -814,7 +823,7 @@ impl MAMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAMA_step_impl(sp: &mut MAMA_StreamState, inReal: f64, outMAMA: &mut f64, outFAMA: &mut f64) {
+    fn MAMA_step_impl(cfg: &MAMA_StreamConfig, sp: &mut MAMA_StreamState, inReal: f64, outMAMA: &mut f64, outFAMA: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut tempReal2: f64 = 0.0_f64;
         let mut adjustedPrevPeriod: f64 = 0.0_f64;
@@ -956,12 +965,12 @@ impl Core {
         }
         // Put Alpha into tempReal
         if tempReal > 1.0 {
-            tempReal = sp.optInFastLimit / tempReal;
-            if tempReal < sp.optInSlowLimit {
-                tempReal = sp.optInSlowLimit;
+            tempReal = cfg.optInFastLimit / tempReal;
+            if tempReal < cfg.optInSlowLimit {
+                tempReal = cfg.optInSlowLimit;
             }
         } else {
-            tempReal = sp.optInFastLimit;
+            tempReal = cfg.optInFastLimit;
         }
         // Calculate MAMA, FAMA
         sp.mama = (1_f64 - tempReal as f64).mul_add(sp.mama, tempReal * todayValue);
@@ -1402,8 +1411,6 @@ impl Core {
         ring_trailingWMAIdx_inReal[..cap_trailingWMAIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingWMAIdx as usize..]);
         let state = MAMA_StreamState {
-            optInFastLimit,
-            optInSlowLimit,
             period,
             periodWMASum,
             periodWMASub,
@@ -1452,7 +1459,7 @@ impl Core {
             ringCap_trailingWMAIdx: cap_trailingWMAIdx as usize,
             ring_trailingWMAIdx_inReal,
         };
-        Ok(MAMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAMA_Stream { config: MAMA_StreamConfig { optInFastLimit, optInSlowLimit, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAMA_Open`] (composition seam).
@@ -1568,7 +1575,7 @@ impl MAMA_Stream {
         }
         let mut outMAMA: f64 = 0.0_f64;
         let mut outFAMA: f64 = 0.0_f64;
-        Core::MAMA_step_impl(&mut self.state, inReal, &mut outMAMA, &mut outFAMA);
+        Core::MAMA_step_impl(&self.config, &mut self.state, inReal, &mut outMAMA, &mut outFAMA);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1607,7 +1614,7 @@ impl MAMA_Stream {
                 return Err(RetCode::BadParam);
             }
             let slot_outFAMA = match outFAMA.as_deref_mut() { Some(_s) => &mut _s[i], None => &mut sink_outFAMA };
-            Core::MAMA_step_impl(&mut self.state, inReal[i], &mut outMAMA[i], slot_outFAMA);
+            Core::MAMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outMAMA[i], slot_outFAMA);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mavp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mavp.rs
@@ -530,6 +530,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MAVP was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MAVP_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MAVP_StreamConfig {
+    optInMinPeriod: i32,
+    optInMaxPeriod: i32,
+    optInMAType: MAType,
+}
+
 /// Live MAVP stream: one value per closed bar, bit-identical to [`Core::MAVP`]
 /// over the same series. Open with [`Core::MAVP_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -539,6 +550,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAVP_Stream")]
 pub struct MAVP_Stream {
+    /// What this stream was opened with — see `MAVP_StreamConfig`.
+    config: MAVP_StreamConfig,
     state: MAVP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -549,6 +562,7 @@ impl MAVP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAVP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -557,9 +571,6 @@ impl MAVP_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MAVP_StreamState {
-    optInMinPeriod: i32,
-    optInMaxPeriod: i32,
-    optInMAType: MAType,
     // One sub-MA stream per period in [optInMinPeriod, optInMaxPeriod], advanced in lockstep.
     bank: Vec<MA_Stream>,
 }
@@ -569,9 +580,6 @@ impl MAVP_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInMinPeriod = src.optInMinPeriod;
-        self.optInMaxPeriod = src.optInMaxPeriod;
-        self.optInMAType = src.optInMAType;
         if self.bank.len() == src.bank.len() {
             for (dst, s) in self.bank.iter_mut().zip(src.bank.iter()) {
                 dst.restore_from(s);
@@ -589,14 +597,14 @@ impl MAVP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAVP_step_impl(sp: &mut MAVP_StreamState, inReal: f64, inPeriods: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn MAVP_step_impl(cfg: &MAVP_StreamConfig, sp: &mut MAVP_StreamState, inReal: f64, inPeriods: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cp: i32 = inPeriods as i32;
-        if cp < sp.optInMinPeriod {
-            cp = sp.optInMinPeriod;
-        } else if cp > sp.optInMaxPeriod {
-            cp = sp.optInMaxPeriod;
+        if cp < cfg.optInMinPeriod {
+            cp = cfg.optInMinPeriod;
+        } else if cp > cfg.optInMaxPeriod {
+            cp = cfg.optInMaxPeriod;
         }
-        let slot: usize = (cp - sp.optInMinPeriod) as usize;
+        let slot: usize = (cp - cfg.optInMinPeriod) as usize;
         for (bankIdx, sub) in sp.bank.iter_mut().enumerate() {
             let subValue = sub.update(inReal)?;
             if bankIdx == slot {
@@ -663,8 +671,8 @@ impl Core {
             cp = optInMaxPeriod;
         }
         let lastValue_outReal: f64 = scratch[(cp - optInMinPeriod) as usize];
-        let state = MAVP_StreamState { optInMinPeriod, optInMaxPeriod, optInMAType, bank };
-        Ok((MAVP_Stream { state, out: OutRange { beg_idx: subStart, count: historyLen - subStart } }, lastValue_outReal))
+        let state = MAVP_StreamState { bank };
+        Ok((MAVP_Stream { config: MAVP_StreamConfig { optInMinPeriod, optInMaxPeriod, optInMAType, }, state, out: OutRange { beg_idx: subStart, count: historyLen - subStart } }, lastValue_outReal))
     }
 
     /// Open a live MAVP stream over the warm-up history; returns the handle and
@@ -779,17 +787,17 @@ impl Core {
             outReal[t - lookbackTotal] = scratch[(cp - optInMinPeriod) as usize];
             t += 1;
         }
-        let state = MAVP_StreamState { optInMinPeriod, optInMaxPeriod, optInMAType, bank };
-        Ok((MAVP_Stream { state, out: OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal } }, OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal }))
+        let state = MAVP_StreamState { bank };
+        Ok((MAVP_Stream { config: MAVP_StreamConfig { optInMinPeriod, optInMaxPeriod, optInMAType, }, state, out: OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal } }, OutRange { beg_idx: lookbackTotal, count: historyLen - lookbackTotal }))
     }
 
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `MAVP_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `MAVP_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static MAVP_PEEK_SCRATCH: std::cell::Cell<Option<Box<MAVP_Stream>>> =
+    static MAVP_PEEK_SCRATCH: std::cell::Cell<Option<Box<MAVP_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -813,7 +821,7 @@ impl MAVP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MAVP_step_impl(&mut self.state, inReal, inPeriods, &mut outReal)?;
+        Core::MAVP_step_impl(&self.config, &mut self.state, inReal, inPeriods, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -846,7 +854,7 @@ impl MAVP_Stream {
             if !inReal[i].is_finite() || !inPeriods[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MAVP_step_impl(&mut self.state, inReal[i], inPeriods[i], &mut outReal[i])?;
+            Core::MAVP_step_impl(&self.config, &mut self.state, inReal[i], inPeriods[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -870,11 +878,13 @@ impl MAVP_Stream {
             return Err(RetCode::BadParam);
         }
         MAVP_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal, inPeriods);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            let stepped = Core::MAVP_step_impl(&self.config, &mut scratch, inReal, inPeriods, &mut outReal);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -360,6 +360,15 @@ impl Core {
 
 /* Using max_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What MAX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MAX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MAX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MAX stream: one value per closed bar, bit-identical to [`Core::MAX`]
 /// over the same series. Open with [`Core::MAX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -369,6 +378,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAX_Stream")]
 pub struct MAX_Stream {
+    /// What this stream was opened with — see `MAX_StreamConfig`.
+    config: MAX_StreamConfig,
     state: MAX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -379,6 +390,7 @@ impl MAX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -387,7 +399,6 @@ impl MAX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MAX_StreamState {
-    optInTimePeriod: i32,
     highest: f64,
     trailingIdx: i32,
     highestIdx: i32,
@@ -402,7 +413,6 @@ impl MAX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.highest = src.highest;
         self.trailingIdx = src.trailingIdx;
         self.highestIdx = src.highestIdx;
@@ -420,7 +430,7 @@ impl MAX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAX_step_impl(sp: &mut MAX_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MAX_step_impl(cfg: &MAX_StreamConfig, sp: &mut MAX_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -562,7 +572,6 @@ impl Core {
             }
         }
         let state = MAX_StreamState {
-            optInTimePeriod,
             highest,
             trailingIdx: (trailingIdx) as i32,
             highestIdx: (highestIdx) as i32,
@@ -571,7 +580,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MAX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAX_Stream { config: MAX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAX_Open`] (composition seam).
@@ -676,7 +685,7 @@ impl MAX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MAX_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MAX_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -709,7 +718,7 @@ impl MAX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MAX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MAX_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -281,6 +281,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MAXINDEX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MAXINDEX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MAXINDEX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MAXINDEX stream: one value per closed bar, bit-identical to [`Core::MAXINDEX`]
 /// over the same series. Open with [`Core::MAXINDEX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -290,6 +299,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MAXINDEX_Stream")]
 pub struct MAXINDEX_Stream {
+    /// What this stream was opened with — see `MAXINDEX_StreamConfig`.
+    config: MAXINDEX_StreamConfig,
     state: MAXINDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -300,6 +311,7 @@ impl MAXINDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MAXINDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -308,7 +320,6 @@ impl MAXINDEX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MAXINDEX_StreamState {
-    optInTimePeriod: i32,
     highest: f64,
     trailingIdx: i32,
     highestIdx: i32,
@@ -323,7 +334,6 @@ impl MAXINDEX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.highest = src.highest;
         self.trailingIdx = src.trailingIdx;
         self.highestIdx = src.highestIdx;
@@ -341,7 +351,7 @@ impl MAXINDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MAXINDEX_step_impl(sp: &mut MAXINDEX_StreamState, inReal: f64, outInteger: &mut i32) {
+    fn MAXINDEX_step_impl(cfg: &MAXINDEX_StreamConfig, sp: &mut MAXINDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -473,7 +483,6 @@ impl Core {
             }
         }
         let state = MAXINDEX_StreamState {
-            optInTimePeriod,
             highest,
             trailingIdx: (trailingIdx) as i32,
             highestIdx: (highestIdx) as i32,
@@ -482,7 +491,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MAXINDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MAXINDEX_Stream { config: MAXINDEX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MAXINDEX_Open`] (composition seam).
@@ -587,7 +596,7 @@ impl MAXINDEX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::MAXINDEX_step_impl(&mut self.state, inReal, &mut outInteger);
+        Core::MAXINDEX_step_impl(&self.config, &mut self.state, inReal, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -620,7 +629,7 @@ impl MAXINDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MAXINDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
+            Core::MAXINDEX_step_impl(&self.config, &mut self.state, inReal[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mfi.rs
@@ -451,6 +451,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MFI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MFI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MFI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MFI stream: one value per closed bar, bit-identical to [`Core::MFI`]
 /// over the same series. Open with [`Core::MFI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -460,6 +469,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MFI_Stream")]
 pub struct MFI_Stream {
+    /// What this stream was opened with — see `MFI_StreamConfig`.
+    config: MFI_StreamConfig,
     state: MFI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -470,6 +481,7 @@ impl MFI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MFI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -478,7 +490,6 @@ impl MFI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MFI_StreamState {
-    optInTimePeriod: i32,
     posSumMF: f64,
     negSumMF: f64,
     prevValue: f64,
@@ -495,7 +506,6 @@ impl MFI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.posSumMF = src.posSumMF;
         self.negSumMF = src.negSumMF;
         self.prevValue = src.prevValue;
@@ -515,7 +525,7 @@ impl MFI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MFI_step_impl(sp: &mut MFI_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
+    fn MFI_step_impl(cfg: &MFI_StreamConfig, sp: &mut MFI_StreamState, inHigh: f64, inLow: f64, inClose: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
         let mut tempValue3: f64 = 0.0_f64;
@@ -540,8 +550,8 @@ impl Core {
         sp.posSumMF += posFlow;
         sp.negSumMF += negFlow;
         sp.nullRun = (if moneyFlow == 0.0 { sp.nullRun + 1 } else { 0 });
-        if sp.nullRun >= ((sp.optInTimePeriod) as usize) {
-            sp.nullRun = (sp.optInTimePeriod) as usize;
+        if sp.nullRun >= ((cfg.optInTimePeriod) as usize) {
+            sp.nullRun = (cfg.optInTimePeriod) as usize;
             sp.posSumMF = 0.0;
             sp.negSumMF = 0.0;
         }
@@ -750,7 +760,6 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let state = MFI_StreamState {
-            optInTimePeriod,
             posSumMF,
             negSumMF,
             prevValue,
@@ -761,7 +770,7 @@ impl Core {
             cb_mflow_positive: mflow_positive,
             cb_mflow_negative: mflow_negative,
         };
-        Ok(MFI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MFI_Stream { config: MFI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MFI_Open`] (composition seam).
@@ -857,10 +866,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `MFI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `MFI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static MFI_PEEK_SCRATCH: std::cell::Cell<Option<Box<MFI_Stream>>> =
+    static MFI_PEEK_SCRATCH: std::cell::Cell<Option<Box<MFI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -884,7 +893,7 @@ impl MFI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MFI_step_impl(&mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
+        Core::MFI_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -917,7 +926,7 @@ impl MFI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MFI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
+            Core::MFI_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -941,11 +950,12 @@ impl MFI_Stream {
             return Err(RetCode::BadParam);
         }
         MFI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose, inVolume);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::MFI_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, inVolume, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -412,6 +412,15 @@ impl Core {
 
 /* Using midpoint_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What MIDPOINT was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MIDPOINT_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MIDPOINT_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MIDPOINT stream: one value per closed bar, bit-identical to [`Core::MIDPOINT`]
 /// over the same series. Open with [`Core::MIDPOINT_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -421,6 +430,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIDPOINT_Stream")]
 pub struct MIDPOINT_Stream {
+    /// What this stream was opened with — see `MIDPOINT_StreamConfig`.
+    config: MIDPOINT_StreamConfig,
     state: MIDPOINT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -431,6 +442,7 @@ impl MIDPOINT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIDPOINT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -439,7 +451,6 @@ impl MIDPOINT_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MIDPOINT_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     highest: f64,
     trailingIdx: i32,
@@ -456,7 +467,6 @@ impl MIDPOINT_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.trailingIdx = src.trailingIdx;
@@ -476,7 +486,7 @@ impl MIDPOINT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIDPOINT_step_impl(sp: &mut MIDPOINT_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MIDPOINT_step_impl(cfg: &MIDPOINT_StreamConfig, sp: &mut MIDPOINT_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmpLow: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -670,7 +680,6 @@ impl Core {
             }
         }
         let state = MIDPOINT_StreamState {
-            optInTimePeriod,
             lowest,
             highest,
             trailingIdx: (trailingIdx) as i32,
@@ -681,7 +690,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MIDPOINT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIDPOINT_Stream { config: MIDPOINT_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIDPOINT_Open`] (composition seam).
@@ -786,7 +795,7 @@ impl MIDPOINT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MIDPOINT_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MIDPOINT_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -819,7 +828,7 @@ impl MIDPOINT_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MIDPOINT_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MIDPOINT_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -427,6 +427,15 @@ impl Core {
 
 /* Using midprice_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What MIDPRICE was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MIDPRICE_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MIDPRICE_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MIDPRICE stream: one value per closed bar, bit-identical to [`Core::MIDPRICE`]
 /// over the same series. Open with [`Core::MIDPRICE_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -436,6 +445,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIDPRICE_Stream")]
 pub struct MIDPRICE_Stream {
+    /// What this stream was opened with — see `MIDPRICE_StreamConfig`.
+    config: MIDPRICE_StreamConfig,
     state: MIDPRICE_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -446,6 +457,7 @@ impl MIDPRICE_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIDPRICE_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -454,7 +466,6 @@ impl MIDPRICE_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MIDPRICE_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     highest: f64,
     trailingIdx: i32,
@@ -472,7 +483,6 @@ impl MIDPRICE_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.trailingIdx = src.trailingIdx;
@@ -493,7 +503,7 @@ impl MIDPRICE_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIDPRICE_step_impl(sp: &mut MIDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn MIDPRICE_step_impl(cfg: &MIDPRICE_StreamConfig, sp: &mut MIDPRICE_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut tmpLow: f64 = 0.0_f64;
         let mut tmpHigh: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -691,7 +701,6 @@ impl Core {
             }
         }
         let state = MIDPRICE_StreamState {
-            optInTimePeriod,
             lowest,
             highest,
             trailingIdx: (trailingIdx) as i32,
@@ -703,7 +712,7 @@ impl Core {
             x_inHigh,
             x_inLow,
         };
-        Ok(MIDPRICE_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIDPRICE_Stream { config: MIDPRICE_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIDPRICE_Open`] (composition seam).
@@ -793,10 +802,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `MIDPRICE_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `MIDPRICE_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static MIDPRICE_PEEK_SCRATCH: std::cell::Cell<Option<Box<MIDPRICE_Stream>>> =
+    static MIDPRICE_PEEK_SCRATCH: std::cell::Cell<Option<Box<MIDPRICE_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -820,7 +829,7 @@ impl MIDPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MIDPRICE_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::MIDPRICE_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -853,7 +862,7 @@ impl MIDPRICE_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MIDPRICE_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::MIDPRICE_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -877,11 +886,12 @@ impl MIDPRICE_Stream {
             return Err(RetCode::BadParam);
         }
         MIDPRICE_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::MIDPRICE_step_impl(&self.config, &mut scratch, inHigh, inLow, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -358,6 +358,15 @@ impl Core {
 
 /* Using min_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What MIN was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MIN_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MIN_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MIN stream: one value per closed bar, bit-identical to [`Core::MIN`]
 /// over the same series. Open with [`Core::MIN_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -367,6 +376,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MIN_Stream")]
 pub struct MIN_Stream {
+    /// What this stream was opened with — see `MIN_StreamConfig`.
+    config: MIN_StreamConfig,
     state: MIN_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -377,6 +388,7 @@ impl MIN_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MIN_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -385,7 +397,6 @@ impl MIN_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MIN_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     trailingIdx: i32,
     lowestIdx: i32,
@@ -400,7 +411,6 @@ impl MIN_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.trailingIdx = src.trailingIdx;
         self.lowestIdx = src.lowestIdx;
@@ -418,7 +428,7 @@ impl MIN_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MIN_step_impl(sp: &mut MIN_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MIN_step_impl(cfg: &MIN_StreamConfig, sp: &mut MIN_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -558,7 +568,6 @@ impl Core {
             }
         }
         let state = MIN_StreamState {
-            optInTimePeriod,
             lowest,
             trailingIdx: (trailingIdx) as i32,
             lowestIdx: (lowestIdx) as i32,
@@ -567,7 +576,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MIN_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MIN_Stream { config: MIN_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MIN_Open`] (composition seam).
@@ -672,7 +681,7 @@ impl MIN_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MIN_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MIN_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -705,7 +714,7 @@ impl MIN_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MIN_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MIN_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -281,6 +281,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MININDEX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MININDEX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MININDEX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MININDEX stream: one value per closed bar, bit-identical to [`Core::MININDEX`]
 /// over the same series. Open with [`Core::MININDEX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -290,6 +299,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MININDEX_Stream")]
 pub struct MININDEX_Stream {
+    /// What this stream was opened with — see `MININDEX_StreamConfig`.
+    config: MININDEX_StreamConfig,
     state: MININDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -300,6 +311,7 @@ impl MININDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MININDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -308,7 +320,6 @@ impl MININDEX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MININDEX_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     trailingIdx: i32,
     lowestIdx: i32,
@@ -323,7 +334,6 @@ impl MININDEX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.trailingIdx = src.trailingIdx;
         self.lowestIdx = src.lowestIdx;
@@ -341,7 +351,7 @@ impl MININDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MININDEX_step_impl(sp: &mut MININDEX_StreamState, inReal: f64, outInteger: &mut i32) {
+    fn MININDEX_step_impl(cfg: &MININDEX_StreamConfig, sp: &mut MININDEX_StreamState, inReal: f64, outInteger: &mut i32) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -473,7 +483,6 @@ impl Core {
             }
         }
         let state = MININDEX_StreamState {
-            optInTimePeriod,
             lowest,
             trailingIdx: (trailingIdx) as i32,
             lowestIdx: (lowestIdx) as i32,
@@ -482,7 +491,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MININDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MININDEX_Stream { config: MININDEX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MININDEX_Open`] (composition seam).
@@ -587,7 +596,7 @@ impl MININDEX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outInteger: i32 = 0_i32;
-        Core::MININDEX_step_impl(&mut self.state, inReal, &mut outInteger);
+        Core::MININDEX_step_impl(&self.config, &mut self.state, inReal, &mut outInteger);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -620,7 +629,7 @@ impl MININDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MININDEX_step_impl(&mut self.state, inReal[i], &mut outInteger[i]);
+            Core::MININDEX_step_impl(&self.config, &mut self.state, inReal[i], &mut outInteger[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -418,6 +418,15 @@ impl Core {
 
 /* Using minmax_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What MINMAX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MINMAX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MINMAX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MINMAX stream: one value per closed bar, bit-identical to [`Core::MINMAX`]
 /// over the same series. Open with [`Core::MINMAX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -427,6 +436,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINMAX_Stream")]
 pub struct MINMAX_Stream {
+    /// What this stream was opened with — see `MINMAX_StreamConfig`.
+    config: MINMAX_StreamConfig,
     state: MINMAX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -437,6 +448,7 @@ impl MINMAX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINMAX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -445,7 +457,6 @@ impl MINMAX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MINMAX_StreamState {
-    optInTimePeriod: i32,
     highest: f64,
     lowest: f64,
     trailingIdx: i32,
@@ -462,7 +473,6 @@ impl MINMAX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.highest = src.highest;
         self.lowest = src.lowest;
         self.trailingIdx = src.trailingIdx;
@@ -482,7 +492,7 @@ impl MINMAX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINMAX_step_impl(sp: &mut MINMAX_StreamState, inReal: f64, outMin: &mut f64, outMax: &mut f64) {
+    fn MINMAX_step_impl(cfg: &MINMAX_StreamConfig, sp: &mut MINMAX_StreamState, inReal: f64, outMin: &mut f64, outMax: &mut f64) {
         let mut tmpHigh: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -673,7 +683,6 @@ impl Core {
             }
         }
         let state = MINMAX_StreamState {
-            optInTimePeriod,
             highest,
             lowest,
             trailingIdx: (trailingIdx) as i32,
@@ -684,7 +693,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MINMAX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MINMAX_Stream { config: MINMAX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MINMAX_Open`] (composition seam).
@@ -798,7 +807,7 @@ impl MINMAX_Stream {
         }
         let mut outMin: f64 = 0.0_f64;
         let mut outMax: f64 = 0.0_f64;
-        Core::MINMAX_step_impl(&mut self.state, inReal, &mut outMin, &mut outMax);
+        Core::MINMAX_step_impl(&self.config, &mut self.state, inReal, &mut outMin, &mut outMax);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -831,7 +840,7 @@ impl MINMAX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MINMAX_step_impl(&mut self.state, inReal[i], &mut outMin[i], &mut outMax[i]);
+            Core::MINMAX_step_impl(&self.config, &mut self.state, inReal[i], &mut outMin[i], &mut outMax[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -314,6 +314,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MINMAXINDEX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MINMAXINDEX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MINMAXINDEX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MINMAXINDEX stream: one value per closed bar, bit-identical to [`Core::MINMAXINDEX`]
 /// over the same series. Open with [`Core::MINMAXINDEX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -323,6 +332,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINMAXINDEX_Stream")]
 pub struct MINMAXINDEX_Stream {
+    /// What this stream was opened with — see `MINMAXINDEX_StreamConfig`.
+    config: MINMAXINDEX_StreamConfig,
     state: MINMAXINDEX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -333,6 +344,7 @@ impl MINMAXINDEX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINMAXINDEX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -341,7 +353,6 @@ impl MINMAXINDEX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MINMAXINDEX_StreamState {
-    optInTimePeriod: i32,
     highest: f64,
     lowest: f64,
     trailingIdx: i32,
@@ -358,7 +369,6 @@ impl MINMAXINDEX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.highest = src.highest;
         self.lowest = src.lowest;
         self.trailingIdx = src.trailingIdx;
@@ -378,7 +388,7 @@ impl MINMAXINDEX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINMAXINDEX_step_impl(sp: &mut MINMAXINDEX_StreamState, inReal: f64, outMinIdx: &mut i32, outMaxIdx: &mut i32) {
+    fn MINMAXINDEX_step_impl(cfg: &MINMAXINDEX_StreamConfig, sp: &mut MINMAXINDEX_StreamState, inReal: f64, outMinIdx: &mut i32, outMaxIdx: &mut i32) {
         let mut tmpHigh: f64 = 0.0_f64;
         let mut tmpLow: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
@@ -552,7 +562,6 @@ impl Core {
             }
         }
         let state = MINMAXINDEX_StreamState {
-            optInTimePeriod,
             highest,
             lowest,
             trailingIdx: (trailingIdx) as i32,
@@ -563,7 +572,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(MINMAXINDEX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MINMAXINDEX_Stream { config: MINMAXINDEX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MINMAXINDEX_Open`] (composition seam).
@@ -677,7 +686,7 @@ impl MINMAXINDEX_Stream {
         }
         let mut outMinIdx: i32 = 0_i32;
         let mut outMaxIdx: i32 = 0_i32;
-        Core::MINMAXINDEX_step_impl(&mut self.state, inReal, &mut outMinIdx, &mut outMaxIdx);
+        Core::MINMAXINDEX_step_impl(&self.config, &mut self.state, inReal, &mut outMinIdx, &mut outMaxIdx);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -710,7 +719,7 @@ impl MINMAXINDEX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MINMAXINDEX_step_impl(&mut self.state, inReal[i], &mut outMinIdx[i], &mut outMaxIdx[i]);
+            Core::MINMAXINDEX_step_impl(&self.config, &mut self.state, inReal[i], &mut outMinIdx[i], &mut outMaxIdx[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
@@ -574,6 +574,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MINUS_DI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MINUS_DI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MINUS_DI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MINUS_DI stream: one value per closed bar, bit-identical to [`Core::MINUS_DI`]
 /// over the same series. Open with [`Core::MINUS_DI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -583,6 +592,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINUS_DI_Stream")]
 pub struct MINUS_DI_Stream {
+    /// What this stream was opened with — see `MINUS_DI_StreamConfig`.
+    config: MINUS_DI_StreamConfig,
     state: MINUS_DI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -593,6 +604,7 @@ impl MINUS_DI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINUS_DI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -601,7 +613,6 @@ impl MINUS_DI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MINUS_DI_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevClose: f64,
@@ -614,7 +625,6 @@ impl MINUS_DI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevClose = src.prevClose;
@@ -630,8 +640,8 @@ impl MINUS_DI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINUS_DI_step_impl(sp: &mut MINUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod <= 1 {
+    fn MINUS_DI_step_impl(cfg: &MINUS_DI_StreamConfig, sp: &mut MINUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
             let mut diffM: f64 = 0.0_f64;
@@ -681,10 +691,10 @@ impl Core {
             sp.prevLow = tempReal;
             if diffM > 0_f64 && diffP < diffM {
                 // Case 2 and 4: +DM=0,-DM=diffM
-                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((sp.optInTimePeriod) as f64) + diffM;
+                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((cfg.optInTimePeriod) as f64) + diffM;
             } else {
                 // Case 1,3,5 and 7
-                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((sp.optInTimePeriod) as f64);
+                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((cfg.optInTimePeriod) as f64);
             }
             // Calculate the prevTR
             let mut _true_range_1: f64;
@@ -699,7 +709,7 @@ impl Core {
             }
             _true_range_1 = range_1;
             tempReal = _true_range_1;
-            sp.prevTR = sp.prevTR - sp.prevTR / ((sp.optInTimePeriod) as f64) + tempReal;
+            sp.prevTR = sp.prevTR - sp.prevTR / ((cfg.optInTimePeriod) as f64) + tempReal;
             sp.prevClose = inClose;
             // Calculate the DI. The value is rounded (see Wilder book).
             if sp.prevTR > 0.0 {
@@ -910,14 +920,13 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = MINUS_DI_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevClose,
                 prevMinusDM,
                 prevTR,
             };
-            Ok(MINUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DI_Stream { config: MINUS_DI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -1176,14 +1185,13 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = MINUS_DI_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevClose,
                 prevMinusDM,
                 prevTR,
             };
-            Ok(MINUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DI_Stream { config: MINUS_DI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1296,7 +1304,7 @@ impl MINUS_DI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MINUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::MINUS_DI_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1329,7 +1337,7 @@ impl MINUS_DI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MINUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::MINUS_DI_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
@@ -433,6 +433,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MINUS_DM was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MINUS_DM_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MINUS_DM_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MINUS_DM stream: one value per closed bar, bit-identical to [`Core::MINUS_DM`]
 /// over the same series. Open with [`Core::MINUS_DM_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -442,6 +451,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MINUS_DM_Stream")]
 pub struct MINUS_DM_Stream {
+    /// What this stream was opened with — see `MINUS_DM_StreamConfig`.
+    config: MINUS_DM_StreamConfig,
     state: MINUS_DM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -452,6 +463,7 @@ impl MINUS_DM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MINUS_DM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -460,7 +472,6 @@ impl MINUS_DM_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MINUS_DM_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevMinusDM: f64,
@@ -471,7 +482,6 @@ impl MINUS_DM_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevMinusDM = src.prevMinusDM;
@@ -485,8 +495,8 @@ impl MINUS_DM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MINUS_DM_step_impl(sp: &mut MINUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod <= 1 {
+    fn MINUS_DM_step_impl(cfg: &MINUS_DM_StreamConfig, sp: &mut MINUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
             let mut diffM: f64 = 0.0_f64;
@@ -518,10 +528,10 @@ impl Core {
             sp.prevLow = tempReal;
             if diffM > 0_f64 && diffP < diffM {
                 // Case 2 and 4: +DM=0,-DM=diffM
-                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((sp.optInTimePeriod) as f64) + diffM;
+                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((cfg.optInTimePeriod) as f64) + diffM;
             } else {
                 // Case 1,3,5 and 7
-                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((sp.optInTimePeriod) as f64);
+                sp.prevMinusDM = sp.prevMinusDM - sp.prevMinusDM / ((cfg.optInTimePeriod) as f64);
             }
             (*outReal) = sp.prevMinusDM;
         }
@@ -677,12 +687,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = MINUS_DM_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevMinusDM,
             };
-            Ok(MINUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DM_Stream { config: MINUS_DM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -847,12 +856,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = MINUS_DM_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevMinusDM,
             };
-            Ok(MINUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(MINUS_DM_Stream { config: MINUS_DM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -962,7 +970,7 @@ impl MINUS_DM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MINUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::MINUS_DM_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -995,7 +1003,7 @@ impl MINUS_DM_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MINUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::MINUS_DM_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/mom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mom.rs
@@ -276,6 +276,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What MOM was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&MOM_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct MOM_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live MOM stream: one value per closed bar, bit-identical to [`Core::MOM`]
 /// over the same series. Open with [`Core::MOM_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -285,6 +294,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_MOM_Stream")]
 pub struct MOM_Stream {
+    /// What this stream was opened with — see `MOM_StreamConfig`.
+    config: MOM_StreamConfig,
     state: MOM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -295,6 +306,7 @@ impl MOM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `MOM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -303,7 +315,6 @@ impl MOM_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct MOM_StreamState {
-    optInTimePeriod: i32,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
     ring_trailingIdx_inReal: Vec<f64>,
@@ -314,7 +325,6 @@ impl MOM_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
         self.ring_trailingIdx_inReal.clone_from(&src.ring_trailingIdx_inReal);
@@ -328,7 +338,7 @@ impl MOM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn MOM_step_impl(sp: &mut MOM_StreamState, inReal: f64, outReal: &mut f64) {
+    fn MOM_step_impl(cfg: &MOM_StreamConfig, sp: &mut MOM_StreamState, inReal: f64, outReal: &mut f64) {
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
         }
@@ -433,12 +443,11 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = MOM_StreamState {
-            optInTimePeriod,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(MOM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(MOM_Stream { config: MOM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::MOM_Open`] (composition seam).
@@ -543,7 +552,7 @@ impl MOM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::MOM_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::MOM_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -576,7 +585,7 @@ impl MOM_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::MOM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::MOM_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/natr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/natr.rs
@@ -439,6 +439,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What NATR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&NATR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct NATR_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live NATR stream: one value per closed bar, bit-identical to [`Core::NATR`]
 /// over the same series. Open with [`Core::NATR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -448,6 +457,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_NATR_Stream")]
 pub struct NATR_Stream {
+    /// What this stream was opened with — see `NATR_StreamConfig`.
+    config: NATR_StreamConfig,
     state: NATR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -458,6 +469,7 @@ impl NATR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `NATR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -466,7 +478,6 @@ impl NATR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct NATR_StreamState {
-    optInTimePeriod: i32,
     prevATR: f64,
     lag1_inClose: f64,
 }
@@ -476,7 +487,6 @@ impl NATR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevATR = src.prevATR;
         self.lag1_inClose = src.lag1_inClose;
     }
@@ -489,7 +499,7 @@ impl NATR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn NATR_step_impl(sp: &mut NATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn NATR_step_impl(cfg: &NATR_StreamConfig, sp: &mut NATR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tempValue: f64 = 0.0_f64;
         let mut val2: f64 = 0.0_f64;
         let mut val3: f64 = 0.0_f64;
@@ -511,10 +521,10 @@ impl Core {
         if val3 > greatest {
             greatest = val3;
         }
-        sp.prevATR *= ((sp.optInTimePeriod - 1) as f64);
+        sp.prevATR *= ((cfg.optInTimePeriod - 1) as f64);
         sp.prevATR += greatest;
-        sp.prevATR /= ((sp.optInTimePeriod) as f64);
-        if sp.optInTimePeriod <= 1 {
+        sp.prevATR /= ((cfg.optInTimePeriod) as f64);
+        if cfg.optInTimePeriod <= 1 {
             // No smoothing: emit the raw True Range (unnormalized).
             (*outReal) = sp.prevATR;
         } else {
@@ -741,11 +751,10 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = NATR_StreamState {
-            optInTimePeriod,
             prevATR,
             lag1_inClose: inClose[historyLen - 1],
         };
-        Ok(NATR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(NATR_Stream { config: NATR_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::NATR_Open`] (composition seam).
@@ -857,7 +866,7 @@ impl NATR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::NATR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::NATR_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -890,7 +899,7 @@ impl NATR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::NATR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::NATR_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
@@ -576,6 +576,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What PLUS_DI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&PLUS_DI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct PLUS_DI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live PLUS_DI stream: one value per closed bar, bit-identical to [`Core::PLUS_DI`]
 /// over the same series. Open with [`Core::PLUS_DI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -585,6 +594,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PLUS_DI_Stream")]
 pub struct PLUS_DI_Stream {
+    /// What this stream was opened with — see `PLUS_DI_StreamConfig`.
+    config: PLUS_DI_StreamConfig,
     state: PLUS_DI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -595,6 +606,7 @@ impl PLUS_DI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PLUS_DI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -603,7 +615,6 @@ impl PLUS_DI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct PLUS_DI_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevClose: f64,
@@ -616,7 +627,6 @@ impl PLUS_DI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevClose = src.prevClose;
@@ -632,8 +642,8 @@ impl PLUS_DI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PLUS_DI_step_impl(sp: &mut PLUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod <= 1 {
+    fn PLUS_DI_step_impl(cfg: &PLUS_DI_StreamConfig, sp: &mut PLUS_DI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
             let mut diffM: f64 = 0.0_f64;
@@ -683,10 +693,10 @@ impl Core {
             sp.prevLow = tempReal;
             if diffP > 0_f64 && diffP > diffM {
                 // Case 1 and 3: +DM=diffP,-DM=0
-                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((sp.optInTimePeriod) as f64) + diffP;
+                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((cfg.optInTimePeriod) as f64) + diffP;
             } else {
                 // Case 2,4,5 and 7
-                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((sp.optInTimePeriod) as f64);
+                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((cfg.optInTimePeriod) as f64);
             }
             // Calculate the prevTR
             let mut _true_range_1: f64;
@@ -701,7 +711,7 @@ impl Core {
             }
             _true_range_1 = range_1;
             tempReal = _true_range_1;
-            sp.prevTR = sp.prevTR - sp.prevTR / ((sp.optInTimePeriod) as f64) + tempReal;
+            sp.prevTR = sp.prevTR - sp.prevTR / ((cfg.optInTimePeriod) as f64) + tempReal;
             sp.prevClose = inClose;
             // Calculate the DI. The value is rounded (see Wilder book).
             if sp.prevTR > 0.0 {
@@ -912,14 +922,13 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = PLUS_DI_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevClose,
                 prevPlusDM,
                 prevTR,
             };
-            Ok(PLUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DI_Stream { config: PLUS_DI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -1178,14 +1187,13 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = PLUS_DI_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevClose,
                 prevPlusDM,
                 prevTR,
             };
-            Ok(PLUS_DI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DI_Stream { config: PLUS_DI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1298,7 +1306,7 @@ impl PLUS_DI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::PLUS_DI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::PLUS_DI_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1331,7 +1339,7 @@ impl PLUS_DI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::PLUS_DI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::PLUS_DI_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
@@ -432,6 +432,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What PLUS_DM was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&PLUS_DM_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct PLUS_DM_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live PLUS_DM stream: one value per closed bar, bit-identical to [`Core::PLUS_DM`]
 /// over the same series. Open with [`Core::PLUS_DM_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -441,6 +450,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PLUS_DM_Stream")]
 pub struct PLUS_DM_Stream {
+    /// What this stream was opened with — see `PLUS_DM_StreamConfig`.
+    config: PLUS_DM_StreamConfig,
     state: PLUS_DM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -451,6 +462,7 @@ impl PLUS_DM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PLUS_DM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -459,7 +471,6 @@ impl PLUS_DM_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct PLUS_DM_StreamState {
-    optInTimePeriod: i32,
     prevHigh: f64,
     prevLow: f64,
     prevPlusDM: f64,
@@ -470,7 +481,6 @@ impl PLUS_DM_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevHigh = src.prevHigh;
         self.prevLow = src.prevLow;
         self.prevPlusDM = src.prevPlusDM;
@@ -484,8 +494,8 @@ impl PLUS_DM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PLUS_DM_step_impl(sp: &mut PLUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod <= 1 {
+    fn PLUS_DM_step_impl(cfg: &PLUS_DM_StreamConfig, sp: &mut PLUS_DM_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod <= 1 {
             let mut tempReal: f64 = 0.0_f64;
             let mut diffP: f64 = 0.0_f64;
             let mut diffM: f64 = 0.0_f64;
@@ -517,10 +527,10 @@ impl Core {
             sp.prevLow = tempReal;
             if diffP > 0_f64 && diffP > diffM {
                 // Case 1 and 3: +DM=diffP,-DM=0
-                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((sp.optInTimePeriod) as f64) + diffP;
+                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((cfg.optInTimePeriod) as f64) + diffP;
             } else {
                 // Case 2,4,5 and 7
-                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((sp.optInTimePeriod) as f64);
+                sp.prevPlusDM = sp.prevPlusDM - sp.prevPlusDM / ((cfg.optInTimePeriod) as f64);
             }
             (*outReal) = sp.prevPlusDM;
         }
@@ -676,12 +686,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = PLUS_DM_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevPlusDM,
             };
-            Ok(PLUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DM_Stream { config: PLUS_DM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut today: usize = 0_usize;
             let mut lookbackTotal: usize = 0_usize;
@@ -846,12 +855,11 @@ impl Core {
 
             // Capture the live batch state into the handle.
             let state = PLUS_DM_StreamState {
-                optInTimePeriod,
                 prevHigh,
                 prevLow,
                 prevPlusDM,
             };
-            Ok(PLUS_DM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(PLUS_DM_Stream { config: PLUS_DM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -961,7 +969,7 @@ impl PLUS_DM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::PLUS_DM_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::PLUS_DM_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -994,7 +1002,7 @@ impl PLUS_DM_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::PLUS_DM_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::PLUS_DM_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ppo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ppo.rs
@@ -331,6 +331,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What PPO was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&PPO_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct PPO_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInMAType: MAType,
+}
+
 /// Live PPO stream: one value per closed bar, bit-identical to [`Core::PPO`]
 /// over the same series. Open with [`Core::PPO_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -340,6 +351,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PPO_Stream")]
 pub struct PPO_Stream {
+    /// What this stream was opened with — see `PPO_StreamConfig`.
+    config: PPO_StreamConfig,
     state: PPO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -350,6 +363,7 @@ impl PPO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PPO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -358,9 +372,6 @@ impl PPO_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct PPO_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInMAType: MAType,
     sub0: MA_Stream,
     sub1: MA_Stream,
 }
@@ -370,9 +381,6 @@ impl PPO_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInMAType = src.optInMAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
     }
@@ -385,7 +393,7 @@ impl PPO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PPO_step_impl(sp: &mut PPO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn PPO_step_impl(cfg: &PPO_StreamConfig, sp: &mut PPO_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
@@ -508,9 +516,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = PPO_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInMAType,
             sub0,
             sub1,
         };
@@ -518,7 +523,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(PPO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(PPO_Stream { config: PPO_StreamConfig { optInFastPeriod, optInSlowPeriod, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::PPO_Open`] (composition seam).
@@ -604,10 +609,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `PPO_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `PPO_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static PPO_PEEK_SCRATCH: std::cell::Cell<Option<Box<PPO_Stream>>> =
+    static PPO_PEEK_SCRATCH: std::cell::Cell<Option<Box<PPO_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -631,7 +636,7 @@ impl PPO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::PPO_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::PPO_step_impl(&self.config, &mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -664,7 +669,7 @@ impl PPO_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::PPO_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::PPO_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -688,11 +693,13 @@ impl PPO_Stream {
             return Err(RetCode::BadParam);
         }
         PPO_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            let stepped = Core::PPO_step_impl(&self.config, &mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/pvo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvo.rs
@@ -331,6 +331,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What PVO was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&PVO_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct PVO_StreamConfig {
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInMAType: MAType,
+}
+
 /// Live PVO stream: one value per closed bar, bit-identical to [`Core::PVO`]
 /// over the same series. Open with [`Core::PVO_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -340,6 +351,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_PVO_Stream")]
 pub struct PVO_Stream {
+    /// What this stream was opened with — see `PVO_StreamConfig`.
+    config: PVO_StreamConfig,
     state: PVO_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -350,6 +363,7 @@ impl PVO_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `PVO_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -358,9 +372,6 @@ impl PVO_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct PVO_StreamState {
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInMAType: MAType,
     sub0: MA_Stream,
     sub1: MA_Stream,
 }
@@ -370,9 +381,6 @@ impl PVO_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInMAType = src.optInMAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
     }
@@ -385,7 +393,7 @@ impl PVO_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn PVO_step_impl(sp: &mut PVO_StreamState, inVolume: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn PVO_step_impl(cfg: &PVO_StreamConfig, sp: &mut PVO_StreamState, inVolume: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut tempReal: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outReal: f64 = 0.0_f64;
@@ -508,9 +516,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = PVO_StreamState {
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInMAType,
             sub0,
             sub1,
         };
@@ -518,7 +523,7 @@ impl Core {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(PVO_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(PVO_Stream { config: PVO_StreamConfig { optInFastPeriod, optInSlowPeriod, optInMAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::PVO_Open`] (composition seam).
@@ -606,10 +611,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `PVO_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `PVO_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static PVO_PEEK_SCRATCH: std::cell::Cell<Option<Box<PVO_Stream>>> =
+    static PVO_PEEK_SCRATCH: std::cell::Cell<Option<Box<PVO_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -633,7 +638,7 @@ impl PVO_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::PVO_step_impl(&mut self.state, inVolume, &mut outReal)?;
+        Core::PVO_step_impl(&self.config, &mut self.state, inVolume, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -666,7 +671,7 @@ impl PVO_Stream {
             if !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::PVO_step_impl(&mut self.state, inVolume[i], &mut outReal[i])?;
+            Core::PVO_step_impl(&self.config, &mut self.state, inVolume[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -690,11 +695,13 @@ impl PVO_Stream {
             return Err(RetCode::BadParam);
         }
         PVO_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inVolume);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            let stepped = Core::PVO_step_impl(&self.config, &mut scratch, inVolume, &mut outReal);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/qstick.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/qstick.rs
@@ -313,6 +313,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What QSTICK was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&QSTICK_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct QSTICK_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live QSTICK stream: one value per closed bar, bit-identical to [`Core::QSTICK`]
 /// over the same series. Open with [`Core::QSTICK_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -322,6 +331,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_QSTICK_Stream")]
 pub struct QSTICK_Stream {
+    /// What this stream was opened with — see `QSTICK_StreamConfig`.
+    config: QSTICK_StreamConfig,
     state: QSTICK_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -332,6 +343,7 @@ impl QSTICK_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `QSTICK_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -340,7 +352,6 @@ impl QSTICK_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct QSTICK_StreamState {
-    optInTimePeriod: i32,
     periodTotal: f64,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
@@ -352,7 +363,6 @@ impl QSTICK_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.periodTotal = src.periodTotal;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
@@ -367,7 +377,7 @@ impl QSTICK_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn QSTICK_step_impl(sp: &mut QSTICK_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
+    fn QSTICK_step_impl(cfg: &QSTICK_StreamConfig, sp: &mut QSTICK_StreamState, inOpen: f64, inClose: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_derived[0] = (inClose - inOpen) as f64;
@@ -375,7 +385,7 @@ impl Core {
         sp.periodTotal += (inClose - inOpen) as f64;
         tempReal = sp.periodTotal;
         sp.periodTotal -= sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx];
-        (*outReal) = tempReal / (sp.optInTimePeriod as f64);
+        (*outReal) = tempReal / (cfg.optInTimePeriod as f64);
         sp.ring_trailingIdx_derived[sp.ringPos_trailingIdx] = (inClose - inOpen) as f64;
         sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
         if sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx {
@@ -492,13 +502,12 @@ impl Core {
             }
         }
         let state = QSTICK_StreamState {
-            optInTimePeriod,
             periodTotal,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_derived,
         };
-        Ok(QSTICK_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(QSTICK_Stream { config: QSTICK_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::QSTICK_Open`] (composition seam).
@@ -611,7 +620,7 @@ impl QSTICK_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::QSTICK_step_impl(&mut self.state, inOpen, inClose, &mut outReal);
+        Core::QSTICK_step_impl(&self.config, &mut self.state, inOpen, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -644,7 +653,7 @@ impl QSTICK_Stream {
             if !inOpen[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::QSTICK_step_impl(&mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
+            Core::QSTICK_step_impl(&self.config, &mut self.state, inOpen[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/roc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/roc.rs
@@ -283,6 +283,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ROC was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ROC_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ROC_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ROC stream: one value per closed bar, bit-identical to [`Core::ROC`]
 /// over the same series. Open with [`Core::ROC_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -292,6 +301,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROC_Stream")]
 pub struct ROC_Stream {
+    /// What this stream was opened with — see `ROC_StreamConfig`.
+    config: ROC_StreamConfig,
     state: ROC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -302,6 +313,7 @@ impl ROC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -310,7 +322,6 @@ impl ROC_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ROC_StreamState {
-    optInTimePeriod: i32,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
     ring_trailingIdx_inReal: Vec<f64>,
@@ -321,7 +332,6 @@ impl ROC_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
         self.ring_trailingIdx_inReal.clone_from(&src.ring_trailingIdx_inReal);
@@ -335,7 +345,7 @@ impl ROC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROC_step_impl(sp: &mut ROC_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROC_step_impl(cfg: &ROC_StreamConfig, sp: &mut ROC_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -451,12 +461,11 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = ROC_StreamState {
-            optInTimePeriod,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROC_Stream { config: ROC_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROC_Open`] (composition seam).
@@ -561,7 +570,7 @@ impl ROC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ROC_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROC_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -594,7 +603,7 @@ impl ROC_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ROC_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROC_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocp.rs
@@ -285,6 +285,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ROCP was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ROCP_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ROCP_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ROCP stream: one value per closed bar, bit-identical to [`Core::ROCP`]
 /// over the same series. Open with [`Core::ROCP_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -294,6 +303,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCP_Stream")]
 pub struct ROCP_Stream {
+    /// What this stream was opened with — see `ROCP_StreamConfig`.
+    config: ROCP_StreamConfig,
     state: ROCP_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -304,6 +315,7 @@ impl ROCP_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCP_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -312,7 +324,6 @@ impl ROCP_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ROCP_StreamState {
-    optInTimePeriod: i32,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
     ring_trailingIdx_inReal: Vec<f64>,
@@ -323,7 +334,6 @@ impl ROCP_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
         self.ring_trailingIdx_inReal.clone_from(&src.ring_trailingIdx_inReal);
@@ -337,7 +347,7 @@ impl ROCP_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCP_step_impl(sp: &mut ROCP_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCP_step_impl(cfg: &ROCP_StreamConfig, sp: &mut ROCP_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -453,12 +463,11 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = ROCP_StreamState {
-            optInTimePeriod,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCP_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCP_Stream { config: ROCP_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCP_Open`] (composition seam).
@@ -563,7 +572,7 @@ impl ROCP_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ROCP_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCP_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -596,7 +605,7 @@ impl ROCP_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ROCP_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCP_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr.rs
@@ -283,6 +283,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ROCR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ROCR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ROCR_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ROCR stream: one value per closed bar, bit-identical to [`Core::ROCR`]
 /// over the same series. Open with [`Core::ROCR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -292,6 +301,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCR_Stream")]
 pub struct ROCR_Stream {
+    /// What this stream was opened with — see `ROCR_StreamConfig`.
+    config: ROCR_StreamConfig,
     state: ROCR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -302,6 +313,7 @@ impl ROCR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -310,7 +322,6 @@ impl ROCR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ROCR_StreamState {
-    optInTimePeriod: i32,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
     ring_trailingIdx_inReal: Vec<f64>,
@@ -321,7 +332,6 @@ impl ROCR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
         self.ring_trailingIdx_inReal.clone_from(&src.ring_trailingIdx_inReal);
@@ -335,7 +345,7 @@ impl ROCR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCR_step_impl(sp: &mut ROCR_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCR_step_impl(cfg: &ROCR_StreamConfig, sp: &mut ROCR_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -451,12 +461,11 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = ROCR_StreamState {
-            optInTimePeriod,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCR_Stream { config: ROCR_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCR_Open`] (composition seam).
@@ -561,7 +570,7 @@ impl ROCR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ROCR_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCR_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -594,7 +603,7 @@ impl ROCR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ROCR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCR_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
@@ -285,6 +285,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ROCR100 was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ROCR100_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ROCR100_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live ROCR100 stream: one value per closed bar, bit-identical to [`Core::ROCR100`]
 /// over the same series. Open with [`Core::ROCR100_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -294,6 +303,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ROCR100_Stream")]
 pub struct ROCR100_Stream {
+    /// What this stream was opened with — see `ROCR100_StreamConfig`.
+    config: ROCR100_StreamConfig,
     state: ROCR100_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -304,6 +315,7 @@ impl ROCR100_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ROCR100_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -312,7 +324,6 @@ impl ROCR100_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ROCR100_StreamState {
-    optInTimePeriod: i32,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
     ring_trailingIdx_inReal: Vec<f64>,
@@ -323,7 +334,6 @@ impl ROCR100_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
         self.ring_trailingIdx_inReal.clone_from(&src.ring_trailingIdx_inReal);
@@ -337,7 +347,7 @@ impl ROCR100_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ROCR100_step_impl(sp: &mut ROCR100_StreamState, inReal: f64, outReal: &mut f64) {
+    fn ROCR100_step_impl(cfg: &ROCR100_StreamConfig, sp: &mut ROCR100_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -453,12 +463,11 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = ROCR100_StreamState {
-            optInTimePeriod,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(ROCR100_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ROCR100_Stream { config: ROCR100_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ROCR100_Open`] (composition seam).
@@ -563,7 +572,7 @@ impl ROCR100_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ROCR100_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::ROCR100_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -596,7 +605,7 @@ impl ROCR100_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ROCR100_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::ROCR100_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -459,6 +459,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What RSI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&RSI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct RSI_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live RSI stream: one value per closed bar, bit-identical to [`Core::RSI`]
 /// over the same series. Open with [`Core::RSI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -468,6 +477,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_RSI_Stream")]
 pub struct RSI_Stream {
+    /// What this stream was opened with — see `RSI_StreamConfig`.
+    config: RSI_StreamConfig,
     state: RSI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -478,6 +489,7 @@ impl RSI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `RSI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -486,7 +498,6 @@ impl RSI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct RSI_StreamState {
-    optInTimePeriod: i32,
     prevGain: f64,
     prevLoss: f64,
     prevValue: f64,
@@ -497,7 +508,6 @@ impl RSI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevGain = src.prevGain;
         self.prevLoss = src.prevLoss;
         self.prevValue = src.prevValue;
@@ -511,25 +521,25 @@ impl RSI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn RSI_step_impl(sp: &mut RSI_StreamState, inReal: f64, outReal: &mut f64) {
+    fn RSI_step_impl(cfg: &RSI_StreamConfig, sp: &mut RSI_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempValue1: f64 = 0.0_f64;
         let mut tempValue2: f64 = 0.0_f64;
-        if sp.optInTimePeriod == 1 {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
         tempValue1 = inReal as f64;
         tempValue2 = tempValue1 - sp.prevValue;
         sp.prevValue = tempValue1;
-        sp.prevLoss *= (sp.optInTimePeriod - 1) as f64;
-        sp.prevGain *= (sp.optInTimePeriod - 1) as f64;
+        sp.prevLoss *= (cfg.optInTimePeriod - 1) as f64;
+        sp.prevGain *= (cfg.optInTimePeriod - 1) as f64;
         if tempValue2 < 0.0 {
             sp.prevLoss -= tempValue2;
         } else {
             sp.prevGain += tempValue2;
         }
-        sp.prevLoss /= sp.optInTimePeriod as f64;
-        sp.prevGain /= sp.optInTimePeriod as f64;
+        sp.prevLoss /= cfg.optInTimePeriod as f64;
+        sp.prevGain /= cfg.optInTimePeriod as f64;
         tempValue1 = sp.prevGain + sp.prevLoss;
         if tempValue1 > 0.0 {
             (*outReal) = 100.0 * (sp.prevGain / tempValue1);
@@ -571,7 +581,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = RSI_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 prevGain: 0.0_f64,
                 prevLoss: 0.0_f64,
                 prevValue: 0.0_f64,
@@ -587,7 +596,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(RSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(RSI_Stream { config: RSI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut today: usize = 0_usize;
@@ -782,12 +791,11 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = RSI_StreamState {
-            optInTimePeriod,
             prevGain,
             prevLoss,
             prevValue,
         };
-        Ok(RSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(RSI_Stream { config: RSI_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::RSI_Open`] (composition seam).
@@ -892,7 +900,7 @@ impl RSI_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::RSI_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::RSI_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -925,7 +933,7 @@ impl RSI_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::RSI_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::RSI_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sar.rs
@@ -512,6 +512,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What SAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&SAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct SAR_StreamConfig {
+    optInAcceleration: f64,
+    optInMaximum: f64,
+}
+
 /// Live SAR stream: one value per closed bar, bit-identical to [`Core::SAR`]
 /// over the same series. Open with [`Core::SAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -521,6 +531,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SAR_Stream")]
 pub struct SAR_Stream {
+    /// What this stream was opened with — see `SAR_StreamConfig`.
+    config: SAR_StreamConfig,
     state: SAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -531,6 +543,7 @@ impl SAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -539,8 +552,6 @@ impl SAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct SAR_StreamState {
-    optInAcceleration: f64,
-    optInMaximum: f64,
     isLong: usize,
     newHigh: f64,
     newLow: f64,
@@ -554,8 +565,6 @@ impl SAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInAcceleration = src.optInAcceleration;
-        self.optInMaximum = src.optInMaximum;
         self.isLong = src.isLong;
         self.newHigh = src.newHigh;
         self.newLow = src.newLow;
@@ -572,7 +581,7 @@ impl SAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SAR_step_impl(sp: &mut SAR_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn SAR_step_impl(cfg: &SAR_StreamConfig, sp: &mut SAR_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut prevHigh: f64 = 0.0_f64;
         let mut prevLow: f64 = 0.0_f64;
         prevLow = sp.newLow;
@@ -596,7 +605,7 @@ impl Core {
                 // Output the overide SAR
                 (*outReal) = sp.sar;
                 // Adjust af and ep
-                sp.af = sp.optInAcceleration;
+                sp.af = cfg.optInAcceleration;
                 sp.ep = sp.newLow;
                 // Calculate the new SAR
                 sp.sar = (sp.af as f64).mul_add(sp.ep - sp.sar, sp.sar);
@@ -615,9 +624,9 @@ impl Core {
                 // Adjust af and ep.
                 if sp.newHigh > sp.ep {
                     sp.ep = sp.newHigh;
-                    sp.af += sp.optInAcceleration;
-                    if sp.af > sp.optInMaximum {
-                        sp.af = sp.optInMaximum;
+                    sp.af += cfg.optInAcceleration;
+                    if sp.af > cfg.optInMaximum {
+                        sp.af = cfg.optInMaximum;
                     }
                 }
                 // Calculate the new SAR
@@ -647,7 +656,7 @@ impl Core {
             // Output the overide SAR
             (*outReal) = sp.sar;
             // Adjust af and ep
-            sp.af = sp.optInAcceleration;
+            sp.af = cfg.optInAcceleration;
             sp.ep = sp.newHigh;
             // Calculate the new SAR
             sp.sar = (sp.af as f64).mul_add(sp.ep - sp.sar, sp.sar);
@@ -666,9 +675,9 @@ impl Core {
             // Adjust af and ep.
             if sp.newLow < sp.ep {
                 sp.ep = sp.newLow;
-                sp.af += sp.optInAcceleration;
-                if sp.af > sp.optInMaximum {
-                    sp.af = sp.optInMaximum;
+                sp.af += cfg.optInAcceleration;
+                if sp.af > cfg.optInMaximum {
+                    sp.af = cfg.optInMaximum;
                 }
             }
             // Calculate the new SAR
@@ -935,8 +944,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = SAR_StreamState {
-            optInAcceleration,
-            optInMaximum,
             isLong,
             newHigh,
             newLow,
@@ -944,7 +951,7 @@ impl Core {
             ep,
             sar,
         };
-        Ok(SAR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SAR_Stream { config: SAR_StreamConfig { optInAcceleration, optInMaximum, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SAR_Open`] (composition seam).
@@ -1053,7 +1060,7 @@ impl SAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::SAR_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::SAR_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1086,7 +1093,7 @@ impl SAR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::SAR_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::SAR_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sarext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sarext.rs
@@ -679,6 +679,22 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What SAREXT was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&SAREXT_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct SAREXT_StreamConfig {
+    optInStartValue: f64,
+    optInOffsetOnReverse: f64,
+    optInAccelerationInitLong: f64,
+    optInAccelerationLong: f64,
+    optInAccelerationMaxLong: f64,
+    optInAccelerationInitShort: f64,
+    optInAccelerationShort: f64,
+    optInAccelerationMaxShort: f64,
+}
+
 /// Live SAREXT stream: one value per closed bar, bit-identical to [`Core::SAREXT`]
 /// over the same series. Open with [`Core::SAREXT_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -688,6 +704,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SAREXT_Stream")]
 pub struct SAREXT_Stream {
+    /// What this stream was opened with — see `SAREXT_StreamConfig`.
+    config: SAREXT_StreamConfig,
     state: SAREXT_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -698,6 +716,7 @@ impl SAREXT_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SAREXT_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -706,14 +725,6 @@ impl SAREXT_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct SAREXT_StreamState {
-    optInStartValue: f64,
-    optInOffsetOnReverse: f64,
-    optInAccelerationInitLong: f64,
-    optInAccelerationLong: f64,
-    optInAccelerationMaxLong: f64,
-    optInAccelerationInitShort: f64,
-    optInAccelerationShort: f64,
-    optInAccelerationMaxShort: f64,
     isLong: usize,
     newHigh: f64,
     newLow: f64,
@@ -728,14 +739,6 @@ impl SAREXT_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInStartValue = src.optInStartValue;
-        self.optInOffsetOnReverse = src.optInOffsetOnReverse;
-        self.optInAccelerationInitLong = src.optInAccelerationInitLong;
-        self.optInAccelerationLong = src.optInAccelerationLong;
-        self.optInAccelerationMaxLong = src.optInAccelerationMaxLong;
-        self.optInAccelerationInitShort = src.optInAccelerationInitShort;
-        self.optInAccelerationShort = src.optInAccelerationShort;
-        self.optInAccelerationMaxShort = src.optInAccelerationMaxShort;
         self.isLong = src.isLong;
         self.newHigh = src.newHigh;
         self.newLow = src.newLow;
@@ -753,7 +756,7 @@ impl SAREXT_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SAREXT_step_impl(sp: &mut SAREXT_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
+    fn SAREXT_step_impl(cfg: &SAREXT_StreamConfig, sp: &mut SAREXT_StreamState, inHigh: f64, inLow: f64, outReal: &mut f64) {
         let mut prevHigh: f64 = 0.0_f64;
         let mut prevLow: f64 = 0.0_f64;
         prevLow = sp.newLow;
@@ -775,12 +778,12 @@ impl Core {
                     sp.sar = sp.newHigh;
                 }
                 // Output the overide SAR
-                if sp.optInOffsetOnReverse != 0.0 {
-                    sp.sar += sp.sar * sp.optInOffsetOnReverse;
+                if cfg.optInOffsetOnReverse != 0.0 {
+                    sp.sar += sp.sar * cfg.optInOffsetOnReverse;
                 }
                 (*outReal) = 0_f64 - sp.sar;
                 // Adjust afShort and ep
-                sp.afShort = sp.optInAccelerationInitShort;
+                sp.afShort = cfg.optInAccelerationInitShort;
                 sp.ep = sp.newLow;
                 // Calculate the new SAR
                 sp.sar = (sp.afShort as f64).mul_add(sp.ep - sp.sar, sp.sar);
@@ -799,9 +802,9 @@ impl Core {
                 // Adjust afLong and ep.
                 if sp.newHigh > sp.ep {
                     sp.ep = sp.newHigh;
-                    sp.afLong += sp.optInAccelerationLong;
-                    if sp.afLong > sp.optInAccelerationMaxLong {
-                        sp.afLong = sp.optInAccelerationMaxLong;
+                    sp.afLong += cfg.optInAccelerationLong;
+                    if sp.afLong > cfg.optInAccelerationMaxLong {
+                        sp.afLong = cfg.optInAccelerationMaxLong;
                     }
                 }
                 // Calculate the new SAR
@@ -829,12 +832,12 @@ impl Core {
                 sp.sar = sp.newLow;
             }
             // Output the overide SAR
-            if sp.optInOffsetOnReverse != 0.0 {
-                sp.sar -= sp.sar * sp.optInOffsetOnReverse;
+            if cfg.optInOffsetOnReverse != 0.0 {
+                sp.sar -= sp.sar * cfg.optInOffsetOnReverse;
             }
             (*outReal) = sp.sar;
             // Adjust afLong and ep
-            sp.afLong = sp.optInAccelerationInitLong;
+            sp.afLong = cfg.optInAccelerationInitLong;
             sp.ep = sp.newHigh;
             // Calculate the new SAR
             sp.sar = (sp.afLong as f64).mul_add(sp.ep - sp.sar, sp.sar);
@@ -853,9 +856,9 @@ impl Core {
             // Adjust afShort and ep.
             if sp.newLow < sp.ep {
                 sp.ep = sp.newLow;
-                sp.afShort += sp.optInAccelerationShort;
-                if sp.afShort > sp.optInAccelerationMaxShort {
-                    sp.afShort = sp.optInAccelerationMaxShort;
+                sp.afShort += cfg.optInAccelerationShort;
+                if sp.afShort > cfg.optInAccelerationMaxShort {
+                    sp.afShort = cfg.optInAccelerationMaxShort;
                 }
             }
             // Calculate the new SAR
@@ -1209,14 +1212,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = SAREXT_StreamState {
-            optInStartValue,
-            optInOffsetOnReverse,
-            optInAccelerationInitLong,
-            optInAccelerationLong,
-            optInAccelerationMaxLong,
-            optInAccelerationInitShort,
-            optInAccelerationShort,
-            optInAccelerationMaxShort,
             isLong,
             newHigh,
             newLow,
@@ -1225,7 +1220,7 @@ impl Core {
             ep,
             sar,
         };
-        Ok(SAREXT_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SAREXT_Stream { config: SAREXT_StreamConfig { optInStartValue, optInOffsetOnReverse, optInAccelerationInitLong, optInAccelerationLong, optInAccelerationMaxLong, optInAccelerationInitShort, optInAccelerationShort, optInAccelerationMaxShort, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SAREXT_Open`] (composition seam).
@@ -1334,7 +1329,7 @@ impl SAREXT_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::SAREXT_step_impl(&mut self.state, inHigh, inLow, &mut outReal);
+        Core::SAREXT_step_impl(&self.config, &mut self.state, inHigh, inLow, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1367,7 +1362,7 @@ impl SAREXT_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::SAREXT_step_impl(&mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
+            Core::SAREXT_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/sma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sma.rs
@@ -272,6 +272,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What SMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&SMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct SMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live SMA stream: one value per closed bar, bit-identical to [`Core::SMA`]
 /// over the same series. Open with [`Core::SMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -281,6 +290,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SMA_Stream")]
 pub struct SMA_Stream {
+    /// What this stream was opened with — see `SMA_StreamConfig`.
+    config: SMA_StreamConfig,
     state: SMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -291,6 +302,7 @@ impl SMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -299,7 +311,6 @@ impl SMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct SMA_StreamState {
-    optInTimePeriod: i32,
     periodTotal: f64,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
@@ -311,7 +322,6 @@ impl SMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.periodTotal = src.periodTotal;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
@@ -326,7 +336,7 @@ impl SMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SMA_step_impl(sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SMA_step_impl(cfg: &SMA_StreamConfig, sp: &mut SMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -334,7 +344,7 @@ impl Core {
         sp.periodTotal += inReal as f64;
         tempReal = sp.periodTotal;
         sp.periodTotal -= sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] as f64;
-        (*outReal) = tempReal / (sp.optInTimePeriod as f64);
+        (*outReal) = tempReal / (cfg.optInTimePeriod as f64);
         sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
         sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
         if sp.ringPos_trailingIdx >= sp.ringCap_trailingIdx {
@@ -426,13 +436,12 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = SMA_StreamState {
-            optInTimePeriod,
             periodTotal,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(SMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SMA_Stream { config: SMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SMA_Open`] (composition seam).
@@ -537,7 +546,7 @@ impl SMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::SMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -570,7 +579,7 @@ impl SMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::SMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/smi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/smi.rs
@@ -636,6 +636,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What SMI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&SMI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct SMI_StreamConfig {
+    optInTimePeriod: i32,
+    optInFastPeriod: i32,
+    optInSlowPeriod: i32,
+    optInSignalPeriod: i32,
+}
+
 /// Live SMI stream: one value per closed bar, bit-identical to [`Core::SMI`]
 /// over the same series. Open with [`Core::SMI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -645,6 +657,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SMI_Stream")]
 pub struct SMI_Stream {
+    /// What this stream was opened with — see `SMI_StreamConfig`.
+    config: SMI_StreamConfig,
     state: SMI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -655,6 +669,7 @@ impl SMI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SMI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -663,10 +678,6 @@ impl SMI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct SMI_StreamState {
-    optInTimePeriod: i32,
-    optInFastPeriod: i32,
-    optInSlowPeriod: i32,
-    optInSignalPeriod: i32,
     kSlow: f64,
     kFast: f64,
     kSignal: f64,
@@ -693,10 +704,6 @@ impl SMI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInFastPeriod = src.optInFastPeriod;
-        self.optInSlowPeriod = src.optInSlowPeriod;
-        self.optInSignalPeriod = src.optInSignalPeriod;
         self.kSlow = src.kSlow;
         self.kFast = src.kFast;
         self.kSignal = src.kSignal;
@@ -726,7 +733,7 @@ impl SMI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SMI_step_impl(sp: &mut SMI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSMI: &mut f64, outSMISignal: &mut f64) {
+    fn SMI_step_impl(cfg: &SMI_StreamConfig, sp: &mut SMI_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSMI: &mut f64, outSMISignal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         let mut num: f64 = 0.0_f64;
         let mut den: f64 = 0.0_f64;
@@ -1125,10 +1132,6 @@ impl Core {
             }
         }
         let state = SMI_StreamState {
-            optInTimePeriod,
-            optInFastPeriod,
-            optInSlowPeriod,
-            optInSignalPeriod,
             kSlow,
             kFast,
             kSignal,
@@ -1149,7 +1152,7 @@ impl Core {
             x_inLow,
             x_inClose,
         };
-        Ok(SMI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SMI_Stream { config: SMI_StreamConfig { optInTimePeriod, optInFastPeriod, optInSlowPeriod, optInSignalPeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SMI_Open`] (composition seam).
@@ -1250,10 +1253,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `SMI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `SMI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static SMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<SMI_Stream>>> =
+    static SMI_PEEK_SCRATCH: std::cell::Cell<Option<Box<SMI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1278,7 +1281,7 @@ impl SMI_Stream {
         }
         let mut outSMI: f64 = 0.0_f64;
         let mut outSMISignal: f64 = 0.0_f64;
-        Core::SMI_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSMI, &mut outSMISignal);
+        Core::SMI_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outSMI, &mut outSMISignal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1311,7 +1314,7 @@ impl SMI_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::SMI_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSMI[i], &mut outSMISignal[i]);
+            Core::SMI_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSMI[i], &mut outSMISignal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1335,11 +1338,13 @@ impl SMI_Stream {
             return Err(RetCode::BadParam);
         }
         SMI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outSMI: f64 = 0.0_f64;
+            let mut outSMISignal: f64 = 0.0_f64;
+            Core::SMI_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outSMI, &mut outSMISignal);
             cell.set(Some(scratch));
-            value
+            Ok((outSMI, outSMISignal))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/stddev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stddev.rs
@@ -295,6 +295,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What STDDEV was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&STDDEV_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct STDDEV_StreamConfig {
+    optInTimePeriod: i32,
+    optInNbDev: f64,
+}
+
 /// Live STDDEV stream: one value per closed bar, bit-identical to [`Core::STDDEV`]
 /// over the same series. Open with [`Core::STDDEV_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -304,6 +314,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STDDEV_Stream")]
 pub struct STDDEV_Stream {
+    /// What this stream was opened with — see `STDDEV_StreamConfig`.
+    config: STDDEV_StreamConfig,
     state: STDDEV_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -314,6 +326,7 @@ impl STDDEV_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STDDEV_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -322,8 +335,6 @@ impl STDDEV_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct STDDEV_StreamState {
-    optInTimePeriod: i32,
-    optInNbDev: f64,
     sub0: VAR_Stream,
 }
 
@@ -332,8 +343,6 @@ impl STDDEV_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInNbDev = src.optInNbDev;
         self.sub0.restore_from(&src.sub0);
     }
 }
@@ -345,14 +354,14 @@ impl STDDEV_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STDDEV_step_impl(sp: &mut STDDEV_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
+    fn STDDEV_step_impl(cfg: &STDDEV_StreamConfig, sp: &mut STDDEV_StreamState, inReal: f64, outReal: &mut f64) -> Result<(), RetCode> {
         let mut cur_outReal: f64 = 0.0_f64;
 
         // Pipeline the new bar through the sub-streams (batch tail order).
         cur_outReal = sp.sub0.update(inReal)?;
         // Combine map (batch tail, per bar).
-        if sp.optInNbDev != 1.0 {
-            cur_outReal = (cur_outReal).sqrt() * sp.optInNbDev;
+        if cfg.optInNbDev != 1.0 {
+            cur_outReal = (cur_outReal).sqrt() * cfg.optInNbDev;
         } else {
             cur_outReal = (cur_outReal).sqrt();
         }
@@ -450,15 +459,13 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = STDDEV_StreamState {
-            optInTimePeriod,
-            optInNbDev,
             sub0,
         };
         if outStride != 1 && *outNBElement > 0 {
             let last_sc_outReal = sc_outReal[*outNBElement - 1];
             outReal[0] = last_sc_outReal;
         }
-        Ok(STDDEV_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STDDEV_Stream { config: STDDEV_StreamConfig { optInTimePeriod, optInNbDev, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STDDEV_Open`] (composition seam).
@@ -563,7 +570,7 @@ impl STDDEV_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::STDDEV_step_impl(&mut self.state, inReal, &mut outReal)?;
+        Core::STDDEV_step_impl(&self.config, &mut self.state, inReal, &mut outReal)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -596,7 +603,7 @@ impl STDDEV_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::STDDEV_step_impl(&mut self.state, inReal[i], &mut outReal[i])?;
+            Core::STDDEV_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -538,6 +538,19 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What STOCH was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&STOCH_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct STOCH_StreamConfig {
+    optInFastK_Period: i32,
+    optInSlowK_Period: i32,
+    optInSlowK_MAType: MAType,
+    optInSlowD_Period: i32,
+    optInSlowD_MAType: MAType,
+}
+
 /// Live STOCH stream: one value per closed bar, bit-identical to [`Core::STOCH`]
 /// over the same series. Open with [`Core::STOCH_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -547,6 +560,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCH_Stream")]
 pub struct STOCH_Stream {
+    /// What this stream was opened with — see `STOCH_StreamConfig`.
+    config: STOCH_StreamConfig,
     state: STOCH_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -557,6 +572,7 @@ impl STOCH_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCH_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -565,11 +581,6 @@ impl STOCH_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct STOCH_StreamState {
-    optInFastK_Period: i32,
-    optInSlowK_Period: i32,
-    optInSlowK_MAType: MAType,
-    optInSlowD_Period: i32,
-    optInSlowD_MAType: MAType,
     lowest: f64,
     highest: f64,
     diff: f64,
@@ -591,11 +602,6 @@ impl STOCH_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastK_Period = src.optInFastK_Period;
-        self.optInSlowK_Period = src.optInSlowK_Period;
-        self.optInSlowK_MAType = src.optInSlowK_MAType;
-        self.optInSlowD_Period = src.optInSlowD_Period;
-        self.optInSlowD_MAType = src.optInSlowD_MAType;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.diff = src.diff;
@@ -620,7 +626,7 @@ impl STOCH_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCH_step_impl(sp: &mut STOCH_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSlowK: &mut f64, outSlowD: &mut f64) -> Result<(), RetCode> {
+    fn STOCH_step_impl(cfg: &STOCH_StreamConfig, sp: &mut STOCH_StreamState, inHigh: f64, inLow: f64, inClose: f64, outSlowK: &mut f64, outSlowD: &mut f64) -> Result<(), RetCode> {
         let mut tmp: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outSlowD: f64 = 0.0_f64;
@@ -970,11 +976,6 @@ impl Core {
             }
         }
         let state = STOCH_StreamState {
-            optInFastK_Period,
-            optInSlowK_Period,
-            optInSlowK_MAType,
-            optInSlowD_Period,
-            optInSlowD_MAType,
             lowest,
             highest,
             diff,
@@ -998,7 +999,7 @@ impl Core {
             let last_sc_outSlowD = sc_outSlowD[*outNBElement - 1];
             outSlowD[0] = last_sc_outSlowD;
         }
-        Ok(STOCH_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCH_Stream { config: STOCH_StreamConfig { optInFastK_Period, optInSlowK_Period, optInSlowK_MAType, optInSlowD_Period, optInSlowD_MAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCH_Open`] (composition seam).
@@ -1099,10 +1100,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `STOCH_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `STOCH_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static STOCH_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCH_Stream>>> =
+    static STOCH_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCH_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1127,7 +1128,7 @@ impl STOCH_Stream {
         }
         let mut outSlowK: f64 = 0.0_f64;
         let mut outSlowD: f64 = 0.0_f64;
-        Core::STOCH_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outSlowK, &mut outSlowD)?;
+        Core::STOCH_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outSlowK, &mut outSlowD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1160,7 +1161,7 @@ impl STOCH_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::STOCH_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSlowK[i], &mut outSlowD[i])?;
+            Core::STOCH_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outSlowK[i], &mut outSlowD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1184,11 +1185,14 @@ impl STOCH_Stream {
             return Err(RetCode::BadParam);
         }
         STOCH_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outSlowK: f64 = 0.0_f64;
+            let mut outSlowD: f64 = 0.0_f64;
+            let stepped = Core::STOCH_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outSlowK, &mut outSlowD);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok((outSlowK, outSlowD))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -492,6 +492,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What STOCHF was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&STOCHF_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct STOCHF_StreamConfig {
+    optInFastK_Period: i32,
+    optInFastD_Period: i32,
+    optInFastD_MAType: MAType,
+}
+
 /// Live STOCHF stream: one value per closed bar, bit-identical to [`Core::STOCHF`]
 /// over the same series. Open with [`Core::STOCHF_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -501,6 +512,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCHF_Stream")]
 pub struct STOCHF_Stream {
+    /// What this stream was opened with — see `STOCHF_StreamConfig`.
+    config: STOCHF_StreamConfig,
     state: STOCHF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -511,6 +524,7 @@ impl STOCHF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCHF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -519,9 +533,6 @@ impl STOCHF_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct STOCHF_StreamState {
-    optInFastK_Period: i32,
-    optInFastD_Period: i32,
-    optInFastD_MAType: MAType,
     lowest: f64,
     highest: f64,
     diff: f64,
@@ -542,9 +553,6 @@ impl STOCHF_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInFastK_Period = src.optInFastK_Period;
-        self.optInFastD_Period = src.optInFastD_Period;
-        self.optInFastD_MAType = src.optInFastD_MAType;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.diff = src.diff;
@@ -568,7 +576,7 @@ impl STOCHF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCHF_step_impl(sp: &mut STOCHF_StreamState, inHigh: f64, inLow: f64, inClose: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
+    fn STOCHF_step_impl(cfg: &STOCHF_StreamConfig, sp: &mut STOCHF_StreamState, inHigh: f64, inLow: f64, inClose: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
         let mut tmp: f64 = 0.0_f64;
         let mut cur_tempBuffer: f64 = 0.0_f64;
         let mut cur_outFastD: f64 = 0.0_f64;
@@ -896,9 +904,6 @@ impl Core {
             }
         }
         let state = STOCHF_StreamState {
-            optInFastK_Period,
-            optInFastD_Period,
-            optInFastD_MAType,
             lowest,
             highest,
             diff,
@@ -921,7 +926,7 @@ impl Core {
             let last_sc_outFastD = sc_outFastD[*outNBElement - 1];
             outFastD[0] = last_sc_outFastD;
         }
-        Ok(STOCHF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCHF_Stream { config: STOCHF_StreamConfig { optInFastK_Period, optInFastD_Period, optInFastD_MAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCHF_Open`] (composition seam).
@@ -1022,10 +1027,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `STOCHF_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `STOCHF_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static STOCHF_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCHF_Stream>>> =
+    static STOCHF_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCHF_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1050,7 +1055,7 @@ impl STOCHF_Stream {
         }
         let mut outFastK: f64 = 0.0_f64;
         let mut outFastD: f64 = 0.0_f64;
-        Core::STOCHF_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outFastK, &mut outFastD)?;
+        Core::STOCHF_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outFastK, &mut outFastD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1083,7 +1088,7 @@ impl STOCHF_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::STOCHF_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outFastK[i], &mut outFastD[i])?;
+            Core::STOCHF_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outFastK[i], &mut outFastD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1107,11 +1112,14 @@ impl STOCHF_Stream {
             return Err(RetCode::BadParam);
         }
         STOCHF_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outFastK: f64 = 0.0_f64;
+            let mut outFastD: f64 = 0.0_f64;
+            let stepped = Core::STOCHF_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outFastK, &mut outFastD);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok((outFastK, outFastD))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
@@ -365,6 +365,18 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What STOCHRSI was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&STOCHRSI_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct STOCHRSI_StreamConfig {
+    optInTimePeriod: i32,
+    optInFastK_Period: i32,
+    optInFastD_Period: i32,
+    optInFastD_MAType: MAType,
+}
+
 /// Live STOCHRSI stream: one value per closed bar, bit-identical to [`Core::STOCHRSI`]
 /// over the same series. Open with [`Core::STOCHRSI_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -374,6 +386,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_STOCHRSI_Stream")]
 pub struct STOCHRSI_Stream {
+    /// What this stream was opened with — see `STOCHRSI_StreamConfig`.
+    config: STOCHRSI_StreamConfig,
     state: STOCHRSI_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -384,6 +398,7 @@ impl STOCHRSI_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `STOCHRSI_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -392,10 +407,6 @@ impl STOCHRSI_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct STOCHRSI_StreamState {
-    optInTimePeriod: i32,
-    optInFastK_Period: i32,
-    optInFastD_Period: i32,
-    optInFastD_MAType: MAType,
     sub0: RSI_Stream,
     sub1: STOCHF_Stream,
 }
@@ -405,10 +416,6 @@ impl STOCHRSI_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInFastK_Period = src.optInFastK_Period;
-        self.optInFastD_Period = src.optInFastD_Period;
-        self.optInFastD_MAType = src.optInFastD_MAType;
         self.sub0.restore_from(&src.sub0);
         self.sub1.restore_from(&src.sub1);
     }
@@ -421,7 +428,7 @@ impl STOCHRSI_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn STOCHRSI_step_impl(sp: &mut STOCHRSI_StreamState, inReal: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
+    fn STOCHRSI_step_impl(cfg: &STOCHRSI_StreamConfig, sp: &mut STOCHRSI_StreamState, inReal: f64, outFastK: &mut f64, outFastD: &mut f64) -> Result<(), RetCode> {
         let mut cur_tempRSIBuffer: f64 = 0.0_f64;
         let mut cur_outFastK: f64 = 0.0_f64;
         let mut cur_outFastD: f64 = 0.0_f64;
@@ -557,10 +564,6 @@ impl Core {
             return Err(RetCode::InsufficientHistory);
         }
         let state = STOCHRSI_StreamState {
-            optInTimePeriod,
-            optInFastK_Period,
-            optInFastD_Period,
-            optInFastD_MAType,
             sub0,
             sub1,
         };
@@ -572,7 +575,7 @@ impl Core {
             let last_sc_outFastD = sc_outFastD[*outNBElement - 1];
             outFastD[0] = last_sc_outFastD;
         }
-        Ok(STOCHRSI_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(STOCHRSI_Stream { config: STOCHRSI_StreamConfig { optInTimePeriod, optInFastK_Period, optInFastD_Period, optInFastD_MAType, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::STOCHRSI_Open`] (composition seam).
@@ -666,10 +669,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `STOCHRSI_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `STOCHRSI_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static STOCHRSI_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCHRSI_Stream>>> =
+    static STOCHRSI_PEEK_SCRATCH: std::cell::Cell<Option<Box<STOCHRSI_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -694,7 +697,7 @@ impl STOCHRSI_Stream {
         }
         let mut outFastK: f64 = 0.0_f64;
         let mut outFastD: f64 = 0.0_f64;
-        Core::STOCHRSI_step_impl(&mut self.state, inReal, &mut outFastK, &mut outFastD)?;
+        Core::STOCHRSI_step_impl(&self.config, &mut self.state, inReal, &mut outFastK, &mut outFastD)?;
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -727,7 +730,7 @@ impl STOCHRSI_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::STOCHRSI_step_impl(&mut self.state, inReal[i], &mut outFastK[i], &mut outFastD[i])?;
+            Core::STOCHRSI_step_impl(&self.config, &mut self.state, inReal[i], &mut outFastK[i], &mut outFastD[i])?;
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -751,11 +754,14 @@ impl STOCHRSI_Stream {
             return Err(RetCode::BadParam);
         }
         STOCHRSI_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outFastK: f64 = 0.0_f64;
+            let mut outFastD: f64 = 0.0_f64;
+            let stepped = Core::STOCHRSI_step_impl(&self.config, &mut scratch, inReal, &mut outFastK, &mut outFastD);
             cell.set(Some(scratch));
-            value
+            stepped?;
+            Ok((outFastK, outFastD))
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/sum.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sum.rs
@@ -264,6 +264,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What SUM was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&SUM_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct SUM_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live SUM stream: one value per closed bar, bit-identical to [`Core::SUM`]
 /// over the same series. Open with [`Core::SUM_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -273,6 +282,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_SUM_Stream")]
 pub struct SUM_Stream {
+    /// What this stream was opened with — see `SUM_StreamConfig`.
+    config: SUM_StreamConfig,
     state: SUM_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -283,6 +294,7 @@ impl SUM_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `SUM_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -291,7 +303,6 @@ impl SUM_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct SUM_StreamState {
-    optInTimePeriod: i32,
     periodTotal: f64,
     ringPos_trailingIdx: usize,
     ringCap_trailingIdx: usize,
@@ -303,7 +314,6 @@ impl SUM_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.periodTotal = src.periodTotal;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
         self.ringCap_trailingIdx = src.ringCap_trailingIdx;
@@ -318,7 +328,7 @@ impl SUM_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn SUM_step_impl(sp: &mut SUM_StreamState, inReal: f64, outReal: &mut f64) {
+    fn SUM_step_impl(cfg: &SUM_StreamConfig, sp: &mut SUM_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         if sp.ringCap_trailingIdx == 0 {
             sp.ring_trailingIdx_inReal[0] = inReal;
@@ -415,13 +425,12 @@ impl Core {
         ring_trailingIdx_inReal[..cap_trailingIdx as usize]
             .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
         let state = SUM_StreamState {
-            optInTimePeriod,
             periodTotal,
             ringPos_trailingIdx: 0_usize,
             ringCap_trailingIdx: cap_trailingIdx as usize,
             ring_trailingIdx_inReal,
         };
-        Ok(SUM_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(SUM_Stream { config: SUM_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::SUM_Open`] (composition seam).
@@ -526,7 +535,7 @@ impl SUM_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::SUM_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::SUM_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -559,7 +568,7 @@ impl SUM_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::SUM_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::SUM_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -457,6 +457,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What T3 was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&T3_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct T3_StreamConfig {
+    optInTimePeriod: i32,
+    optInVFactor: f64,
+}
+
 /// Live T3 stream: one value per closed bar, bit-identical to [`Core::T3`]
 /// over the same series. Open with [`Core::T3_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -466,6 +476,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_T3_Stream")]
 pub struct T3_Stream {
+    /// What this stream was opened with — see `T3_StreamConfig`.
+    config: T3_StreamConfig,
     state: T3_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -476,6 +488,7 @@ impl T3_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `T3_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -484,8 +497,6 @@ impl T3_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct T3_StreamState {
-    optInTimePeriod: i32,
-    optInVFactor: f64,
     k: f64,
     one_minus_k: f64,
     e1: f64,
@@ -505,8 +516,6 @@ impl T3_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInVFactor = src.optInVFactor;
         self.k = src.k;
         self.one_minus_k = src.one_minus_k;
         self.e1 = src.e1;
@@ -529,8 +538,8 @@ impl T3_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn T3_step_impl(sp: &mut T3_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn T3_step_impl(cfg: &T3_StreamConfig, sp: &mut T3_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -581,8 +590,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = T3_StreamState {
-                optInTimePeriod: optInTimePeriod,
-                optInVFactor: optInVFactor,
                 k: 0.0_f64,
                 one_minus_k: 0.0_f64,
                 e1: 0.0_f64,
@@ -607,7 +614,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(T3_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(T3_Stream { config: T3_StreamConfig { optInTimePeriod, optInVFactor, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut outIdx: usize = 0_usize;
         let mut lookbackTotal: usize = 0_usize;
@@ -759,8 +766,6 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = T3_StreamState {
-            optInTimePeriod,
-            optInVFactor,
             k,
             one_minus_k,
             e1,
@@ -774,7 +779,7 @@ impl Core {
             c3,
             c4,
         };
-        Ok(T3_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(T3_Stream { config: T3_StreamConfig { optInTimePeriod, optInVFactor, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::T3_Open`] (composition seam).
@@ -879,7 +884,7 @@ impl T3_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::T3_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::T3_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -912,7 +917,7 @@ impl T3_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::T3_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::T3_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tema.rs
@@ -430,6 +430,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What TEMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&TEMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct TEMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live TEMA stream: one value per closed bar, bit-identical to [`Core::TEMA`]
 /// over the same series. Open with [`Core::TEMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -439,6 +448,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TEMA_Stream")]
 pub struct TEMA_Stream {
+    /// What this stream was opened with — see `TEMA_StreamConfig`.
+    config: TEMA_StreamConfig,
     state: TEMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -449,6 +460,7 @@ impl TEMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TEMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -457,7 +469,6 @@ impl TEMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct TEMA_StreamState {
-    optInTimePeriod: i32,
     prevEMA1: f64,
     prevEMA2: f64,
     prevEMA3: f64,
@@ -469,7 +480,6 @@ impl TEMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevEMA1 = src.prevEMA1;
         self.prevEMA2 = src.prevEMA2;
         self.prevEMA3 = src.prevEMA3;
@@ -484,8 +494,8 @@ impl TEMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TEMA_step_impl(sp: &mut TEMA_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod == 1 {
+    fn TEMA_step_impl(cfg: &TEMA_StreamConfig, sp: &mut TEMA_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -528,7 +538,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = TEMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 prevEMA1: 0.0_f64,
                 prevEMA2: 0.0_f64,
                 prevEMA3: 0.0_f64,
@@ -545,7 +554,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(TEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(TEMA_Stream { config: TEMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut prevEMA1: f64 = 0.0_f64;
         let mut prevEMA2: f64 = 0.0_f64;
@@ -696,13 +705,12 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = TEMA_StreamState {
-            optInTimePeriod,
             prevEMA1,
             prevEMA2,
             prevEMA3,
             optInK_1,
         };
-        Ok(TEMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TEMA_Stream { config: TEMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TEMA_Open`] (composition seam).
@@ -807,7 +815,7 @@ impl TEMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::TEMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TEMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -840,7 +848,7 @@ impl TEMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::TEMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TEMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/trima.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trima.rs
@@ -499,6 +499,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What TRIMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&TRIMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct TRIMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live TRIMA stream: one value per closed bar, bit-identical to [`Core::TRIMA`]
 /// over the same series. Open with [`Core::TRIMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -508,6 +517,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TRIMA_Stream")]
 pub struct TRIMA_Stream {
+    /// What this stream was opened with — see `TRIMA_StreamConfig`.
+    config: TRIMA_StreamConfig,
     state: TRIMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -518,6 +529,7 @@ impl TRIMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TRIMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -526,7 +538,6 @@ impl TRIMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct TRIMA_StreamState {
-    optInTimePeriod: i32,
     numerator: f64,
     numeratorSub: f64,
     numeratorAdd: f64,
@@ -545,7 +556,6 @@ impl TRIMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.numerator = src.numerator;
         self.numeratorSub = src.numeratorSub;
         self.numeratorAdd = src.numeratorAdd;
@@ -567,8 +577,8 @@ impl TRIMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TRIMA_step_impl(sp: &mut TRIMA_StreamState, inReal: f64, outReal: &mut f64) {
-        if sp.optInTimePeriod % 2 == 1 {
+    fn TRIMA_step_impl(cfg: &TRIMA_StreamConfig, sp: &mut TRIMA_StreamState, inReal: f64, outReal: &mut f64) {
+        if cfg.optInTimePeriod % 2 == 1 {
             if sp.ringCap_middleIdx == 0 {
                 sp.ring_middleIdx_inReal[0] = inReal;
             }
@@ -876,7 +886,6 @@ impl Core {
             ring_trailingIdx_inReal[..cap_trailingIdx as usize]
                 .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
             let state = TRIMA_StreamState {
-                optInTimePeriod,
                 numerator,
                 numeratorSub,
                 numeratorAdd,
@@ -889,7 +898,7 @@ impl Core {
                 ringCap_trailingIdx: cap_trailingIdx as usize,
                 ring_trailingIdx_inReal,
             };
-            Ok(TRIMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(TRIMA_Stream { config: TRIMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         } else {
             let mut lookbackTotal: usize = 0_usize;
             let mut numerator: f64 = 0.0_f64;
@@ -1084,7 +1093,6 @@ impl Core {
             ring_trailingIdx_inReal[..cap_trailingIdx as usize]
                 .copy_from_slice(&inReal[historyLen - cap_trailingIdx as usize..]);
             let state = TRIMA_StreamState {
-                optInTimePeriod,
                 numerator,
                 numeratorSub,
                 numeratorAdd,
@@ -1097,7 +1105,7 @@ impl Core {
                 ringCap_trailingIdx: cap_trailingIdx as usize,
                 ring_trailingIdx_inReal,
             };
-            Ok(TRIMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+            Ok(TRIMA_Stream { config: TRIMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
         }
     }
 
@@ -1184,10 +1192,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `TRIMA_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `TRIMA_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static TRIMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<TRIMA_Stream>>> =
+    static TRIMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<TRIMA_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1211,7 +1219,7 @@ impl TRIMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::TRIMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TRIMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1244,7 +1252,7 @@ impl TRIMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::TRIMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TRIMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1268,11 +1276,12 @@ impl TRIMA_Stream {
             return Err(RetCode::BadParam);
         }
         TRIMA_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::TRIMA_step_impl(&self.config, &mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/trix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trix.rs
@@ -384,6 +384,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What TRIX was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&TRIX_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct TRIX_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live TRIX stream: one value per closed bar, bit-identical to [`Core::TRIX`]
 /// over the same series. Open with [`Core::TRIX_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -393,6 +402,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TRIX_Stream")]
 pub struct TRIX_Stream {
+    /// What this stream was opened with — see `TRIX_StreamConfig`.
+    config: TRIX_StreamConfig,
     state: TRIX_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -403,6 +414,7 @@ impl TRIX_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TRIX_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -411,7 +423,6 @@ impl TRIX_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct TRIX_StreamState {
-    optInTimePeriod: i32,
     prevEMA1: f64,
     prevEMA2: f64,
     prevEMA3: f64,
@@ -423,7 +434,6 @@ impl TRIX_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.prevEMA1 = src.prevEMA1;
         self.prevEMA2 = src.prevEMA2;
         self.prevEMA3 = src.prevEMA3;
@@ -438,7 +448,7 @@ impl TRIX_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TRIX_step_impl(sp: &mut TRIX_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TRIX_step_impl(cfg: &TRIX_StreamConfig, sp: &mut TRIX_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         tempReal = sp.prevEMA3;
         sp.prevEMA1 = (inReal - sp.prevEMA1 as f64).mul_add(sp.optInK_1, sp.prevEMA1);
@@ -595,13 +605,12 @@ impl Core {
 
         // Capture the live batch state into the handle.
         let state = TRIX_StreamState {
-            optInTimePeriod,
             prevEMA1,
             prevEMA2,
             prevEMA3,
             optInK_1,
         };
-        Ok(TRIX_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TRIX_Stream { config: TRIX_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TRIX_Open`] (composition seam).
@@ -706,7 +715,7 @@ impl TRIX_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::TRIX_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TRIX_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -739,7 +748,7 @@ impl TRIX_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::TRIX_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TRIX_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/tsf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tsf.rs
@@ -431,6 +431,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What TSF was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&TSF_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct TSF_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live TSF stream: one value per closed bar, bit-identical to [`Core::TSF`]
 /// over the same series. Open with [`Core::TSF_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -440,6 +449,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_TSF_Stream")]
 pub struct TSF_Stream {
+    /// What this stream was opened with — see `TSF_StreamConfig`.
+    config: TSF_StreamConfig,
     state: TSF_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -450,6 +461,7 @@ impl TSF_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `TSF_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -458,7 +470,6 @@ impl TSF_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct TSF_StreamState {
-    optInTimePeriod: i32,
     lookbackTotal: usize,
     trailingIdx: i32,
     SumX: f64,
@@ -479,7 +490,6 @@ impl TSF_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackTotal = src.lookbackTotal;
         self.trailingIdx = src.trailingIdx;
         self.SumX = src.SumX;
@@ -503,7 +513,7 @@ impl TSF_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn TSF_step_impl(sp: &mut TSF_StreamState, inReal: f64, outReal: &mut f64) {
+    fn TSF_step_impl(cfg: &TSF_StreamConfig, sp: &mut TSF_StreamState, inReal: f64, outReal: &mut f64) {
         let mut m: f64 = 0.0_f64;
         let mut b: f64 = 0.0_f64;
         let mut windowStart: usize = 0_usize;
@@ -517,7 +527,7 @@ impl Core {
             sp.j -= rebaseShift;
         }
         sp.x_inReal[(sp.today & sp.xMask) as usize] = inReal;
-        weightedTrailing = (sp.optInTimePeriod as f64) * sp.trailingValue;
+        weightedTrailing = (cfg.optInTimePeriod as f64) * sp.trailingValue;
         sp.SumXY = sp.SumXY + sp.SumY - weightedTrailing;
         sp.SumY = sp.SumY - sp.trailingValue + sp.x_inReal[(sp.today & sp.xMask) as usize];
         sp.sumAbs = sp.sumAbs - (sp.trailingValue).abs() + (sp.x_inReal[(sp.today & sp.xMask) as usize]).abs();
@@ -581,7 +591,7 @@ impl Core {
         // to at least lookbackTotal.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 || (weightedTrailing).abs() > 100.0 * sp.sumAbs {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             windowStart = (sp.today - ((sp.lookbackTotal) as i32)) as usize;
             sp.SumY = 0.0;
             sp.SumXY = 0.0;
@@ -598,11 +608,11 @@ impl Core {
                 sp.j += 1;
             }
         }
-        m = (((sp.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
-        b = (sp.SumY - m * sp.SumX) / (sp.optInTimePeriod as f64);
+        m = (((cfg.optInTimePeriod) as f64) * sp.SumXY - sp.SumX * sp.SumY) / sp.Divisor;
+        b = (sp.SumY - m * sp.SumX) / (cfg.optInTimePeriod as f64);
         sp.trailingValue = sp.x_inReal[(sp.trailingIdx & sp.xMask) as usize];
         sp.trailingIdx += 1;
-        (*outReal) = (m as f64).mul_add(sp.optInTimePeriod as f64, b);
+        (*outReal) = (m as f64).mul_add(cfg.optInTimePeriod as f64, b);
         sp.today += 1;
     }
 
@@ -823,7 +833,6 @@ impl Core {
             }
         }
         let state = TSF_StreamState {
-            optInTimePeriod,
             lookbackTotal,
             trailingIdx: (trailingIdx) as i32,
             SumX,
@@ -838,7 +847,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(TSF_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(TSF_Stream { config: TSF_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::TSF_Open`] (composition seam).
@@ -943,7 +952,7 @@ impl TSF_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::TSF_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::TSF_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -976,7 +985,7 @@ impl TSF_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::TSF_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::TSF_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -557,6 +557,17 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What ULTOSC was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&ULTOSC_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct ULTOSC_StreamConfig {
+    optInTimePeriod1: i32,
+    optInTimePeriod2: i32,
+    optInTimePeriod3: i32,
+}
+
 /// Live ULTOSC stream: one value per closed bar, bit-identical to [`Core::ULTOSC`]
 /// over the same series. Open with [`Core::ULTOSC_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -566,6 +577,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_ULTOSC_Stream")]
 pub struct ULTOSC_Stream {
+    /// What this stream was opened with — see `ULTOSC_StreamConfig`.
+    config: ULTOSC_StreamConfig,
     state: ULTOSC_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -576,6 +589,7 @@ impl ULTOSC_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `ULTOSC_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -584,9 +598,6 @@ impl ULTOSC_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct ULTOSC_StreamState {
-    optInTimePeriod1: i32,
-    optInTimePeriod2: i32,
-    optInTimePeriod3: i32,
     a1Total: f64,
     a2Total: f64,
     a3Total: f64,
@@ -609,9 +620,6 @@ impl ULTOSC_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod1 = src.optInTimePeriod1;
-        self.optInTimePeriod2 = src.optInTimePeriod2;
-        self.optInTimePeriod3 = src.optInTimePeriod3;
         self.a1Total = src.a1Total;
         self.a2Total = src.a2Total;
         self.a3Total = src.a3Total;
@@ -637,7 +645,7 @@ impl ULTOSC_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn ULTOSC_step_impl(sp: &mut ULTOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn ULTOSC_step_impl(cfg: &ULTOSC_StreamConfig, sp: &mut ULTOSC_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut trueLow: f64 = 0.0_f64;
         let mut trueRange: f64 = 0.0_f64;
         let mut closeMinusTrueLow: f64 = 0.0_f64;
@@ -679,14 +687,14 @@ impl Core {
         } else {
             sp.nullRun = 0;
         }
-        if sp.nullRun >= ((sp.optInTimePeriod1) as usize) {
+        if sp.nullRun >= ((cfg.optInTimePeriod1) as usize) {
             sp.a1Total = 0.0;
             sp.b1Total = 0.0;
-            if sp.nullRun >= ((sp.optInTimePeriod2) as usize) {
+            if sp.nullRun >= ((cfg.optInTimePeriod2) as usize) {
                 sp.a2Total = 0.0;
                 sp.b2Total = 0.0;
-                if sp.nullRun >= ((sp.optInTimePeriod3) as usize) {
-                    sp.nullRun = (sp.optInTimePeriod3) as usize;
+                if sp.nullRun >= ((cfg.optInTimePeriod3) as usize) {
+                    sp.nullRun = (cfg.optInTimePeriod3) as usize;
                     sp.a3Total = 0.0;
                     sp.b3Total = 0.0;
                 }
@@ -710,13 +718,13 @@ impl Core {
         sp.a1Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos1];
         sp.b1Total -= sp.cb_term_trueRange[sp.trailingPos1];
         sp.trailingPos1 += 1;
-        if sp.trailingPos1 >= ((sp.optInTimePeriod3) as usize) {
+        if sp.trailingPos1 >= ((cfg.optInTimePeriod3) as usize) {
             sp.trailingPos1 = 0;
         }
         sp.a2Total -= sp.cb_term_closeMinusTrueLow[sp.trailingPos2];
         sp.b2Total -= sp.cb_term_trueRange[sp.trailingPos2];
         sp.trailingPos2 += 1;
-        if sp.trailingPos2 >= ((sp.optInTimePeriod3) as usize) {
+        if sp.trailingPos2 >= ((cfg.optInTimePeriod3) as usize) {
             sp.trailingPos2 = 0;
         }
         sp.term_Idx = sp.term_Idx + 1;
@@ -1032,9 +1040,6 @@ impl Core {
             return Err(RetCode::InternalError);
         }
         let state = ULTOSC_StreamState {
-            optInTimePeriod1,
-            optInTimePeriod2,
-            optInTimePeriod3,
             a1Total,
             a2Total,
             a3Total,
@@ -1051,7 +1056,7 @@ impl Core {
             cb_term_closeMinusTrueLow: term_closeMinusTrueLow,
             cb_term_trueRange: term_trueRange,
         };
-        Ok(ULTOSC_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(ULTOSC_Stream { config: ULTOSC_StreamConfig { optInTimePeriod1, optInTimePeriod2, optInTimePeriod3, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::ULTOSC_Open`] (composition seam).
@@ -1144,10 +1149,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `ULTOSC_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `ULTOSC_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static ULTOSC_PEEK_SCRATCH: std::cell::Cell<Option<Box<ULTOSC_Stream>>> =
+    static ULTOSC_PEEK_SCRATCH: std::cell::Cell<Option<Box<ULTOSC_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -1171,7 +1176,7 @@ impl ULTOSC_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::ULTOSC_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::ULTOSC_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -1204,7 +1209,7 @@ impl ULTOSC_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::ULTOSC_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::ULTOSC_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -1228,11 +1233,12 @@ impl ULTOSC_Stream {
             return Err(RetCode::BadParam);
         }
         ULTOSC_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::ULTOSC_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -411,6 +411,16 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What VAR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&VAR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct VAR_StreamConfig {
+    optInTimePeriod: i32,
+    optInNbDev: f64,
+}
+
 /// Live VAR stream: one value per closed bar, bit-identical to [`Core::VAR`]
 /// over the same series. Open with [`Core::VAR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -420,6 +430,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_VAR_Stream")]
 pub struct VAR_Stream {
+    /// What this stream was opened with — see `VAR_StreamConfig`.
+    config: VAR_StreamConfig,
     state: VAR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -430,6 +442,7 @@ impl VAR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `VAR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -438,8 +451,6 @@ impl VAR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct VAR_StreamState {
-    optInTimePeriod: i32,
-    optInNbDev: f64,
     shift: f64,
     periodTotal1: f64,
     periodTotal2: f64,
@@ -459,8 +470,6 @@ impl VAR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
-        self.optInNbDev = src.optInNbDev;
         self.shift = src.shift;
         self.periodTotal1 = src.periodTotal1;
         self.periodTotal2 = src.periodTotal2;
@@ -483,7 +492,7 @@ impl VAR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn VAR_step_impl(sp: &mut VAR_StreamState, inReal: f64, outReal: &mut f64) {
+    fn VAR_step_impl(cfg: &VAR_StreamConfig, sp: &mut VAR_StreamState, inReal: f64, outReal: &mut f64) {
         let mut tempReal: f64 = 0.0_f64;
         let mut meanValue1: f64 = 0.0_f64;
         let mut variance: f64 = 0.0_f64;
@@ -522,7 +531,7 @@ impl Core {
         // reseeding it every bar. Guarantees a non-negative output.
         sp.barsSinceReseed -= 1;
         if variance < 0.000001 * (sp.periodTotal2 * sp.invPeriod) || tempReal > 1000000.0 * sp.periodTotal2 || sp.barsSinceReseed <= 0 {
-            sp.barsSinceReseed = (32 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (32 * cfg.optInTimePeriod) as usize;
             sp.windowStart = sp.i - ((sp.nbInitialElementNeeded) as i32);
             tempReal = 0.0;
             // for( sp.j = sp.windowStart; sp.j <= sp.i; sp.j += 1 )
@@ -820,8 +829,6 @@ impl Core {
             }
         }
         let state = VAR_StreamState {
-            optInTimePeriod,
-            optInNbDev,
             shift,
             periodTotal1,
             periodTotal2,
@@ -835,7 +842,7 @@ impl Core {
             xMask: (physX - 1) as i32,
             x_inReal,
         };
-        Ok(VAR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(VAR_Stream { config: VAR_StreamConfig { optInTimePeriod, optInNbDev, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::VAR_Open`] (composition seam).
@@ -940,7 +947,7 @@ impl VAR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::VAR_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::VAR_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -973,7 +980,7 @@ impl VAR_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::VAR_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::VAR_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/vwma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwma.rs
@@ -343,6 +343,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What VWMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&VWMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct VWMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live VWMA stream: one value per closed bar, bit-identical to [`Core::VWMA`]
 /// over the same series. Open with [`Core::VWMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -352,6 +361,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_VWMA_Stream")]
 pub struct VWMA_Stream {
+    /// What this stream was opened with — see `VWMA_StreamConfig`.
+    config: VWMA_StreamConfig,
     state: VWMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -362,6 +373,7 @@ impl VWMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `VWMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -370,7 +382,6 @@ impl VWMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct VWMA_StreamState {
-    optInTimePeriod: i32,
     sumPV: f64,
     sumV: f64,
     ringPos_trailingIdx: usize,
@@ -384,7 +395,6 @@ impl VWMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.sumPV = src.sumPV;
         self.sumV = src.sumV;
         self.ringPos_trailingIdx = src.ringPos_trailingIdx;
@@ -401,11 +411,11 @@ impl VWMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn VWMA_step_impl(sp: &mut VWMA_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
+    fn VWMA_step_impl(cfg: &VWMA_StreamConfig, sp: &mut VWMA_StreamState, inReal: f64, inVolume: f64, outReal: &mut f64) {
         let mut tempPV: f64 = 0.0_f64;
         let mut tempV: f64 = 0.0_f64;
         let mut tempReal: f64 = 0.0_f64;
-        if sp.optInTimePeriod == 1 {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -426,7 +436,7 @@ impl Core {
         tempReal = sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] * sp.ring_trailingIdx_inVolume[sp.ringPos_trailingIdx];
         sp.sumPV -= tempReal;
         sp.sumV -= sp.ring_trailingIdx_inVolume[sp.ringPos_trailingIdx];
-        (*outReal) = tempPV / (sp.optInTimePeriod as f64) / (tempV / (sp.optInTimePeriod as f64));
+        (*outReal) = tempPV / (cfg.optInTimePeriod as f64) / (tempV / (cfg.optInTimePeriod as f64));
         sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
         sp.ring_trailingIdx_inVolume[sp.ringPos_trailingIdx] = inVolume;
         sp.ringPos_trailingIdx = sp.ringPos_trailingIdx + 1;
@@ -471,7 +481,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = VWMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 sumPV: 0.0_f64,
                 sumV: 0.0_f64,
                 ringPos_trailingIdx: 0_usize,
@@ -490,7 +499,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(VWMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(VWMA_Stream { config: VWMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut sumPV: f64 = 0.0_f64;
         let mut sumV: f64 = 0.0_f64;
@@ -573,7 +582,6 @@ impl Core {
         ring_trailingIdx_inVolume[..cap_trailingIdx as usize]
             .copy_from_slice(&inVolume[historyLen - cap_trailingIdx as usize..]);
         let state = VWMA_StreamState {
-            optInTimePeriod,
             sumPV,
             sumV,
             ringPos_trailingIdx: 0_usize,
@@ -581,7 +589,7 @@ impl Core {
             ring_trailingIdx_inReal,
             ring_trailingIdx_inVolume,
         };
-        Ok(VWMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(VWMA_Stream { config: VWMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::VWMA_Open`] (composition seam).
@@ -673,10 +681,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `VWMA_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `VWMA_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static VWMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<VWMA_Stream>>> =
+    static VWMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<VWMA_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -700,7 +708,7 @@ impl VWMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::VWMA_step_impl(&mut self.state, inReal, inVolume, &mut outReal);
+        Core::VWMA_step_impl(&self.config, &mut self.state, inReal, inVolume, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -733,7 +741,7 @@ impl VWMA_Stream {
             if !inReal[i].is_finite() || !inVolume[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::VWMA_step_impl(&mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
+            Core::VWMA_step_impl(&self.config, &mut self.state, inReal[i], inVolume[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -757,11 +765,12 @@ impl VWMA_Stream {
             return Err(RetCode::BadParam);
         }
         VWMA_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal, inVolume);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::VWMA_step_impl(&self.config, &mut scratch, inReal, inVolume, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -447,6 +447,15 @@ impl Core {
 
 /* Using willr_ALT1 for TA_ALT={STREAM,ALL_LANGUAGES} */
 
+/// What WILLR was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&WILLR_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct WILLR_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live WILLR stream: one value per closed bar, bit-identical to [`Core::WILLR`]
 /// over the same series. Open with [`Core::WILLR_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -456,6 +465,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WILLR_Stream")]
 pub struct WILLR_Stream {
+    /// What this stream was opened with — see `WILLR_StreamConfig`.
+    config: WILLR_StreamConfig,
     state: WILLR_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -466,6 +477,7 @@ impl WILLR_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WILLR_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -474,7 +486,6 @@ impl WILLR_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct WILLR_StreamState {
-    optInTimePeriod: i32,
     lowest: f64,
     highest: f64,
     diff: f64,
@@ -494,7 +505,6 @@ impl WILLR_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lowest = src.lowest;
         self.highest = src.highest;
         self.diff = src.diff;
@@ -517,7 +527,7 @@ impl WILLR_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WILLR_step_impl(sp: &mut WILLR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
+    fn WILLR_step_impl(cfg: &WILLR_StreamConfig, sp: &mut WILLR_StreamState, inHigh: f64, inLow: f64, inClose: f64, outReal: &mut f64) {
         let mut tmp: f64 = 0.0_f64;
         if sp.today >= 1073741824 {
             let rebaseShift: i32 = sp.trailingIdx & !sp.xMask;
@@ -736,7 +746,6 @@ impl Core {
             }
         }
         let state = WILLR_StreamState {
-            optInTimePeriod,
             lowest,
             highest,
             diff,
@@ -750,7 +759,7 @@ impl Core {
             x_inLow,
             x_inClose,
         };
-        Ok(WILLR_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WILLR_Stream { config: WILLR_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WILLR_Open`] (composition seam).
@@ -843,10 +852,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `WILLR_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `WILLR_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static WILLR_PEEK_SCRATCH: std::cell::Cell<Option<Box<WILLR_Stream>>> =
+    static WILLR_PEEK_SCRATCH: std::cell::Cell<Option<Box<WILLR_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -870,7 +879,7 @@ impl WILLR_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::WILLR_step_impl(&mut self.state, inHigh, inLow, inClose, &mut outReal);
+        Core::WILLR_step_impl(&self.config, &mut self.state, inHigh, inLow, inClose, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -903,7 +912,7 @@ impl WILLR_Stream {
             if !inHigh[i].is_finite() || !inLow[i].is_finite() || !inClose[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::WILLR_step_impl(&mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
+            Core::WILLR_step_impl(&self.config, &mut self.state, inHigh[i], inLow[i], inClose[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -927,11 +936,12 @@ impl WILLR_Stream {
             return Err(RetCode::BadParam);
         }
         WILLR_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inHigh, inLow, inClose);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::WILLR_step_impl(&self.config, &mut scratch, inHigh, inLow, inClose, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 

--- a/ta_codegen/output/rust/library/src/ta_func/wma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wma.rs
@@ -400,6 +400,15 @@ impl Core {
 }
 /**** Streaming API *****/
 
+/// What WMA was opened with: read on every bar, written by none of
+/// them. Held beside the state so a step takes it as `&WMA_StreamConfig`
+/// (`noalias` + `readonly`) and `peek`'s scratch never copies it.
+#[derive(Debug, Clone, Copy)]
+#[allow(non_snake_case, dead_code)]
+struct WMA_StreamConfig {
+    optInTimePeriod: i32,
+}
+
 /// Live WMA stream: one value per closed bar, bit-identical to [`Core::WMA`]
 /// over the same series. Open with [`Core::WMA_Open`]; dropping the handle
 /// closes the stream. Cloning it forks an independent stream.
@@ -409,6 +418,8 @@ impl Core {
 #[derive(Debug, Clone)]
 #[doc(alias = "TA_WMA_Stream")]
 pub struct WMA_Stream {
+    /// What this stream was opened with — see `WMA_StreamConfig`.
+    config: WMA_StreamConfig,
     state: WMA_StreamState,
     /// The bars this handle has produced a value for — see [`Self::out_range`].
     out: OutRange,
@@ -419,6 +430,7 @@ impl WMA_Stream {
     /// Overwrite from `src`, reusing this handle's buffers instead of
     /// allocating new ones. See `WMA_StreamState::restore_from`.
     pub(crate) fn restore_from(&mut self, src: &Self) {
+        self.config = src.config;
         self.state.restore_from(&src.state);
         self.out = src.out;
     }
@@ -427,7 +439,6 @@ impl WMA_Stream {
 #[derive(Debug, Clone)]
 #[allow(non_snake_case, dead_code)]
 struct WMA_StreamState {
-    optInTimePeriod: i32,
     lookbackWin: usize,
     barsSinceReseed: usize,
     periodSum: f64,
@@ -447,7 +458,6 @@ impl WMA_StreamState {
     /// Overwrite every field from `src`, reusing this value's buffers
     /// instead of allocating new ones — `peek`'s scratch restore.
     fn restore_from(&mut self, src: &Self) {
-        self.optInTimePeriod = src.optInTimePeriod;
         self.lookbackWin = src.lookbackWin;
         self.barsSinceReseed = src.barsSinceReseed;
         self.periodSum = src.periodSum;
@@ -470,11 +480,11 @@ impl WMA_StreamState {
 #[allow(unused_assignments)]
 #[allow(unused_parens)]
 impl Core {
-    fn WMA_step_impl(sp: &mut WMA_StreamState, inReal: f64, outReal: &mut f64) {
+    fn WMA_step_impl(cfg: &WMA_StreamConfig, sp: &mut WMA_StreamState, inReal: f64, outReal: &mut f64) {
         let mut j: usize = 0_usize;
         let mut rw: usize = 0_usize;
         let mut tempReal: f64 = 0.0_f64;
-        if sp.optInTimePeriod == 1 {
+        if cfg.optInTimePeriod == 1 {
             (*outReal) = inReal;
             return;
         }
@@ -487,7 +497,7 @@ impl Core {
         tempReal = inReal;
         sp.periodSub += tempReal;
         sp.periodSub -= sp.trailingValue;
-        sp.periodSum += tempReal * ((sp.optInTimePeriod) as f64);
+        sp.periodSum += tempReal * ((cfg.optInTimePeriod) as f64);
         // Re-anchor: rebuild both totals from the window itself.
         //
         // periodSum and periodSub were running totals that were never
@@ -532,7 +542,7 @@ impl Core {
         // startIdx-lookbackTotal+outIdx, which is >= outIdx.
         sp.barsSinceReseed -= 1;
         if sp.barsSinceReseed <= 0 {
-            sp.barsSinceReseed = (8 * sp.optInTimePeriod) as usize;
+            sp.barsSinceReseed = (8 * cfg.optInTimePeriod) as usize;
             sp.periodSub = 0.0 as f64;
             sp.periodSum = 0.0 as f64;
             rw = 1;
@@ -600,7 +610,6 @@ impl Core {
                 return Err(RetCode::InsufficientHistory);
             }
             let state = WMA_StreamState {
-                optInTimePeriod: optInTimePeriod,
                 lookbackWin: 0_usize,
                 barsSinceReseed: 0_usize,
                 periodSum: 0.0_f64,
@@ -625,7 +634,7 @@ impl Core {
                     fillIdx += 1;
                 }
             }
-            return Ok(WMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
+            return Ok(WMA_Stream { config: WMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } });
         }
         let mut inIdx: usize = 0_usize;
         let mut outIdx: usize = 0_usize;
@@ -795,7 +804,6 @@ impl Core {
         let mut win_j_inReal: Vec<f64> = vec![0.0_f64; cap_j as usize];
         win_j_inReal.copy_from_slice(&inReal[historyLen - cap_j as usize..]);
         let state = WMA_StreamState {
-            optInTimePeriod,
             lookbackWin,
             barsSinceReseed,
             periodSum,
@@ -809,7 +817,7 @@ impl Core {
             winCap_j: cap_j as usize,
             win_j_inReal,
         };
-        Ok(WMA_Stream { state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
+        Ok(WMA_Stream { config: WMA_StreamConfig { optInTimePeriod, }, state, out: OutRange { beg_idx: *outBegIdx, count: *outNBElement } })
     }
 
     /// Internal startIdx-anchored open behind [`Core::WMA_Open`] (composition seam).
@@ -895,10 +903,10 @@ impl Core {
 }
 
 thread_local! {
-    /// `peek`'s reusable scratch handle (see `WMA_StreamState::restore_from`).
+    /// `peek`'s reusable scratch state (see `WMA_StreamState::restore_from`).
     /// Taken for the duration of the step and put back after, so a
     /// panicking step costs the scratch, never leaves it borrowed.
-    static WMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<WMA_Stream>>> =
+    static WMA_PEEK_SCRATCH: std::cell::Cell<Option<Box<WMA_StreamState>>> =
         const { std::cell::Cell::new(None) };
 }
 
@@ -922,7 +930,7 @@ impl WMA_Stream {
             return Err(RetCode::BadParam);
         }
         let mut outReal: f64 = 0.0_f64;
-        Core::WMA_step_impl(&mut self.state, inReal, &mut outReal);
+        Core::WMA_step_impl(&self.config, &mut self.state, inReal, &mut outReal);
         if self.out.count < Core::MAX_INDEX {
             self.out.count += 1;
         }
@@ -955,7 +963,7 @@ impl WMA_Stream {
             if !inReal[i].is_finite() {
                 return Err(RetCode::BadParam);
             }
-            Core::WMA_step_impl(&mut self.state, inReal[i], &mut outReal[i]);
+            Core::WMA_step_impl(&self.config, &mut self.state, inReal[i], &mut outReal[i]);
             if self.out.count < Core::MAX_INDEX {
                 self.out.count += 1;
             }
@@ -979,11 +987,12 @@ impl WMA_Stream {
             return Err(RetCode::BadParam);
         }
         WMA_PEEK_SCRATCH.with(|cell| {
-            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.clone()));
-            scratch.restore_from(self);
-            let value = scratch.update(inReal);
+            let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
+            scratch.restore_from(&self.state);
+            let mut outReal: f64 = 0.0_f64;
+            Core::WMA_step_impl(&self.config, &mut scratch, inReal, &mut outReal);
             cell.set(Some(scratch));
-            value
+            Ok(outReal)
         })
     }
 


### PR DESCRIPTION
Closes #276.

## What moved

#274 took the candlestick settings out of the `Core` a handle embedded. What
stayed behind in the *state* is the same kind of value: `optInTimePeriod` and
the private extra params (EMA's k factor) are fixed at `Open` and read on every
bar, written by no step. Sitting in the state they were copied by every `peek`
— the scratch restore has to reproduce a field it can never have changed — and
the step reached them through the same `&mut` the rings arrive by, so nothing
told the compiler a bar could not move them.

A handle is now `config` + `state` + `out`:

```rust
struct SMA_StreamConfig { optInTimePeriod: i32 }          // Copy, Open-time

pub struct SMA_Stream {
    config: SMA_StreamConfig,
    state:  SMA_StreamState,   // periodTotal, ring, ringPos, ringCap
    out:    OutRange,
}

fn SMA_step_impl(cfg: &SMA_StreamConfig, sp: &mut SMA_StreamState, ..)
```

`&Config` is `noalias` + `readonly`, so a config read hoists across a write
through `sp` without the compiler having to prove non-aliasing by inlining.

On the 73 functions `scratch_pays()` selects — the ones whose clone the
optimizer was never folding — `peek`'s thread-local scratch is now a bare
`<F>_StreamState` rather than a whole handle, and the step runs on it directly
with the live handle's `&config`:

```rust
BBANDS_PEEK_SCRATCH.with(|cell| {
    let mut scratch = cell.take().unwrap_or_else(|| Box::new(self.state.clone()));
    scratch.restore_from(&self.state);
    ...
    let stepped = Core::BBANDS_step_impl(&self.config, &mut scratch, inReal, ..);
    cell.set(Some(scratch));
    stepped?;
    Ok((outRealUpperBand, outRealMiddleBand, outRealLowerBand))
})
```

That drops four things per peek: the config copy, the `out` copy, the range
bookkeeping `peek` computed and threw away, and the second `is_finite` that
re-entering `update` performed on a bar `peek` had already checked — the three
the issue names, plus the `out` copy.

The other 65 changed functions keep the pre-#201 throwaway clone verbatim.
Their peek was already measuring *below* their own `update` because the clone
is folded away; there is nothing there to win and #201 documents the loss.

**A bug the new gate caught on its first run.** The loopless composed tier was
building the params into its state by hand, and kept doing so after the split —
BBANDS carried all four in *both* places, dead weight the scratch still copied
every peek. Its state is now its two sub-handles and nothing else, which is
most of why BBANDS' peek moves as far as it does below.

A function with neither a setting nor a param emits no config struct, no field
and no parameter — 38 of the 176, whose generated code is byte-identical across
this change and which are therefore the benchmark's control.

## Numbers

`scripts/stream_ab.py --base=<prev> --lang=rust`, six interleaved rounds,
iters=500000. Two independent full-corpus runs agree per function at r=0.97.

| group | n | peek median | update median |
|---|---|---|---|
| control (file byte-identical) | 38 | +0.3% | +0.1% |
| scratch-reuse tier | 73 | **−3.0%** (p25 −5.0%) | +0.6% |
| throwaway-clone tier | 65 | +0.7% | −0.1% |

Best peek rows: `CMF` −41%, `BBANDS` −22%, `CDLDRAGONFLYDOJI` −15%,
`AROONOSC` −14%, `BETA` −10%, `WMA` −10%.

The three-way split is the result, not any single row: the tier whose peek
changed moves, the tier deliberately left alone does not, and the
byte-identical control does not.

## The one cost, stated

`MACDEXT`'s `update` is the single row above the control band in every run
(+24% there, against a control max of +14% — this instrument is one single-CGU
LTO binary, so 138 changed files move everyone's layout).

Verified on a second instrument, a one-function-per-process binary, min of 40,
three interleaved passes, with `TRANGE` (byte-identical) as the control:

| | base | head | change |
|---|---|---|---|
| TRANGE.update (control) | 2.6521 ns | 2.6538 ns | +0.1% |
| TRANGE.peek (control) | 2.6506 ns | 2.6512 ns | +0.0% |
| MACDEXT.update | 16.04 ns | 17.18 ns | **+7.1%** |
| MACDEXT.peek | 37.84 ns | 36.38 ns | −3.9% |

A third arm carrying the config split but the **old** peek reads
MACDEXT.update 17.01 ns (+6.0%) — so the cost is the split itself, not peek's
second call site, and #201's inlining concern is not what is happening here.
`#[inline]` on the step does not recover it (measured, +20.5% vs +20.2% on the
corpus instrument).

Unlike #274 this is **not** a size win: splitting one struct into two adds
padding, so handles are flat or slightly larger (`BBANDS_Stream` 768 → 816,
`STDDEV_Stream` 152 → 176, most unchanged). What shrank is what a `peek`
copies, not what a handle is.

So the trade on the heaviest composed step is roughly +1.1 ns of `update` for
−1.5 ns of `peek`. Corpus-wide `update` is flat. Whether that is the right
trade for `MACDEXT` specifically is your call, and I did not try to buy it back
by special-casing that function.

## Not measured

- No C# lane exists for either tool, so the C# stream tier is unmeasured here
  (it is also unchanged by this).
- The `open` tier (`--call=open`) was not swept; the config is built at the
  same site the state was, so no change was expected, but I did not check it.

## Gates

- `--xlang-hash --language=rust`: 278,274 cases, 0 mismatches, bit-identical at
  zero tolerance.
- `--codegen=c,rust,java`: Stream verify 21,642 legs bit-exact vs batch;
  State-equivalence, OutRange, OpenAndFill, UpdateAndFill all clean; all three
  languages pass.
- Crate: 83 value tests (`stream_finite`, `stream_out_range`, `div_zero`,
  `scratch_election`, `no_phantom_io`, `nullable_outputs`,
  `stream_open_contract`) and 358 doctests.
- Generator: full suite, clippy pedantic clean on both the generator and the
  generated crate.
- Rust-only by construction — C's settings are file-scope globals, Java holds a
  `Core` reference, C# a class reference. A full `generate` leaves
  `src/ta_func`, the Java, C# and C outputs, the four servers and both benches
  byte-identical.

## The new gate, and its controls

`a_stream_handle_splits_into_open_time_config_and_per_bar_state` pins four rows
that control each other: `SMA` (one param, no setting — and the param must be
on the config and **off** the state), `BBANDS` (four fields plus a peek
scratch), `CDLCOUNTERATTACK` (settings, no param) and `TRANGE` (neither, so
nothing is emitted at all).

Each was broken in the generator and watched fail:

| break | row that reddens |
|---|---|
| emit the config struct unconditionally | `trange`: has no invariant, must emit no config struct |
| leave the params on the state as well | `sma`: `optInTimePeriod` is on the state as well as the config |
| put peek back on `update` over a whole-handle scratch | `bbands`: the reused scratch holds a bare state |
| pass the config by value | `sma`: the step must take its config first, by reference |

The two #274 gates and three `rust_stream_suite` assertions that pinned the old
spelling are updated to the new one.

One thing worth flagging for the next change here: `fma::stream_base` and
`rust_lang::strip_state_prefix` are name-keyed and had to learn the `cfg.`
prefix. Left alone they silently drop an `as f64` and change which sites fuse
`a*b+c` — the hazard `ta_codegen/generator/CLAUDE.md` warns about, reached for
real by this change.

