### PR TITLE
test(rust): the crate README's examples are claims, and nothing compiled them (#179)

### DIFF
--- a/ta_codegen/generator/src/main.rs
+++ b/ta_codegen/generator/src/main.rs
@@ -2628,6 +2628,24 @@ path = "src/lib.rs"
 mod ta_func;
 pub mod abstract_api;
 pub use ta_func::*;
+
+// The README is the crate's front page on crates.io and on GitHub, and its Rust
+// sample is a claim about this API — yet nothing in the tree compiled it:
+// `readme = "README.md"` is packaging metadata, and every other doctest here
+// comes from a generated per-function page. So the front page was the one piece
+// of Rust in this crate that could say anything, and twice it did: the install
+// line resolved to no published version (#179 A1) and the indicator count was
+// seven stale (#179 A2), both found by reading rather than by a gate. The counts
+// and the install requirement are derived now; this covers the code.
+//
+// `cfg(doctest)` is what keeps it to `cargo test --doc`: the item does not exist
+// during `cargo build`, `cargo clippy` or `cargo doc`, so the README's headings
+// never appear in the rendered docs and its links are not resolved as intra-doc
+// links (they are ordinary Markdown links, and must stay that way to render on
+// crates.io).
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+struct ReadmeExamples;
 "#;
     let lib_path = src_dir.join("lib.rs");
     write_if_changed(&lib_path, fill(lib_rs)).unwrap();
@@ -2692,11 +2710,16 @@ period and candlestick thresholds — are chosen up front with a builder and the
 frozen:
 
 ```rust
-use ta_lib::{Core, FuncUnstId};
+use ta_lib::{Core, FuncUnstId, RetCode};
 
-let core = Core::builder()
-    .unstable_period(FuncUnstId::EMA, 10)
-    .build()?;
+fn main() -> Result<(), RetCode> {
+    let core = Core::builder()
+        .unstable_period(FuncUnstId::EMA, 10)
+        .build()?;
+
+    assert_eq!(core.get_unstable_period(FuncUnstId::EMA)?, 10);
+    Ok(())
+}
 ```
 
 The setters are infallible so that they chain; a rejected argument is reported

--- a/ta_codegen/output/rust/library/README.md
+++ b/ta_codegen/output/rust/library/README.md
@@ -56,11 +56,16 @@ period and candlestick thresholds — are chosen up front with a builder and the
 frozen:
 
 ```rust
-use ta_lib::{Core, FuncUnstId};
+use ta_lib::{Core, FuncUnstId, RetCode};
 
-let core = Core::builder()
-    .unstable_period(FuncUnstId::EMA, 10)
-    .build()?;
+fn main() -> Result<(), RetCode> {
+    let core = Core::builder()
+        .unstable_period(FuncUnstId::EMA, 10)
+        .build()?;
+
+    assert_eq!(core.get_unstable_period(FuncUnstId::EMA)?, 10);
+    Ok(())
+}
 ```
 
 The setters are infallible so that they chain; a rejected argument is reported

--- a/ta_codegen/output/rust/library/src/lib.rs
+++ b/ta_codegen/output/rust/library/src/lib.rs
@@ -91,3 +91,21 @@
 mod ta_func;
 pub mod abstract_api;
 pub use ta_func::*;
+
+// The README is the crate's front page on crates.io and on GitHub, and its Rust
+// sample is a claim about this API — yet nothing in the tree compiled it:
+// `readme = "README.md"` is packaging metadata, and every other doctest here
+// comes from a generated per-function page. So the front page was the one piece
+// of Rust in this crate that could say anything, and twice it did: the install
+// line resolved to no published version (#179 A1) and the indicator count was
+// seven stale (#179 A2), both found by reading rather than by a gate. The counts
+// and the install requirement are derived now; this covers the code.
+//
+// `cfg(doctest)` is what keeps it to `cargo test --doc`: the item does not exist
+// during `cargo build`, `cargo clippy` or `cargo doc`, so the README's headings
+// never appear in the rendered docs and its links are not resolved as intra-doc
+// links (they are ordinary Markdown links, and must stay that way to render on
+// crates.io).
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+struct ReadmeExamples;


