### PR TITLE
docs(rust): a category index on the crate front page, from the grouping the registry already had (#179 D6)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_doc.rs
+++ b/ta_codegen/generator/src/backends/rust_doc.rs
@@ -15,7 +15,7 @@
 use super::doc_meta::{self, ensure_period, RangeMeta};
 use crate::ir::{DocDef, EnumDef, FuncDef, OptInput, Output, ParamType};
 use crate::registry::Registry;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Content width for wrapped doc lines: rustfmt max_width 100 minus `    /// `.
 const WRAP: usize = 92;
@@ -180,6 +180,53 @@ pub fn guarded_docs(
         out.push_str(&format!("    #[doc(alias = \"{alias}\")]\n"));
     }
     out
+}
+
+/// The crate-docs category index (#179 D6): every indicator, under the group the
+/// registry files it in, as `//!` lines for the `lib.rs` scaffolding.
+///
+/// The registry already knew the grouping — `FuncInfo::group`, a closed `Group`
+/// enum — but no doc page said it. `Core` carries its methods in one flat
+/// alphabetical list, so "which ones are the candlestick recognizers?" was
+/// answerable only by noticing that they all happen to start with `CDL`.
+///
+/// Rendered from the two fields the registry row itself carries and from nothing
+/// else: the `name`, which is also the method's name, and the `hint`, which
+/// becomes `FuncInfo::hint` and the `FuncId` variant's own doc line. So the index
+/// cannot say something about a function that the registry does not — including
+/// the missing-hint case, where the registry stores `""` and this writes no
+/// description rather than inventing one from another field.
+///
+/// Every definition is walked and its group decides only where it lands, never
+/// whether it appears; `rust_category_index_lists_every_function_once` in
+/// `tests/backend_suite.rs` is what keeps that true. The links themselves are
+/// gated by the nightly's `RUSTDOCFLAGS=-D warnings` rustdoc step: a name that is
+/// not a `Core` method is `rustdoc::broken_intra_doc_links`.
+///
+/// `BTreeMap` orders the groups by their display string, which is the order
+/// `Group::ALL` declares them in, so the front page and the registry enumerate
+/// categories the same way.
+pub fn category_index(funcs: &[FuncDef]) -> String {
+    let mut by_group: BTreeMap<&str, Vec<&FuncDef>> = BTreeMap::new();
+    for f in funcs {
+        by_group.entry(f.group.as_str()).or_default().push(f);
+    }
+    let mut s = String::new();
+    for (group, mut members) in by_group {
+        members.sort_by(|a, b| a.name.cmp(&b.name));
+        s.push_str(&format!("//! ## {group} ({})\n//!\n", members.len()));
+        for f in members {
+            let hint = f.hint.as_deref().unwrap_or_default();
+            let dash = if hint.is_empty() { "" } else { " — " };
+            s.push_str(&format!("//! * [`{0}`](Core::{0}){dash}{hint}\n", f.name));
+        }
+        s.push_str("//!\n");
+    }
+    // The blank line before the scaffolding's first inner attribute is the
+    // template's own; drop the trailing `//!` separator this loop leaves behind,
+    // and the newline with it — the placeholder sits on a line of its own.
+    s.truncate(s.trim_end_matches("//!\n").trim_end().len());
+    s
 }
 
 /// Rustdoc block for the `<snake>_lookback` function.

