### PR TITLE
test(abstract): name the defect in the Java and C# fold sweeps too (#278 follow-up)

### DIFF
--- a/ta_codegen/output/csharp/library/test/MetadataTest.cs
+++ b/ta_codegen/output/csharp/library/test/MetadataTest.cs
@@ -222,27 +222,45 @@ public static class MetadataTest
         // a digit or an underscore (CDL2CROWS, HT_DCPERIOD), and no single name
         // stands in for those. Between the all-lower and the alternating
         // spelling every letter position is presented in both cases.
+        int canonical = 0;
         foreach (FunctionInfo f in c)
         {
             Check(c.TryGet(AsciiLower(f.Name), out FunctionInfo? lower) && ReferenceEquals(lower, f),
                   $"{f.Name}: lower-case lookup finds it");
             Check(c.TryGet(Alternating(f.Name), out FunctionInfo? mixed) && ReferenceEquals(mixed, f),
                   $"{f.Name}: mixed-case lookup finds it");
-            // A third line stood here asserting lower.Name == f.Name, "the name
-            // reported back stays canonical". It cannot fail: the line above
-            // pins ReferenceEquals(lower, f), so it compares one object's name
-            // to itself. Nothing replaces it, though the reason is not the fold:
-            // _byName IS OrdinalIgnoreCase, so a row stored in lower case is
-            // still found by every casing and both lookups above stay green.
-            // What catches it is the rest of the suite, which is keyed on the
-            // stored spelling ordinally. Measured, by lower-casing the TRIX
-            // row: without this line four checks still fail (no typed overload
-            // matched, compared every function, XML describes trix, XML
-            // describes every function), plus NoPhantomIoTest and StreamApiTest.
-            // C has no such second reader -- its whole regtest is green with a
-            // lower-cased row -- so there the canonical spelling is asserted
-            // outright, as it already is in Rust.
+
+            // "Canonical" has to name something for a fold to fold onto it.
+            // Both spellings probed above are derived from the stored one, and
+            // here the fold is on both sides -- _byName is OrdinalIgnoreCase --
+            // so a row stored in lower case is still found by every casing and
+            // both lookups above stay green. Nothing in this sweep sees it.
+            // Same assertion C (test_abstract.c, nameFoldCb) and Rust
+            // (abstract_api.rs, registry_tests) carry.
+            //
+            // It is not the line that used to stand here. That one asserted
+            // lower.Name == f.Name, "the name reported back stays canonical",
+            // which cannot fail: ReferenceEquals(lower, f) above pins the two
+            // to one object, so it compared a name to itself.
+            //
+            // The defect does not escape the suite without this line -- the
+            // rest of it is keyed on the stored spelling ordinally -- but
+            // nothing that fails names it. Measured, by lower-casing the TRIX
+            // row: four MetadataTest checks fail (no typed overload matched,
+            // compared every function, XML describes trix, XML describes every
+            // function), plus NoPhantomIoTest and StreamApiTest. This line
+            // fails here instead, saying what is actually wrong.
+            Check(IsStoredUpperCase(f.Name), $"{f.Name}: is stored in its canonical upper case");
+            canonical++;
         }
+
+        // The sweep's own non-vacuity guard, the counterpart of C's
+        // `nbCanonical == 0` check. It is insurance, not a second
+        // discriminator: RegistryIsComplete already fails on an empty
+        // catalogue, so the only way here is if enumeration stopped agreeing
+        // with Count.
+        Check(canonical > 0 && canonical == c.Count,
+              $"the canonical-spelling check ran on every row ({canonical}/{c.Count})");
 
         // What actually holds the line, and the reason it is spelled as the
         // comparer rather than as a Unicode probe.
@@ -280,6 +298,27 @@ public static class MetadataTest
         Check(!c.TryGet("ht-dcperiod", out _), "a separator is still part of the name");
         Check(!c.TryGet("", out _), "the empty name resolves to nothing");
         Check(!c.TryGet(new string('s', 512), out _), "a name longer than any real one matches nothing");
