### PR TITLE
fix(rust): FUNCS is a slice, so the registry's size is not public API (#179 C9)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_abstract.rs
+++ b/ta_codegen/generator/src/backends/rust_abstract.rs
@@ -85,21 +85,38 @@ pub fn render(funcs: &[FuncDef], enums: &HashMap<String, EnumDef>) -> String {
     let _ = writeln!(o, "    /// Number of functions in the registry.");
     let _ = writeln!(o, "    pub const COUNT: usize = {n};");
     o.push_str("    /// Metadata for this function (O(1) index into the const table).\n");
-    o.push_str("    #[inline] pub fn info(self) -> &'static FuncInfo { &FUNCS[self as usize] }\n");
+    o.push_str("    #[inline] pub fn info(self) -> &'static FuncInfo { &FUNC_TABLE[self as usize] }\n");
     o.push_str("    /// Upper-case TA name, e.g. \"RSI\".\n");
-    o.push_str("    #[inline] pub fn name(self) -> &'static str { FUNCS[self as usize].name }\n");
+    o.push_str("    #[inline] pub fn name(self) -> &'static str { FUNC_TABLE[self as usize].name }\n");
     o.push_str("}\n\n");
 
     // --- model types (fixed) ---
     o.push_str(MODEL);
 
     // --- the one flat master table ---
-    let _ = writeln!(o, "/// All function metadata, indexed by [`FuncId`]. Link-time const, in `.rodata`.");
-    let _ = writeln!(o, "pub static FUNCS: [FuncInfo; {n}] = [");
+    //
+    // The array is private and the public handle is a slice over it, so the row
+    // count is not part of any published type (#179 C9): adding an indicator
+    // moves `FUNCS.len()` and `FuncId::COUNT`, not `FUNCS`'s signature. The
+    // array stays a named symbol rather than an inline `&[...]` so the two O(1)
+    // paths above (`FuncId::info`, `FuncId::name`) still index it directly,
+    // with no slice pointer to load first.
+    let _ = writeln!(o, "/// Backing storage for [`FUNCS`], indexed by [`FuncId`]. Link-time const, in");
+    let _ = writeln!(o, "/// `.rodata`. Private, so its length is nobody's business but this module's.");
+    let _ = writeln!(o, "static FUNC_TABLE: [FuncInfo; {n}] = [");
     for f in &sorted {
         emit_func(&mut o, f);
     }
     o.push_str("];\n\n");
+    o.push_str(
+        "/// All function metadata, indexed by [`FuncId`]. Link-time const, in `.rodata`.\n\
+         ///\n\
+         /// A slice, not a `[FuncInfo; N]`: the row count is deliberately kept out of\n\
+         /// the public type, so adding an indicator is not a breaking change for code\n\
+         /// that names this static's type. [`FuncId::COUNT`] and `FUNCS.len()` are the\n\
+         /// count.\n",
+    );
+    o.push_str("pub static FUNCS: &[FuncInfo] = &FUNC_TABLE;\n\n");
 
     // --- API surface (C-recognizable names, idiomatic shapes) ---
     emit_api(&mut o, &sorted, &enum_params);
@@ -1169,6 +1186,20 @@ mod registry_tests {
         for (i, f) in FUNCS.iter().enumerate() {
             assert_eq!(f.id as usize, i, "FuncId discriminant must equal its FUNCS index");
         }
+    }
+
+    /// The row count must not be part of `FUNCS`'s published type (#179 C9).
+    ///
+    /// This is a type assertion, not a value one, and it is the only thing in
+    /// the tree that can fail on the shape: every other reader here goes
+    /// through `.len()` or `.iter()`, which an array answers just as well. A
+    /// `[FuncInfo; N]` does not coerce to `&'static [FuncInfo]` by value, so
+    /// re-freezing the count stops the test target compiling rather than
+    /// passing quietly.
+    #[test]
+    fn funcs_is_a_slice_so_the_count_is_not_public_api() {
+        let table: &'static [FuncInfo] = FUNCS;
+        assert_eq!(table.len(), FuncId::COUNT);
     }
 
     #[test]

--- a/ta_codegen/output/rust/library/src/abstract_api.rs
+++ b/ta_codegen/output/rust/library/src/abstract_api.rs
@@ -400,9 +400,9 @@ impl FuncId {
     /// Number of functions in the registry.
     pub const COUNT: usize = 176;
     /// Metadata for this function (O(1) index into the const table).
-    #[inline] pub fn info(self) -> &'static FuncInfo { &FUNCS[self as usize] }
+    #[inline] pub fn info(self) -> &'static FuncInfo { &FUNC_TABLE[self as usize] }
     /// Upper-case TA name, e.g. "RSI".
-    #[inline] pub fn name(self) -> &'static str { FUNCS[self as usize].name }
+    #[inline] pub fn name(self) -> &'static str { FUNC_TABLE[self as usize].name }
 }
 
 /// Function group (closed set — replaces C's runtime group-string table + linear `getGroupId`).
@@ -721,8 +721,9 @@ impl FuncInfo {
     #[inline] pub const fn nb_output(&self) -> usize { self.outputs.len() }
 }
 
-/// All function metadata, indexed by [`FuncId`]. Link-time const, in `.rodata`.
-pub static FUNCS: [FuncInfo; 176] = [
+/// Backing storage for [`FUNCS`], indexed by [`FuncId`]. Link-time const, in
+/// `.rodata`. Private, so its length is nobody's business but this module's.
+static FUNC_TABLE: [FuncInfo; 176] = [
     FuncInfo {
         id: FuncId::AC,
         name: "AC",
@@ -2660,6 +2661,14 @@ pub static FUNCS: [FuncInfo; 176] = [
         unst_id: None,
     },
 ];
+
+/// All function metadata, indexed by [`FuncId`]. Link-time const, in `.rodata`.
+///
+/// A slice, not a `[FuncInfo; N]`: the row count is deliberately kept out of
+/// the public type, so adding an indicator is not a breaking change for code
+/// that names this static's type. [`FuncId::COUNT`] and `FUNCS.len()` are the
+/// count.
+pub static FUNCS: &[FuncInfo] = &FUNC_TABLE;
 
 /// Resolve a function name (e.g. "RSI") to its [`FuncId`], exact-case first.
 ///
@@ -5754,6 +5763,20 @@ mod registry_tests {
         for (i, f) in FUNCS.iter().enumerate() {
             assert_eq!(f.id as usize, i, "FuncId discriminant must equal its FUNCS index");
         }
+    }
+
+    /// The row count must not be part of `FUNCS`'s published type (#179 C9).
+    ///
+    /// This is a type assertion, not a value one, and it is the only thing in
+    /// the tree that can fail on the shape: every other reader here goes
+    /// through `.len()` or `.iter()`, which an array answers just as well. A
+    /// `[FuncInfo; N]` does not coerce to `&'static [FuncInfo]` by value, so
+    /// re-freezing the count stops the test target compiling rather than
+    /// passing quietly.
+    #[test]
+    fn funcs_is_a_slice_so_the_count_is_not_public_api() {
+        let table: &'static [FuncInfo] = FUNCS;
+        assert_eq!(table.len(), FuncId::COUNT);
     }
 
     #[test]


### PR DESCRIPTION
The registry's public handle is `pub static FUNCS: [FuncInfo; 176]`. The row count
is part of that type, so the day a 177th indicator lands the signature changes —
a breaking change for anyone who wrote it down. Nothing needs the count to live in
the type: `FuncId::COUNT` and `FUNCS.len()` both already report it, and C9 notes
that a slice or an accessor "is free now" (`funcs()` has existed for a while, so
this is only about the static).

## What changed

One generator site, `backends/rust_abstract.rs`:

- the flat master table is emitted as a private `static FUNC_TABLE: [FuncInfo; N]`
- `pub static FUNCS: &[FuncInfo] = &FUNC_TABLE;` becomes the public handle
- `FuncId::info` and `FuncId::name` index `FUNC_TABLE`, not `FUNCS`

The array stays a named private symbol rather than becoming an inline `&[...]`
literal so those two O(1) accessors keep indexing an array directly, with no slice
pointer to load first. I did not measure the difference — I kept the shape rather
than argue about whether LLVM would fold the load.

Row content is untouched. The generated diff is the two `FuncId` accessor lines,
the table's declaration line, the new public static with its doc, and the new test.
`FuncId::COUNT` is still `176`.

## The gate, and the control

`registry_tests::funcs_is_a_slice_so_the_count_is_not_public_api` is a **type**
assertion, not a value one:

```rust
let table: &'static [FuncInfo] = FUNCS;
```

It is the only thing in the tree that can fail on the shape. Every other reader —
`count_matches_table_and_indices_align`, `name_handle_roundtrip`, the group
sweeps, `funcs()` / `funcs_in_group()` / `for_each_func`, `id_by_name` — goes
through `.len()` or `.iter()`, which an array answers exactly as well, so all of
them stay green against either shape.

Control: I pointed the assertion at the raw array (`= FUNC_TABLE`) and rebuilt.
The test target does not compile:

```
error[E0308]: mismatched types
     |                    -------------------   ^^^^^^^^^^ expected `&[FuncInfo]`, found `[FuncInfo; 176]`
error: could not compile `ta-lib` (lib test) due to 1 previous error
```

That is the failure mode I want: re-freezing the count breaks the build instead of
passing quietly.

## What I ran

- `cargo run -- generate` (bare, whole corpus), then `git status` — only the two
  files in this PR are modified. No C, Java or C# output moved.
- generator: `cargo test` green across all suites; `cargo clippy --all-targets` clean.
- crate: `cargo build -p ta-lib`; `cargo test --tests -p ta-lib` (73 + 6 + 7);
  `cargo test --doc -p ta-lib` (534); `cargo clippy --all-targets -p ta-lib` clean;
  `cargo doc --no-deps -p ta-lib` warning-free.
- `ta_regtest` C reference suite: green.
- `ta_regtest --xlang-hash --language=rust`: 278,274 cases, 0 mismatches,
  bit-identical.

## What I did not check

- The `--codegen` metadata-parity leg (`test_abstract.c`) did not run. It needs
  `bin/ta_ref_serve`, built from the pinned pre-cutover worktree, and I did not
  build it. That is the leg that proves the Rust server's abstract answers against
  C's `ta_abstract` — the surface this touches. Nothing in the diff moves a row
  value, and the crate's own registry sweeps read every row through `FUNCS`, but I
  did not run the parity leg itself.
- No Java or C# build ran. The generator emits their files identically, which I
  verified by `git status` after a bare `generate`, not by compiling them.

## The cost

This is a breaking change to the crate's public API, deliberately, and cheapest
before the first `ta-lib` publish that #179 is scoped to. Code that names
`[FuncInfo; 176]`, or that moves the static by value, stops compiling. `FUNCS[i]`,
`FUNCS.len()`, `FUNCS.iter()` and `&FUNCS[..]` are unaffected — nothing in this
repository named the array type, so nothing here changed but the definition.

External callers who index `FUNCS[i]` directly now pay one pointer load for the
slice before the index. The two internal O(1) accessors avoid it by construction,
as above; I did not benchmark either path, since the change is about the published
type rather than about speed.
