### PR TITLE
test(codegen): a produced count of zero was the one answer the cross-language leg never compared

### DIFF
--- a/src/tools/ta_regtest/test_codegen.c
+++ b/src/tools/ta_regtest/test_codegen.c
@@ -203,6 +203,27 @@ static long g_startSweepWithOutput[NUM_LANGUAGES];
  * ref_diverges_on_partial_range). Printed, so the carve-out cannot quietly grow
  * to swallow the axis. */
 static long g_startSweepSkipped98 = 0;
+
+/* ---- zero-produced-count comparisons ----
+ * Calls where C answered TA_SUCCESS with outNBElement == 0 and the server's own
+ * count was compared against it. Per LANGUAGE, for the reason the two counter
+ * blocks above give: one server dropping out of the check is invisible in a
+ * total the others keep non-zero.
+ *
+ * These are the calls the sibling counters deliberately do NOT count as
+ * coverage — no output element is diffed, so as evidence about VALUES they are
+ * vacuous. That is a statement about values, and it was read as a statement
+ * about the whole response: the count comparison was skipped along with them.
+ * It is cheap and it is not vacuous, because the two sides can disagree.
+ *
+ * What is still NOT compared at a zero count is outBegIdx. C's early returns
+ * write 0 into it, but that is the C library's habit rather than a documented
+ * contract, and the four backends were never held to it; asserting it here
+ * would be a new cross-backend requirement rather than the closing of a hole,
+ * so it stays a separate question. Named rather than left implicit — an
+ * unstated omission here is what this counter exists to prevent. */
+static long g_zeroCountCompared[NUM_LANGUAGES];
+
 /* ---- Return-code census (#236 step 4) ----
  * The retCode of every value-comparison call and every index-range case,
  * counted per LANGUAGE and per code. NOT every code on the wire: the unstable
@@ -1169,9 +1190,42 @@ static void compare_codegen_output_generic(
     if( p->lastRetCode != TA_SUCCESS )
         return;
 
-    /* If C produced no output, skip comparison */
-    if( p->lastNbElement == 0 )
+    /* Compare outNBElement.
+     *
+     * BEFORE the zero-output return below, not after it. The produced count is
+     * a claim the server makes whatever its value, and at C's zero it was the
+     * one claim nothing checked: the early return skipped this compare along
+     * with the value diff, so a server answering "success, 3 elements" where C
+     * answered "success, 0" read as agreement. The other direction — C
+     * produces, the server does not — always failed here, so the leg was
+     * one-sided rather than absent, which is why a green run said nothing
+     * about it.
+     *
+     * That is not a corner of the corpus. Every range short of the lookback
+     * lands here, which is most of what the startIdx axis sends (its own
+     * counters split `compared` from `withOutput` for exactly this reason),
+     * and a produced count is precisely what an off-by-one in a backend's
+     * lookback arithmetic gets wrong at the boundary where output begins. */
+    int cg_nbElement = json_get_int(p->responseBuf, "outNBElement");
+    if( p->lastNbElement != cg_nbElement )
+    {
+        printf("CODEGEN MISMATCH [TA_%s]: outNBElement C=%d codegen=%d\n",
+               p->funcInfo->name, (int)p->lastNbElement, cg_nbElement);
+        p->codegenError = TA_CODEGEN_NBELEMENT_MISMATCH;
         return;
+    }
+
+    /* Both sides produced nothing: the counts agreed just above, and there is
+     * no element to diff. outBegIdx is deliberately NOT compared here — see
+     * the counter's comment at the top of this file for what that leaves open
+     * and why it is a separate question. Counted per language and per output
+     * so the check above cannot go quiet unnoticed. */
+    if( p->lastNbElement == 0 )
+    {
+        if( p->langIndex >= 0 && p->langIndex < (int)NUM_LANGUAGES )
+            g_zeroCountCompared[p->langIndex]++;
+        return;
+    }
 
     /* Compare outBegIdx */
     int cg_begIdx = json_get_int(p->responseBuf, "outBegIdx");