### PR DESCRIPTION
`readme = "README.md"` is packaging metadata. The 534 doctests this crate ran all came from generated per-function pages, so the front page a user actually reads — on crates.io, on GitHub, behind docs.rs' sidebar link — was the only Rust in this crate that could say anything at all.

It has, twice: the install line resolved to no published version (#179 A1) and the indicator count sat seven behind (#179 A2). Both were caught by someone reading the page. The counts and the install requirement are derived from the corpus now; the two code blocks were still ungated.

## The vacuity, measured before the change

Change the README's `assert_eq!(sma[0], 12.0)` to `12.5` — a false claim about this API, on the crate's front page — and `cargo test --doc` stays green:

```
test result: ok. 534 passed; 0 failed
```

Identical to the unsabotaged run. Nothing reads that file.

## The change

One item, at the end of the generated crate root:

```rust
#[cfg(doctest)]
#[doc = include_str!("../README.md")]
struct ReadmeExamples;
```

This is the shape `ta-lib-dispatch` already uses for its own README — there as `#![doc = include_str!(...)]`, because that README *is* its crate docs and carries no code.

## What it found on the first run

The **Configuration** example does not compile:

```
error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option`
   --> library/README.md
    |
    |     .build()?;
    |             ^ cannot use the `?` operator in a function that returns `()`
```

It ends `.build()?` with nothing to return the error to, so the snippet as printed could never have worked for a reader who pasted it. It is now a `fn main() -> Result<(), RetCode>` — the shape the quick-start block above it already used — and it asserts the setting reads back, so the block claims something rather than merely having a shape:

```rust
use ta_lib::{Core, FuncUnstId, RetCode};

fn main() -> Result<(), RetCode> {
    let core = Core::builder()
        .unstable_period(FuncUnstId::EMA, 10)
        .build()?;

    assert_eq!(core.get_unstable_period(FuncUnstId::EMA)?, 10);
    Ok(())
}
```

The quick-start block compiled and passed as written.

## The gate, after

536 doctests, both README blocks among them, and each sabotage fails exactly its own block and nothing else:

| sabotage in README.md | result |
|---|---|
| none | `ok. 536 passed; 0 failed` |
| `assert_eq!(sma[0], 12.0)` → `12.5` | `FAILED` — quick start, `left: 12.0, right: 12.5` |
| `get_unstable_period(...)? , 10` → `11` | `FAILED` — configuration, `left: 10, right: 11` |

Both were run; the failures above are quoted from those runs, not predicted.

## What `cfg(doctest)` buys, and what it therefore does not cover

The item does not exist for `cargo build`, `cargo clippy` or `cargo doc` — verified: `cargo doc --no-deps` is clean and `ReadmeExamples` appears nowhere under `target/doc`. That is deliberate, because the README's links must stay ordinary Markdown links to render on crates.io, and pulling them into rendered rustdoc would put them in front of the intra-doc link lint that #290 adds to the PR gate.

The cost of that choice, stated plainly: rustdoc never resolves those links, so **a broken link in this README is still ungated**. Only the code blocks are covered. The ` ```toml ` install block is not compiled either — its version is guarded only by being generator-derived.

## Cost

Two more doctest compiles per `cargo test --doc`. One run each: 28.62s for 534 doctests, 28.32s for 536. That is not separable from run-to-run variance and I did not repeat the runs, so it should be read as "no measurable change", not as a speedup.

## Verification

- `cargo test --doc -p ta-lib` — 536 pass (534 before)
- `cargo test --tests -p ta-lib` — 85 pass
- `cargo test` in `ta_codegen/generator` — 859 pass
- `cargo clippy --all-targets -- -D warnings` — clean, generator and crate
- `cargo doc --no-deps -p ta-lib` — clean
- full `cargo run -- generate`, whose only diff is the three files in this PR

Not run, and not touched by this change: `ta_regtest`, `--xlang-hash`, `scripts/build.py check-source-lists`, and the C / Java / .NET backends.

## Shape

The generator emits the README and the crate root, so both changed files under `ta_codegen/output/` are regenerated output; `ta_codegen/generator/src/main.rs` is the edit.
