### PR TITLE
Support pkg-config in ta-lib for CMake Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,16 @@ if(UNIX)
 		@ONLY
 	)
 	install(SCRIPT "${CMAKE_BINARY_DIR}/warn-stale-installs.cmake")
+
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    set(exec_prefix ${CMAKE_INSTALL_PREFIX}/bin)
+    set(libdir ${CMAKE_INSTALL_PREFIX}/lib)
+    set(includedir ${CMAKE_INSTALL_PREFIX}/include)
+    set(PACKAGE_VERSION ${PROJECT_VERSION})
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/ta-lib.pc.in"
+        "${CMAKE_BINARY_DIR}/ta-lib.pc" @ONLY)
+    install(FILES ${CMAKE_BINARY_DIR}/ta-lib.pc DESTINATION lib/pkgconfig)
 endif()
 
 # The dev tools use internal, non-exported library symbols, so they need the

--- a/ta-lib.pc.in
+++ b/ta-lib.pc.in
@@ -8,5 +8,5 @@ Description: TA-Lib : Technical Analysis Library
 URL: https://github.com/TA-Lib/ta-lib
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} -lta-lib
+Libs: -L${libdir} -lta-lib -lm
 Libs.private: @LIBM@


### PR DESCRIPTION
The `autoconf`build supports `pkg-config` file generation and install, but the CMake build did not. Adding a couple of lines in CMake to support this on UNIX platforms.