### PR TITLE
test(abstract): the fold sweeps' third check asserted nothing, in all three remaining backends (#278 follow-up)

### DIFF
--- a/src/tools/ta_regtest/test_abstract.c
+++ b/src/tools/ta_regtest/test_abstract.c
@@ -1732,6 +1732,7 @@ static ErrorNumber d2_param_vectors( const char *funcName, const TA_FuncHandle *
 typedef struct
 {
    int nbChecked;
+   int nbCanonical;
    int nbFailed;
 } NameFoldCtx;
 
@@ -1774,6 +1775,24 @@ static void nameFoldCb( const TA_FuncInfo *funcInfo, void *opaqueData )
       return;
    }
 
+   /* "Canonical" has to name something for a fold to fold onto it. Every
+    * spelling probed below is derived from this entry, so a table entry stored
+    * in lower case would fold onto itself just as happily and no probe here
+    * would notice; this is the only line that does. Same assertion the Rust
+    * registry sweep carries (abstract_api.rs, registry_tests).
+    */
+   ctx->nbCanonical++;
+   for( i = 0; i < len; i++ )
+   {
+      if( funcInfo->name[i] >= 'a' && funcInfo->name[i] <= 'z' )
+      {
+         printf( "  ABSTRACT ERROR: '%s' is not stored in its canonical upper case\n",
+                 funcInfo->name );
+         ctx->nbFailed++;
+         break;
+      }
+   }
+
    for( variant = 0; variant < 2; variant++ )
    {
       ctx->nbChecked++;
@@ -1794,13 +1813,23 @@ static void nameFoldCb( const TA_FuncInfo *funcInfo, void *opaqueData )
          continue;
       }
 
-      /* Only the match folds. The name reported back is still canonical, so
-       * this comparison stays case-sensitive on purpose.
+      /* Anchored to the row being enumerated, not to a second lookup of its
+       * own name. `handle == canonical` alone would be satisfied by a lookup
+       * that sent every spelling of every name to the SAME wrong function, so
+       * on its own it says only that the fold is consistent, not that it is
+       * right. TA_ForEachFunc hands out `funcDef->funcInfo` and TA_GetFuncInfo
+       * answers that same pointer (ta_abstract.c), so identity here is the C
+       * spelling of what the other three backends assert directly against the
+       * row they are iterating (`lower == f` / `Some(f.id)`).
+       *
+       * Comparing `back->name` to `funcInfo->name` instead, as this did, says
+       * the same thing only while every name in the table is unique -- which
+       * is true, and which nothing in this sweep checks. Pointer identity does
+       * not lean on it.
        */
-      if( TA_GetFuncInfo( handle, &back ) != TA_SUCCESS ||
-          strcmp( back->name, funcInfo->name ) != 0 )
+      if( TA_GetFuncInfo( handle, &back ) != TA_SUCCESS || back != funcInfo )
       {
-         printf( "  ABSTRACT ERROR: '%s' reports back as '%s', not '%s'\n",
+         printf( "  ABSTRACT ERROR: '%s' resolves to '%s', not to the '%s' row\n",
                  spelling[variant],
                  ( back && back->name ) ? back->name : "(none)",
                  funcInfo->name );
@@ -1831,11 +1860,12 @@ static ErrorNumber checkFuncHandleFoldsCase( void )
       "NOSUCHFUNCTION"
    };
 
-   ctx.nbChecked = 0;
-   ctx.nbFailed  = 0;
+   ctx.nbChecked   = 0;
+   ctx.nbCanonical = 0;
+   ctx.nbFailed    = 0;
    TA_ForEachFunc( nameFoldCb, &ctx );
 
-   if( ctx.nbChecked == 0 )
+   if( ctx.nbChecked == 0 || ctx.nbCanonical == 0 )
    {
       printf( "  ABSTRACT ERROR: the case-fold probe compared nothing\n" );
       return TA_ABS_TST_FAIL_NAME_CASE_FOLD;
@@ -1863,8 +1893,9 @@ static ErrorNumber checkFuncHandleFoldsCase( void )
    if( ctx.nbFailed != 0 )
       return TA_ABS_TST_FAIL_NAME_CASE_FOLD;
 
-   printf( "  Name lookup case fold: %d spellings resolved, all canonical\n",
-           ctx.nbChecked );
+   printf( "  Name lookup case fold: %d spellings resolved to their own row, "
+           "%d name(s) stored upper case\n",
+           ctx.nbChecked, ctx.nbCanonical );
    return TA_TEST_PASS;
 }
 

--- a/ta_codegen/output/csharp/library/test/MetadataTest.cs
+++ b/ta_codegen/output/csharp/library/test/MetadataTest.cs
@@ -228,8 +228,20 @@ public static class MetadataTest
                   $"{f.Name}: lower-case lookup finds it");
             Check(c.TryGet(Alternating(f.Name), out FunctionInfo? mixed) && ReferenceEquals(mixed, f),
                   $"{f.Name}: mixed-case lookup finds it");