--- a/ta_codegen/generator/src/main.rs
+++ b/ta_codegen/generator/src/main.rs
@@ -2323,6 +2323,12 @@ fn generate_rust_crate_scaffolding(
     let install_req = crate_version
         .rsplit_once('.')
         .map_or_else(|| crate_version.clone(), |(major_minor, _)| major_minor.to_string());
+    // The crate-docs category index (#179 D6): the grouping the registry has
+    // always known, finally said in the docs. Built in `rust_doc` rather than
+    // here so it is reachable from `tests/backend_suite.rs` — `funcs` is the
+    // whole corpus, and the property worth pinning is that every one of them
+    // reaches the page.
+    let func_index = backends::rust_doc::category_index(funcs);
     // Applied to the two long prose literals below, which hold Rust and TOML
     // samples and so cannot be `format!` strings (every brace would need
     // doubling, in text that is read far more often than it is edited).
@@ -2330,6 +2336,7 @@ fn generate_rust_crate_scaffolding(
         text.replace("$N_FUNCS", &n_funcs.to_string())
             .replace("$N_CANDLES", &n_candles.to_string())
             .replace("$INSTALL_REQ", &install_req)
+            .replace("$FUNC_INDEX", &func_index)
     };
     // Two-crate Cargo workspace: `library/` is the published `ta-lib` crate;
     // `tools/` holds the JSON-RPC server/bench — a layer on top of the library.
@@ -2607,6 +2614,17 @@ path = "src/lib.rs"
 //!
 //! The full function reference, grouped by category, is at
 //! [ta-lib.org/functions](https://ta-lib.org/functions/).
+//!
+//! # Indicators by category
+//!
+//! Every indicator is a method on [`Core`], and the methods are one flat
+//! alphabetical list — so this is where the grouping lives. It is the same
+//! grouping the registry answers at run time ([`abstract_api::Group`], reported
+//! per function as [`FuncInfo::group`](abstract_api::FuncInfo::group)), and each
+//! entry carries that row's own one-line hint. Follow a link for the function's
+//! formula, arguments, ranges and a runnable example.
+//!
+$FUNC_INDEX
 
 #![forbid(unsafe_code)]
 // Every public item, and every public enum variant and struct field, carries its

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -13331,3 +13331,56 @@ fn a_reused_peek_scratch_is_a_bare_state_stepped_directly() {
         "the throwaway tier keeps the pre-#201 clone verbatim\n{peek}"
     );
 }
+
+/// The crate front page's category index (#179 D6) must list every indicator in
+/// the corpus exactly once, under the group its own definition names.
+///
+/// Rustdoc gates the *links* — a `[`X`](Core::X)` naming a method that does not
+/// exist is `rustdoc::broken_intra_doc_links`, and the nightly runs rustdoc with
+/// `-D warnings`. Nothing gates an *omission*: a filter that quietly drops a
+/// function leaves a page that still builds clean and simply never mentions it.
+/// That is the failure this test exists for, so it counts rather than samples.
+#[test]
+fn rust_category_index_lists_every_function_once() {
+    let funcs: Vec<ir::FuncDef> = discover_indicators()
+        .iter()
+        .map(|name| load_indicator(name).0)
+        .collect();
+    assert!(funcs.len() >= 176, "only {} indicators in the corpus", funcs.len());
+
+    let index = backends::rust_doc::category_index(&funcs);
+
+    // One bullet per function, spelled as the link rustdoc will resolve.
+    for f in &funcs {
+        let line = format!("//! * [`{0}`](Core::{0})", f.name);
+        assert_eq!(
+            index.matches(&line).count(),
+            1,
+            "{} must appear exactly once in the category index",
+            f.name
+        );
+    }
+    assert_eq!(
+        index.matches("//! * [`").count(),
+        funcs.len(),
+        "the index must carry no entry beyond the corpus"
+    );
+
+    // Each heading's count is the number of bullets that follow it, so a reader
+    // can trust "Pattern Recognition (61)" without counting the list.
+    let mut heading_total = 0;
+    for section in index.split("//! ## ").skip(1) {
+        let (heading, body) = section.split_once('\n').expect("a heading ends its line");
+        let (group, count) = heading.rsplit_once(" (").expect("a heading carries its count");
+        let count: usize = count.trim_end_matches(')').parse().expect("a decimal count");
+        let bullets = body.matches("//! * [`").count();
+        assert_eq!(count, bullets, "{group} says {count} but lists {bullets}");
+        assert_eq!(
+            bullets,
+            funcs.iter().filter(|f| f.group == group).count(),
+            "{group} must list every function filed under it"
+        );
+        heading_total += bullets;
+    }
+    assert_eq!(heading_total, funcs.len(), "every function must land under a heading");
+}

--- a/ta_codegen/output/rust/library/src/lib.rs
+++ b/ta_codegen/output/rust/library/src/lib.rs
@@ -70,6 +70,221 @@
 //!
 //! The full function reference, grouped by category, is at
 //! [ta-lib.org/functions](https://ta-lib.org/functions/).
