### PR TITLE
test(java): the binder's call() path never read the Core it was handed (#172 C1)

### DIFF
--- a/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
+++ b/ta_codegen/output/java/library/src/test/java/io/github/talib/test/MetadataTest.java
@@ -861,6 +861,57 @@ public class MetadataTest {
               "newCall(core) uses the given Core (" + viaTuned + " vs " + tuned.RSI_Lookback(14) + ")");
         check(viaTuned == viaDefault + 9,
               "the unstable period reaches the binder: " + viaDefault + " + 9 == " + viaTuned);
+
+        /* lookback() is not call(). Dispatch reads `h.core()` in two places --
+         * `Dispatch.lookback` (above) and `Dispatch.call` -- and only the first
+         * of them was pinned. Measured on this tree: rewriting the one line in
+         * `Dispatch.call` to `Core core = Core.DEFAULT;`, so that every
+         * call-by-name silently ignores the Core it was handed, leaves all six
+         * Java suites green (BatchApiTest 181, CoreApiTest 66, DivZeroTest 91,
+         * MetadataTest 1540, SMathOverflowTest 4, StreamSmokeTest 3859). The
+         * blanket rewrite of BOTH lines fails 2 of 1540 -- the three checks
+         * above -- which is exactly the half that was already covered.
+         *
+         * The unstable period is the oracle again, and it discriminates on the
+         * range rather than on the values: it does not change how RSI is
+         * computed, it withholds the first 9 bars it computes. So a call that
+         * honours `tuned` starts 9 bars later and produces 9 fewer values.
+         */
+        double[] outDefault = new double[N];
+        OutRange rDefault = rsi.newCall()
+            .setInput(0, CLOSE).setOptInput(0, 14).setOutput(0, outDefault).call(0, N - 1);
+        double[] outTuned = new double[N];
+        OutRange rTuned = rsi.newCall(tuned)
+            .setInput(0, CLOSE).setOptInput(0, 14).setOutput(0, outTuned).call(0, N - 1);
+
+        check(rTuned.begIdx() == rDefault.begIdx() + 9,
+              "call(core) starts where that Core's lookback says: "
+              + rDefault.begIdx() + " + 9 == " + rTuned.begIdx());
+        check(rTuned.count() == rDefault.count() - 9,
+              "call(core) withholds the 9 unstable bars: "
+              + rDefault.count() + " - 9 == " + rTuned.count());
+
+        /* And the binder's answer is the typed call's answer on that same Core,
+         * bit for bit -- the same standard callByNameMatchesTheTypedApi() holds
+         * the 176 functions to on Core.DEFAULT, now on a Core that is not it.
+         */
+        double[] direct = new double[N];
+        OutRange rDirect = tuned.RSI(0, N - 1, CLOSE, 14, direct);
+        check(rDirect.begIdx() == rTuned.begIdx() && rDirect.count() == rTuned.count(),
+              "the binder and the typed call agree on the range for the tuned Core");
+        boolean sameBits = true;
+        for (int i = 0; i < rTuned.count(); i++) {
+            sameBits &= Double.doubleToRawLongBits(direct[i])
+                     == Double.doubleToRawLongBits(outTuned[i]);
+        }
+        check(sameBits, "the binder and the typed call agree bit for bit on the tuned Core");
+        /* Non-vacuity: the bit compare above had something to compare, and the
+         * two Cores really do answer differently -- without this a binder that
+         * produced nothing at all would satisfy every check above.
+         */
+        check(rTuned.count() > 0 && rDefault.count() > rTuned.count(),
+              "both calls produced values, and the tuned Core produced fewer ("
+              + rDefault.count() + " vs " + rTuned.count() + ")");
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
`#172 C1` reads "`FunctionInfo.newCall(Core)` is never exercised". It is exercised
now — `newCallCarriesTheGivenCore` in `MetadataTest` went in earlier — but only
through `lookback()`. `Dispatch` reads `h.core()` in **two** places, and nothing
anywhere read the second one:

| site | pinned before this PR |
|---|---|
| `Dispatch.lookback` (`Dispatch.java:596`) | yes — three checks |
| `Dispatch.call` (`Dispatch.java:57`) | **no** |

Every other call-by-name test in the tree runs on `Core.DEFAULT`, where routing
to the given `Core` and routing to the default are the same answer, so none of
them could tell the two apart.

## Measured

Rewriting the one line in `Dispatch.call` to `Core core = Core.DEFAULT;`, so that
every call-by-name silently drops the `Core` it was handed:

| suite | before this PR | after this PR |
|---|---|---|
| BatchApiTest | ALL PASS (181) | ALL PASS (181) |
| CoreApiTest | ALL PASS (66) | ALL PASS (66) |
| DivZeroTest | ALL PASS (91) | ALL PASS (91) |
| MetadataTest | **ALL PASS (1540)** | **5 of 1545 FAILED** |
| SMathOverflowTest | ALL PASS (4) | ALL PASS (4) |
| StreamSmokeTest | ALL PASS (3859) | ALL PASS (3859) |

5741 checks, and before this PR not one of them was looking. After it, the five
that fail are exactly the five added here and the other five suites are
unchanged — the coverage is this and nothing is double-counted.

The blanket rewrite of **both** `h.core()` lines fails 2 of 1540 before this PR:
the lookback half that was already pinned. That split is what this closes.

## What discriminates

The unstable period again, and it bites on the **range**, not on the values. It
does not change how RSI is computed; it withholds the first 9 bars of what RSI
computes. So a call that honours the tuned `Core` starts 9 bars later
(`begIdx` 14 → 23) and produces 9 fewer values (146 → 137). Under the sabotage
both calls answer 146 values from index 14 — which is what the two range checks
catch, and why a values-only comparison would have stayed green.

Five checks:

1. the tuned `begIdx` is the default's + 9;
2. the tuned `count` is the default's − 9;
3. the binder's range equals the typed `tuned.RSI(...)` range;
4. the binder's values equal the typed call's **bit for bit** over that range —
   the standard `callByNameMatchesTheTypedApi` holds all 176 functions to on
   `Core.DEFAULT`, here applied on a `Core` that is not it;
5. non-vacuity: both calls produced values at all, and the tuned one produced
   fewer. Without it a binder that produced nothing would satisfy (4) vacuously.

## Cost

MetadataTest 1540 → 1545. One hand-written test file, no new data series and no
new run — it reuses the `CLOSE` series and the `tuned` Core the method already
built. `generate` produces no diff: `MetadataTest.java` is hand-written, and the
generator only mentions it in a comment.

## Not run / not checked here

- **Not run:** the Maven gate (`./mvnw`), the C `ta_regtest` legs, and the
  cross-language `--codegen` legs. No file this touches is compiled into a
  language server or into the C library. The six Java suites were compiled with
  `javac --release 17` over `src/`, the same sources Maven compiles.
- **Not checked:** whether C# has the same hole. Statically it looks like it
  does — `FunctionInfo.CreateCall(Core)` exists in `Model.g.cs` and
  `MetadataTest.cs` never builds a tuned `Core` — but there is no .NET SDK in the
  environment this was written in, so there is no control run behind that. It is
  an observation, not a claim, and it is worth a follow-up by someone who can
  measure it. (C#'s no-arg `CreateCall()` also allocates a fresh `new Core()`
  where Java's returns the shared `Core.DEFAULT`; noted, not touched.)
