### PR TITLE
perf(tooling): a C# arm for stream_ab.py — and the Java arm has been measuring nothing since #278 (#299)

### DIFF
--- a/.claude/skills/ta-bench/SKILL.md
+++ b/.claude/skills/ta-bench/SKILL.md
@@ -112,27 +112,40 @@ cd bin && ./ta_bench_stream --points=20000 --iters=50
 ./ta_bench_stream --points=20000 --iters=50 --min-ratio=0.35   # exits 1 if any func is below
 ```
 
-`ta_bench_stream` is **C only**. For the Rust and Java streaming tiers,
+`ta_bench_stream` is **C only**. For the Rust, Java and C# streaming tiers,
 `scripts/stream_ab.py` A/Bs `update` (or `peek`) per bar — or `open`, which times
 the whole warm-up instead of one bar — between the working tree
 and a git revision — same generated harness compiled against two copies of the
 library, interleaved rounds with alternating arm order, every streaming function
-so the untouched ones are the control. It reads only the generated Rust crate and
-Java fragments (no ta_abstract, no servers, no C build) and derives every call
-from the emitted signatures, so adding an indicator needs no edit there.
+so the untouched ones are the control. It reads only the generated Rust crate,
+Java fragments and C# library (no ta_abstract, no servers, no C build) and
+derives every call from the emitted signatures, so adding an indicator needs no
+edit there.
 
-**C# streams too, but has no lane in either tool** — there is no C# row in any
-benchmark table, and `ta_bench --mode=open` answers `unsupported_mode` for it.
-So the C# peek-scratch election is Java's predicate shipped unchanged, and the
-emitted docs deliberately state what `Peek` allocates rather than claiming it is
-cheaper, which is a comparison nothing here has measured. Adding a C# lane needs
-a control arm first: reproduce a *known* effect (switch the copy constructor to
-`Clone()` and require ~2x on array-owning functions while the array-less ones
-stay flat) before trusting the tool to settle an unknown one.
+Every arm asserts a **floor** (`FUNC_FLOOR`, 170 against 176 today) on how many
+functions it parsed. That is not a style check: #278 recased the Rust and Java
+stream APIs and both arms' regexes kept the old spelling, so each parsed zero —
+Rust's until `c308e789`, Java's for a further day. Nothing but a person trying
+to use the tool noticed either. If an arm dies saying it is under the floor, the
+generated API moved: fix the parser, do not lower the floor.
+
+The **C# arm** pins `TieredCompilation` off in the harness project, so every
+method is fully optimised on its first call. The cost, stated rather than
+hidden: dynamic PGO is off with it, so the C# ns columns are static-opt numbers
+rather than what a long-lived process settles at. Both arms get the same
+treatment, so the change column — the output — is unaffected, and the ns columns
+were never comparable across invocations anyway. Note also that `TALib.csproj`
+sets `TreatWarningsAsErrors`, so a `--base` from an older revision has to compile
+*warning-clean* under today's SDK, a higher bar than the other two arms impose.
+
+There is still **no C# row in `ta_bench`** — `ta_bench --mode=open` answers
+`unsupported_mode` for it — so batch-vs-stream ratios remain a three-language
+table.
 
 ```bash
-scripts/stream_ab.py --base=origin/dev                                  # both languages
+scripts/stream_ab.py --base=origin/dev                                  # all three
 scripts/stream_ab.py --base=HEAD~1 --lang=rust --call=peek --mark=MIN,MAX