+//!
+//! # Indicators by category
+//!
+//! Every indicator is a method on [`Core`], and the methods are one flat
+//! alphabetical list — so this is where the grouping lives. It is the same
+//! grouping the registry answers at run time ([`abstract_api::Group`], reported
+//! per function as [`FuncInfo::group`](abstract_api::FuncInfo::group)), and each
+//! entry carries that row's own one-line hint. Follow a link for the function's
+//! formula, arguments, ranges and a runnable example.
+//!
+//! ## Cycle Indicators (5)
+//!
+//! * [`HT_DCPERIOD`](Core::HT_DCPERIOD) — Hilbert Transform - Dominant Cycle Period
+//! * [`HT_DCPHASE`](Core::HT_DCPHASE) — Hilbert Transform - Dominant Cycle Phase
+//! * [`HT_PHASOR`](Core::HT_PHASOR) — Hilbert Transform - Phasor Components
+//! * [`HT_SINE`](Core::HT_SINE) — Hilbert Transform - SineWave
+//! * [`HT_TRENDMODE`](Core::HT_TRENDMODE) — Hilbert Transform - Trend vs Cycle Mode
+//!
+//! ## Math Operators (11)
+//!
+//! * [`ADD`](Core::ADD) — Vector Arithmetic Add
+//! * [`DIV`](Core::DIV) — Vector Arithmetic Div
+//! * [`MAX`](Core::MAX) — Highest value over a specified period
+//! * [`MAXINDEX`](Core::MAXINDEX) — Index of highest value over a specified period
+//! * [`MIN`](Core::MIN) — Lowest value over a specified period
+//! * [`MININDEX`](Core::MININDEX) — Index of lowest value over a specified period
+//! * [`MINMAX`](Core::MINMAX) — Lowest and highest values over a specified period
+//! * [`MINMAXINDEX`](Core::MINMAXINDEX) — Indexes of lowest and highest values over a specified period
+//! * [`MULT`](Core::MULT) — Vector Arithmetic Mult
+//! * [`SUB`](Core::SUB) — Vector Arithmetic Subtraction
+//! * [`SUM`](Core::SUM) — Summation
+//!
+//! ## Math Transform (15)
+//!
+//! * [`ACOS`](Core::ACOS) — Vector Trigonometric ACos
+//! * [`ASIN`](Core::ASIN) — Vector Trigonometric ASin
+//! * [`ATAN`](Core::ATAN) — Vector Trigonometric ATan
+//! * [`CEIL`](Core::CEIL) — Vector Ceil
+//! * [`COS`](Core::COS) — Vector Trigonometric Cos
+//! * [`COSH`](Core::COSH) — Vector Trigonometric Cosh
+//! * [`EXP`](Core::EXP) — Vector Arithmetic Exp
+//! * [`FLOOR`](Core::FLOOR) — Vector Floor
+//! * [`LN`](Core::LN) — Vector Log Natural
+//! * [`LOG10`](Core::LOG10) — Vector Log10
+//! * [`SIN`](Core::SIN) — Vector Trigonometric Sin
+//! * [`SINH`](Core::SINH) — Vector Trigonometric Sinh
+//! * [`SQRT`](Core::SQRT) — Vector Square Root
+//! * [`TAN`](Core::TAN) — Vector Trigonometric Tan
+//! * [`TANH`](Core::TANH) — Vector Trigonometric Tanh
+//!
+//! ## Momentum Indicators (37)
+//!
+//! * [`AC`](Core::AC) — Accelerator/Decelerator Oscillator
+//! * [`ADX`](Core::ADX) — Average Directional Movement Index
+//! * [`ADXR`](Core::ADXR) — Average Directional Movement Index Rating
+//! * [`AO`](Core::AO) — Awesome Oscillator
+//! * [`APO`](Core::APO) — Absolute Price Oscillator
+//! * [`AROON`](Core::AROON) — Aroon
+//! * [`AROONOSC`](Core::AROONOSC) — Aroon Oscillator
+//! * [`BOP`](Core::BOP) — Balance Of Power
+//! * [`CCI`](Core::CCI) — Commodity Channel Index
+//! * [`CMO`](Core::CMO) — Chande Momentum Oscillator
+//! * [`CMOU`](Core::CMOU) — Chande Momentum Oscillator (Unsmoothed)
+//! * [`DX`](Core::DX) — Directional Movement Index
+//! * [`IMI`](Core::IMI) — Intraday Momentum Index
+//! * [`MACD`](Core::MACD) — Moving Average Convergence/Divergence
+//! * [`MACDEXT`](Core::MACDEXT) — MACD with controllable MA type
+//! * [`MACDFIX`](Core::MACDFIX) — Moving Average Convergence/Divergence Fix 12/26
+//! * [`MFI`](Core::MFI) — Money Flow Index
+//! * [`MINUS_DI`](Core::MINUS_DI) — Minus Directional Indicator
+//! * [`MINUS_DM`](Core::MINUS_DM) — Minus Directional Movement
+//! * [`MOM`](Core::MOM) — Momentum
+//! * [`PLUS_DI`](Core::PLUS_DI) — Plus Directional Indicator
+//! * [`PLUS_DM`](Core::PLUS_DM) — Plus Directional Movement
+//! * [`PPO`](Core::PPO) — Percentage Price Oscillator
+//! * [`QSTICK`](Core::QSTICK) — Qstick
+//! * [`ROC`](Core::ROC) — Rate of change : ((price/prevPrice)-1)*100
+//! * [`ROCP`](Core::ROCP) — Rate of change Percentage: (price-prevPrice)/prevPrice
+//! * [`ROCR`](Core::ROCR) — Rate of change ratio: (price/prevPrice)
+//! * [`ROCR100`](Core::ROCR100) — Rate of change ratio 100 scale: (price/prevPrice)*100
+//! * [`RSI`](Core::RSI) — Relative Strength Index
+//! * [`SMI`](Core::SMI) — Stochastic Momentum Index
+//! * [`STOCH`](Core::STOCH) — Stochastic
+//! * [`STOCHF`](Core::STOCHF) — Stochastic Fast
+//! * [`STOCHRSI`](Core::STOCHRSI) — Stochastic Relative Strength Index
+//! * [`TRIX`](Core::TRIX) — 1-day Rate-Of-Change (ROC) of a Triple Smooth EMA
+//! * [`ULTOSC`](Core::ULTOSC) — Ultimate Oscillator
+//! * [`WAD`](Core::WAD) — Williams' Accumulation/Distribution
+//! * [`WILLR`](Core::WILLR) — Williams' %R
+//!
+//! ## Overlap Studies (20)
+//!
+//! * [`ACCBANDS`](Core::ACCBANDS) — Acceleration Bands
+//! * [`BBANDS`](Core::BBANDS) — Bollinger Bands
+//! * [`DEMA`](Core::DEMA) — Double Exponential Moving Average
+//! * [`EMA`](Core::EMA) — Exponential Moving Average
+//! * [`HMA`](Core::HMA) — Hull Moving Average
+//! * [`HT_TRENDLINE`](Core::HT_TRENDLINE) — Hilbert Transform - Instantaneous Trendline
+//! * [`KAMA`](Core::KAMA) — Kaufman Adaptive Moving Average
+//! * [`MA`](Core::MA) — Moving average
+//! * [`MAMA`](Core::MAMA) — MESA Adaptive Moving Average
+//! * [`MAVP`](Core::MAVP) — Moving average with variable period
+//! * [`MIDPOINT`](Core::MIDPOINT) — MidPoint over period
+//! * [`MIDPRICE`](Core::MIDPRICE) — Midpoint Price over period
+//! * [`SAR`](Core::SAR) — Parabolic SAR
+//! * [`SAREXT`](Core::SAREXT) — Parabolic SAR - Extended
+//! * [`SMA`](Core::SMA) — Simple Moving Average
+//! * [`T3`](Core::T3) — Triple Exponential Moving Average (T3)
+//! * [`TEMA`](Core::TEMA) — Triple Exponential Moving Average
+//! * [`TRIMA`](Core::TRIMA) — Triangular Moving Average
+//! * [`VWMA`](Core::VWMA) — Volume Weighted Moving Average
+//! * [`WMA`](Core::WMA) — Weighted Moving Average
+//!
+//! ## Pattern Recognition (61)
+//!
+//! * [`CDL2CROWS`](Core::CDL2CROWS) — Two Crows
+//! * [`CDL3BLACKCROWS`](Core::CDL3BLACKCROWS) — Three Black Crows
+//! * [`CDL3INSIDE`](Core::CDL3INSIDE) — Three Inside Up/Down
+//! * [`CDL3LINESTRIKE`](Core::CDL3LINESTRIKE) — Three-Line Strike
+//! * [`CDL3OUTSIDE`](Core::CDL3OUTSIDE) — Three Outside Up/Down
+//! * [`CDL3STARSINSOUTH`](Core::CDL3STARSINSOUTH) — Three Stars In The South
+//! * [`CDL3WHITESOLDIERS`](Core::CDL3WHITESOLDIERS) — Three Advancing White Soldiers
+//! * [`CDLABANDONEDBABY`](Core::CDLABANDONEDBABY) — Abandoned Baby
+//! * [`CDLADVANCEBLOCK`](Core::CDLADVANCEBLOCK) — Advance Block
+//! * [`CDLBELTHOLD`](Core::CDLBELTHOLD) — Belt-hold
+//! * [`CDLBREAKAWAY`](Core::CDLBREAKAWAY) — Breakaway
+//! * [`CDLCLOSINGMARUBOZU`](Core::CDLCLOSINGMARUBOZU) — Closing Marubozu
+//! * [`CDLCONCEALBABYSWALL`](Core::CDLCONCEALBABYSWALL) — Concealing Baby Swallow
+//! * [`CDLCOUNTERATTACK`](Core::CDLCOUNTERATTACK) — Counterattack
+//! * [`CDLDARKCLOUDCOVER`](Core::CDLDARKCLOUDCOVER) — Dark Cloud Cover
+//! * [`CDLDOJI`](Core::CDLDOJI) — Doji
+//! * [`CDLDOJISTAR`](Core::CDLDOJISTAR) — Doji Star
+//! * [`CDLDRAGONFLYDOJI`](Core::CDLDRAGONFLYDOJI) — Dragonfly Doji
+//! * [`CDLENGULFING`](Core::CDLENGULFING) — Engulfing Pattern
+//! * [`CDLEVENINGDOJISTAR`](Core::CDLEVENINGDOJISTAR) — Evening Doji Star
+//! * [`CDLEVENINGSTAR`](Core::CDLEVENINGSTAR) — Evening Star
+//! * [`CDLGAPSIDESIDEWHITE`](Core::CDLGAPSIDESIDEWHITE) — Up/Down-gap side-by-side white lines
+//! * [`CDLGRAVESTONEDOJI`](Core::CDLGRAVESTONEDOJI) — Gravestone Doji
+//! * [`CDLHAMMER`](Core::CDLHAMMER) — Hammer
+//! * [`CDLHANGINGMAN`](Core::CDLHANGINGMAN) — Hanging Man
+//! * [`CDLHARAMI`](Core::CDLHARAMI) — Harami Pattern
+//! * [`CDLHARAMICROSS`](Core::CDLHARAMICROSS) — Harami Cross Pattern
+//! * [`CDLHIGHWAVE`](Core::CDLHIGHWAVE) — High-Wave Candle
+//! * [`CDLHIKKAKE`](Core::CDLHIKKAKE) — Hikkake Pattern
+//! * [`CDLHIKKAKEMOD`](Core::CDLHIKKAKEMOD) — Modified Hikkake Pattern
+//! * [`CDLHOMINGPIGEON`](Core::CDLHOMINGPIGEON) — Homing Pigeon
+//! * [`CDLIDENTICAL3CROWS`](Core::CDLIDENTICAL3CROWS) — Identical Three Crows
+//! * [`CDLINNECK`](Core::CDLINNECK) — In-Neck Pattern
+//! * [`CDLINVERTEDHAMMER`](Core::CDLINVERTEDHAMMER) — Inverted Hammer
+//! * [`CDLKICKING`](Core::CDLKICKING) — Kicking
+//! * [`CDLKICKINGBYLENGTH`](Core::CDLKICKINGBYLENGTH) — Kicking - bull/bear determined by the longer marubozu
+//! * [`CDLLADDERBOTTOM`](Core::CDLLADDERBOTTOM) — Ladder Bottom
+//! * [`CDLLONGLEGGEDDOJI`](Core::CDLLONGLEGGEDDOJI) — Long Legged Doji
+//! * [`CDLLONGLINE`](Core::CDLLONGLINE) — Long Line Candle
+//! * [`CDLMARUBOZU`](Core::CDLMARUBOZU) — Marubozu
+//! * [`CDLMATCHINGLOW`](Core::CDLMATCHINGLOW) — Matching Low
+//! * [`CDLMATHOLD`](Core::CDLMATHOLD) — Mat Hold
+//! * [`CDLMORNINGDOJISTAR`](Core::CDLMORNINGDOJISTAR) — Morning Doji Star
+//! * [`CDLMORNINGSTAR`](Core::CDLMORNINGSTAR) — Morning Star
+//! * [`CDLONNECK`](Core::CDLONNECK) — On-Neck Pattern
+//! * [`CDLPIERCING`](Core::CDLPIERCING) — Piercing Pattern
+//! * [`CDLRICKSHAWMAN`](Core::CDLRICKSHAWMAN) — Rickshaw Man
+//! * [`CDLRISEFALL3METHODS`](Core::CDLRISEFALL3METHODS) — Rising/Falling Three Methods
+//! * [`CDLSEPARATINGLINES`](Core::CDLSEPARATINGLINES) — Separating Lines
+//! * [`CDLSHOOTINGSTAR`](Core::CDLSHOOTINGSTAR) — Shooting Star
+//! * [`CDLSHORTLINE`](Core::CDLSHORTLINE) — Short Line Candle
+//! * [`CDLSPINNINGTOP`](Core::CDLSPINNINGTOP) — Spinning Top
+//! * [`CDLSTALLEDPATTERN`](Core::CDLSTALLEDPATTERN) — Stalled Pattern
+//! * [`CDLSTICKSANDWICH`](Core::CDLSTICKSANDWICH) — Stick Sandwich
+//! * [`CDLTAKURI`](Core::CDLTAKURI) — Takuri (Dragonfly Doji with very long lower shadow)
+//! * [`CDLTASUKIGAP`](Core::CDLTASUKIGAP) — Tasuki Gap
+//! * [`CDLTHRUSTING`](Core::CDLTHRUSTING) — Thrusting Pattern
+//! * [`CDLTRISTAR`](Core::CDLTRISTAR) — Tristar Pattern
+//! * [`CDLUNIQUE3RIVER`](Core::CDLUNIQUE3RIVER) — Unique 3 River
+//! * [`CDLUPSIDEGAP2CROWS`](Core::CDLUPSIDEGAP2CROWS) — Upside Gap Two Crows
+//! * [`CDLXSIDEGAP3METHODS`](Core::CDLXSIDEGAP3METHODS) — Upside/Downside Gap Three Methods
+//!
+//! ## Price Transform (5)
+//!
+//! * [`AVGDEV`](Core::AVGDEV) — Average Deviation
+//! * [`AVGPRICE`](Core::AVGPRICE) — Average Price
+//! * [`MEDPRICE`](Core::MEDPRICE) — Median Price
+//! * [`TYPPRICE`](Core::TYPPRICE) — Typical Price
+//! * [`WCLPRICE`](Core::WCLPRICE) — Weighted Close Price
+//!
+//! ## Statistic Functions (9)
+//!
+//! * [`BETA`](Core::BETA) — Beta
+//! * [`CORREL`](Core::CORREL) — Pearson's Correlation Coefficient (r)
+//! * [`LINEARREG`](Core::LINEARREG) — Linear Regression
+//! * [`LINEARREG_ANGLE`](Core::LINEARREG_ANGLE) — Linear Regression Angle
+//! * [`LINEARREG_INTERCEPT`](Core::LINEARREG_INTERCEPT) — Linear Regression Intercept
+//! * [`LINEARREG_SLOPE`](Core::LINEARREG_SLOPE) — Linear Regression Slope
+//! * [`STDDEV`](Core::STDDEV) — Standard Deviation
+//! * [`TSF`](Core::TSF) — Time Series Forecast
+//! * [`VAR`](Core::VAR) — Variance
+//!
+//! ## Volatility Indicators (3)
+//!
+//! * [`ATR`](Core::ATR) — Average True Range
+//! * [`NATR`](Core::NATR) — Normalized Average True Range
+//! * [`TRANGE`](Core::TRANGE) — True Range
+//!
+//! ## Volume Indicators (10)
+//!
+//! * [`AD`](Core::AD) — Chaikin A/D Line
+//! * [`ADOSC`](Core::ADOSC) — Chaikin A/D Oscillator
+//! * [`CMF`](Core::CMF) — Chaikin Money Flow
+//! * [`EFI`](Core::EFI) — Elder's Force Index
+//! * [`MARKETFI`](Core::MARKETFI) — Market Facilitation Index
+//! * [`NVI`](Core::NVI) — Negative Volume Index
+//! * [`OBV`](Core::OBV) — On Balance Volume
+//! * [`PVI`](Core::PVI) — Positive Volume Index
+//! * [`PVO`](Core::PVO) — Percentage Volume Oscillator
+//! * [`VWAP`](Core::VWAP) — Volume Weighted Average Price
 
 #![forbid(unsafe_code)]
 // Every public item, and every public enum variant and struct field, carries its


