### PR TITLE
test(rust): every integer-output example states its output's domain (#179 E8)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_doc.rs
+++ b/ta_codegen/generator/src/backends/rust_doc.rs
@@ -541,9 +541,12 @@ fn example_doctest(
     // Optional parameters at their documented defaults. An `enum:` parameter is
     // named, not numbered -- the example is the first thing a reader copies, and
     // a bare `1` there would not even compile now that the parameter is typed.
-    for opt in &func.optional_inputs {
-        args.push(example_opt_literal(opt, enums));
-    }
+    let opt_args: Vec<String> = func
+        .optional_inputs
+        .iter()
+        .map(|opt| example_opt_literal(opt, enums))
+        .collect();
+    args.extend(opt_args.iter().cloned());
 
     lines.push(String::new());
     lines.push("let core = Core::new();".to_string());
@@ -594,10 +597,122 @@ fn example_doctest(
             "assert!({var}[..out_range.count].iter().all(|v| v.is_finite()));"
         ));
     }
+    // An integer output has no finiteness to check, which is why the 61
+    // candlestick examples and the four other integer-output examples asserted
+    // nothing beyond `count > 0` (#179 E8, deferred from #136). Two things about
+    // such a call are checkable without re-implementing the indicator, and both
+    // are checked: that it wrote through the end of the history, and the domain
+    // of the values it wrote.
+    //
+    // Not `beg_idx == <N>_Lookback(..)`: the body of a candlestick takes its own
+    // `lookbackTotal` from that very call, so the equality holds by construction
+    // and cannot fail. It was in this example until a control -- CDLDOJI's
+    // `_Lookback` returning `avgPeriod + 1` -- left the doctest green.
+    if func
+        .outputs
+        .iter()
+        .any(|o| o.param_type == ParamType::Integer)
+    {
+        lines.push(format!(
+            "assert_eq!(out_range.beg_idx + out_range.count, {first}.len());"
+        ));
+        let period = func
+            .optional_inputs
+            .iter()
+            .position(|o| o.name == "optInTimePeriod")
+            .map(|i| opt_args[i].clone());
+        for output in &func.outputs {
+            if output.param_type == ParamType::Integer {
+                let var = output_var_name(output);
+                lines.extend(integer_domain_claim(
+                    func,
+                    output,
+                    &var,
+                    &first,
+                    period.as_deref(),
+                ));
+            }
+        }
+    }
     // Lets the example above use `?`; hidden from the rendered docs.
     lines.push("# Ok::<(), ta_lib::RetCode>(())".to_string());
     lines.push("```".to_string());
     Some(lines)
