### PR TITLE
ci(gate): the PR gate never ran the generated crate's own tests (#211 follow-up)

### DIFF
--- a/.github/workflows/pr-codegen-gate.yml
+++ b/.github/workflows/pr-codegen-gate.yml
@@ -121,3 +121,31 @@ jobs:
             echo "::error::Clippy failed on the generated crate. Its scaffolding emits a crate-level #![allow(clippy::all, clippy::pedantic)], so a failure here is the emitter's, not the emitted code's — fix the backend, never the generated file."
             exit 1
           fi
+
+      # The crate's hand-written test modules (templates/rust/, copied in by
+      # `generate`) plus the generated registry's own sweeps: 85 tests today,
+      # over types.rs's Core/CoreBuilder API (#144), scratch_election (#146),
+      # stream_finite, stream_out_range (#241), div_zero (#249),
+      # no_phantom_io (#265), tests/nullable_outputs.rs (#262),
+      # tests/stream_open_contract.rs, and abstract_api's registry/binder
+      # sweeps — the by-name ASCII fold from #278 among them.
+      #
+      # Nothing in this gate executed any of them. `clippy --all-targets` above
+      # only COMPILES the test target, and `cargo test --doc` in the other job
+      # skips it, so until now the only thing that ran them was the 5AM dev
+      # nightly — after merge, the one-branch-too-late this file exists to fix
+      # (#211).
+      #
+      # `--tests`, not `--lib`: the latter excludes tests/, and it selects the
+      # lib's own unittest binary as well. Same argument the nightly records.
+      #
+      # It is in THIS job, not next to the doctests, for the reason clippy is:
+      # the job finishes far inside regen-check's wall-clock, so the step costs
+      # the PR nothing it was not already waiting on.
+      - name: Run the generated crate's unit and integration tests
+        shell: bash
+        run: |
+          if ! cargo test --tests -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml; then
+            echo "::error::A test in the generated crate failed. These are the crate's own modules, not the cross-language value gates — a failure here is a contract the emitted code no longer keeps (registry lookup, stream range, div-zero, phantom I/O, Core/CoreBuilder). Reproduce with the same command on the pinned toolchain; fix the backend, never the generated file."
+            exit 1
+          fi


### PR DESCRIPTION
The PR Codegen Gate runs five things today: `regen-check`, the crate's doctests,
the generator's own suite, and clippy on both crates. None of them **executes**
the generated crate's test modules. `clippy --all-targets` only *compiles* the
test target, and `cargo test --doc` skips it — so the only thing anywhere that
runs them is the 5AM dev nightly, after merge. That is the one-branch-too-late
this file was created to fix (#211), and the nightly's own comment on that step
already says it is the only place they run.

This adds one step to the existing `clippy` job.

## What was unguarded on a PR

85 tests, in two groups:

- The hand-written modules copied in from `templates/rust/` by `generate` —
  `types.rs`'s Core/CoreBuilder API (#144), `scratch_election` (#146),
  `stream_finite`, `stream_out_range` (#241), `div_zero` (#249),
  `no_phantom_io` (#265), `tests/nullable_outputs.rs` (#262), and
  `tests/stream_open_contract.rs`.
- The generated registry's own sweeps in `abstract_api.rs` —
  `registry_tests` (10) and `binder_tests` (8). The by-name ASCII fold that
  landed as #280 is in there, so today a PR can delete the Rust
  half of that gate's *subject* and this file stays green.

## The gap is real, and I measured it rather than asserting it

Control: I patched the Rust abstract backend
(`backends/rust_abstract.rs:272`) so `get_func_handle` emits
`f.name == name` instead of `f.name.eq_ignore_ascii_case(name)` — the exact
regression #280 exists to prevent — regenerated every backend, and ran every
step of this gate against that tree.

| Gate step | Broken tree | Clean tree |
|---|---|---|
| regen-check (full `generate`, tree matches input) | **green** | green |
| `cargo test --doc -p ta-lib` | **green** — exit 0 | green |
| `cargo test` (generator suite) | **green** — exit 0 | green |
| `cargo clippy --all-targets` (generator) | **green** — exit 0 | green |
| `cargo clippy --all-targets` (generated crate) | **green** — exit 0 | green |
| `cargo doc --no-deps` with `-D warnings` (the step in #290) | **green** — exit 0 | green |
| **`cargo test --tests -p ta-lib`** (this PR) | **red** — exit 101, `registry_tests::lookup_is_ascii_case_insensitive`, `left: None, right: Some(AC)` | green — 72 + 6 + 7 pass |

So the discriminating claim is not just that the new step goes red; it is that
the gate as it stands today ships that tree green, every step of it. I broke it
and watched each row land where the table says.

On regen-check specifically: I could not run `scripts/build.py regen-check`
directly — this environment runs as root and the script refuses that — so I ran
the equivalent by hand: a full `cargo run -- generate` across all backends, then
`git status`, which showed exactly the two files I had edited (the backend and
its own output) and nothing else. A tree carrying that sabotage as a commit
regenerates clean, which is all regen-check asserts.

## Cost

Measured locally, on the pinned 1.97.0 toolchain, from an empty
`CARGO_TARGET_DIR` each time:

| | wall clock |
|---|---|
| the step alone, cold | 22.2 s |
| the step after the two clippy runs in this job (the real sequence) | **23.6 s** |
| the `clippy` job as it stands today (both clippy steps, cold) | 42.7 s |
| the step, warm | 0.5 s |

Clippy artifacts are not reusable for a real build, so the step recompiles the
crate — that is the 23.6 s, not a cache miss to tune away. It takes the job from
~43 s to ~67 s, against `regen-check`'s ~3m28s–4m31s on recent runs of this
gate, so the PR waits on nothing new. That is the same argument `24299e8d7`
made for putting clippy here, and the same one #290 makes for rustdoc.

**I did not measure this on a GitHub runner** — every number above is local. A
cold runner is slower; the headroom is minutes, so I expect it to hold, but I
have not proven it.

The alternative placement, next to the doctests in `regen-check`, is cheaper in
CPU (17.3 s there, because that job has already built the lib once) but that job
*is* the critical path, so those 17.3 s would be PR wall-clock. I chose the job
with slack. Say the word if you would rather have the two `cargo test` steps
adjacent.

## What this does not do

It does not retire the nightly's step, and nothing here should: most commits
reach `dev` as direct pushes that `on: pull_request` never sees. Same reasoning
the file already records for clippy and the doctests.

## Two things that are your call

- **The job's display name is still `Rust clippy`** and it now runs clippy and
  the crate's tests — the nightly's equivalent job is called
  `Rust clippy + generator tests`. I did not rename it, for the reason #290
  gives: if the name is pinned as a required status check, a rename silently
  detaches the requirement. I cannot see the branch-protection config. #290
  raises the same question, so one rename should settle both.
- **This will conflict with #290 if that merges first.** Both append a step to
  the end of the same job. The resolution is to keep both steps in either
  order; I will rebase on request, or you can take them in whichever order you
  merge.

## Verification

On the clean tree, on the pinned toolchain, the exact command the step runs:

```
cargo test --tests -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
```

exits 0 — 72 unit, 6 `nullable_outputs`, 7 `stream_open_contract`. The workflow
parses (`yaml.safe_load`), and the `::error::` line was run through bash to
confirm it emits literally.

The branch is one commit and touches one file:
`.github/workflows/pr-codegen-gate.yml`, +28 lines, no deletions.