+scripts/stream_ab.py --base=origin/dev --lang=csharp --call=peek
 scripts/stream_ab.py --base=origin/dev --call=open --mark=BBANDS,STDDEV   # the Open tier
 ```
 

--- a/scripts/stream_ab.py
+++ b/scripts/stream_ab.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""A/B the Rust and Java streaming tier between two revisions of this tree.
+"""A/B the Rust, Java and C# streaming tier between two revisions of this tree.
 
 `ta_bench_stream` measures the C streaming tier only. This measures the other
-two: it times `update` (or `peek`) per bar for every streaming function -- or
+three: it times `update` (or `peek`) per bar for every streaming function -- or
 `open`, which times a whole warm-up pass rather than one bar -- in two
 arms — the working tree and a git revision — and reports the per-function
 change with the untouched functions as the control.
 
     scripts/stream_ab.py --base=origin/dev
     scripts/stream_ab.py --base=HEAD~1 --lang=rust --call=peek --mark=MIN,MAX
+    scripts/stream_ab.py --base=origin/dev --lang=csharp --call=peek
 
 The two arms are the SAME harness source compiled against two copies of the
 library, so a row is a library difference, not a harness difference. Rounds are
@@ -26,17 +27,29 @@ varied between them (`--period`, `--call`, the revision). Sweeping a parameter
 one invocation per point and reading the result as a curve reports build layout
 as if it were the parameter.
 
-Inputs: the generated `ta_codegen/output/rust/library` crate and
-`ta_codegen/output/java/fragments`. Nothing else — no ta_abstract, no C library,
-no servers, no ta_regtest. Needs `cargo` for --lang=rust, `javac`/`java` for
---lang=java. Both revisions must expose the same stream API surface; if they do
-not, the base arm fails to compile and says so.
+Inputs: the generated `ta_codegen/output/rust/library` crate,
+`ta_codegen/output/java/fragments` and `ta_codegen/output/csharp/library`.
+Nothing else — no ta_abstract, no C library, no servers, no ta_regtest. Needs
+`cargo` for --lang=rust, `javac`/`java` for --lang=java, `dotnet` for
+--lang=csharp. Both revisions must expose the same stream API surface; if they
+do not, the base arm fails to compile and says so. For C# that bar is higher
+than for the other two: `TALib.csproj` sets `TreatWarningsAsErrors`, so a base
+arm from an older revision must still compile *warning-clean* under whatever SDK
+is installed today, not merely compile.
 
 The harness calls every function through its generated signature with the
 default-value sentinels (i32::MIN / -4e37 / MAType.DEFAULT), so it needs no
 per-function knowledge and nothing here needs editing when a function is added.
 A function whose Open signature it cannot render is REPORTED, never dropped
 silently.
+
+Every arm takes the function name off the FILENAME, never off the method, and
+asserts a floor (FUNC_FLOOR) on how many it parsed. #278 recased the Rust and
+Java stream APIs and each arm's signature regex still spelled the old names, so
+both parsed zero functions; Rust's exited 0 and Java's reported every requested
+function as "not benchable" for a day. Neither breakage was caught by anything
+except someone trying to use the tool. A benchmark that measures nothing must
+not be able to exit 0.
 
 `--funcs` is for iterating, not for the number you quote: a short set is a
 different binary and a different JIT state (Java reads ~3x faster over 7
@@ -57,9 +70,26 @@ import tempfile
 HIST = 4096          # bars of history handed to Open
 FEED = 4096          # bars cycled through update/peek (power of two: index & mask)
 
+# Floor on how many functions an arm must parse before it is allowed to measure
+# anything. There are 176 streaming functions today, in each of the three
+# languages, and the number only ever grows. This is not a style check: #278
+# recased the Rust and Java stream APIs, both arms' Open regexes still spelled
+# the old names, and each silently parsed ZERO -- Rust's until c308e789, Java's
+# until this commit. Neither was found by CI; both were found by someone trying
+# to use the tool. A benchmark that measures nothing must fail, loudly, saying
+# what moved.
+FUNC_FLOOR = 170
+
 
 # --------------------------------------------------------------------------
 # Signature parsing — over the generated sources, one regex per language.
+#
+# Every arm takes the function NAME off the filename and decides indicator-ness
+# on something outside the stream API, so a recasing of that API turns a
+# function into a reported decline rather than a silent disappearance. The
+# emitted call still carries the spelling read out of the source, because that
+# is what has to compile; only the report key is filename-derived, which is what
+# `--funcs`/`--mark` and every other tool in this tree spell.
 # --------------------------------------------------------------------------
 
 def parse_rust(root):
@@ -69,17 +99,18 @@ def parse_rust(root):
     for fn in sorted(os.listdir(d)):
         if not fn.endswith(".rs"):
             continue
+        name = fn[:-3].upper()
         src = open(os.path.join(d, fn)).read()
-        # #278 recased the Rust stream API: `SMA_Open` -> `sma_open`,
-        # `SMA_Stream` -> `SmaStream`. The report still keys on the uppercase
-        # function name, which is what `--funcs`/`--mark` and every other tool
-        # here spell, so the emitted call carries its own spelling.
-        m = re.search(r"pub fn (\w+)_open\(&self, (.*?)\) -> Result<\((\w+Stream)\b", src)
-        if not m:
+        # The batch entry point, not the stream API: it is what separates an
+        # indicator from types.rs / mod.rs / the shared stream helpers, and it
+        # does not move when the stream API is recased.
+        if not re.search(r"pub fn %s_Lookback\(" % re.escape(name), src):
             continue
-        name = m.group(1).upper()
-        open_fn = f"{m.group(1)}_open"
-        handle = m.group(3)
+        m = re.search(r"pub fn (\w+_open)\(&self, ([^)]*?)\) -> Result<\((\w+Stream)\b", src)
+        if not m:
+            declined[name] = "no Open signature matched"
+            continue
+        open_fn, handle = m.group(1), m.group(3)
         args, why = [], None
         for a in [x.strip() for x in m.group(2).split(",") if x.strip()]:
             an, at = [x.strip() for x in a.split(":", 1)]
@@ -91,7 +122,7 @@ def parse_rust(root):
         if why:
             declined[name] = why
             continue
-        # Every `impl <N>_Stream` block, not just the first: the handle carries
+        # Every `impl <handle>` block, not just the first: the handle carries
         # more than one (the scratch restore lives in its own).
         m2 = None
         for impl in re.finditer(r"impl %s \{(.*?)\n\}" % handle, src, re.S):
@@ -113,15 +144,16 @@ def parse_java(root):
     for fn in sorted(os.listdir(d)):
         if not fn.startswith("Core_") or not fn.endswith(".java"):
             continue
+        name = fn[len("Core_"):-len(".java")]
         src = open(os.path.join(d, fn)).read()
         # #278 recased the Java stream API: `SMA_Open` -> `smaOpen`,
         # `SMA_Stream` -> `SmaStream`. The report keys on the uppercase function
         # name, which is what `--funcs`/`--mark` and every other tool here
         # spell, so it comes off the FILENAME and the emitted call carries its
         # own spelling. `OpenAndFill` cannot collide: the `(` is required.
-        name = fn[len("Core_"):-len(".java")]
         m = re.search(r"public (\w+Stream) (\w+Open)\( (.*?) \)\n", src)
         if not m:
+            declined[name] = "no Open signature matched"
             continue
         cls, open_fn = m.group(1), m.group(2)
         args, why = [], None
@@ -150,6 +182,54 @@ def parse_java(root):
         call = [x.split()[1] for x in m2.group(2).split(",") if x.strip()]
         funcs[name] = {"open": args, "call": call, "ret": m2.group(1),
                        "cls": cls, "openfn": open_fn}
+    return funcs, declined
+
+
+def parse_csharp(root):
+    """Same, from the generated C# per-function `partial class Core` files."""
+    d = os.path.join(root, "ta_codegen/output/csharp/library/src")
+    funcs, declined = {}, {}
+    for fn in sorted(os.listdir(d)):
+        if not (fn.startswith("Core_") and fn.endswith(".cs")):
+            continue                       # MAType.cs, FuncUnstId.cs
+        name = fn[len("Core_"):-len(".cs")]
+        src = open(os.path.join(d, fn)).read()
+        m = re.search(r"^   public (\w+Stream) (\w+Open)\( ([^)]*?) \)$", src, re.M)
+        if not m:
+            declined[name] = "no Open signature matched"
+            continue
+        handle, open_fn = m.group(1), m.group(2)
+        args, why = [], None
+        for a in [x.strip() for x in m.group(3).split(",") if x.strip()]:
+            ty, an = a.rsplit(" ", 1)
+            kind = {"ReadOnlySpan<double>": "slice", "int": "int",
+                    "double": "real", "MAType": "matype"}.get(ty)
+            if kind is None:
+                why = f"Open parameter {an}: {ty}"
+                break
+            args.append((kind, an))
+        if why:
+            declined[name] = why
+            continue
+        m2 = re.search(r"^      public (\S+) Update\( ([^)]*?) \)$", src, re.M)
+        if not m2:
+            declined[name] = "no Update method"
+            continue
+        ret = m2.group(1)
+        # A multi-output Update returns a `readonly record struct` declared in
+        # this same file. Consuming its first component keeps the sink one
+        # add — GetHashCode() would put a different amount of work in the timed
+        # loop for the multi-output functions than for the single-output ones.
+        member = None
+        if ret not in ("double", "int"):
+            mv = re.search(r"public readonly record struct %s\( \w+ (\w+)" % re.escape(ret), src)
+            if not mv:
+                declined[name] = f"Update returns {ret}, whose shape did not parse"
+                continue
+            member = mv.group(1)
+        call = [x.rsplit(" ", 1)[1] for x in m2.group(2).split(",") if x.strip()]
+        funcs[name] = {"open": args, "call": call, "ret": ret, "member": member,
+                       "openfn": open_fn}
     return funcs, declined
 
 
@@ -349,19 +429,146 @@ JAVA_BLOCK = """
       }"""
 
 
+# The .NET arm. Two differences from Java, both deliberate:
+#
+# `TieredCompilation` is pinned OFF in the harness csproj. With tiering on, a
+# method is first jitted at tier 0 and only re-jitted after it is called enough,
+# so the FIRST timed block in the process reads systematically slower than the
+# later ones purely from block order -- the hand-rolled bench that preceded this
+# arm showed exactly that. Discarding warm-up passes does not fix it, because
+# the effect is per-process and per-position, not per-pass. Off means every
+# method is fully optimised on its first call. The cost, stated rather than
+# hidden: this also disables dynamic PGO, so what is measured is the static-opt
+# code, not what a long-lived production process would eventually run. Both arms
+# get identical treatment, so the CHANGE column -- the output -- is unaffected;
+# the absolute ns are not production numbers, which was already true of the ns
+# columns in every arm here.
+#
+# Timing is `Stopwatch.GetTimestamp()` scaled by `Stopwatch.Frequency`, not
+# `DateTime`, and every number is formatted with the invariant culture so a
+# box with a comma decimal separator does not emit rows this script cannot parse.
+CSHARP_HEAD = """// Generated by scripts/stream_ab.py. Do not edit; do not commit.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using TALib;
+
+static class BenchStream
+{
+   const int HIST = %d;
+   const int FEED = %d;
+   static double sink = 0.0;
+   static double[][] c = new double[7][];
+   static double[] h_opn, h_high, h_low, h_close, h_vol, h_real1, h_periods;
+   static double[] f_opn, f_high, f_low, f_close, f_vol, f_real1, f_periods;
+   static long seed = 42L;
+
+   static double nxt()
+   {
+      seed = unchecked(seed * 6364136223846793005L + 1442695040888963407L);
+      return ((double)(seed >>> 33)) / 2147483648.0 - 0.5;
+   }
+
+   static void corpus(int n)
+   {
+      // Deterministic random walk. Timing-only: never hashed, unrelated to
+      // fuzz_data.h and to bench_corpus.h. Bit-for-bit the Rust and Java walk.
+      for (int k = 0; k < 7; k++) c[k] = new double[n];
+      double px = 100.0;
+      for (int i = 0; i < n; i++)
+      {
+         double op = px;
+         px = Math.Max(px + nxt(), 1.0);
+         c[0][i] = op;
+         c[1][i] = Math.Max(op, px) + 0.5 * Math.Abs(nxt());
+         c[2][i] = Math.Max(Math.Min(op, px) - 0.5 * Math.Abs(nxt()), 0.5);
+         c[3][i] = px;
+         c[4][i] = 1000.0 + 100.0 * nxt();
+         c[5][i] = px * 0.99 + 0.3;
+         c[6][i] = 14.0;
+      }
+   }
+
+   static double[] cut(int k, int from, int len)
+   {
+      double[] r = new double[len];
+      Array.Copy(c[k], from, r, 0, len);
+      return r;
+   }
+
+   static readonly double TICK_NS = 1e9 / Stopwatch.Frequency;
+   static double NsPer(long t0, int iters) => (Stopwatch.GetTimestamp() - t0) * TICK_NS / iters;
+   static void Say(string name, double ns) =>
+      Console.WriteLine("RESULT " + name + " " + ns.ToString("F4", CultureInfo.InvariantCulture));
+
+   static void Main(string[] argv)
+   {
+      CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+      int iters = argv.Length > 0 ? int.Parse(argv[0], CultureInfo.InvariantCulture) : 500000;
+      int passes = argv.Length > 1 ? int.Parse(argv[1], CultureInfo.InvariantCulture) : 5;
+      corpus(HIST + FEED);
+      h_opn = cut(0, 0, HIST); h_high = cut(1, 0, HIST); h_low = cut(2, 0, HIST);
+      h_close = cut(3, 0, HIST); h_vol = cut(4, 0, HIST); h_real1 = cut(5, 0, HIST);
+      h_periods = cut(6, 0, HIST);
+      f_opn = cut(0, HIST, FEED); f_high = cut(1, HIST, FEED); f_low = cut(2, HIST, FEED);
+      f_close = cut(3, HIST, FEED); f_vol = cut(4, HIST, FEED); f_real1 = cut(5, HIST, FEED);
+      f_periods = cut(6, HIST, FEED);
+      Core core = new Core();
+"""
+
+CSHARP_BLOCK = """
+      try
+      {
+         var all = new List<double>();
+         for (int p = 0; p < passes + 2; p++)
+         {
+            var st = core.%(openfn)s(%(oargs)s);
+            for (int i = 0; i < 20000; i++) { var r = st.%(call)s(%(cargs)s); %(consume)s }
+            long t0 = Stopwatch.GetTimestamp();
+            for (int i = 0; i < iters; i++) { var r = st.%(call)s(%(cargs)s); %(consume)s }
+            if (p >= 2) all.Add(NsPer(t0, iters));
+         }
+         all.Sort();
+         Say("%(name)s", all[0]);
+      }
+      catch (Exception e) { Console.WriteLine("OPENFAIL %(name)s " + e.GetType().Name); }"""
+
+CSHARP_OPEN_BLOCK = """
+      try
+      {
+         var all = new List<double>();
+         for (int p = 0; p < passes + 2; p++)
+         {
+            for (int i = 0; i < 200; i++) { sink += core.%(openfn)s(%(oargs)s) != null ? 1 : 0; }
+            long t0 = Stopwatch.GetTimestamp();
+            for (int i = 0; i < iters; i++) { sink += core.%(openfn)s(%(oargs)s) != null ? 1 : 0; }
+            if (p >= 2) all.Add(NsPer(t0, iters));
+         }
+         all.Sort();
+         Say("%(name)s", all[0]);
+      }
+      catch (Exception e) { Console.WriteLine("OPENFAIL %(name)s " + e.GetType().Name); }"""
+
+
+# How each language spells "use the documented default for this parameter".
+SENTINEL = {
+    "rust":   {"int": "i32::MIN", "real": "-4e37", "matype": "MAType::DEFAULT"},
+    "java":   {"int": "Integer.MIN_VALUE", "real": "-4e37", "matype": "MAType.DEFAULT"},
+    "csharp": {"int": "int.MinValue", "real": "-4e37", "matype": "MAType.DEFAULT"},
+}
+
+
 def open_args(f, lang, name, period, marked):
     """Open's arguments: history slices, and the default sentinel for each param."""
     out = []
     for kind, an in f["open"]:
         if kind == "slice":
             out.append("h_" + series(an))
-        elif kind == "int":
-            use = period if (period and name in marked) else None
-            out.append(str(use) if use else ("i32::MIN" if lang == "rust" else "Integer.MIN_VALUE"))
-        elif kind == "real":
-            out.append("-4e37")
+        elif kind == "int" and period and name in marked:
+            out.append(str(period))
         else:
-            out.append("MAType::DEFAULT" if lang == "rust" else "MAType.DEFAULT")
+            out.append(SENTINEL[lang][kind])
     return ", ".join(out)
 
 
@@ -405,22 +612,50 @@ def emit_java(funcs, names, call, period, marked):
     return "".join(s)
 
 
+def emit_csharp(funcs, names, call, period, marked):
+    s = [CSHARP_HEAD % (HIST, FEED)]
+    for name in names:
+        f = funcs[name]
+        if call == "open":
+            s.append(CSHARP_OPEN_BLOCK % {
+                "name": name, "openfn": f["openfn"],
+                "oargs": open_args(f, "csharp", name, period, marked),
+            })
+            continue
+        s.append(CSHARP_BLOCK % {
+            "name": name, "openfn": f["openfn"],
+            "call": call.capitalize(),          # C# spells them Update / Peek
+            "consume": "sink += r;" if f["member"] is None else f"sink += r.{f['member']};",
+            "oargs": open_args(f, "csharp", name, period, marked),
+            "cargs": ", ".join(f"f_{series(a)}[i & {FEED - 1}]" for a in f["call"]),
+        })
+    s.append('\n      Console.Error.WriteLine("sink " + sink);\n   }\n}\n')
+    return "".join(s)
+
+
 # --------------------------------------------------------------------------
 # Arm staging and build
 # --------------------------------------------------------------------------
 
-def run(cmd, cwd=None, check=True):
-    p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+def run(cmd, cwd=None, check=True, env=None):
+    p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=env)
     if check and p.returncode != 0:
         sys.exit(f"FAILED: {' '.join(cmd)}\n{p.stdout[-4000:]}{p.stderr[-4000:]}")
     return p
 
 
-def stage_tree(root, rev, dest, paths, strip):
+def stage_tree(root, rev, dest, paths, strip, ignore=None):
     os.makedirs(dest, exist_ok=True)
     if rev is None:
+        # `ignore` matters for the head arm only: `git archive` never carries
+        # untracked build output, but a copytree of the working tree does, and a
+        # stale obj/project.assets.json pins absolute paths from the tree it was
+        # restored in — which then fails the staged build with a message about a
+        # directory the user never asked to build.
+        ig = shutil.ignore_patterns(*ignore) if ignore else None
         for p in paths:
-            shutil.copytree(os.path.join(root, p), os.path.join(dest, os.path.basename(p)))
+            shutil.copytree(os.path.join(root, p), os.path.join(dest, os.path.basename(p)),
+                            ignore=ig)
         return
     ar = subprocess.run(["git", "archive", rev, "--"] + paths,
                         cwd=root, capture_output=True)
@@ -482,6 +717,51 @@ def build_java(root, arm, rev, work, src):
     return ["java", "-cp", classes, "BenchStream"]
 
 
+# TieredCompilation off: see the CSHARP_HEAD comment. The rest is the minimum
+# that compiles — this project is a throwaway, so it does not inherit the
+# library's TreatWarningsAsErrors/Nullable, which exist to police shipped code.
+CSHARP_BENCH_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>%s</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <AssemblyName>stream_ab</AssemblyName>
+    <Optimize>true</Optimize>
+    <TieredCompilation>false</TieredCompilation>
+    <TieredPGO>false</TieredPGO>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../library/TALib.csproj" />
+  </ItemGroup>
+</Project>
+"""
+
+
+def build_csharp(root, arm, rev, work, src):
+    d = os.path.join(work, "csharp", arm)
+    stage_tree(root, rev, d, ["ta_codegen/output/csharp/library"], strip=3,
+               ignore=["bin", "obj"])
+    csproj = os.path.join(d, "library/TALib.csproj")
+    if not os.path.exists(csproj):
+        sys.exit(f"[csharp/{arm}] no TALib.csproj in {rev or 'the working tree'}")
+    # Read the TFM off the arm's own library rather than pinning one here: the
+    # two arms are different revisions and the library has retargeted before.
+    m = re.search(r"<TargetFramework>(.*?)</TargetFramework>", open(csproj).read())
+    if not m:
+        sys.exit(f"[csharp/{arm}] TALib.csproj declares no <TargetFramework>")
+    tfm = m.group(1)
+    bench = os.path.join(d, "bench")
+    os.makedirs(bench, exist_ok=True)
+    open(os.path.join(bench, "stream_ab.csproj"), "w").write(CSHARP_BENCH_CSPROJ % tfm)
+    open(os.path.join(bench, "Program.cs"), "w").write(src)
+    env = dict(os.environ, DOTNET_CLI_TELEMETRY_OPTOUT="1", DOTNET_NOLOGO="1")
+    run(["dotnet", "build", "-c", "Release", "--nologo", "stream_ab.csproj"],
+        cwd=bench, env=env)
+    return ["dotnet", os.path.join(bench, f"bin/Release/{tfm}/stream_ab.dll")]
+
+
 # --------------------------------------------------------------------------
 # Run and report
 # --------------------------------------------------------------------------
@@ -528,11 +808,24 @@ def report(lang, call, data, marked, rounds, iters):
     return rows
 
 
+# parse / emit / build, per --lang value.
+ARMS = {
+    "rust":   (parse_rust, emit_rust, build_rust),
+    "java":   (parse_java, emit_java, build_java),
+    "csharp": (parse_csharp, emit_csharp, build_csharp),
+}
+
+# Checked up front for every requested arm: the rust leg alone is minutes, and
+# finding out only then that the next arm has no compiler wastes all of it.
+TOOLCHAIN = {"rust": ["cargo"], "java": ["javac", "java"], "csharp": ["dotnet"]}
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--base", required=True, help="git revision to compare the working tree against")
-    ap.add_argument("--lang", default="rust,java", help="rust,java (default both)")
+    ap.add_argument("--lang", default="rust,java,csharp",
+                    help="rust,java,csharp (default all three)")
     ap.add_argument("--call", default="update", choices=["update", "peek", "open"])
     ap.add_argument("--rounds", type=int, default=6, help="interleaved A/B rounds (default 6)")
     ap.add_argument("--iters", type=int, default=None,
@@ -550,6 +843,15 @@ def main():
         # where update/peek cost nanoseconds; 500k of them would run for hours.
         args.iters = 2000 if args.call == "open" else 500000
 
+    langs = [l for l in args.lang.split(",") if l]
+    for lang in langs:
+        if lang not in ARMS:
+            sys.exit(f"unknown --lang={lang}; known: {', '.join(sorted(ARMS))}")
+        for tool in TOOLCHAIN[lang]:
+            if shutil.which(tool) is None:
+                sys.exit(f"--lang={lang} needs `{tool}` on PATH, and it is not "
+                         f"there. Drop it from --lang to run the other arms.")
+
     root = run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
     marked = {f for f in args.mark.split(",") if f}
     only = {f for f in args.funcs.split(",") if f}
@@ -557,24 +859,35 @@ def main():
     keep = bool(args.workdir)
 
     try:
-        for lang in [l for l in args.lang.split(",") if l]:
-            funcs, declined = (parse_rust(root) if lang == "rust" else parse_java(root))
+        for lang in langs:
+            parse, emit, build = ARMS[lang]
+            funcs, declined = parse(root)
             if declined:
+                # Capped: when a rename takes out the whole API, every function
+                # declines for the same reason, and 176 of them bury the one
+                # line that says what to do about it.
+                shown = list(declined.items())[:8]
                 print(f"[{lang}] not benchable ({len(declined)}): " +
-                      ", ".join(f"{k} ({v})" for k, v in declined.items()))
+                      ", ".join(f"{k} ({v})" for k, v in shown) +
+                      (f", ... and {len(declined) - len(shown)} more"
+                       if len(declined) > len(shown) else ""))
+            # The floor is on what was PARSED, not on what `--funcs` selected:
+            # it is a claim about the parser, and it must fire whether or not
+            # this invocation narrowed the set.
+            if len(funcs) < FUNC_FLOOR:
+                sys.exit(f"[{lang}] parsed {len(funcs)} streaming functions, "
+                         f"below the floor of {FUNC_FLOOR} - the generated API "
+                         f"spelling has moved out from under this parser. A run "
+                         f"that measures nothing must not report a clean sweep. "
+                         f"Fix parse_{lang}() (and raise the floor if the count "
+                         f"is genuinely lower now).")
             names = sorted(f for f in funcs if not only or f in only)
             missing = (marked | only) - set(names)
             if missing:
                 sys.exit(f"[{lang}] requested but not benchable: {sorted(missing)}")
-            if not names:
-                sys.exit(f"[{lang}] parsed 0 benchable functions - the generated "
-                         f"API spelling has moved out from under this parser. A run "
-                         f"that measures nothing must not report a clean sweep.")
             print(f"[{lang}] {len(names)} functions, {len(marked)} marked; building both arms")
 
-            emit = emit_rust if lang == "rust" else emit_java
             src = emit(funcs, names, args.call, args.period, marked)
-            build = build_rust if lang == "rust" else build_java
             cmds = {"head": build(root, "head", None, work, src),
                     "base": build(root, "base", args.base, work, src)}
 
@@ -592,7 +905,7 @@ def main():
 
             rows = report(lang, args.call, data, marked, args.rounds, args.iters)
             if args.json:
-                path = args.json if len(args.lang.split(",")) == 1 else f"{args.json}.{lang}"
+                path = args.json if len(langs) == 1 else f"{args.json}.{lang}"
                 json.dump({"lang": lang, "call": args.call, "base": args.base,
                            "rounds": args.rounds, "iters": args.iters,
                            "raw": data, "rows": rows}, open(path, "w"), indent=1)


### PR DESCRIPTION
#299 asks for a `--lang=csharp` arm on `scripts/stream_ab.py` matching the two that exist, and a floor assertion so a benchmark that measures nothing cannot exit 0. Building the first one turned up the second's motivating case still live.

## The Java arm parses 0 of 176 functions on `dev` today

#299 records that #278's recasing broke both existing arms, that Rust's was fixed in `c308e789`, and that Java's "stayed broken until 2026-08-30". On `dev` at `12987063` it is still broken. `parse_java` looks for

    public (\w+)_Stream (\w+)_Open\( (.*?) \)

and the generator has emitted `public SmaStream smaOpen( double inReal[], ... )` since #280 landed. Measured on this tree before any change here:

    rust parsed 176 declined 0
    java parsed 0   declined 0

The consequence is not silent — `--lang=java` dies at the existing "parsed 0" guard, or reports every `--mark`ed function as "requested but not benchable" — but the Java streaming tier has had no A/B tool at all since 28 Aug. This PR fixes it: the Open regex, the handle-class regex, and the emitted `Core.SMA_Stream st = core.SMA_Open(...)` call, which had the same stale spelling baked into `JAVA_BLOCK`/`JAVA_OPEN_BLOCK`.

## The floor gate

`FUNC_FLOOR = 170` (against 176 today, in each of the three languages), asserted on what the parser *found*, not on what `--funcs` selected — it is a claim about the parser, so it must fire whether or not the invocation narrowed the set.

Each arm also now takes the function NAME off the filename rather than off the method, and decides indicator-ness on something outside the stream API (Rust: the batch `XXX_Lookback`; Java/C#: the `Core_XXX.` filename). A stream-API recasing therefore turns a function into a reported *decline* instead of a silent disappearance. The decline list is capped at 8 entries plus a count — when a rename takes out the whole API, 176 identical reasons bury the one line that says what to do.

**Control, and it goes red.** I edited each arm's Open regex back to its pre-#278 spelling, one arm at a time, and ran it:

    [rust]   parsed 0 streaming functions, below the floor of 170 - ... Fix parse_rust() ...     exit=1
    [java]   parsed 0 streaming functions, below the floor of 170 - ... Fix parse_java() ...     exit=1
    [csharp] parsed 0 streaming functions, below the floor of 170 - ... Fix parse_csharp() ...   exit=1

All three fire before any build work. Reverted; all three then parse 176.

## The C# arm

Signatures come from `ta_codegen/output/csharp/library/src/Core_<NAME>.cs`, one file per function. All 176 parse with no declines. The arm builds a generated `stream_ab.csproj` with a `ProjectReference` to that arm's `TALib.csproj`, taking the TFM off the arm's own csproj rather than pinning one here, since the two arms are different revisions and the library has retargeted before.

Two decisions worth stating, both costs rather than wins:

**`TieredCompilation` is pinned off** in the harness project. #299 reports that tiering makes the first timed block in the process read systematically slower than later ones purely from position, which discarding warm-up passes cannot fix because the effect is per-process and per-position. Off means every method is fully optimised on its first call. **The cost: dynamic PGO goes off with it**, so the C# ns columns are static-opt numbers, not what a long-lived process settles at. Both arms get identical treatment so the change column — the output — is unaffected, and the ns columns were never comparable across invocations anyway. I did *not* independently reproduce the block-order effect; I pinned the setting the issue names, which is deterministic and arm-symmetric either way.

**`--lang` now defaults to `rust,java,csharp`**, so a bare `scripts/stream_ab.py --base=X` now needs `dotnet` as well as `cargo` and `javac`. That is a real new prerequisite for the default invocation. There is a preflight check for every requested arm's toolchain that names the missing tool and says to drop it from `--lang`, run before any build so the rust leg's minutes are not spent first. If you would rather the default stay `rust,java`, that is a one-line change — say so and I will make it.

Smaller notes: the arm runs the built dll rather than `dotnet run` (as #299 suggested), because `measure()` invokes the command 8 times per round and `dotnet run` re-evaluates the project each time; building once keeps the arm's binary fixed for the whole run, as the other two arms do. And `stage_tree` now takes an `ignore` list, used for `bin`/`obj`: `git archive` never carries build output but the head arm's `copytree` does, and a stale `obj/project.assets.json` pins absolute paths from the tree it was restored in.

## Proving the arm can see something

Per the `ta-bench` skill's standing requirement for a C# lane — reproduce a *known* effect before trusting the tool on an unknown one.

**Null control.** Both arms byte-identical (`--base=HEAD`), full 176-function sweep, `--call=peek --rounds=4 --iters=100000 --passes=3`:

    marked   n=110  median -0.5%  (-0.45 ns)
    control  n=66   median -0.3%  (-0.07 ns)  past 10%: 2  past 25%: 0
    median control spread 10.7%

**Known effect.** 81 of the 176 generated C# `Peek`s reuse a cached `peekScratch` handle; the other 95 allocate a fresh copy. In a throwaway working-tree edit (never committed) I rewrote those 81 to allocate too, marked exactly them, and left the other 95 as byte-identical code. Same settings:

    marked   n=81   median +143.0%  (+101.82 ns)
    control  n=95   median -0.2%   (-0.09 ns)  past 10%: 18  past 25%: 1
    median control spread 22.5%

The effect group moves +143% and the untouched group sits at -0.2%. The arm sees a real change and does not manufacture one.

Both runs on .NET SDK 10.0.400 / `net10.0`, on a shared box — hence the 10–22% median per-row spread, which is why the group medians and not any single row are the readable part.

## What I did not check

- Only Linux. Nothing here was run on Windows or macOS.
- The full-sweep evidence above is `--call=peek`. `--call=update` and `--call=open` were smoke-run on small function sets for all three arms, not swept.
- The `TreatWarningsAsErrors` hazard #299 names — a base arm from an older revision must compile *warning-clean* under today's SDK, not merely compile — is documented in the docstring and the skill, and I saw it fire once (an unused-field CS0169 during the sabotage run above). A real older base does work: `--base=edb9c6c6 --lang=csharp` (29 Aug, a different C# library than HEAD) builds both arms clean under SDK 10.0.400. I did not survey how far back a `--base` can reach before it stops building, and a pre-#278 base will not work at all, since the emitted harness is written against today's signatures.

## Files

- `scripts/stream_ab.py` — the C# arm, the Java fix, the floor, the toolchain preflight, filename-derived names.
- `.claude/skills/ta-bench/SKILL.md` — the C# lane is no longer a gap; the floor and the tiering cost are written down where someone defending a number will read them.