### PR DESCRIPTION
D6: "1020 methods on one `Core` with no category index, prelude, or grouping. `abstract_api::Group` already encodes the grouping at runtime but is not surfaced as docs. 'How do I find the candlestick ones?' works only by alphabetical accident."

The alphabetical accident is real but partial. The 61 recognizers do all start with `CDL`, and nothing else does — so that one question happens to have an answer. It buys nothing for the other nine groups: `AD`, `ADOSC`, `CMF`, `EFI`, `MARKETFI`, `NVI`, `OBV`, `PVI`, `PVO` and `VWAP` are the volume studies, and their names say so only to a reader who already knows.

## What this adds

`rust_doc::category_index` renders the grouping as `//!` lines that the `lib.rs` scaffolding substitutes into the crate docs: one `##` heading per group with its member count, and under it one line per function — a link to that function's own page, then that row's `hint`.

```
//! ## Volume Indicators (10)
//!
//! * [`AD`](Core::AD) — Chaikin A/D Line
//! * [`ADOSC`](Core::ADOSC) — Chaikin A/D Oscillator
...
```

Groups come out in the order `Group::ALL` declares them: a `BTreeMap` over the display strings, which is the same order, so the front page and the registry enumerate categories identically.

Two fields, both straight off the definition — the `name` that is also the method's name, and the `hint` that becomes `FuncInfo::hint` and the `FuncId` variant's own doc line. No third source, so the index cannot say something about a function that the registry does not. That includes the empty-hint case: the registry stores `""`, and the index writes the link alone rather than falling back to `description` and reading differently from every other surface. No shipped function has an empty hint today; the rule is there so that adding one cannot make the two disagree.

