### PR TITLE
ci(gate): compile the publishable crates on the MSRV they declare (#179 E2)

### DIFF
--- a/.github/workflows/pr-codegen-gate.yml
+++ b/.github/workflows/pr-codegen-gate.yml
@@ -121,3 +121,71 @@ jobs:
             echo "::error::Clippy failed on the generated crate. Its scaffolding emits a crate-level #![allow(clippy::all, clippy::pedantic)], so a failure here is the emitter's, not the emitted code's — fix the backend, never the generated file."
             exit 1
           fi
+
+  # The two publishable crates declare `rust-version = "1.86"`, and until now
+  # nothing in this repo had ever compiled them with it (#179 E2). Every other
+  # Rust step here and in the nightly runs on the pinned toolchain from
+  # rust-toolchain.toml — 1.97.0 — so a post-1.86 API or syntax reaching the
+  # generated crate is green everywhere and breaks only for the consumer whose
+  # toolchain is older than ours. That consumer is exactly who the declared
+  # floor is a promise to, and after publish the promise is in a released
+  # version that cannot be edited.
+  #
+  # This job is where that promise is compiled. It runs concurrently with
+  # regen-check (~4m), and the crates have no external dependencies at all —
+  # ta-lib's only dep is the sibling dispatch macro by path — so it is a
+  # toolchain download plus a cold check of two crates, well inside that
+  # window and costing the PR no wall-clock.
+  #
+  # The version is READ from the manifests, not written here: bumping the floor
+  # in ta_codegen/generator/src/main.rs moves this gate with it, and cannot
+  # leave the gate testing a floor the crates no longer declare. The two reads
+  # are also the job's non-vacuity guard — a missing or disagreeing
+  # rust-version fails before any toolchain is installed, rather than quietly
+  # compiling nothing.
+  #
+  # What this does NOT cover: the direct-push path. dev takes pushes that
+  # `on: pull_request` never sees, and the nightly has no MSRV counterpart —
+  # see the PR discussion. It also only proves the floor is high ENOUGH; that
+  # 1.86 is the LOWEST version that works is still the hand comment in
+  # main.rs (safe `#[target_feature]`, stabilized 1.86), unverified.
+  msrv:
+    name: Rust MSRV floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read the declared floor from the two publishable manifests
+        id: floor
+        shell: bash
+        run: |
+          read_msrv() { sed -n 's/^rust-version *= *"\([^"]*\)".*/\1/p' "$1" | head -n 1; }
+          lib=$(read_msrv ta_codegen/output/rust/library/Cargo.toml)
+          dispatch=$(read_msrv ta_codegen/output/rust/dispatch/Cargo.toml)
+          if [ -z "$lib" ] || [ -z "$dispatch" ]; then
+            echo "::error::A publishable crate declares no rust-version (ta-lib='$lib', ta-lib-dispatch='$dispatch'), so this job has no floor to compile against. Both manifests are generated — restore the literal in ta_codegen/generator/src/main.rs and re-run 'scripts/build.py generate'."
+            exit 1
+          fi
+          if [ "$lib" != "$dispatch" ]; then
+            echo "::error::The publishable crates declare different floors (ta-lib='$lib', ta-lib-dispatch='$dispatch'). ta-lib pins ta-lib-dispatch with '=', so the two ship as a pair and only one floor is meaningful. Both literals live in ta_codegen/generator/src/main.rs."
+            exit 1
+          fi
+          echo "Declared MSRV: $lib"
+          echo "msrv=$lib" >> "$GITHUB_OUTPUT"
+
+      # rustup is preinstalled on ubuntu-latest. `+<version>` overrides
+      # rust-toolchain.toml for this one invocation, so the pin stays the
+      # default for every other step and job.
+      - name: Install the declared floor toolchain
+        shell: bash
+        run: rustup toolchain install "${{ steps.floor.outputs.msrv }}" --profile minimal --no-self-update
+
+      - name: Compile the publishable crates on the declared floor
+        shell: bash
+        run: |
+          if ! cargo "+${{ steps.floor.outputs.msrv }}" check -p ta-lib -p ta-lib-dispatch --all-targets --manifest-path ta_codegen/output/rust/Cargo.toml; then
+            echo "::error::The publishable crates do not compile on their own declared MSRV (${{ steps.floor.outputs.msrv }}). Either the code reached for something newer -- a 'use of unstable library feature' or 'stable since 1.NN' note names it -- in which case fix the generator that emits it, or the floor genuinely has to rise, in which case raise rust-version in ta_codegen/generator/src/main.rs (both crates) and say why in the commit. Reproduce locally: rustup toolchain install ${{ steps.floor.outputs.msrv }} && cargo +${{ steps.floor.outputs.msrv }} check -p ta-lib -p ta-lib-dispatch --all-targets --manifest-path ta_codegen/output/rust/Cargo.toml"
+            exit 1
+          fi


### PR DESCRIPTION
`ta-lib` and `ta-lib-dispatch` both declare `rust-version = "1.86"`. Nothing in
this repo had ever compiled them with 1.86.

`rust-toolchain.toml` pins 1.97.0, and every Rust step we have runs on that pin:
clippy on both crates, the generated crate's doctests, the generator's own
suite, and the nightly's `--tests` and rustdoc legs. None of them can see a
post-1.86 API or syntax reaching the generated crate — it compiles green on 1.97
and always will. The first reader who can see it is a consumer whose toolchain
is older than ours, after publish, in a version that cannot be edited.

This adds an `msrv` job to the PR gate.

## The floor is read, not written

The workflow does not carry `1.86` anywhere. It reads `rust-version` out of both
manifests, requires them to be present and equal, and installs that. Raising the
floor in `ta_codegen/generator/src/main.rs` (where both literals live, since both
manifests are generated) moves the gate with it, and the gate cannot end up
testing a floor the crates no longer declare.

Those two reads are also the job's non-vacuity guard, and they fail before any
toolchain is installed.

## Measured

Toolchain: 1.86.0 (05f9846f8 2025-03-31), installed with `rustup toolchain
install 1.86 --profile minimal`. Pinned toolchain for the control group: 1.97.0.

**Baseline — the declared floor is honest.** On a clean tree,
`cargo +1.86 check -p ta-lib -p ta-lib-dispatch --all-targets` succeeds. So this
gate lands green; it is not a known-red check being introduced.

**Control A — a post-1.86 API in the shipped crate.** `(id as usize).is_multiple_of(1)`
added to the `get_unstable_period` bound check in
`ta_codegen/generator/templates/rust/types.rs`, then `generate` re-run so the
committed output matches. The added conjunct is always true for a `usize`, so
behaviour is unchanged; `is_multiple_of` on unsigned integers stabilized in 1.87.

| gate | result |
| --- | --- |
| **`msrv` (this PR)** | **RED** — `error[E0658]: use of unstable library feature 'unsigned_is_multiple_of'`, `library/src/ta_func/types.rs:421`, exit 101 |
| `regen-check` | green — regenerating again produced no drift |
| clippy, generator + generated crate, `-D warnings` | green, exit 0 |
| `cargo test --doc -p ta-lib` | green, 534 passed |
| generator's own suite | green, all suites pass |

So the four existing gate steps are all blind to it, and this one names it.

**Control B — `rust-version` deleted from `ta-lib`'s manifest.** The read step
exits 1 with `A publishable crate declares no rust-version (ta-lib='',
ta-lib-dispatch='1.86')`, before installing anything. Without this the job would
have had no floor and would have silently checked nothing.

**Control C — the two manifests disagree (1.86 vs 1.88).** The read step exits 1
with both values named. `ta-lib` pins `ta-lib-dispatch` with `=`, so the two ship
as a pair and only one floor is meaningful.

## Cost

A toolchain download plus a cold `cargo check` of two crates. Neither crate has
an external dependency — `ta-lib`'s only dep is the sibling dispatch macro, by
path — so the compile is small: 14.19s cold locally. The job runs concurrently
with `regen-check` (~4m), the same reasoning the clippy job beside it already
uses, so it should cost the PR no wall-clock.

I did not measure the job on a GitHub runner. The download time in particular is
not something I can time here, and the workflow has not executed anywhere yet.

## Not covered

- **The direct-push path.** `dev` takes pushes that `on: pull_request` never
  sees, and the nightly has no MSRV counterpart, so an MSRV break can still
  reach `dev` without going through a PR. I deliberately did not add a step to
  `dev-nightly-tests.yml`, only to keep this change off a file another open
  change is already editing. If you would rather have it in both, say so and it
  is a two-line follow-up.
- **That 1.86 is the *lowest* version that works.** This proves the floor is high
  enough, never that it is not too high. The reasoning for 1.86 specifically
  (safe `#[target_feature]`, stabilized there) stays a hand comment in
  `main.rs`, unverified.
- **Running anything on 1.86.** `--all-targets` compiles the crate's unit tests
  but does not run them, and does not build doctests at all. This is a
  compile-only gate.
- The C, Java, C# and cross-language legs were not run. No file outside
  `.github/workflows/pr-codegen-gate.yml` is touched.