+    }
+
+    /// <summary>
+    /// True if the stored spelling carries no ASCII lower case.
+    /// </summary>
+    /// <remarks>
+    /// Spelled as "no lower-case letter" rather than <c>s == s.ToUpperInvariant()</c>
+    /// so it stays an ASCII claim, and so it does not depend on whether the run
+    /// is globalization-invariant: a name is upper case here in the same sense
+    /// <see cref="AsciiLower"/> is a fold, and neither borrows a culture's opinion.
+    /// </remarks>
+    private static bool IsStoredUpperCase(string s)
+    {
+        foreach (char ch in s)
+        {
+            if (ch >= 'a' && ch <= 'z')
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     /// <summary>ASCII-only lower fold, so the probe cannot inherit the bug it looks for.</summary>

--- a/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
+++ b/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
@@ -196,25 +196,44 @@ public class MetadataTest {
      * and no single case stands in for them.
      */
     static void byNameFoldsAsciiCase() {
+        int canonical = 0;
         for (FunctionInfo f : Functions.all()) {
             FunctionInfo lower = Functions.byName(asciiLower(f.name()));
             FunctionInfo mixed = Functions.byName(alternating(f.name()));
             check(lower == f, f.name() + ": lower-case lookup finds it");
             check(mixed == f, f.name() + ": mixed-case lookup finds it");
-            // A third line stood here asserting lower.name().equals(f.name()),
-            // "the name reported back stays canonical". It cannot fail: the
-            // line above pins lower == f, so it compares one object's name to
-            // itself. Nothing replaces it, and the reason is specific to this
-            // backend -- BY_NAME is keyed on the STORED spelling while byName
-            // folds upward, so a row stored in lower case is unreachable by
-            // its own name. Measured, by lower-casing the SMA row: four checks
-            // fail (byName(SMA), byName round-trips, and both lookups here).
-            // C matches case-insensitively on both sides and has no second
-            // reader of the stored spelling anywhere in ta_regtest, so there
-            // the canonical spelling is asserted outright, as it already is in
-            // Rust. C# folds on both sides too but is caught by the rest of
-            // its own suite; see the note at the same site there.
+
+            // "Canonical" has to name something for a fold to fold onto it.
+            // Both spellings probed above are derived from the stored one, so
+            // a row stored in lower case folds onto itself just as happily and
+            // neither lookup notices; this is the line that does. Same
+            // assertion C (test_abstract.c, nameFoldCb) and Rust
+            // (abstract_api.rs, registry_tests) carry.
+            //
+            // It is not the line that used to stand here. That one asserted
+            // lower.name().equals(f.name()), "the name reported back stays
+            // canonical", which cannot fail: `lower == f` above pins the two
+            // to one object, so it compared a name to itself.
+            //
+            // A lower-cased row is not invisible to Java without this -- and
+            // that is the reason to say it rather than leave it. BY_NAME is
+            // keyed on the STORED spelling while byName folds upward, so the
+            // row becomes unreachable by its own name and four checks fail
+            // (byName(SMA), byName round-trips, and both lookups above),
+            // none of them naming the defect. This one names it.
+            check(isStoredUpperCase(f.name()),
+                  f.name() + ": is stored in its canonical upper case");
+            canonical++;
         }
+
+        // The sweep's own non-vacuity guard, the counterpart of C's
+        // `nbCanonical == 0` check. It is insurance, not a second
+        // discriminator: registryIsComplete() already fails on an empty
+        // registry, so the only way here is if all() stopped agreeing with
+        // itself between two calls.
+        check(canonical > 0 && canonical == Functions.all().size(),
+              "the canonical-spelling check ran on every row (" + canonical + "/"
+              + Functions.all().size() + ")");
 
         // Caught rather than chained: a regression here throws, and the suite
         // has to report that as one failed check instead of a stack trace that
@@ -239,6 +258,23 @@ public class MetadataTest {
         check(Functions.byName("sma ") == null, "a trailing space is still part of the name");
         check(Functions.byName("ht-dcperiod") == null, "a separator is still part of the name");
         check(Functions.byName("") == null, "the empty name resolves to nothing");
+    }
+
+    /**
+     * True if the stored spelling carries no ASCII lower case.
+     *
+     * <p>Spelled as "no lower-case letter" rather than {@code s.equals(upper(s))}
+     * so it stays an ASCII claim: a name is upper case here in the same sense
+     * {@code asciiLower} is a fold, and neither borrows a locale's opinion.
+     */
+    private static boolean isStoredUpperCase(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c >= 'a' && c <= 'z') {
+                return false;
+            }
+        }
+        return true;
     }
 
     /** ASCII-only lower fold, so the probe cannot inherit the bug it looks for. */


### PR DESCRIPTION
Asked for on #285:

> On your offer at the end: yes, please, for both. The two deleted lines were
> vacuous and deleting them is right, but what replaces them in Java and C# is
> a failure somewhere else in the suite [...] C and Rust now say it outright;
> the other two should as well, with the redundancy stated at the site rather
> than implied. Same shape as the C one, its own counter.

Two files, both hand-written: `ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java`
and `ta_codegen/output/csharp/library/test/MetadataTest.cs`. `generate` leaves
both alone; no generator change is involved.

## What the assertion is

Per row, in each sweep: the stored spelling carries no ASCII lower case. Same
claim `nameFoldCb` makes in `test_abstract.c` and `registry_tests` makes in
`abstract_api.rs`. Every spelling either sweep probes is derived from the
stored one, so a row stored in lower case folds onto itself just as happily
and neither lookup notices — this is the line that does.

Spelled as "no lower-case letter", not `s == upper(s)`. It stays an ASCII
claim on both sides, the same sense in which `asciiLower` / `AsciiLower` is a
fold. In C# that also keeps it independent of whether the run is
globalization-invariant, which this suite already had to reason about once for
the U+017F probe.

The comment the deleted line left behind is rewritten at each site, so the
next reader finds why the old one was vacuous (`lower == f` pins the two to
one object, so it compared a name to itself) next to the line that replaced it.

## What the counter is, and what it is not

Each sweep counts the rows the canonical check ran on and asserts the count is
non-zero and equal to the registry size — the counterpart of C's
`nbCanonical == 0` guard.

**It is insurance, not a second discriminator, and the comment at each site
says so.** An empty registry already fails `registryIsComplete` /
`RegistryIsComplete`; the only thing this catches on top is enumeration
disagreeing with `size()` / `Count` between two calls in the same run. It is
here because C has it and the shapes should match, not because it closes a
gap. Recorded rather than smoothed over, so nobody reads it as coverage it
does not carry.

## Measured, with a clean control either side

**Java** — lower-casing the `SMA` row in `Functions.java`:

| | result |
|---|---|
| before | the four failures the old comment recorded: `byName(SMA)`, `byName round-trips`, and both lookups in the sweep. None names the defect. |
| after | those four, **plus** `FAIL: sma: is stored in its canonical upper case` |

Worth stating because it is visible in that run and is not this commit's
doing: on that sabotage the suite does not reach the end either way —
`flagVocabularyIsComplete` NPEs on `byName("SMA")` returning null a few sweeps
later. Pre-existing, untouched here.

**C#** — lower-casing the `TRIX` row in `FunctionCatalog.g.cs`:

| | result |
|---|---|
| before | the fold sweep itself stays **green** (`_byName` is `OrdinalIgnoreCase`, so every casing still resolves). What fails is four other `MetadataTest` checks — no typed overload matched, compared every function, and both XML checks — plus `NoPhantomIoTest` and `StreamApiTest`, all of them about a *missing* `TRIX` rather than a mis-stored one. |
| after | `FAIL: trix: is stored in its canonical upper case` is the **first** failure printed. |

## Cost

One check per function plus one counter, and nothing else:

| suite | before | after |
|---|---|---|
| Java `MetadataTest` | 1540 | 1717 |
| C# `MetadataTest` | 3255 | 3432 |

## Run here

- Seven Java suites ALL PASS (`javac --release 17` over `src/`, the same
  sources Maven compiles): CoreApi 66, BatchApi 181, SMathOverflow 4,
  Metadata 1717, StreamSmoke 3859, DivZero 91, NoPhantomIo 4075.
- Seven C# suites ALL PASS on .NET 10.0.11 (`dotnet run` on
  `test/TALib.Test.csproj`, `InvariantGlobalization=true` as declared).
- `cargo run -- generate` leaves both files untouched.

**Not run here:** the Maven gate itself (`./mvnw`), the C `ta_regtest` legs,
and the cross-language `--codegen` legs. No file this touches is compiled into
a language server or into the C library.