## What gates it, and what did not

**rustdoc, already.** `[`SMA`](Core::SMA)` naming a method that does not exist is `rustdoc::broken_intra_doc_links`, and the nightly's clippy job runs `cargo doc` under `RUSTDOCFLAGS=-D warnings`. Control, watched: rewriting one entry to `Core::SMAX` fails that step —

```
error: unresolved link to `Core::SMAX`
   --> library/src/lib.rs:179:15
    | //! * [`SMA`](Core::SMAX) — Simple Moving Average
    |               ^^^^^^^^^^ the struct `Core` has no field or associated item named `SMAX`
    = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
```

**Nothing gated an omission**, and that is why the builder lives in `rust_doc` rather than inline in `main.rs`: there it is reachable from the test suite. A filter that quietly drops a function leaves a page that still builds clean and simply never mentions it. `rust_category_index_lists_every_function_once` walks the corpus and requires each name exactly once, no entry beyond the corpus, and each heading's count equal to the bullets under it. Both halves watched red:

| sabotage | result |
|---|---|
| builder skips `Pattern Recognition` | `CDL2CROWS must appear exactly once in the category index` |
| heading count `members.len() + 1` | `Cycle Indicators says 6 but lists 5` |

## The cost

The front page grows: **108,739 → 137,217 bytes** of rendered HTML (+26%), 215 lines of `//!` in a generated file. That is the whole of it, and it is the maintainer's call whether a longer front page is worth a category index; nothing is special-cased to hide it.

