### PR TITLE
fix(codegen): the generator is clippy-red on the pinned toolchain after #278

### DIFF
--- a/ta_codegen/generator/src/backends/csharp_stream.rs
+++ b/ta_codegen/generator/src/backends/csharp_stream.rs
@@ -3425,9 +3425,9 @@ fn emit_period_bank(
     let _ = helpers;
     let callee = plan.callee.as_str();
     // `callee_base` stays raw for the callee's (unchanged, batch-tier) `_Lookback`;
-    // `callee_cbase` is the PascalCase form for the callee's own stream `_Open*` family.
+    // `callee_pascal` is the PascalCase form for the callee's own stream `_Open*` family.
     let callee_base = registry.name_of(callee);
-    let callee_cbase = pascal_words(&callee_base);
+    let callee_pascal = pascal_words(&callee_base);
     let subty = callee_stream_class(registry, callee);
     let callee_out0 = registry.callee_outputs(callee)[0].clone();
     let min = plan.min_param.as_str();
@@ -3541,7 +3541,7 @@ fn emit_period_bank(
     let _ = writeln!(o, "      int nBank = {max} - {min} + 1;");
     let _ = writeln!(o, "      {subty}[] bank = new {subty}[nBank];");
     let _ = writeln!(o, "      for( int bankIdx = 0; bankIdx < nBank; bankIdx++ ) {{");
-    let _ = writeln!(o, "         bank[bankIdx] = {callee_cbase}OpenInternal({price}, subStart, {open_opts});");
+    let _ = writeln!(o, "         bank[bankIdx] = {callee_pascal}OpenInternal({price}, subStart, {open_opts});");
     let _ = writeln!(o, "      }}");
     let _ = writeln!(o, "      int cp = (int){period}[historyLen - 1];");
     let _ = writeln!(o, "      if( cp < {min} ) {{");
@@ -3584,7 +3584,7 @@ fn emit_period_bank(
     let _ = writeln!(o, "      double[] seedPrefix = new double[lookbackTotal + 1];");
     let _ = writeln!(o, "      {price}.Slice(0, lookbackTotal + 1).CopyTo(seedPrefix);");
     let _ = writeln!(o, "      for( int bankIdx = 0; bankIdx < nBank; bankIdx++ ) {{");
-    let _ = writeln!(o, "         {subty} sub = {callee_cbase}OpenInternal(seedPrefix, lookbackTotal, {open_opts});");
+    let _ = writeln!(o, "         {subty} sub = {callee_pascal}OpenInternal(seedPrefix, lookbackTotal, {open_opts});");
     let _ = writeln!(o, "         bank[bankIdx] = sub;");
     let _ = writeln!(o, "         scratch[bankIdx] = sub.cur_{callee_out0};");
     let _ = writeln!(o, "      }}");

--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -3008,10 +3008,10 @@ fn emit_period_bank(
 ) {
     let _ = helpers;
     let callee = plan.callee.as_str();
-    // Raw, for the callee's unchanged batch `_Lookback`; `callee_jbase` (below)
+    // Raw, for the callee's unchanged batch `_Lookback`; `callee_camel` (below)
     // is the recased base for the callee's streaming family.
     let callee_base = registry.name_of(callee);
-    let callee_jbase = common::camel_words(&callee_base);
+    let callee_camel = common::camel_words(&callee_base);
     let subty = callee_stream_class(registry, callee);
     let callee_out0 = registry.callee_outputs(callee)[0].clone();
     let min = plan.min_param.as_str();
@@ -3117,7 +3117,7 @@ fn emit_period_bank(
     let _ = writeln!(o, "      int nBank = {max} - {min} + 1;");
     let _ = writeln!(o, "      {subty}[] bank = new {subty}[nBank];");
     let _ = writeln!(o, "      for( int bankIdx = 0; bankIdx < nBank; bankIdx++ ) {{");
-    let _ = writeln!(o, "         bank[bankIdx] = {callee_jbase}OpenInternal({price}, subStart, {open_opts});");
+    let _ = writeln!(o, "         bank[bankIdx] = {callee_camel}OpenInternal({price}, subStart, {open_opts});");
     let _ = writeln!(o, "      }}");
     let _ = writeln!(o, "      int cp = (int){period}[historyLen - 1];");
     let _ = writeln!(o, "      if( cp < {min} ) {{");
@@ -3161,7 +3161,7 @@ fn emit_period_bank(
         "      double[] seedPrefix = java.util.Arrays.copyOfRange({price}, 0, lookbackTotal + 1);"
     );
     let _ = writeln!(o, "      for( int bankIdx = 0; bankIdx < nBank; bankIdx++ ) {{");
-    let _ = writeln!(o, "         {subty} sub = {callee_jbase}OpenInternal(seedPrefix, lookbackTotal, {open_opts});");
+    let _ = writeln!(o, "         {subty} sub = {callee_camel}OpenInternal(seedPrefix, lookbackTotal, {open_opts});");
     let _ = writeln!(o, "         bank[bankIdx] = sub;");
     let _ = writeln!(o, "         scratch[bankIdx] = sub.cur_{callee_out0};");
     let _ = writeln!(o, "      }}");


### PR DESCRIPTION
`c4cecde3a` introduced two `clippy::similar_names` errors. `src/lib.rs` carries
`#![deny(clippy::pedantic)]`, so they are errors, not warnings:

```
error: binding's name is too similar to existing binding
    --> src/backends/csharp_stream.rs:3430:9   callee_cbase  (vs callee_base:3429)
    --> src/backends/java_stream.rs:3014:9     callee_jbase  (vs callee_base:3013)
error: could not compile `ta-codegen` (lib) due to 2 previous errors
```

This is not a runner-image drift that might not reproduce. `rust-toolchain.toml`
pins `1.97.0` — the file's own comment says it exists precisely so
`similar_names` cannot fire differently in CI than locally — and the errors
reproduce on a pristine `dev` worktree at `c308e789b` on that pinned version.

The dev nightly's `clippy` job runs

```
cargo clippy --all-targets --manifest-path ta_codegen/generator/Cargo.toml -- -D warnings
```

as its first step, and its own comment describes it as a hard gate added
because "pedantic errors landed on dev unnoticed". So it will go red on the
next nightly.

## The change

The rename the lint asks for, naming what the binding *is* rather than which
backend it belongs to:

- `callee_cbase` → `callee_pascal` (C#)
- `callee_jbase` → `callee_camel` (Java)

Both are function-local, four uses each. Nothing else.

## Verified

- `cargo clippy --all-targets` on the generator — clean.
- The generator's own suites — 382 + 310 + 24 + 4 + … , 0 failures.
- `cargo run -- generate` followed by `git status` leaves **only these two
  source files** modified, so every generated byte across all four backends is
  identical. This is a rename with no output.

## Scope

Deliberately separate from the #278 gate work on
`issue-278-name-case-fold`, so that PR is not widened by a fix to a different
commit's lint break. Either can land first; they do not touch the same files.
