### PR TITLE
ci(gate): drop #290/#291's PR-gate steps, already covered by the nightly

### DIFF
--- a/.github/workflows/pr-codegen-gate.yml
+++ b/.github/workflows/pr-codegen-gate.yml
@@ -114,74 +114,10 @@ jobs:
             exit 1
           fi
 
-      # Rustdoc's lints are a set no other step on this gate can reach, and
-      # `rustdoc::broken_intra_doc_links` is the one that matters: only rustdoc
-      # resolves a `[`Core::<F>`]` link, so only rustdoc can report that one
-      # does not resolve. Measured, on a tree where the doc backend emitted 176
-      # unresolvable links: regen-check green (the tree regenerates clean from
-      # input), 534 doctests green, the generator's suite green, both clippy
-      # steps green, and this step the only red. Everything else on this gate
-      # is blind to it by construction.
-      #
-      # It belongs here, not only in the 5AM nightly, for the reason the whole
-      # file exists: the nightly reports after merge, one branch too late. And
-      # it is free — it documents a crate this job compiles anyway (~3s
-      # locally), inside a job that finishes ~50s against regen-check's ~4m,
-      # so the PR waits no longer than it does today.
-      #
-      # It sits ahead of the generated-crate clippy step rather than at the end
-      # of the job so that it and the `cargo test --tests` step proposed for
-      # this same job in #211 do not both append at the file's end, where
-      # whichever lands second would conflict on nothing but position. The
-      # ordering itself is free: doc-then-clippy and clippy-then-doc totalled
-      # 17.3s/18.2s against 17.8s/18.0s locally, two runs each from a clean
-      # target — indistinguishable.
-      #
-      # The blast radius is real and growing: the registry alone carries 176
-      # generated links, and docs.rs is the first place rustdoc runs on a
-      # release, where a broken link renders as literal text (#179 E4).
-      - name: Rustdoc the generated crate
-        shell: bash
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-        run: |
-          if ! cargo doc --no-deps -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml; then
-            echo "::error::Rustdoc failed on the generated crate. An 'unresolved link' names a [\`Core::<item>\`] that does not exist — fix the doc backend that emits it (ta_codegen/generator/src/backends/rust_doc.rs), never the generated file. Reproduce locally with RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml"
-            exit 1
-          fi
-
       - name: Clippy the generated crate
         shell: bash
         run: |
           if ! cargo clippy --all-targets --manifest-path ta_codegen/output/rust/Cargo.toml -- -D warnings; then
             echo "::error::Clippy failed on the generated crate. Its scaffolding emits a crate-level #![allow(clippy::all, clippy::pedantic)], so a failure here is the emitter's, not the emitted code's — fix the backend, never the generated file."
-            exit 1
-          fi
-
-      # The crate's hand-written test modules (templates/rust/, copied in by
-      # `generate`) plus the generated registry's own sweeps: 85 tests today,
-      # over types.rs's Core/CoreBuilder API (#144), scratch_election (#146),
-      # stream_finite, stream_out_range (#241), div_zero (#249),
-      # no_phantom_io (#265), tests/nullable_outputs.rs (#262),
-      # tests/stream_open_contract.rs, and abstract_api's registry/binder
-      # sweeps — the by-name ASCII fold from #278 among them.
-      #
-      # Nothing in this gate executed any of them. `clippy --all-targets` above
-      # only COMPILES the test target, and `cargo test --doc` in the other job
-      # skips it, so until now the only thing that ran them was the 5AM dev
-      # nightly — after merge, the one-branch-too-late this file exists to fix
-      # (#211).
-      #
-      # `--tests`, not `--lib`: the latter excludes tests/, and it selects the
-      # lib's own unittest binary as well. Same argument the nightly records.
-      #
-      # It is in THIS job, not next to the doctests, for the reason clippy is:
-      # the job finishes far inside regen-check's wall-clock, so the step costs
-      # the PR nothing it was not already waiting on.
-      - name: Run the generated crate's unit and integration tests
-        shell: bash
-        run: |
-          if ! cargo test --tests -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml; then
-            echo "::error::A test in the generated crate failed. These are the crate's own modules, not the cross-language value gates — a failure here is a contract the emitted code no longer keeps (registry lookup, stream range, div-zero, phantom I/O, Core/CoreBuilder). Reproduce with the same command on the pinned toolchain; fix the backend, never the generated file."
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #290 and #291. Both landed a step in \`pr-codegen-gate.yml\`'s
\`clippy\` job that runs a command already present in
\`dev-nightly-tests.yml\`'s \`clippy + generator tests\` job, verbatim:

- #290: \`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ta-lib\`
- #291: \`cargo test --tests -p ta-lib\`

Unlike #298's MSRV job (genuinely new coverage, moved to the nightly in
#300), the nightly already ran both of these before #290/#291 landed, so
keeping them on the PR gate too pays extra runner time on every PR for zero
net new coverage. Same "PR gate stays lightweight, nightly is the
only-ever-addition" reasoning, applied to a duplicate rather than a gap.

This removes exactly the two added blocks — the file is byte-identical to
its state before #290/#291 (\`git diff b3041f69b -- .github/workflows/pr-codegen-gate.yml\`
is empty).