Doc **build time** is not part of the cost, and I am not claiming it is cheaper either: three warm `cargo doc --no-deps` runs each way gave 2.88 / 3.04 / 2.91 s before and 2.82 / 2.90 / 2.91 s after. The ranges overlap — the numbers do not discriminate.

## Deliberately not done here

Each is a decision rather than a rendering, so each is yours:

* **The `prelude` D6 also asks for.** A public re-export set is API surface, not docs, and it freezes before the first publish.
* **The same index in `README.md`.** `Core::SMA` links resolve in rustdoc and nowhere else, so crates.io and GitHub would render 176 dead spans.
* **A group label on each `FuncId` variant.** The row knows its group; whether the variant doc should repeat it is a taste call about a page that is already 176 lines long.

## Verification

Run here:

* generator `cargo test --no-fail-fast` — green; `backend_suite` 311, one of them new.
* `cargo clippy --all-targets -- -D warnings` — clean on the generator and on the generated crate.
* `cargo doc --no-deps -p ta-lib` under `RUSTDOCFLAGS=-D warnings` — clean.
* the crate's 534 doctests, and its `--tests` suites — green.
* `generate` leaves the tree clean apart from this diff: no C, Java or C# file moves.

NOT run here: `ta_regtest` and the cross-language servers. Nothing this touches is compiled into one — the diff is a doc comment and the code that writes it.