@@ -1180,16 +1234,6 @@ static void compare_codegen_output_generic(
         printf("CODEGEN MISMATCH [TA_%s]: outBegIdx C=%d codegen=%d\n",
                p->funcInfo->name, (int)p->lastBegIdx, cg_begIdx);
         p->codegenError = TA_CODEGEN_BEGIDX_MISMATCH;
-        return;
-    }
-
-    /* Compare outNBElement */
-    int cg_nbElement = json_get_int(p->responseBuf, "outNBElement");
-    if( p->lastNbElement != cg_nbElement )
-    {
-        printf("CODEGEN MISMATCH [TA_%s]: outNBElement C=%d codegen=%d\n",
-               p->funcInfo->name, (int)p->lastNbElement, cg_nbElement);
-        p->codegenError = TA_CODEGEN_NBELEMENT_MISMATCH;
         return;
     }
 
@@ -9418,6 +9462,30 @@ ErrorNumber test_codegen(const TA_History *history,
                 startSweepTotal += g_startSweepWithOutput[li];
                 valuesCompared  += g_codegenCompared[li];
             }
+            /* Non-vacuity for the zero-produced-count compare, DIFFERENTIALLY
+             * rather than against a literal floor. Whether a run reaches a
+             * zero-count call at all is a property of the corpus — a
+             * --function= filter naming only lookback-0 functions legitimately
+             * never does — so the assertion is that no language sits at zero
+             * while another, on the same corpus, is answering them. That is
+             * the shape the counter is for: one server dropping out of a check
+             * every other server is taking. */
+            {
+                long zeroSeen = 0;
+                for( unsigned int li = 0; li < NUM_LANGUAGES; li++ )
+                    zeroSeen += g_zeroCountCompared[li];
+                if( zeroSeen > 0 )
+                    for( unsigned int li = 0; li < NUM_LANGUAGES; li++ )
+                        if( g_codegenCompared[li] > 0 && g_zeroCountCompared[li] == 0 )
+                        {
+                            printf("\nCODEGEN FAILED: no produced-count-of-zero "
+                                   "comparison reached %s, on a run where the other "
+                                   "server(s) took %ld of them — the same corpus "
+                                   "reached them and not it\n",
+                                   ALL_LANGUAGES[li].display, zeroSeen);
+                            return TA_CODEGEN_OUTPUT_MISMATCH;
+                        }
+            }
             if( valuesCompared > 0 && startSweepTotal == 0 )
             {
                 printf("\nCODEGEN FAILED: the startIdx-axis sweep compared "
@@ -9554,6 +9622,28 @@ ErrorNumber test_codegen(const TA_History *history,
                     printf(", %ld withheld (TRIX/NATR partial range — the frozen "
                            "reference predates issue #98)", g_startSweepSkipped98);
                 printf("\n");
+            }
+
+            /* Printed per language, not as a total: the differential floor
+             * above tests one language against the others, so the numbers it
+             * reads have to be visible. Printed even where the value legs found
+             * plenty, because a produced count of zero is the one answer the
+             * value legs cannot examine. */
+            {
+                long zeroTotal = 0;
+                for( unsigned int li = 0; li < NUM_LANGUAGES; li++ )
+                    zeroTotal += g_zeroCountCompared[li];
+                if( zeroTotal > 0 )
+                {
+                    printf("  produced count at zero:");
+                    for( unsigned int li = 0; li < NUM_LANGUAGES; li++ )
+                        if( g_codegenCompared[li] > 0 || g_zeroCountCompared[li] > 0 )
+                            printf(" %s=%ld", ALL_LANGUAGES[li].display,
+                                   g_zeroCountCompared[li]);
+                    printf("  (comparison(s), one per output, where C produced nothing "
+                           "and the server's own count was checked against it; no "
+                           "output element is diffed there)\n");
+                }
             }
         }
 


### PR DESCRIPTION
`compare_codegen_output_generic` returned early when the in-process C library
answered `TA_SUCCESS` with `outNBElement == 0`, and the `outNBElement`
comparison sat *after* that return. So at C's zero the server's own count was
never read: a server answering "success, 3 elements" where C answered
"success, 0" was counted as agreement, and the call was banked as compared.

The hole is one-sided, which is why a green run said nothing about it. The
other direction — C produces N, the server answers 0 — always failed here,
since that comparison is reached whenever C produced output.

It is also not a corner of the corpus. Every range short of the lookback lands
in it: an unfiltered `--codegen` run takes **2884** such comparisons per
language, against the **903** ranges per language the startIdx axis counts as
having produced output. The axis counters already split `compared` from
`withOutput` for exactly this shape — but that split is a statement about
VALUES, and it had been read as a statement about the whole response.

## The change

`src/tools/ta_regtest/test_codegen.c` only. No generator change, nothing
regenerated, no backend touched.

- The `outNBElement` compare is hoisted above the zero-output return, so the
  count is compared on every successful call whatever its value.
- A per-language counter records the comparisons landing at a zero count, and
  the summary prints it.
- A non-vacuity floor, differential rather than literal: no language may sit at
  zero while another, on the same corpus, is taking them. Whether a run reaches
  a zero-count call at all is a property of the corpus — a `--function=` filter
  naming only lookback-0 functions legitimately never does — so a fixed floor
  would be wrong. One server dropping out of a check the others take is the
  shape worth failing on, and it is what the per-language counters elsewhere in
  this file exist for.

## What this deliberately does NOT do

`outBegIdx` is still not compared at a zero count. C's early returns write 0
into it, but that is the C library's habit rather than a documented contract,
and the four backends have never been held to it, so asserting it here would be
a new cross-backend requirement rather than the closing of a hole. It is named
in the code rather than left implicit.

I measured it rather than leaving it hypothetical. A throwaway build of
`ta_regtest` that *also* compares `outBegIdx` at a zero count reports, on the
same unfiltered run:

```
  PROBE outBegIdx at a zero count: C=0/2884 differ Rust=0/2884 differ Java=0/2884 differ
```

So every backend writes there what C writes, and the assertion would pass today
if you want it. Passing today is not the same as being a contract, and adding
it would bind all four backends to one — your call, not this PR's. That probe
build is not part of the diff.

## Evidence

**The gate is live and non-vacuous.** Unfiltered
`./ta_regtest --codegen=c,rust,java` on this branch:

```
  startIdx-axis sweep: 2709 range(s) with output compared at startIdx > 0, 24 withheld (...)
  produced count at zero: C=2884 Rust=2884 Java=2884  (comparison(s), one per output, ...)
All 3 language(s) passed codegen verification (float leg: 965 acknowledged comparison(s))
```

All three servers agree on every one of those counts today, so this lands green
and adds a check rather than a fix.

**It goes red when the claim is false.** Sabotage: every one of the C server's
176 per-function handlers reports `outNBElement = 1` where it produced 0
(`(outNBElement==0?1:outNBElement)` in the response, output array untouched),
rebuilt, then `./ta_regtest --codegen=c --function=SMA`:

```
CODEGEN MISMATCH [TA_SMA]: outNBElement C=0 codegen=1
  (edge range was (0,0))
CODEGEN FAILED (code=1107)
```

exit 83.

**The same sabotage passes before this change.** `ta_regtest` built from this
branch's parent (dev `12987063d`), run against that same sabotaged server:
`* All tests succeeded *`, exit 0, no mismatch line. That is the hole, observed
rather than argued: a server misreporting its produced count on every function
in the corpus was invisible.

## Costs

- One extra `json_get_int(responseBuf, "outNBElement")` per zero-count
  comparison — 2884 per language on an unfiltered run. I did not measure the
  wall-clock effect and make no claim about it; the run is minutes long and
  this is a scan of one field in a response already parsed several times.
- The two structural compares swap order. When a response gets *both*
  `outBegIdx` and `outNBElement` wrong, the failure now names the count and
  reports `TA_CODEGEN_NBELEMENT_MISMATCH` where it used to name the index and
  report `TA_CODEGEN_BEGIDX_MISMATCH`. Same failure, different first line.

## What I did not check

- The **C# server**. This environment has no .NET SDK, so `csharp` was never
  built or run here — the numbers above are C, Rust and Java. The change is
  language-agnostic driver code and the PR gate covers C#, but I did not
  observe it.
- `--fuzz-064` and `--xlang-hash` are untouched: neither routes through this
  function, and I did not run them.