+}
+
+/// The claim a generated example makes about the values of one integer output.
+///
+/// The domain is a property of the individual function, and the metadata does not
+/// carry it: all 66 integer outputs in the corpus declare the same `line` output
+/// flag, which says how to plot the values and nothing about what they are. So the
+/// four shapes are spelled out here — the same way [`unit_domain`] names the three
+/// functions whose example input has to live in `[-1, 1]`.
+///
+/// An integer output with no entry here renders no claim, which is the gap #179
+/// E8 records — so `every_integer_output_carries_an_example_claim` sweeps the
+/// shipped corpus and goes red on one. The gate is a test rather than a panic
+/// here because `input_synth/`'s fixtures carry an integer output too, and a
+/// fixture's example ships nowhere.
+fn integer_domain_claim(
+    func: &FuncDef,
+    output: &Output,
+    var: &str,
+    series: &str,
+    period: Option<&str>,
+) -> Vec<String> {
+    match (func.name.to_uppercase().as_str(), output.name.as_str()) {
+        ("MAXINDEX", _) | ("MINMAXINDEX", "outMaxIdx") => {
+            window_extremum_claim(var, series, period, true)
+        }
+        ("MININDEX", _) | ("MINMAXINDEX", "outMinIdx") => {
+            window_extremum_claim(var, series, period, false)
+        }
+        // ta_HT_TRENDMODE.c writes its `trend` local, which is only ever 0 or 1.
+        ("HT_TRENDMODE", _) => vec![
+            "// the mode is a flag: 1 in a trend, 0 in a cycle".to_string(),
+            format!("assert!({var}[..out_range.count].iter().all(|&v| v == 0 || v == 1));"),
+        ],
+        // Every candlestick pattern: 0, or +-80/+-100 for a pattern, or +-200 for
+        // one the next bar confirmed (CDLHIKKAKE, CDLHIKKAKEMOD). The bound is the
+        // one `TA_OUT_PATTERN_STRENGTH` already publishes to a metadata consumer.
+        _ if func.flags.iter().any(|f| f == "candlestick") => vec![
+            "// a candlestick pattern reports 0 where it does not fire, and a signed".to_string(),
+            "// strength -- negative bearish, positive bullish -- where it does".to_string(),
+            format!("assert!({var}[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));"),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+/// An index output names a bar; the claim re-derives which bar it should be.
+///
+/// This is the one integer domain worth checking by re-computation rather than by
+/// bound: the value is an index into the input, so the example can look up what it
+/// points at and confirm it is the window's extremum. It is also the shape a reader
+/// most needs shown — that the index is absolute, into the whole input, not relative
+/// to the window.
+fn window_extremum_claim(
+    var: &str,
+    series: &str,
+    period: Option<&str>,
+    is_max: bool,
+) -> Vec<String> {
+    let period = period.expect("an index function carries optInTimePeriod");
+    let (cmp, word) = if is_max {
+        ("<=", "highest")
+    } else {
+        (">=", "lowest")
+    };
+    vec![
+        format!("// every reported index locates the {word} value of its {period}-bar window"),
+        format!("for (k, &idx) in {var}[..out_range.count].iter().enumerate() {{"),
+        "    let (bar, idx) = (out_range.beg_idx + k, idx as usize);".to_string(),
+        format!("    assert!(bar + 1 - {period} <= idx && idx <= bar);"),
+        format!(
+            "    assert!({series}[bar + 1 - {period}..=bar].iter().all(|&v| v {cmp} {series}[idx]));"
+        ),
+        "}".to_string(),
+    ]
 }
 
 /// `let <name>: Vec<f64> = (0..252).map(|i| <expr>).collect();`

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -4895,6 +4895,57 @@ fn rust_public_entry_documents_exactly_its_parameters() {
 }
 
 #[test]
+fn every_integer_output_carries_an_example_claim() {
+    // The generated example checks a real output for finiteness. An integer output
+    // has nothing analogous, so 65 of them -- 61 candlestick patterns, HT_TRENDMODE
+    // and the three index functions -- asserted nothing about their values at all
+    // (#179 E8, deferred from #136). The domain is per-function data and lives in
+    // `rust_doc::integer_domain_claim`; nothing in the metadata carries it, since
+    // all 66 integer outputs declare the same `line` flag. This is the gate that a
+    // function arriving with an integer output states its domain instead of
+    // silently rejoining that set.
+    let registry = make_registry();
+    let helpers = make_helpers();
+    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../ta_codegen/input");
+    let mut checked = 0usize;
+    for entry in std::fs::read_dir(&base).expect("input dir") {
+        let entry = entry.expect("dir entry");
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let dir = entry.path();
+        if !dir.join(format!("{name}.c")).is_file() || !dir.join(format!("{name}.yaml")).is_file() {
+            continue;
+        }
+        let (func, enums) = load_indicator(&name);
+        let ints = func
+            .outputs
+            .iter()
+            .filter(|o| o.param_type == ir::ParamType::Integer)
+            .count();
+        if ints == 0 {
+            continue;
+        }
+        let out = backends::rust_lang::generate(&func, &enums, &registry, &helpers);
+        // One claim per integer output. Both shapes -- the `all(..)` domain test and
+        // the index loop -- read the written values as `<var>[..out_range.count]`,
+        // and nothing else in the example does.
+        let claims = out.matches("[..out_range.count]").count();
+        assert!(
+            claims >= ints,
+            "{name}: {ints} integer output(s) but {claims} example claim(s) -- add the \
+             output's domain to rust_doc::integer_domain_claim"
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked, 65,
+        "expected the 65 integer-output functions, swept {checked}"
+    );
+}
+
+#[test]
 fn rust_cross_indicator_vec_input_gets_ref() {
     // Indicators that allocate a local buffer (Vec) and pass it to a cross-indicator
     // call should render the Vec as `&name` in input position. (MACD was the original

--- a/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
@@ -284,6 +284,10 @@ impl Core {
     ///
     /// let out_range = core.CDL2CROWS(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
@@ -327,6 +327,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
@@ -349,6 +349,10 @@ impl Core {
     ///
     /// let out_range = core.CDL3INSIDE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
@@ -313,6 +313,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
@@ -208,6 +208,10 @@ impl Core {
     ///
     /// let out_range = core.CDL3OUTSIDE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
@@ -524,6 +524,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
@@ -581,6 +581,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -485,6 +485,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
@@ -668,6 +668,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
@@ -347,6 +347,10 @@ impl Core {
     ///
     /// let out_range = core.CDLBELTHOLD(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
@@ -282,6 +282,10 @@ impl Core {
     ///
     /// let out_range = core.CDLBREAKAWAY(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
@@ -346,6 +346,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
@@ -331,6 +331,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
@@ -371,6 +371,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -309,6 +309,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
@@ -266,6 +266,10 @@ impl Core {
     ///
     /// let out_range = core.CDLDOJI(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
@@ -354,6 +354,10 @@ impl Core {
     ///
     /// let out_range = core.CDLDOJISTAR(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
@@ -351,6 +351,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
@@ -217,6 +217,10 @@ impl Core {
     ///
     /// let out_range = core.CDLENGULFING(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -445,6 +445,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -427,6 +427,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
@@ -356,6 +356,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
@@ -350,6 +350,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
@@ -482,6 +482,10 @@ impl Core {
     ///
     /// let out_range = core.CDLHAMMER(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
@@ -484,6 +484,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
@@ -366,6 +366,10 @@ impl Core {
     ///
     /// let out_range = core.CDLHARAMI(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
@@ -368,6 +368,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
@@ -344,6 +344,10 @@ impl Core {
     ///
     /// let out_range = core.CDLHIGHWAVE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
@@ -257,6 +257,10 @@ impl Core {
     ///
     /// let out_range = core.CDLHIKKAKE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
@@ -368,6 +368,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
@@ -355,6 +355,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
@@ -420,6 +420,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
@@ -352,6 +352,10 @@ impl Core {
     ///
     /// let out_range = core.CDLINNECK(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
@@ -416,6 +416,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
@@ -387,6 +387,10 @@ impl Core {
     ///
     /// let out_range = core.CDLKICKING(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
@@ -385,6 +385,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
@@ -290,6 +290,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
@@ -348,6 +348,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
@@ -330,6 +330,10 @@ impl Core {
     ///
     /// let out_range = core.CDLLONGLINE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
@@ -341,6 +341,10 @@ impl Core {
     ///
     /// let out_range = core.CDLMARUBOZU(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
@@ -283,6 +283,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -436,6 +436,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -486,6 +486,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -469,6 +469,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
@@ -351,6 +351,10 @@ impl Core {
     ///
     /// let out_range = core.CDLONNECK(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
@@ -334,6 +334,10 @@ impl Core {
     ///
     /// let out_range = core.CDLPIERCING(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
@@ -413,6 +413,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
@@ -458,6 +458,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
@@ -418,6 +418,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
@@ -415,6 +415,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
@@ -340,6 +340,10 @@ impl Core {
     ///
     /// let out_range = core.CDLSHORTLINE(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
@@ -270,6 +270,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
@@ -540,6 +540,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
@@ -282,6 +282,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
@@ -403,6 +403,10 @@ impl Core {
     ///
     /// let out_range = core.CDLTAKURI(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
@@ -291,6 +291,10 @@ impl Core {
     ///
     /// let out_range = core.CDLTASUKIGAP(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
@@ -386,6 +386,10 @@ impl Core {
     ///
     /// let out_range = core.CDLTHRUSTING(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
@@ -285,6 +285,10 @@ impl Core {
     ///
     /// let out_range = core.CDLTRISTAR(0, open.len() - 1, &open, &high, &low, &close, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
@@ -353,6 +353,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
@@ -356,6 +356,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
@@ -217,6 +217,10 @@ impl Core {
     ///     &mut out,
     /// )?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, open.len());
+    /// // a candlestick pattern reports 0 where it does not fire, and a signed
+    /// // strength -- negative bearish, positive bullish -- where it does
+    /// assert!(out[..out_range.count].iter().all(|&v| (-200..=200).contains(&v)));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -649,6 +649,9 @@ impl Core {
     ///
     /// let out_range = core.HT_TRENDMODE(0, data.len() - 1, &data, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, data.len());
+    /// // the mode is a flag: 1 in a trend, 0 in a cycle
+    /// assert!(out[..out_range.count].iter().all(|&v| v == 0 || v == 1));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -227,6 +227,13 @@ impl Core {
     ///
     /// let out_range = core.MAXINDEX(0, data.len() - 1, &data, 30, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, data.len());
+    /// // every reported index locates the highest value of its 30-bar window
+    /// for (k, &idx) in out[..out_range.count].iter().enumerate() {
+    ///     let (bar, idx) = (out_range.beg_idx + k, idx as usize);
+    ///     assert!(bar + 1 - 30 <= idx && idx <= bar);
+    ///     assert!(data[bar + 1 - 30..=bar].iter().all(|&v| v <= data[idx]));
+    /// }
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -227,6 +227,13 @@ impl Core {
     ///
     /// let out_range = core.MININDEX(0, data.len() - 1, &data, 30, &mut out)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, data.len());
+    /// // every reported index locates the lowest value of its 30-bar window
+    /// for (k, &idx) in out[..out_range.count].iter().enumerate() {
+    ///     let (bar, idx) = (out_range.beg_idx + k, idx as usize);
+    ///     assert!(bar + 1 - 30 <= idx && idx <= bar);
+    ///     assert!(data[bar + 1 - 30..=bar].iter().all(|&v| v >= data[idx]));
+    /// }
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -255,6 +255,19 @@ impl Core {
     ///
     /// let out_range = core.MINMAXINDEX(0, data.len() - 1, &data, 30, &mut min_idx, &mut max_idx)?;
     /// assert!(out_range.count > 0);
+    /// assert_eq!(out_range.beg_idx + out_range.count, data.len());
+    /// // every reported index locates the lowest value of its 30-bar window
+    /// for (k, &idx) in min_idx[..out_range.count].iter().enumerate() {
+    ///     let (bar, idx) = (out_range.beg_idx + k, idx as usize);
+    ///     assert!(bar + 1 - 30 <= idx && idx <= bar);
+    ///     assert!(data[bar + 1 - 30..=bar].iter().all(|&v| v >= data[idx]));
+    /// }
+    /// // every reported index locates the highest value of its 30-bar window
+    /// for (k, &idx) in max_idx[..out_range.count].iter().enumerate() {
+    ///     let (bar, idx) = (out_range.beg_idx + k, idx as usize);
+    ///     assert!(bar + 1 - 30 <= idx && idx <= bar);
+    ///     assert!(data[bar + 1 - 30..=bar].iter().all(|&v| v <= data[idx]));
+    /// }
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
     ///


### PR DESCRIPTION
The generated example checks a real output for finiteness — a successful call
never emits NaN or infinity. An integer output has nothing analogous, so 65 of
them asserted nothing about their values at all: the 61 candlestick patterns,
`HT_TRENDMODE`, and the three index functions (`MAXINDEX`, `MININDEX`,
`MINMAXINDEX`, whose two outputs make 66 integer outputs in all). #179 E8 records
this, deferred from #136.

Two things about such a call are checkable without re-implementing the indicator,
and the example now checks both.

**The range it wrote.** `assert_eq!(out_range.beg_idx + out_range.count,
close.len())` — the call produced values through the end of the history.

**The domain of the values it wrote**, in four shapes:

| | claim |
|---|---|
| 61 candlestick patterns | `(-200..=200).contains(&v)` — 0 where the pattern does not fire, a signed strength where it does |
| `HT_TRENDMODE` | `v == 0 \|\| v == 1` — the mode is a flag |
| `MAXINDEX`, `MINMAXINDEX::outMaxIdx` | the index locates the highest value of its 30-bar window |
| `MININDEX`, `MINMAXINDEX::outMinIdx` | the index locates the lowest value of its 30-bar window |

An index output is the one worth checking by re-computation rather than by bound:
the example looks up what the index points at and confirms it is the window's
extremum. That is also the shape a reader most needs shown — the index is
absolute, into the whole input, not relative to the window.

```rust
let out_range = core.MAXINDEX(0, data.len() - 1, &data, 30, &mut out)?;
assert!(out_range.count > 0);
assert_eq!(out_range.beg_idx + out_range.count, data.len());
// every reported index locates the highest value of its 30-bar window
for (k, &idx) in out[..out_range.count].iter().enumerate() {
    let (bar, idx) = (out_range.beg_idx + k, idx as usize);
    assert!(bar + 1 - 30 <= idx && idx <= bar);
    assert!(data[bar + 1 - 30..=bar].iter().all(|&v| v <= data[idx]));
}
```

The domain is per-function data and the metadata does not carry it: all 66
integer outputs declare the same `line` output flag, which says how to plot the
values and nothing about what they are. So the four shapes are spelled in
`rust_doc::integer_domain_claim`, beside the `unit_domain` list that already
names the three functions whose example input has to live in `[-1, 1]`.
`every_integer_output_carries_an_example_claim` sweeps the corpus, so a function
arriving with an integer output states its domain instead of silently rejoining
that set. (A `generate`-time failure was the first shape of that gate; it fires
on `input_synth/`'s fixtures too, whose examples ship nowhere, so it is a test.)

## One claim was written, then removed

`assert_eq!(out_range.beg_idx, core.CDLDOJI_Lookback()?)` was in this example
until its control ran: with `CDLDOJI_Lookback` returning `avgPeriod + 1`, the
doctest stayed **green**. Every candlestick body takes its own `lookbackTotal`
from that very call (`lookbackTotal = self.CDLDOJI_Lookback()`), so the equality
holds by construction and cannot fail. It is gone, and the reason is a comment in
the emitter so it does not come back.

## Controls

Each sabotage was applied to the generated Rust, the one doctest run, then
reverted. All red:

| # | sabotage | claim it must trip |
|---|---|---|
| A | `MAXINDEX` batch loop `while today <= endIdx` → `<` | wrote through end of history |
| B | `MAXINDEX` reports `trailingIdx`, not `highestIdx` | window extremum |
| C | `MININDEX` reports `trailingIdx`, not `lowestIdx` | window extremum |
| D | `CDLDOJI` emits `300` where it emits `100` | pattern domain, on a pattern that fires |
| E | `CDL3BLACKCROWS` emits `300` where it emits `0` | pattern domain, on one that never fires here |
| F | `HT_TRENDMODE` writes `trend + 1` | flag domain |
| G | `MINMAXINDEX` max leg reports `trailingIdx` | window extremum |
| H | `HT_TRENDMODE`'s arm removed from the claim table | the corpus gate — `1 integer output(s) but 0 example claim(s)` |

## What this does not catch, and the number behind it

On the example series the candlestick examples share, **16 of the 61 patterns
emit a non-zero value anywhere; 45 emit all zeros** (measured with a throwaway
integration test over the abstract API, on the exact series the examples build;
observed value set across all 61: `{-100, 0, 100}`). For those 45 the domain
assertion is satisfied by the zeros: control E shows it still catches a wrong
constant, but nothing here can catch a pattern that stopped firing, or one that
fires where it should not. The range claim discriminates for all 65.

Making most patterns fire means a candlestick-specific example series, which is a
larger change than this one and touches the series that `AD`/`ADOSC`/`CMF` depend
on (the second harmonic on `close`, #136). Worth doing or worth declining — your
call, not something to slip in here.

## Verified

- `cargo test --doc -p ta-lib` — 534 passed, 0 failed
- `cargo test --tests -p ta-lib` — green
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ta-lib` — clean
- `cargo clippy --all-targets -p ta-lib` — clean
- generator: `cargo test` (17 suites, all ok) and `cargo clippy --all-targets -- -D warnings` — clean
- full `generate`, then `git status`: the 65 Rust files and the two generator
  files, nothing else. C, Java, C#, `ta_func_api.xml` and the website are
  byte-unchanged.

**I did not build or run the C library, `ta_regtest`, or `--xlang-hash`.** No
generated C, Java or C# file moved, so there is nothing there for them to see. I
did not run the dev-nightly.

Cost: +443 lines of generated rustdoc, 6–13 per file.