-            Check(lower is not null && lower.Name == f.Name,
-                  $"{f.Name}: the name reported back stays canonical");
+            // A third line stood here asserting lower.Name == f.Name, "the name
+            // reported back stays canonical". It cannot fail: the line above
+            // pins ReferenceEquals(lower, f), so it compares one object's name
+            // to itself. Nothing replaces it, though the reason is not the fold:
+            // _byName IS OrdinalIgnoreCase, so a row stored in lower case is
+            // still found by every casing and both lookups above stay green.
+            // What catches it is the rest of the suite, which is keyed on the
+            // stored spelling ordinally. Measured, by lower-casing the TRIX
+            // row: without this line four checks still fail (no typed overload
+            // matched, compared every function, XML describes trix, XML
+            // describes every function), plus NoPhantomIoTest and StreamApiTest.
+            // C has no such second reader -- its whole regtest is green with a
+            // lower-cased row -- so there the canonical spelling is asserted
+            // outright, as it already is in Rust.
         }
 
         // What actually holds the line, and the reason it is spelled as the

--- a/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
+++ b/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
@@ -188,7 +188,7 @@ public class MetadataTest {
     }
 
     /**
-     * byName folds ASCII case; the name it reports back does not.
+     * byName folds ASCII case; the name the registry stores does not.
      *
      * <p>Swept over the corpus rather than spot-checked on {@code "sma"}: the
      * long names ({@code CDL3STARSINSOUTH}) and the ones carrying a digit or an
@@ -201,11 +201,19 @@ public class MetadataTest {
             FunctionInfo mixed = Functions.byName(alternating(f.name()));
             check(lower == f, f.name() + ": lower-case lookup finds it");
             check(mixed == f, f.name() + ": mixed-case lookup finds it");
-            // Guarded rather than chained: a regressed fold returns null here,
-            // and this suite has to report that as a failure, not a stack trace
-            // that stops the remaining checks from running at all.
-            check(lower != null && lower.name().equals(f.name()),
-                  f.name() + ": the name reported back stays canonical");
+            // A third line stood here asserting lower.name().equals(f.name()),
+            // "the name reported back stays canonical". It cannot fail: the
+            // line above pins lower == f, so it compares one object's name to
+            // itself. Nothing replaces it, and the reason is specific to this
+            // backend -- BY_NAME is keyed on the STORED spelling while byName
+            // folds upward, so a row stored in lower case is unreachable by
+            // its own name. Measured, by lower-casing the SMA row: four checks
+            // fail (byName(SMA), byName round-trips, and both lookups here).
+            // C matches case-insensitively on both sides and has no second
+            // reader of the stored spelling anywhere in ta_regtest, so there
+            // the canonical spelling is asserted outright, as it already is in
+            // Rust. C# folds on both sides too but is caught by the rest of
+            // its own suite; see the note at the same site there.
         }
 
         // Caught rather than chained: a regression here throws, and the suite


### PR DESCRIPTION
Follow-up to `4eb9a6d1d`, which fixed this in Rust and left the note:

> The same comparison is redundant after the identity check in the C, Java and C#
> sweeps too; left alone here, worth a follow-up.

It is redundant in all three, for the same reason — the line above it already
pins the looked-up object to the row being iterated — but the *consequence*
differs per backend, so the three do not get the same edit. Each backend's
reason is recorded at the site rather than in this description.

## C — the sweep gains cover it did not have

Two changes in `test_abstract.c`.

**The anchor.** C's identity check is `handle == canonical`, against a *second
lookup of the row's own name*, not against the row being enumerated. So the
string compare was the only thing tying the sweep to that row — and it does that
only while every name in the table is unique, which is true and which nothing in
this sweep checks. It is now pointer identity against `funcInfo`.
`TA_ForEachFunc` hands out `funcDef->funcInfo` and `TA_GetFuncInfo` answers that
same pointer, so this is the C spelling of what the other three already assert
directly (`lower == f` / `ReferenceEquals(lower, f)` / `Some(f.id)`).

**The new assertion:** the stored name carries no ASCII lower case. Every
spelling the sweep probes is derived from the stored one, and
`TA_GetFuncHandle` folds on both sides, so a lower-cased table entry resolves
under every casing and reads back as itself.

Sabotage, with the control:

| | before this PR | after |
|---|---|---|
| SMA's stored name lower-cased | **all of `ta_regtest` green**, gate prints `352 spellings resolved, all canonical` | `'sma' is not stored in its canonical upper case`, error 627, exit 115 |

The sabotage is a constructor over `TA_INFO_SMA`, so the *library's* table
carries the lower-cased name — not the probe's view of it. Nothing else in
`ta_regtest` reads a stored spelling, which is why the control is green
everywhere, not merely elsewhere.

## Java and C# — the line goes, nothing replaces it

Both already compare the looked-up object to the row being iterated, so the
third line compares one object's name to itself and cannot fail for any
registry. Neither needs the canonical-spelling assertion C now carries, and the
reasons are different:

| | why the fold sweep does not need it | measured, by lower-casing one row |
|---|---|---|
| **Java** | `BY_NAME` is keyed on the stored spelling while `byName` folds *upward*, so a lower-cased row is unreachable by its own name | SMA: four checks fail — `byName(SMA)`, `byName round-trips`, and both lookups in the sweep |
| **C#** | `_byName` IS `OrdinalIgnoreCase`, so the fold checks stay green — but the rest of the suite is keyed on the stored spelling ordinally | TRIX: four `MetadataTest` checks fail (no typed overload matched, compared every function, both XML checks), plus `NoPhantomIoTest` and `StreamApiTest` |

Adding the assertion to these two anyway would have traded one redundant
assertion for another. Recording *why* each backend does or does not need it is
the part that survives the next reader.

## What this costs

One assertion per function disappears in each of Java and C#, so their check
counts drop by exactly 176: **Java 1716 → 1540, C# 3431 → 3255**. That is
visible in the gate output and is the honest price of the change; nothing that
could fail stopped being checked. If you would rather keep a per-function line
there for the diagnosis it gives — `is not stored in its canonical upper case`
names the defect more directly than `lower-case lookup finds it` does — say so
and I will add it back to both, with the redundancy stated rather than implied.

## Verified here

* `ta_regtest` green: `352 spellings resolved to their own row, 176 name(s)
  stored upper case`, `All tests succeeded`.
* Java `MetadataTest`: `ALL PASS (1540 checks)` (compiled with `javac --release
  17` over `src/main` + `src/test`, not through `./mvnw` — this session has no
  Maven cache).
* C#: all seven suites pass on .NET 10.0.11 (`dotnet run -c Release` in
  `csharp/library/test`).
* `cargo run -- generate` leaves the tree clean, confirming all three files are
  hand-written.

**Not run here:** the cross-language `--codegen` legs, which need the language
servers built. No file this touches is compiled into a server.
