### PR TITLE
docs(rust): trim Formula/Notes off rustdoc, link to ta-lib.org instead (#179 D6 follow-up)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_doc.rs
+++ b/ta_codegen/generator/src/backends/rust_doc.rs
@@ -2,10 +2,17 @@
 //!
 //! Renders each function's canonical documentation (`ta_codegen/input/<name>/<name>.md`,
 //! parsed into [`DocDef`]) as idiomatic rustdoc on the generated `Core` methods:
-//! summary, plain-text formula, notes, `# Arguments` with ranges/defaults injected
-//! from the YAML metadata, `# Errors` / `# Panics`, a runnable `# Examples` doctest,
-//! `# See also` intra-doc links, references, a ta-lib.org deep link, and
+//! summary, a ta-lib.org deep link for formula/notes, `# Arguments` with
+//! ranges/defaults injected from the YAML metadata, `# Errors` / `# Panics`, a
+//! runnable `# Examples` doctest, `# See also` intra-doc links, references, and
 //! `#[doc(alias)]` attributes for docs.rs search.
+//!
+//! Formula and Notes stay ta-lib.org-only, not duplicated here: the canonical
+//! `.md` can grow LaTeX-like notation and eventually images on that page, and
+//! rustdoc's plain-CommonMark renderer has no path to match it. Keeping only
+//! Summary here (short, plain prose, never at that risk) and linking out for
+//! the rest means the two never need two renderings of the same formula to
+//! agree.
 //!
 //! Prose is escaped for rustdoc's markdown: `[` and `<` outside code spans would
 //! otherwise be parsed as intra-doc links / HTML tags (the canonical docs are full
@@ -38,25 +45,15 @@ pub fn guarded_docs(
 
     d.paragraph(&summary_text(func, doc));
 
-    if let Some(formula) = &doc.formula {
-        d.blank();
-        d.paragraph("# Formula");
-        d.blank();
-        d.fenced_text(formula);
-        if let Some(note) = &doc.formula_note {
-            d.blank();
-            d.paragraph(&escape_prose(note));
-        }
-    }
-
-    if !doc.notes.is_empty() {
-        d.blank();
-        d.paragraph("# Notes");
-        d.blank();
-        for note in &doc.notes {
-            d.bullet(&escape_prose(note));
-        }
-    }
+    // The site builds flat files (`dist/functions/sma.html`), so the slug is the
+    // lower-cased name and carries no trailing slash: `/functions/SMA` and
+    // `/functions/sma/` both 404. Same rule as `docs_site::generate`, which is
+    // what names the page.
+    let slug = func.name.to_lowercase();
+    d.blank();
+    d.paragraph(&format!(
+        "Formula and more info at [ta-lib.org/functions/{slug}](https://ta-lib.org/functions/{slug})."
+    ));
 
     d.blank();
     d.paragraph("# Arguments");
@@ -164,16 +161,6 @@ pub fn guarded_docs(
             d.bullet(&escape_prose(r));
         }
     }
-
-    d.blank();
-    // The site builds flat files (`dist/functions/sma.html`), so the slug is the
-    // lower-cased name and carries no trailing slash: `/functions/SMA` and
-    // `/functions/sma/` both 404. Same rule as `docs_site::generate`, which is
-    // what names the page.
-    let slug = func.name.to_lowercase();
-    d.paragraph(&format!(
-        "Further reading: [ta-lib.org/functions/{slug}](https://ta-lib.org/functions/{slug})"
-    ));
 
     let mut out = d.finish();
     for alias in doc_aliases(func, doc) {
@@ -817,15 +804,6 @@ impl DocWriter {
                 self.push_line(&format!("  {line}"));
             }
         }
-    }
-
-    /// Emit a ```text fenced block, lines verbatim (no wrapping, no escaping).
-    fn fenced_text(&mut self, body: &str) {
-        self.push_line_raw("```text");
-        for line in body.lines() {
-            self.push_line_raw(line);
-        }
-        self.push_line_raw("```");
     }
 
     /// Emit pre-built raw markdown lines verbatim (e.g. a doctest).

--- a/ta_codegen/output/rust/library/src/ta_func/ac.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ac.rs
@@ -311,13 +311,7 @@ impl Core {
     /// alongside the Awesome Oscillator ([`AO`](https://ta-lib.org/functions/ao)) and the
     /// Alligator.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// median_t = ( high_t + low_t ) / 2  
-    /// AO_t = SMA(median, fast)_t − SMA(median, slow)_t  
-    /// AC_t = AO_t − SMA(AO, signal)_t
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/ac](https://ta-lib.org/functions/ac).
     ///
     /// # Arguments
     ///
@@ -385,8 +379,6 @@ impl Core {
     ///   reports its first value at the same bar. Its moving average re-sums the stored window on
     ///   every bar where TA-Lib rolls a running total, so the two agree to rounding rather than to
     ///   the bit.
-    ///
-    /// Further reading: [ta-lib.org/functions/ac](https://ta-lib.org/functions/ac)
     #[doc(alias = "AcceleratorOscillator")]
     #[doc(alias = "DeceleratorOscillator")]
     #[doc(alias = "AcceleratorDecelerator")]

--- a/ta_codegen/output/rust/library/src/ta_func/accbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/accbands.rs
@@ -247,13 +247,8 @@ impl Core {
     /// Acceleration Bands: three overlap lines around price. The middle band is an SMA of the
     /// close; the upper/lower bands are SMAs of the high/low scaled by an intraday-range factor.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// factor = 4*(H-L)/(H+L)
-    /// upperRaw = H*(1+factor), lowerRaw = L*(1-factor)
-    /// Upper = SMA(upperRaw, N), Middle = SMA(Close, N), Lower = SMA(lowerRaw, N)
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/accbands](https://ta-lib.org/functions/accbands).
     ///
     /// # Arguments
     ///
@@ -316,8 +311,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SMA`] · [`Core::BBANDS`]
-    ///
-    /// Further reading: [ta-lib.org/functions/accbands](https://ta-lib.org/functions/accbands)
     #[doc(alias = "AccelerationBands")]
     pub fn ACCBANDS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/acos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/acos.rs
@@ -107,16 +107,7 @@ impl Core {
     }
     /// Element-wise arc cosine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = acos(inReal[i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Outside \[-1, 1] there is no angle whose cosine is that value, so those elements come out
-    ///   NaN.
+    /// Formula and more info at [ta-lib.org/functions/acos](https://ta-lib.org/functions/acos).
     ///
     /// # Arguments
     ///
@@ -166,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Inverse trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Inverse_trigonometric_functions](https://en.wikipedia.org/wiki/Inverse_trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/acos](https://ta-lib.org/functions/acos)
     #[doc(alias = "ArcCosine")]
     #[doc(alias = "InverseCosine")]
     #[doc(alias = "arccos")]

--- a/ta_codegen/output/rust/library/src/ta_func/ad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ad.rs
@@ -148,11 +148,7 @@ impl Core {
     /// volume-weighted money-flow multiplier per bar to gauge buying vs. selling pressure. Rising
     /// line = accumulation (buying pressure); falling = distribution.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MFM = ((close-low) - (high-close)) / (high-low); AD_t = AD_{t-1} + MFM_t * volume_t (running sum, seeded at 0)
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/ad](https://ta-lib.org/functions/ad).
     ///
     /// # Arguments
     ///
@@ -207,8 +203,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ADOSC`] · [`Core::OBV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/ad](https://ta-lib.org/functions/ad)
     #[doc(alias = "ChaikinADLine")]
     #[doc(alias = "AccumulationDistributionLine")]
     #[doc(alias = "AccumulationDistribution")]

--- a/ta_codegen/output/rust/library/src/ta_func/add.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/add.rs
@@ -109,11 +109,7 @@ impl Core {
     }
     /// Element-wise addition of two input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = inReal0[i] + inReal1[i]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/add](https://ta-lib.org/functions/add).
     ///
     /// # Arguments
     ///
@@ -162,8 +158,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SUB`] · [`Core::MULT`] · [`Core::DIV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/add](https://ta-lib.org/functions/add)
     #[doc(alias = "VectorAdd")]
     #[doc(alias = "VectorArithmeticAdd")]
     pub fn ADD(

--- a/ta_codegen/output/rust/library/src/ta_func/adosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adosc.rs
@@ -295,14 +295,7 @@ impl Core {
     /// Accumulation/Distribution line. Highlights momentum in accumulation/distribution volume
     /// flow. Positive/rising suggests accumulation; negative/falling suggests distribution.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ad += ((close-low)-(high-close))/(high-low) * volume   (only when high>low)
-    /// fastEMA = fastk*ad + (1-fastk)*fastEMA,  fastk = 2/(optInFastPeriod+1)
-    /// slowEMA = slowk*ad + (1-slowk)*slowEMA,  slowk = 2/(optInSlowPeriod+1)
-    /// ADOSC = fastEMA - slowEMA
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/adosc](https://ta-lib.org/functions/adosc).
     ///
     /// # Arguments
     ///
@@ -369,8 +362,6 @@ impl Core {
     /// # References
     ///
     /// * Marc Chaikin
-    ///
-    /// Further reading: [ta-lib.org/functions/adosc](https://ta-lib.org/functions/adosc)
     #[doc(alias = "ChaikinADOscillator")]
     #[doc(alias = "ChaikinOscillator")]
     pub fn ADOSC(

--- a/ta_codegen/output/rust/library/src/ta_func/adx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adx.rs
@@ -486,15 +486,7 @@ impl Core {
     /// regardless of direction. Higher values indicate a stronger trend (a common convention treats
     /// \>25 as trending); says nothing about direction.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// +DI = 100*(+DM_p/TR_p), -DI = 100*(-DM_p/TR_p); DX = 100*|(-DI)-(+DI)| / ((-DI)+(+DI)); first ADX = mean of the first `period` DX; then ADX = (prevADX*(period-1) + DX)/period. +DM_p/-DM_p/TR_p use Wilder smoothing: X = X - X/period + today's one-bar value.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Wilder's original integer rounding is not applied.
+    /// Formula and more info at [ta-lib.org/functions/adx](https://ta-lib.org/functions/adx).
     ///
     /// # Arguments
     ///
@@ -556,8 +548,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/adx](https://ta-lib.org/functions/adx)
     #[doc(alias = "AverageDirectionalMovementIndex")]
     #[doc(alias = "AverageDirectionalIndex")]
     pub fn ADX(

--- a/ta_codegen/output/rust/library/src/ta_func/adxr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adxr.rs
@@ -183,15 +183,7 @@ impl Core {
     /// (period-1) bars earlier. Further damps ADX to gauge trend strength. Higher values mean a
     /// stronger trend; smoother and more lagging than ADX.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ADXR[i] = (ADX[i] + ADX[i-(period-1)]) / 2
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Wilder's original integer rounding is not applied (unreliable when values are near 1).
+    /// Formula and more info at [ta-lib.org/functions/adxr](https://ta-lib.org/functions/adxr).
     ///
     /// # Arguments
     ///
@@ -252,8 +244,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/adxr](https://ta-lib.org/functions/adxr)
     #[doc(alias = "AverageDirectionalMovementIndexRating")]
     pub fn ADXR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/ao.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ao.rs
@@ -244,14 +244,7 @@ impl Core {
     /// alongside the Alligator and the Accelerator/Decelerator
     /// ([`AC`](https://ta-lib.org/functions/ac)).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// median_t = ( high_t + low_t ) / 2  
-    /// AO_t = SMA(median, fast)_t − SMA(median, slow)_t
-    ///
-    /// An inverted pair is not swapped: passing a fast period longer than the slow one is well defined and simply yields −AO.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/ao](https://ta-lib.org/functions/ao).
     ///
     /// # Arguments
     ///
@@ -315,8 +308,6 @@ impl Core {
     ///   inputs, and both report the first value at the same bar.
     /// * pandas-ta-classic swaps an inverted pair before computing, so it answers AO(slow, fast)
     ///   where this answers its negation.
-    ///
-    /// Further reading: [ta-lib.org/functions/ao](https://ta-lib.org/functions/ao)
     #[doc(alias = "AwesomeOscillator")]
     #[doc(alias = "BillWilliamsAwesomeOscillator")]
     #[doc(alias = "BWAO")]

--- a/ta_codegen/output/rust/library/src/ta_func/apo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/apo.rs
@@ -203,19 +203,7 @@ impl Core {
     /// input, in price units. Measures short- vs long-term momentum. Positive when fast MA > slow
     /// MA (upward momentum); negative otherwise.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $APO = MA_{fast}(inReal) - MA_{slow}(inReal)$, both MAs of type optInMAType
-    ///
-    /// The standard form is exponential — APO with EMA and periods 12/26 is the fast-minus-slow EMA construction underlying the MACD (in price units). `optInMAType` therefore **defaults to EMA** — the moving average Gerald Appel used for the original MACD; pass another type (e.g. `TA_MAType_SMA`) to override.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * `optInMAType` applies to both the fast and slow moving average. `TA_MAType_MAMA` ignores
-    ///   its period argument, so with `optInMAType = TA_MAType_MAMA` the fast and slow MAs are
-    ///   identical and the output is zero at every bar.
+    /// Formula and more info at [ta-lib.org/functions/apo](https://ta-lib.org/functions/apo).
     ///
     /// # Arguments
     ///
@@ -275,8 +263,6 @@ impl Core {
     ///   newsletter). The APO is the same fast-minus-slow moving-average oscillator in price units;
     ///   with exponential moving averages and periods 12/26 it is the oscillator underlying the
     ///   MACD line. Appel's original definition uses **exponential** moving averages.
-    ///
-    /// Further reading: [ta-lib.org/functions/apo](https://ta-lib.org/functions/apo)
     #[doc(alias = "AbsolutePriceOscillator")]
     pub fn APO(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -213,11 +213,7 @@ impl Core {
     /// Up near 100 = a very recent new high (strong uptrend); Down near 100 = a very recent new
     /// low. Up/Down crossovers signal trend shifts.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Up = 100*(period-(today-highestIdx))/period; Down = 100*(period-(today-lowestIdx))/period, where highestIdx/lowestIdx index the highest high / lowest low over the window [today-period .. today].
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/aroon](https://ta-lib.org/functions/aroon).
     ///
     /// # Arguments
     ///
@@ -279,8 +275,6 @@ impl Core {
     /// # References
     ///
     /// * Tushar S. Chande
-    ///
-    /// Further reading: [ta-lib.org/functions/aroon](https://ta-lib.org/functions/aroon)
     pub fn AROON(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
@@ -222,15 +222,8 @@ impl Core {
     /// and strength on a -100..+100 scale. Positive when the high is more recent than the low
     /// (up-trend); negative when the low is more recent (down-trend).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// factor = 100 / optInTimePeriod
-    /// AroonUp   = factor * (period - (today - highestIdx))
-    /// AroonDown = factor * (period - (today - lowestIdx))
-    /// AroonOsc  = AroonUp - AroonDown = factor * (highestIdx - lowestIdx)
-    /// highestIdx/lowestIdx = bar index of the highest high / lowest low in the last (period+1) bars.
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/aroonosc](https://ta-lib.org/functions/aroonosc).
     ///
     /// # Arguments
     ///
@@ -286,8 +279,6 @@ impl Core {
     /// # References
     ///
     /// * Tushar S. Chande
-    ///
-    /// Further reading: [ta-lib.org/functions/aroonosc](https://ta-lib.org/functions/aroonosc)
     #[doc(alias = "AroonOscillator")]
     pub fn AROONOSC(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/asin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/asin.rs
@@ -107,16 +107,7 @@ impl Core {
     }
     /// Element-wise arcsine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = asin(inReal[i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Outside \[-1, 1] there is no angle whose sine is that value, so those elements come out
-    ///   NaN.
+    /// Formula and more info at [ta-lib.org/functions/asin](https://ta-lib.org/functions/asin).
     ///
     /// # Arguments
     ///
@@ -166,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Inverse trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Inverse_trigonometric_functions](https://en.wikipedia.org/wiki/Inverse_trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/asin](https://ta-lib.org/functions/asin)
     #[doc(alias = "arcsine")]
     #[doc(alias = "inversesine")]
     pub fn ASIN(

--- a/ta_codegen/output/rust/library/src/ta_func/atan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atan.rs
@@ -108,11 +108,7 @@ impl Core {
     }
     /// Element-wise arctangent of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = atan(inReal[i])  (radians, range (-pi/2, pi/2))
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/atan](https://ta-lib.org/functions/atan).
     ///
     /// # Arguments
     ///
@@ -162,8 +158,6 @@ impl Core {
     ///
     /// * Wikipedia, *Inverse trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Inverse_trigonometric_functions](https://en.wikipedia.org/wiki/Inverse_trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/atan](https://ta-lib.org/functions/atan)
     #[doc(alias = "arctangent")]
     #[doc(alias = "arctan")]
     #[doc(alias = "inversetangent")]

--- a/ta_codegen/output/rust/library/src/ta_func/atr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atr.rs
@@ -268,13 +268,7 @@ impl Core {
     /// Wilder-smoothed average of the True Range over a period, measuring price volatility
     /// regardless of direction. Higher ATR means greater volatility; no directional bias.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// TR_t = max(high-low, |prevClose-high|, |prevClose-low|)
-    /// ATR seed = simple average of first `period` TR values
-    /// ATR_t = (ATR_{t-1} * (period-1) + TR_t) / period
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/atr](https://ta-lib.org/functions/atr).
     ///
     /// # Arguments
     ///
@@ -334,8 +328,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/atr](https://ta-lib.org/functions/atr)
     #[doc(alias = "AverageTrueRange")]
     pub fn ATR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
@@ -158,11 +158,7 @@ impl Core {
     /// last N periods. Measures dispersion around the window mean. Higher values indicate greater
     /// spread; zero when all values in the window are equal.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $mean_t = \frac{1}{N}\sum_{i=0}^{N-1} x_{t-i}$; $AVGDEV_t = \frac{1}{N}\sum_{i=0}^{N-1} |x_{t-i} - mean_t|$ (N = optInTimePeriod)
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/avgdev](https://ta-lib.org/functions/avgdev).
     ///
     /// # Arguments
     ///
@@ -211,8 +207,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::STDDEV`] · [`Core::VAR`] · [`Core::SMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/avgdev](https://ta-lib.org/functions/avgdev)
     #[doc(alias = "AverageDeviation")]
     #[doc(alias = "MeanAbsoluteDeviation")]
     #[doc(alias = "MAD")]

--- a/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
@@ -117,11 +117,8 @@ impl Core {
     /// Average Price: the arithmetic mean of each bar's open, high, low, and close. A
     /// price-transform overlap condensing OHLC into a single representative price.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = (High[i] + Low[i] + Close[i] + Open[i]) / 4
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/avgprice](https://ta-lib.org/functions/avgprice).
     ///
     /// # Arguments
     ///
@@ -176,8 +173,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MEDPRICE`] · [`Core::TYPPRICE`] · [`Core::WCLPRICE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/avgprice](https://ta-lib.org/functions/avgprice)
     #[doc(alias = "AveragePrice")]
     pub fn AVGPRICE(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -483,29 +483,7 @@ impl Core {
     /// Bollinger Bands: a moving-average middle band with upper and lower bands offset by a
     /// multiple of the standard deviation. Used to gauge relative price volatility.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $$
-    /// \begin{aligned}
-    /// \text{middle}_t &= \operatorname{MA}(X, n, \text{matype})_t \\
-    /// \sigma_t &= \operatorname{STDDEV}(X, n)_t \\
-    /// \text{upper}_t &= \text{middle}_t + k_{\text{up}}\,\sigma_t \\
-    /// \text{lower}_t &= \text{middle}_t - k_{\text{dn}}\,\sigma_t
-    /// \end{aligned}
-    /// $$
-    /// ```
-    ///
-    /// where $X$ is the input series, $n$ the period, $\text{matype}$ the moving-average type, and
-    /// $k_{\text{up}}$, $k_{\text{dn}}$ the upper and lower deviation multipliers.
-    ///
-    /// # Notes
-    ///
-    /// * The defaults reproduce Bollinger's original definition: a 20-period SMA middle band with
-    ///   $k_{\text{up}} = k_{\text{dn}} = 2$. Any other $\text{matype}$ is a TA-Lib generalisation.
-    /// * $\text{matype}$ sets where the envelope is centred; $n$ and $k$ set how wide it is. The
-    ///   two are independent — $\sigma$ depends only on the price window, so changing the middle
-    ///   band re-centres the bands without resizing them.
+    /// Formula and more info at [ta-lib.org/functions/bbands](https://ta-lib.org/functions/bbands).
     ///
     /// # Arguments
     ///
@@ -572,8 +550,6 @@ impl Core {
     /// # References
     ///
     /// * John A. Bollinger, *Bollinger on Bollinger Bands*, McGraw-Hill Trade (ISBN 0071373683)
-    ///
-    /// Further reading: [ta-lib.org/functions/bbands](https://ta-lib.org/functions/bbands)
     #[doc(alias = "BollingerBands")]
     pub fn BBANDS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/beta.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/beta.rs
@@ -462,11 +462,7 @@ impl Core {
     /// security moves relative to a market index. Beta = 1 moves with the index; \< 1 less
     /// volatile, > 1 more volatile.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Per-bar returns: $x_i=(p^0_i-p^0_{i-1})/p^0_{i-1}$ from inReal0, $y_i=(p^1_i-p^1_{i-1})/p^1_{i-1}$ from inReal1. With $n$=period over the window: $\beta = \dfrac{n\,S_{xy}-S_x S_y}{n\,S_{xx}-S_x^2}$, where $S_{xx}=\sum x^2,\ S_{xy}=\sum xy,\ S_x=\sum x,\ S_y=\sum y$.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/beta](https://ta-lib.org/functions/beta).
     ///
     /// # Arguments
     ///
@@ -520,8 +516,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CORREL`] · [`Core::LINEARREG_SLOPE`] · [`Core::VAR`] · [`Core::STDDEV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/beta](https://ta-lib.org/functions/beta)
     #[doc(alias = "Betacoefficient")]
     pub fn BETA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/bop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bop.rs
@@ -130,11 +130,7 @@ impl Core {
     /// high-low range. A per-bar oscillator with no smoothing. Positive: close above open (buyers
     /// dominated); negative: sellers dominated.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// BOP = (Close - Open) / (High - Low)
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/bop](https://ta-lib.org/functions/bop).
     ///
     /// # Arguments
     ///
@@ -185,8 +181,6 @@ impl Core {
     /// assert!(out[..out_range.count].iter().all(|v| v.is_finite()));
     /// # Ok::<(), ta_lib::RetCode>(())
     /// ```
-    ///
-    /// Further reading: [ta-lib.org/functions/bop](https://ta-lib.org/functions/bop)
     #[doc(alias = "BalanceOfPower")]
     pub fn BOP(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cci.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cci.rs
@@ -244,14 +244,7 @@ impl Core {
     /// average, scaled by mean absolute deviation. Momentum oscillator flagging overbought/oversold
     /// extremes. CCI > +100 overbought; CCI \< -100 oversold.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// TP_i = (High_i + Low_i + Close_i)/3
-    /// SMA = (1/N) * sum(TP over N bars)
-    /// meanDev = (1/N) * sum(|TP - SMA| over N bars)
-    /// CCI = (TP_last - SMA) / (0.015 * meanDev)
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/cci](https://ta-lib.org/functions/cci).
     ///
     /// # Arguments
     ///
@@ -311,8 +304,6 @@ impl Core {
     /// # References
     ///
     /// * Donald Lambert
-    ///
-    /// Further reading: [ta-lib.org/functions/cci](https://ta-lib.org/functions/cci)
     #[doc(alias = "CommodityChannelIndex")]
     pub fn CCI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
@@ -229,13 +229,8 @@ impl Core {
     /// body. A hit (-100) signals a bearish reversal; significant in an uptrend, which this
     /// function does not verify.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior uptrend the pattern classically assumes for significance.
-    /// * Bulkowski's testing found this reverses bearishly only 54% of the time — "near random"
-    ///   — despite the pattern's classic always-bearish label; the breakout direction cannot be
-    ///   predicted with any real accuracy.
-    ///   ([thepatternsite.com](https://thepatternsite.com/TwoCrows.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl2crows](https://ta-lib.org/functions/cdl2crows).
     ///
     /// # Arguments
     ///
@@ -290,8 +285,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLUPSIDEGAP2CROWS`] · [`Core::CDLIDENTICAL3CROWS`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdl2crows](https://ta-lib.org/functions/cdl2crows)
     #[doc(alias = "TwoCrows")]
     pub fn CDL2CROWS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
@@ -274,9 +274,8 @@ impl Core {
     /// successively lower closes, each opening inside the prior black's real body. It is a bearish
     /// reversal signal. A hit (-100) signals a bearish reversal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior mature uptrend the pattern classically assumes for significance.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3blackcrows](https://ta-lib.org/functions/cdl3blackcrows).
     ///
     /// # Arguments
     ///
@@ -333,9 +332,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3WHITESOLDIERS`] · [`Core::CDLIDENTICAL3CROWS`] · [`Core::CDLADVANCEBLOCK`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdl3blackcrows](https://ta-lib.org/functions/cdl3blackcrows)
     #[doc(alias = "ThreeBlackCrows")]
     #[doc(alias = "3BlackCrows")]
     pub fn CDL3BLACKCROWS(

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
@@ -292,14 +292,8 @@ impl Core {
     /// first candle's open. Signals a bullish reversal (three inside up, significant in a
     /// downtrend) or a bearish reversal (three inside down, significant in an uptrend).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the pattern classically assumes (three inside up is
-    ///   meaningful in a downtrend, three inside down in an uptrend).
-    /// * Bulkowski's testing found Three Inside Up succeeds as a bullish reversal 65% of the time
-    ///   (rank 20 of 103 overall) and Three Inside Down succeeds as a bearish reversal 60% of the
-    ///   time (rank 56 of 103) — both meaningfully better than a coin flip.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ThreeInsideUp.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3inside](https://ta-lib.org/functions/cdl3inside).
     ///
     /// # Arguments
     ///
@@ -355,8 +349,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMI`] · [`Core::CDL3OUTSIDE`] · [`Core::CDLENGULFING`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdl3inside](https://ta-lib.org/functions/cdl3inside)
     #[doc(alias = "ThreeInsideUpDown")]
     #[doc(alias = "ThreeInside")]
     #[doc(alias = "ThreeInsideUp")]

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
@@ -253,14 +253,8 @@ impl Core {
     /// continuation-style signal keyed to the color of the first three candles, traditionally read
     /// as significant only inside a trend matching those three candles.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the surrounding trend the pattern classically assumes for significance.
-    /// * TA-Lib's sign follows the classic continuation reading. Thomas Bulkowski's statistical
-    ///   study of the pattern (*Encyclopedia of Candlestick Charts*) found the opposite in practice
-    ///   — it acted as a reversal far more often than a continuation — so traders who follow
-    ///   his research read this pattern's signal in the opposite direction from what its sign here
-    ///   suggests.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3linestrike](https://ta-lib.org/functions/cdl3linestrike).
     ///
     /// # Arguments
     ///
@@ -319,9 +313,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3WHITESOLDIERS`] · [`Core::CDL3BLACKCROWS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdl3linestrike](https://ta-lib.org/functions/cdl3linestrike)
     #[doc(alias = "Three-LineStrike")]
     #[doc(alias = "3-LineStrike")]
     pub fn CDL3LINESTRIKE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
@@ -151,15 +151,8 @@ impl Core {
     /// followed by a third candle that confirms in the engulfing direction. Signals a bullish
     /// reversal (Three Outside Up) or bearish reversal (Three Outside Down).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the pattern classically assumes (three outside up is
-    ///   meaningful in a downtrend, three outside down in an uptrend).
-    /// * Bulkowski's testing puts Three Outside Up at a 75% bullish-reversal success rate versus
-    ///   69% for Three Outside Down — both notably higher than the closely related Three Inside
-    ///   Up/Down (65%/60%), i.e. the engulfing "outside" variant tests as more reliable than the
-    ///   harami "inside" variant.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ThreeOutsideUp.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3outside](https://ta-lib.org/functions/cdl3outside).
     ///
     /// # Arguments
     ///
@@ -214,9 +207,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3INSIDE`] · [`Core::CDLENGULFING`] · [`Core::CDL3LINESTRIKE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdl3outside](https://ta-lib.org/functions/cdl3outside)
     #[doc(alias = "ThreeOutsideUpDown")]
     #[doc(alias = "ThreeOutside")]
     pub fn CDL3OUTSIDE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
@@ -465,14 +465,8 @@ impl Core {
     /// range. A hit signals a bullish reversal; per the code comment it is meaningful in a
     /// downtrend, but the function does not verify prior trend.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior downtrend the pattern classically assumes for significance.
-    /// * Thomas Bulkowski's statistical study found this has the best reversal rate of the 103
-    ///   candlestick patterns he tracked (86% bullish reversal) — but that rests on just 9
-    ///   occurrences in 4.7 million candle lines, and its overall post-breakout performance ranks
-    ///   dead last, 103rd of 103.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ThreeStarsSouth.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3starsinsouth](https://ta-lib.org/functions/cdl3starsinsouth).
     ///
     /// # Arguments
     ///
@@ -530,9 +524,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3BLACKCROWS`] · [`Core::CDLIDENTICAL3CROWS`] · [`Core::CDL3WHITESOLDIERS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdl3starsinsouth](https://ta-lib.org/functions/cdl3starsinsouth)
     #[doc(alias = "ThreeStarsInTheSouth")]
     pub fn CDL3STARSINSOUTH(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
@@ -523,13 +523,8 @@ impl Core {
     /// opening within/near the prior body and each with a very short upper shadow. A hit is a
     /// bullish reversal signal, most meaningful in a downtrend, which the code does not verify.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior downtrend the pattern classically assumes for significance.
-    /// * Bulkowski's testing found this reverses a downtrend 82% of the time, but cautions the high
-    ///   rate mostly reflects how rare downward breakouts are afterward — moves following an
-    ///   upward breakout perform poorly.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ThreeWhiteSoldiers.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdl3whitesoldiers](https://ta-lib.org/functions/cdl3whitesoldiers).
     ///
     /// # Arguments
     ///
@@ -587,9 +582,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3BLACKCROWS`] · [`Core::CDLADVANCEBLOCK`] · [`Core::CDLIDENTICAL3CROWS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdl3whitesoldiers](https://ta-lib.org/functions/cdl3whitesoldiers)
     #[doc(alias = "ThreeAdvancingWhiteSoldiers")]
     #[doc(alias = "ThreeWhiteSoldiers")]
     pub fn CDL3WHITESOLDIERS(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -421,13 +421,8 @@ impl Core {
     /// opposite color that gaps back the other way and closes deep into the first body. Bullish
     /// (bottom) or bearish (top) reversal signal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the pattern classically assumes for significance.
-    /// * Bulkowski found the Abandoned Baby both very rare (293 occurrences out of 4.7 million
-    ///   candle lines, frequency rank 92 of 103) and unusually reliable when it does occur (70%
-    ///   success as a reversal, overall performance rank 9 of 103).
-    ///   ([thepatternsite.com](https://thepatternsite.com/AbandonBabyBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlabandonedbaby](https://ta-lib.org/functions/cdlabandonedbaby).
     ///
     /// # Arguments
     ///
@@ -492,9 +487,6 @@ impl Core {
     ///
     /// [`Core::CDLEVENINGDOJISTAR`] · [`Core::CDLMORNINGDOJISTAR`] · [`Core::CDLEVENINGSTAR`] ·
     /// [`Core::CDLMORNINGSTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlabandonedbaby](https://ta-lib.org/functions/cdlabandonedbaby)
     #[doc(alias = "AbandonedBaby")]
     pub fn CDLABANDONEDBABY(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
@@ -611,12 +611,8 @@ impl Core {
     /// Signals that an uptrend's advance is being blocked. A hit (-100) is bearish: the advance is
     /// stalling/blocked; meaningful mainly within an existing uptrend.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior uptrend the pattern classically assumes for significance.
-    /// * Although classically read as a bearish reversal, Bulkowski's testing found the Advance
-    ///   Block actually acts as a bullish continuation 64% of the time.
-    ///   ([thepatternsite.com](https://thepatternsite.com/AdvanceBlock.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdladvanceblock](https://ta-lib.org/functions/cdladvanceblock).
     ///
     /// # Arguments
     ///
@@ -674,9 +670,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3WHITESOLDIERS`] · CDLDELIBERATION · [`Core::CDLSTALLEDPATTERN`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdladvanceblock](https://ta-lib.org/functions/cdladvanceblock)
     #[doc(alias = "AdvanceBlock")]
     pub fn CDLADVANCEBLOCK(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
@@ -285,20 +285,8 @@ impl Core {
     /// long black candle with no/very short upper shadow. A white hit is bullish (opens at the low,
     /// closes strong); a black hit is bearish (opens at the high, closes weak).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle. Requires real body > BodyLong average (long body), then either: white body (close>=open) AND lower shadow < ShadowVeryShort average -> bullish; OR black body (close<open) AND upper shadow < ShadowVeryShort average -> bearish. No prior-trend or gap conditions are checked.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend that the pattern's bullish/bearish reading classically
-    ///   assumes.
-    /// * Bulkowski's testing ranks the bullish Belt-Hold's 71% reversal rate 11th of 103 patterns
-    ///   for pure reversal reliability (bearish reverses 68% of the time) — though its overall
-    ///   post-breakout performance rank is a more middling 62nd/63rd of 103.
-    ///   ([thepatternsite.com](https://thepatternsite.com/BeltHoldBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlbelthold](https://ta-lib.org/functions/cdlbelthold).
     ///
     /// # Arguments
     ///
@@ -353,9 +341,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLCLOSINGMARUBOZU`] · [`Core::CDLMARUBOZU`] · [`Core::CDLLONGLINE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlbelthold](https://ta-lib.org/functions/cdlbelthold)
     #[doc(alias = "Belt-hold")]
     #[doc(alias = "BeltHoldLine")]
     pub fn CDLBELTHOLD(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
@@ -226,14 +226,8 @@ impl Core {
     /// fifth candle that closes back inside the gap. Emits a bullish signal (bottom reversal) or
     /// bearish signal (top reversal).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the pattern classically assumes (a breakaway matters most
-    ///   against a preceding move).
-    /// * Bulkowski's data shows a directional asymmetry TA-Lib's symmetric output doesn't capture:
-    ///   bullish Breakaway reverses only 59% of the time ("near random"), while bearish Breakaway
-    ///   reverses 63% of the time overall.
-    ///   ([thepatternsite.com](https://thepatternsite.com/BullBreakaway.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlbreakaway](https://ta-lib.org/functions/cdlbreakaway).
     ///
     /// # Arguments
     ///
@@ -288,9 +282,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLGAPSIDESIDEWHITE`] · [`Core::CDLRISEFALL3METHODS`] · [`Core::CDL3LINESTRIKE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlbreakaway](https://ta-lib.org/functions/cdlbreakaway)
     #[doc(alias = "Breakaway")]
     pub fn CDLBREAKAWAY(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
@@ -284,17 +284,8 @@ impl Core {
     /// the close sits at the candle's extreme. A strong directional bar, not a defined
     /// reversal/continuation signal — white is bullish, black is bearish.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle. Requires: (1) long real body: real body > the BodyLong average; AND (2) very short shadow at the closing end: if white (close>=open) upper shadow < the ShadowVeryShort average [close at/near high]; if black (close<open) lower shadow < the ShadowVeryShort average [close at/near low].
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Bulkowski's testing found Closing Marubozu continues in its expected direction only
-    ///   marginally more than chance — 52% for the black variant — which he calls "near
-    ///   random." ([thepatternsite.com](https://thepatternsite.com/CloseBlkMarubozu.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlclosingmarubozu](https://ta-lib.org/functions/cdlclosingmarubozu).
     ///
     /// # Arguments
     ///
@@ -352,9 +343,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLMARUBOZU`] · [`Core::CDLLONGLINE`] · [`Core::CDLBELTHOLD`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlclosingmarubozu](https://ta-lib.org/functions/cdlclosingmarubozu)
     #[doc(alias = "ClosingMarubozu")]
     pub fn CDLCLOSINGMARUBOZU(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
@@ -273,13 +273,8 @@ impl Core {
     /// upper shadow into the prior body, then a larger black candle fully engulfing the third. A
     /// hit signals a bullish reversal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend the pattern classically assumes.
-    /// * Despite the bullish-reversal label, Bulkowski's testing found this pattern actually
-    ///   behaves as a bearish continuation 75% of the time — though the finding rests on just 4
-    ///   occurrences out of 4.7 million candle lines, and it ranks 101st of 103 patterns overall.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ConcealBaby.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlconcealbabyswall](https://ta-lib.org/functions/cdlconcealbabyswall).
     ///
     /// # Arguments
     ///
@@ -337,9 +332,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLMARUBOZU`] · [`Core::CDLENGULFING`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlconcealbabyswall](https://ta-lib.org/functions/cdlconcealbabyswall)
     #[doc(alias = "ConcealingBabySwallow")]
     pub fn CDLCONCEALBABYSWALL(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
@@ -313,13 +313,8 @@ impl Core {
     /// (nearly) equal. Emits a bullish signal when the second candle is white and a bearish signal
     /// when it is black (a reversal signal, though its trend context is not checked).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the reversal signal classically assumes.
-    /// * Bulkowski's testing found the bearish Counterattack/Meeting Lines does not reliably
-    ///   reverse at all — it acts as a bullish CONTINUATION 51% of the time — and the bullish
-    ///   version reverses only 56% of the time, both "near random" by his classification.
-    ///   ([thepatternsite.com](https://thepatternsite.com/MeetingLinesBear.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlcounterattack](https://ta-lib.org/functions/cdlcounterattack).
     ///
     /// # Arguments
     ///
@@ -377,9 +372,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLPIERCING`] · [`Core::CDLDARKCLOUDCOVER`] · [`Core::CDLGAPSIDESIDEWHITE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlcounterattack](https://ta-lib.org/functions/cdlcounterattack)
     #[doc(alias = "Counterattack")]
     #[doc(alias = "CounterattackLines")]
     #[doc(alias = "MeetingLines")]

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -249,9 +249,8 @@ impl Core {
     /// threshold. Signals a potential top. A hit (-100) is a bearish reversal signal, most
     /// meaningful after an uptrend.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding uptrend the bearish reversal classically assumes.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdldarkcloudcover](https://ta-lib.org/functions/cdldarkcloudcover).
     ///
     /// # Arguments
     ///
@@ -315,9 +314,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLPIERCING`] · [`Core::CDLENGULFING`] · [`Core::CDLONNECK`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdldarkcloudcover](https://ta-lib.org/functions/cdldarkcloudcover)
     #[doc(alias = "DarkCloudCover")]
     pub fn CDLDARKCLOUDCOVER(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
@@ -214,11 +214,8 @@ impl Core {
     /// Single-candle Doji recognizer: fires when the real body (|close-open|) is at or below the
     /// BodyDoji threshold. Market indecision; neither bullish nor bearish on its own.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// match if $|close-open| \le \text{CandleAverage(BodyDoji)}$
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdldoji](https://ta-lib.org/functions/cdldoji).
     ///
     /// # Arguments
     ///
@@ -273,8 +270,6 @@ impl Core {
     ///
     /// [`Core::CDLDOJISTAR`] · [`Core::CDLDRAGONFLYDOJI`] · [`Core::CDLGRAVESTONEDOJI`] ·
     /// [`Core::CDLLONGLEGGEDDOJI`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdldoji](https://ta-lib.org/functions/cdldoji)
     #[doc(alias = "Doji")]
     pub fn CDLDOJI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
@@ -291,20 +291,8 @@ impl Core {
     /// prevailing trend (bullish in a downtrend, bearish in an uptrend), which the code does not
     /// itself verify.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two candles. Candle 1: long real body (realbody > BodyLong average). Candle 2: doji (realbody <= BodyDoji average). Gap: either candle 1 white (color==1) AND candle 2 real body gaps up above it (the real bodies gap up), or candle 1 black (color==-1) AND candle 2 real body gaps down below it (the real bodies gap down).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the reversal signal classically assumes.
-    /// * Bulkowski's testing contradicts the classic reading for the bullish case: theory says a
-    ///   bullish Doji Star (gapping down after a black candle) should be a bullish reversal, but he
-    ///   found it instead acts as a bearish CONTINUATION 64% of the time — almost 2 out of 3, the
-    ///   opposite of the textbook signal.
-    ///   ([thepatternsite.com](https://thepatternsite.com/DojiStarBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdldojistar](https://ta-lib.org/functions/cdldojistar).
     ///
     /// # Arguments
     ///
@@ -361,9 +349,6 @@ impl Core {
     ///
     /// [`Core::CDLMORNINGDOJISTAR`] · [`Core::CDLEVENINGDOJISTAR`] · [`Core::CDLDOJI`] ·
     /// [`Core::CDLMORNINGSTAR`] · [`Core::CDLEVENINGSTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdldojistar](https://ta-lib.org/functions/cdldojistar)
     #[doc(alias = "DojiStar")]
     pub fn CDLDOJISTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
@@ -287,19 +287,8 @@ impl Core {
     /// hit marks a dragonfly doji; treated as a potential reversal, but direction (bullish/bearish)
     /// must be read from the trend it appears in.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Single candle. realbody <= BodyDoji average (doji body) AND upper shadow < ShadowVeryShort average (no/very short upper shadow) AND lower shadow > ShadowVeryShort average (lower shadow present, not very short). No color, gap, or trend test.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend that determines the pattern's bullish/bearish meaning.
-    /// * Bulkowski's testing found this reverses the prior trend only about 50% of the time —
-    ///   statistically no better than a coin flip — and ranks 98th of 103 candlestick patterns
-    ///   for post-breakout performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/Dragonfly.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdldragonflydoji](https://ta-lib.org/functions/cdldragonflydoji).
     ///
     /// # Arguments
     ///
@@ -358,9 +347,6 @@ impl Core {
     ///
     /// [`Core::CDLDOJI`] · [`Core::CDLGRAVESTONEDOJI`] · [`Core::CDLLONGLEGGEDDOJI`] ·
     /// [`Core::CDLTAKURI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdldragonflydoji](https://ta-lib.org/functions/cdldragonflydoji)
     #[doc(alias = "DragonflyDoji")]
     pub fn CDLDRAGONFLYDOJI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
@@ -159,15 +159,8 @@ impl Core {
     /// reversal signal; ideally after a downtrend (bullish) or uptrend (bearish), which the code
     /// does not verify.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend (down for bullish, up for bearish) the reversal
-    ///   classically assumes.
-    /// * Bulkowski's testing found bearish Engulfing has a strong 79% reversal rate (5th-best of
-    ///   103 patterns by that measure alone) but a weak overall post-breakout performance rank of
-    ///   91st of 103 — the reversal fires reliably but rarely sustains. Bullish Engulfing
-    ///   reverses 63% of the time with a similarly weak overall rank of 84th of 103.
-    ///   ([thepatternsite.com](https://thepatternsite.com/BearEngulfing.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlengulfing](https://ta-lib.org/functions/cdlengulfing).
     ///
     /// # Arguments
     ///
@@ -223,9 +216,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMI`] · [`Core::CDLCOUNTERATTACK`] · [`Core::CDLHARAMICROSS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlengulfing](https://ta-lib.org/functions/cdlengulfing)
     #[doc(alias = "EngulfingPattern")]
     #[doc(alias = "Engulfing")]
     #[doc(alias = "BullishBearishEngulfing")]

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -386,9 +386,8 @@ impl Core {
     /// star), then a black candle closing well down into the first candle's body. A stricter
     /// Evening Star whose middle candle must be a doji. Hit (-100) signals a bearish top reversal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding uptrend the bearish reversal classically assumes.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdleveningdojistar](https://ta-lib.org/functions/cdleveningdojistar).
     ///
     /// # Arguments
     ///
@@ -452,9 +451,6 @@ impl Core {
     ///
     /// [`Core::CDLEVENINGSTAR`] · [`Core::CDLMORNINGDOJISTAR`] · [`Core::CDLDOJISTAR`] ·
     /// [`Core::CDLABANDONEDBABY`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdleveningdojistar](https://ta-lib.org/functions/cdleveningdojistar)
     #[doc(alias = "EveningDojiStar")]
     pub fn CDLEVENINGDOJISTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -367,11 +367,8 @@ impl Core {
     /// up, then a black candle closing well down into the first candle's body. A hit signals a
     /// bearish reversal (most significant in an uptrend).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding uptrend the bearish reversal classically assumes.
-    /// * The third candle only needs a body longer than short, not the full long body some
-    ///   definitions require.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdleveningstar](https://ta-lib.org/functions/cdleveningstar).
     ///
     /// # Arguments
     ///
@@ -434,9 +431,6 @@ impl Core {
     ///
     /// [`Core::CDLEVENINGDOJISTAR`] · [`Core::CDLMORNINGSTAR`] · [`Core::CDLMORNINGDOJISTAR`] ·
     /// CDLSTARSINSOUTH
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdleveningstar](https://ta-lib.org/functions/cdleveningstar)
     #[doc(alias = "EveningStar")]
     pub fn CDLEVENINGSTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
@@ -296,14 +296,8 @@ impl Core {
     /// about the same level. It is a continuation signal whose sign reports the gap direction; the
     /// code does not verify a prior trend.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend the continuation signal classically assumes.
-    /// * Bulkowski's data shows the bullish form is rare (984 occurrences out of 4.7 million candle
-    ///   lines, frequency rank 73/103) but continues as labeled 66% of the time; the bearish form
-    ///   is rarer still (frequency rank 86/103) and its 56% continuation rate is "near random" —
-    ///   Bulkowski cautions the bearish sample is too thin to trust.
-    ///   ([thepatternsite.com](https://thepatternsite.com/SidebySideWhiteLinesBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlgapsidesidewhite](https://ta-lib.org/functions/cdlgapsidesidewhite).
     ///
     /// # Arguments
     ///
@@ -362,9 +356,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLTASUKIGAP`] · [`Core::CDLXSIDEGAP3METHODS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlgapsidesidewhite](https://ta-lib.org/functions/cdlgapsidesidewhite)
     #[doc(alias = "UpDown-gapside-by-sidewhitelines")]
     #[doc(alias = "Gappingside-by-sidewhitelines")]
     pub fn CDLGAPSIDESIDEWHITE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
@@ -287,18 +287,8 @@ impl Core {
     /// vs bearish reversal meaning must be read against the prevailing trend, which this function
     /// does not check.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle. Detected when all hold: (1) doji body: realbody |close-open| <= BodyDoji average; (2) very short/absent lower shadow: lowerShadow < ShadowVeryShort average; (3) non-short upper shadow: upperShadow > ShadowVeryShort average (open/close at the low with an upper shadow).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend that determines the pattern's bullish/bearish meaning.
-    /// * Bulkowski's testing found the bearish reversal traders expect actually shows up only 51%
-    ///   of the time — essentially random — and it ranks 77th of 103 patterns for post-breakout
-    ///   performance. ([thepatternsite.com](https://thepatternsite.com/Gravestone.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlgravestonedoji](https://ta-lib.org/functions/cdlgravestonedoji).
     ///
     /// # Arguments
     ///
@@ -357,9 +347,6 @@ impl Core {
     ///
     /// [`Core::CDLDOJI`] · [`Core::CDLDRAGONFLYDOJI`] · [`Core::CDLLONGLEGGEDDOJI`] ·
     /// [`Core::CDLDOJISTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlgravestonedoji](https://ta-lib.org/functions/cdlgravestonedoji)
     #[doc(alias = "GravestoneDoji")]
     pub fn CDLGRAVESTONEDOJI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
@@ -426,14 +426,8 @@ impl Core {
     /// and little or no upper shadow, sitting at or near the prior candle's low. A hit flags a
     /// potential bullish reversal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend that the pattern classically assumes; confirm the
-    ///   trend context yourself.
-    /// * Bulkowski's testing found the Hammer reverses a preceding downtrend about 60% of the time
-    ///   — in his words "not far from random (50%)" — and it ranks a modest 65th of 103
-    ///   patterns for post-breakout performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/Hammer.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhammer](https://ta-lib.org/functions/cdlhammer).
     ///
     /// # Arguments
     ///
@@ -488,8 +482,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLINVERTEDHAMMER`] · [`Core::CDLHANGINGMAN`] · [`Core::CDLTAKURI`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlhammer](https://ta-lib.org/functions/cdlhammer)
     #[doc(alias = "Hammer")]
     pub fn CDLHAMMER(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
@@ -426,14 +426,8 @@ impl Core {
     /// sitting at or near the highs of the prior candle. Bearish reversal signal. A hit is a
     /// bearish reversal signal (meaningful at the top of an uptrend).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding uptrend that the pattern classically assumes; confirm the
-    ///   trend context yourself.
-    /// * Bulkowski's testing found this acts as a bullish continuation 59% of the time — the
-    ///   opposite of the bearish-reversal reading it's named for ("near random") — and it ranks
-    ///   87th of 103 patterns for post-breakout performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HangingMan.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhangingman](https://ta-lib.org/functions/cdlhangingman).
     ///
     /// # Arguments
     ///
@@ -491,9 +485,6 @@ impl Core {
     ///
     /// [`Core::CDLHAMMER`] · [`Core::CDLINVERTEDHAMMER`] · [`Core::CDLSHOOTINGSTAR`] ·
     /// [`Core::CDLTAKURI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlhangingman](https://ta-lib.org/functions/cdlhangingman)
     #[doc(alias = "HangingMan")]
     pub fn CDLHANGINGMAN(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
@@ -309,14 +309,8 @@ impl Core {
     /// first candle's real body. A reversal signal whose direction is the opposite of the first
     /// candle's color.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend (downtrend for bullish, uptrend for bearish) that the
-    ///   reversal signal assumes.
-    /// * Bulkowski's testing found the bearish Harami actually acts as a bullish CONTINUATION 53%
-    ///   of the time — more often than it reverses the prior uptrend — rating the pattern "near
-    ///   random" overall (rank 72 of 103).
-    ///   ([thepatternsite.com](https://thepatternsite.com/HaramiBear.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlharami](https://ta-lib.org/functions/cdlharami).
     ///
     /// # Arguments
     ///
@@ -372,8 +366,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMICROSS`] · [`Core::CDLENGULFING`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlharami](https://ta-lib.org/functions/cdlharami)
     #[doc(alias = "Harami")]
     #[doc(alias = "HaramiPattern")]
     pub fn CDLHARAMI(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
@@ -307,15 +307,8 @@ impl Core {
     /// contained within the first candle's real body (the doji variant of the Harami). Bullish
     /// after a black first candle, bearish after a white first candle.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend (downtrend for bullish, uptrend for bearish) that the
-    ///   reversal signal assumes.
-    /// * Bulkowski's testing found the bearish Harami Cross behaves opposite its textbook label
-    ///   even more strongly than the plain Harami: it acts as a bullish CONTINUATION 57% of the
-    ///   time rather than a bearish reversal, and the bullish Harami Cross likewise fails to
-    ///   reverse the downtrend 55% of the time.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HaramiCrossBear.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlharamicross](https://ta-lib.org/functions/cdlharamicross).
     ///
     /// # Arguments
     ///
@@ -374,9 +367,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMI`] · [`Core::CDLDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlharamicross](https://ta-lib.org/functions/cdlharamicross)
     #[doc(alias = "HaramiCross")]
     pub fn CDLHARAMICROSS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
@@ -284,18 +284,8 @@ impl Core {
     /// bullish/bearish direction. A hit marks indecision (long-legged candle); not directional -
     /// sign encodes only the candle's color.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle at index i. Hit when all hold: (1) short real body: real body < the BodyShort average; (2) very long upper shadow: upper shadow > the ShadowVeryLong average; (3) very long lower shadow: lower shadow > the ShadowVeryLong average. No color, gap, or trend condition.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Bulkowski's testing found the High-Wave candle acts as a reversal only 51% of the time —
-    ///   statistically indistinguishable from random — which he notes actually agrees with the
-    ///   pattern's theoretical meaning of pure indecision.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HighWave.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhighwave](https://ta-lib.org/functions/cdlhighwave).
     ///
     /// # Arguments
     ///
@@ -351,9 +341,6 @@ impl Core {
     ///
     /// [`Core::CDLLONGLEGGEDDOJI`] · [`Core::CDLSPINNINGTOP`] · [`Core::CDLRICKSHAWMAN`] ·
     /// [`Core::CDLDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlhighwave](https://ta-lib.org/functions/cdlhighwave)
     #[doc(alias = "High-WaveCandle")]
     #[doc(alias = "HighWave")]
     pub fn CDLHIGHWAVE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
@@ -201,14 +201,8 @@ impl Core {
     /// breakout direction. A false-breakout setup: positive = bullish, negative = bearish;
     /// magnitude 200 flags the confirming bar.
     ///
-    /// # Notes
-    ///
-    /// * The name comes from the Japanese word for a deceptive move or "trap" — fitting, since
-    ///   the pattern exists to catch traders acting on a false breakout. Bulkowski's testing of the
-    ///   confirmed pattern found the trap itself barely beats a coin flip: the bullish variant
-    ///   continues as expected only 52% of the time and the bearish variant exactly 50% ("random"),
-    ///   both ranking in the bottom fifth (83rd-84th of 105) for post-breakout performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HikkakeBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhikkake](https://ta-lib.org/functions/cdlhikkake).
     ///
     /// # Arguments
     ///
@@ -263,8 +257,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHIKKAKEMOD`] · [`Core::CDLHARAMI`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlhikkake](https://ta-lib.org/functions/cdlhikkake)
     #[doc(alias = "HikkakePattern")]
     #[doc(alias = "Hikkake")]
     pub fn CDLHIKKAKE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
@@ -313,10 +313,8 @@ impl Core {
     /// Bullish (+) or bearish (-) reversal; per the code's note it is significant in a downtrend
     /// (bull) or uptrend (bear), context the code does not verify.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the prior trend (downtrend for bullish, uptrend for bearish) that this
-    ///   reversal pattern assumes.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhikkakemod](https://ta-lib.org/functions/cdlhikkakemod).
     ///
     /// # Arguments
     ///
@@ -374,9 +372,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHIKKAKE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlhikkakemod](https://ta-lib.org/functions/cdlhikkakemod)
     #[doc(alias = "ModifiedHikkake")]
     #[doc(alias = "ModifiedHikkakePattern")]
     pub fn CDLHIKKAKEMOD(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
@@ -291,19 +291,8 @@ impl Core {
     /// sits inside the prior body. A hit signals a bullish reversal, most meaningful in a
     /// downtrend, which the code does not verify.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two candles at i-1 and i. Both black: close[i-1] < open[i-1] and close[i] < open[i]. First body long: realbody[i-1] > BodyLong average. Second body short: realbody[i] <= BodyShort average. Second body contained by first: open[i] < open[i-1] and close[i] > close[i-1].
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend that the bullish reversal classically assumes.
-    /// * Despite the bullish-reversal label, Bulkowski's testing found this behaves as a bearish
-    ///   continuation 56% of the time — "near random" by his own description — though its
-    ///   overall post-breakout performance rank (21st of 103) is comparatively strong.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HomingPigeon.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlhomingpigeon](https://ta-lib.org/functions/cdlhomingpigeon).
     ///
     /// # Arguments
     ///
@@ -361,9 +350,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMI`] · [`Core::CDLMATCHINGLOW`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlhomingpigeon](https://ta-lib.org/functions/cdlhomingpigeon)
     #[doc(alias = "HomingPigeon")]
     pub fn CDLHOMINGPIGEON(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
@@ -364,11 +364,8 @@ impl Core {
     /// with a very short (or no) lower shadow, where each candle after the first opens at or very
     /// near the prior candle's close. A hit signals a bearish reversal (pattern is always bearish).
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding uptrend that the bearish reversal classically assumes.
-    /// * Does not require the three bodies to be equal in size; 'identical' refers only to each
-    ///   candle opening at or near the previous candle's close.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlidentical3crows](https://ta-lib.org/functions/cdlidentical3crows).
     ///
     /// # Arguments
     ///
@@ -426,9 +423,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3BLACKCROWS`] · [`Core::CDL2CROWS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlidentical3crows](https://ta-lib.org/functions/cdlidentical3crows)
     #[doc(alias = "IdenticalThreeCrows")]
     pub fn CDLIDENTICAL3CROWS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
@@ -292,18 +292,8 @@ impl Core {
     /// a bearish continuation signal. A hit signals bearish continuation (the down move is expected
     /// to resume).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two candles. First: black (close1 < open1) with a long real body (realbody > candleaverage(BodyLong)). Second: white (close2 >= open2), opens below the first candle's low (open2 < low1), and closes slightly into the first body: close2 >= close1 AND close2 <= close1 + candleaverage(Equal). No prior-trend check is performed.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend that this bearish continuation pattern assumes.
-    /// * Bulkowski's testing found the bearish continuation holds only 53% of the time — "near
-    ///   random" — though its overall post-breakout performance still ranks a strong 17th of 103.
-    ///   ([thepatternsite.com](https://www.thepatternsite.com/InNeck.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlinneck](https://ta-lib.org/functions/cdlinneck).
     ///
     /// # Arguments
     ///
@@ -358,8 +348,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLONNECK`] · [`Core::CDLTHRUSTING`] · [`Core::CDLMATCHINGLOW`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlinneck](https://ta-lib.org/functions/cdlinneck)
     #[doc(alias = "In-NeckPattern")]
     #[doc(alias = "In-NeckLine")]
     pub fn CDLINNECK(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
@@ -357,14 +357,8 @@ impl Core {
     /// Single-candle pattern: a small real body with a long upper shadow and little-to-no lower
     /// shadow that gaps down from the prior candle. A hit flags a potential bullish reversal.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend that the pattern classically assumes; it only
-    ///   checks the gap down from the immediately preceding candle.
-    /// * Despite the bullish-reversal label, Bulkowski's testing found this actually behaves as a
-    ///   bearish continuation 65% of the time — yet its overall post-breakout performance rank
-    ///   (6th of 103) is among the best of all candlestick patterns he studied.
-    ///   ([thepatternsite.com](https://thepatternsite.com/HammerInv.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlinvertedhammer](https://ta-lib.org/functions/cdlinvertedhammer).
     ///
     /// # Arguments
     ///
@@ -422,9 +416,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHAMMER`] · [`Core::CDLSHOOTINGSTAR`] · [`Core::CDLHANGINGMAN`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlinvertedhammer](https://ta-lib.org/functions/cdlinvertedhammer)
     #[doc(alias = "InvertedHammer")]
     pub fn CDLINVERTEDHAMMER(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
@@ -333,12 +333,8 @@ impl Core {
     /// separated by a price gap. A reversal signal whose direction is set by the second candle's
     /// color.
     ///
-    /// # Notes
-    ///
-    /// * Bulkowski's testing found Kicking reverses only 53% (bullish) / 54% (bearish) of the time
-    ///   — both "near random" — and it's also one of the rarest patterns he tracked (frequency
-    ///   rank 100/103 bullish, 102/103 bearish).
-    ///   ([thepatternsite.com](https://thepatternsite.com/KickingBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlkicking](https://ta-lib.org/functions/cdlkicking).
     ///
     /// # Arguments
     ///
@@ -393,8 +389,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLKICKINGBYLENGTH`] · [`Core::CDLMARUBOZU`] · [`Core::CDLGAPSIDESIDEWHITE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlkicking](https://ta-lib.org/functions/cdlkicking)
     #[doc(alias = "Kicking")]
     pub fn CDLKICKING(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
@@ -334,6 +334,9 @@ impl Core {
     /// ends) separated by a gap. A strong directional/reversal signal whose bull/bear bias is set
     /// by the longer of the two marubozu.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlkickingbylength](https://ta-lib.org/functions/cdlkickingbylength).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -391,9 +394,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLKICKING`] · [`Core::CDLMARUBOZU`] · [`Core::CDLGAPSIDESIDEWHITE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlkickingbylength](https://ta-lib.org/functions/cdlkickingbylength)
     #[doc(alias = "KickingbyLength")]
     #[doc(alias = "Kicking-bullbeardecidedbythelongermarubozu")]
     pub fn CDLKICKINGBYLENGTH(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
@@ -232,13 +232,8 @@ impl Core {
     /// prior open and closes above the prior high. A hit is a bullish reversal signal, most
     /// meaningful after a downtrend.
     ///
-    /// # Notes
-    ///
-    /// * Does not verify the preceding downtrend that this bullish reversal classically assumes.
-    /// * Bulkowski's testing found this reverses a downtrend only 56% of the time — "near random"
-    ///   — and it is extremely rare (451 occurrences out of 4.7 million candle lines), ranking
-    ///   41st of 103 patterns for overall performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/LadderBottom.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlladderbottom](https://ta-lib.org/functions/cdlladderbottom).
     ///
     /// # Arguments
     ///
@@ -296,9 +291,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL3BLACKCROWS`] · [`Core::CDLMATCHINGLOW`] · [`Core::CDLBREAKAWAY`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlladderbottom](https://ta-lib.org/functions/cdlladderbottom)
     #[doc(alias = "LadderBottom")]
     pub fn CDLLADDERBOTTOM(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
@@ -283,20 +283,8 @@ impl Core {
     /// not a directional bias. Marks indecision/uncertainty; not inherently bullish or bearish
     /// despite the positive sign.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle. Hit when: real body <= BodyDoji average (doji body) AND (lower shadow > ShadowLong average OR upper shadow > ShadowLong average), i.e. at least one long shadow.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Only one long shadow (upper or lower) is required, whereas the classic pattern shows both
-    ///   long upper and lower shadows.
-    /// * Bulkowski's testing found this continues in the direction of the prior trend only 51% of
-    ///   the time — statistically random — and ranks 37th of 103 patterns overall; in his
-    ///   words, "it means nothing."
-    ///   ([thepatternsite.com](https://thepatternsite.com/LongLegDoji.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdllongleggeddoji](https://ta-lib.org/functions/cdllongleggeddoji).
     ///
     /// # Arguments
     ///
@@ -355,9 +343,6 @@ impl Core {
     ///
     /// [`Core::CDLDOJI`] · [`Core::CDLGRAVESTONEDOJI`] · [`Core::CDLDRAGONFLYDOJI`] ·
     /// [`Core::CDLRICKSHAWMAN`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdllongleggeddoji](https://ta-lib.org/functions/cdllongleggeddoji)
     #[doc(alias = "LongLeggedDoji")]
     pub fn CDLLONGLEGGEDDOJI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
@@ -283,6 +283,9 @@ impl Core {
     /// strong directional conviction on the bar. Not intrinsically a reversal or continuation
     /// signal.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdllongline](https://ta-lib.org/functions/cdllongline).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -337,9 +340,6 @@ impl Core {
     ///
     /// [`Core::CDLSHORTLINE`] · [`Core::CDLCLOSINGMARUBOZU`] · [`Core::CDLMARUBOZU`] ·
     /// [`Core::CDLLONGLEGGEDDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdllongline](https://ta-lib.org/functions/cdllongline)
     #[doc(alias = "LongLineCandle")]
     #[doc(alias = "LongLine")]
     pub fn CDLLONGLINE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
@@ -282,17 +282,8 @@ impl Core {
     /// close sit at the range extremes. Bullish (white) or bearish (black) reversal/strength signal
     /// per the body color.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle at i. Match when: realbody(i) > BodyLong average AND upperShadow(i) < ShadowVeryShort average AND lowerShadow(i) < ShadowVeryShort average. If matched emit candlecolor(i)*100 (+100 white when close>=open, -100 black when close<open); else 0.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Despite the shape's strong-conviction reputation, Bulkowski's testing found a Marubozu
-    ///   continues in its expected direction only about 53% (black) to 56% (white) of the time —
-    ///   both "near random." ([thepatternsite.com](https://thepatternsite.com/BlackMarubozu.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlmarubozu](https://ta-lib.org/functions/cdlmarubozu).
     ///
     /// # Arguments
     ///
@@ -347,9 +338,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLCLOSINGMARUBOZU`] · [`Core::CDLLONGLINE`] · [`Core::CDLBELTHOLD`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlmarubozu](https://ta-lib.org/functions/cdlmarubozu)
     #[doc(alias = "Marubozu")]
     #[doc(alias = "ShavenHeadBottom")]
     pub fn CDLMARUBOZU(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
@@ -219,19 +219,8 @@ impl Core {
     /// tolerance). Treated as a bullish reversal signal. A hit signals a potential bullish reversal
     /// (shared support close after two down candles).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two candles i-1, i. Candle i-1: black (close<open). Candle i: black (close<open). Equal closes: close[i-1]-E <= close[i] <= close[i-1]+E, where E = the Equal average. No shadow, body-size, or gap conditions are checked.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The bullish-reversal reading assumes a prior downtrend, which is not verified.
-    /// * Although classically read as a bullish reversal (and TA-Lib only emits +100), Bulkowski's
-    ///   testing found it actually acts as a bearish continuation 61% of the time — even so, it
-    ///   still ranks a strong 8th of 103 patterns for overall performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/MatchingLow.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlmatchinglow](https://ta-lib.org/functions/cdlmatchinglow).
     ///
     /// # Arguments
     ///
@@ -289,9 +278,6 @@ impl Core {
     /// # See also
     ///
     /// CDLMATCHINGHIGH · [`Core::CDLHOMINGPIGEON`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlmatchinglow](https://ta-lib.org/functions/cdlmatchinglow)
     #[doc(alias = "MatchingLow")]
     pub fn CDLMATCHINGLOW(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -371,15 +371,8 @@ impl Core {
     /// final white candle closing above the reaction days' highs. Signals continuation of the prior
     /// uptrend. Hit = bullish continuation of the existing uptrend.
     ///
-    /// # Notes
-    ///
-    /// * The colors of the third and fourth (reaction) candles are not checked, although they are
-    ///   classically black.
-    /// * The continuation reading assumes a prior uptrend, which is not verified.
-    /// * Bulkowski's own dataset contains only 52 Mat Hold occurrences out of 4.7 million candle
-    ///   lines; he explicitly warns the 78% continuation rate he measured "will likely be wrong or
-    ///   at least subject to large change as additional samples become available."
-    ///   ([thepatternsite.com](https://thepatternsite.com/MatHold.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlmathold](https://ta-lib.org/functions/cdlmathold).
     ///
     /// # Arguments
     ///
@@ -442,8 +435,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLRISEFALL3METHODS`] · [`Core::CDLXSIDEGAP3METHODS`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlmathold](https://ta-lib.org/functions/cdlmathold)
     #[doc(alias = "MatHold")]
     pub fn CDLMATHOLD(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -424,11 +424,8 @@ impl Core {
     /// variant of the morning star. A hit (+100) signals a bullish reversal; most meaningful after
     /// a downtrend, which this function does not verify.
     ///
-    /// # Notes
-    ///
-    /// * The gap-down is measured between the candles' real bodies, not between their high/low
-    ///   ranges.
-    /// * A prior downtrend is not verified.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlmorningdojistar](https://ta-lib.org/functions/cdlmorningdojistar).
     ///
     /// # Arguments
     ///
@@ -493,9 +490,6 @@ impl Core {
     ///
     /// [`Core::CDLMORNINGSTAR`] · [`Core::CDLEVENINGDOJISTAR`] · [`Core::CDLEVENINGSTAR`] ·
     /// [`Core::CDLDOJISTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlmorningdojistar](https://ta-lib.org/functions/cdlmorningdojistar)
     #[doc(alias = "MorningDojiStar")]
     pub fn CDLMORNINGDOJISTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -404,15 +404,8 @@ impl Core {
     /// signal. A hit signals a bullish reversal (most meaningful after a downtrend, which the code
     /// does not check).
     ///
-    /// # Notes
-    ///
-    /// * The gap-down is measured between the candles' real bodies, not between their high/low
-    ///   ranges.
-    /// * A prior downtrend is not verified.
-    /// * Bulkowski ranks the Morning Star unusually high — 6th of 103 for reversal rate (78%) and
-    ///   12th of 103 for overall post-breakout performance — one of the few classic candle
-    ///   patterns whose textbook reputation his statistics confirm rather than debunk.
-    ///   ([thepatternsite.com](https://thepatternsite.com/MorningStar.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlmorningstar](https://ta-lib.org/functions/cdlmorningstar).
     ///
     /// # Arguments
     ///
@@ -476,9 +469,6 @@ impl Core {
     ///
     /// [`Core::CDLMORNINGDOJISTAR`] · [`Core::CDLEVENINGSTAR`] · [`Core::CDLABANDONEDBABY`] ·
     /// [`Core::CDLDOJISTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlmorningstar](https://ta-lib.org/functions/cdlmorningstar)
     #[doc(alias = "MorningStar")]
     pub fn CDLMORNINGSTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
@@ -291,18 +291,8 @@ impl Core {
     /// below the prior candle's low and closes right at that low. Bearish continuation signal. A
     /// hit is bearish (bearish continuation); the code does not verify the assumed prior downtrend.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two candles. 1st: black (close<open) with long real body (realbody > BodyLong average). 2nd: white (close>=open); open < prior low; close within the Equal band of the prior low, i.e. (prior_low - EqualAvg) <= close2 <= (prior_low + EqualAvg).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The bearish-continuation reading assumes a prior downtrend, which is not verified.
-    /// * Bulkowski's testing found the bearish continuation holds only 56% of the time, which he
-    ///   explicitly calls "near random."
-    ///   ([thepatternsite.com](https://thepatternsite.com/OnNeck.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlonneck](https://ta-lib.org/functions/cdlonneck).
     ///
     /// # Arguments
     ///
@@ -357,8 +347,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLINNECK`] · [`Core::CDLTHRUSTING`] · CDLMEETINGLINES
-    ///
-    /// Further reading: [ta-lib.org/functions/cdlonneck](https://ta-lib.org/functions/cdlonneck)
     #[doc(alias = "On-NeckPattern")]
     #[doc(alias = "On-NeckLine")]
     pub fn CDLONNECK(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
@@ -283,9 +283,8 @@ impl Core {
     /// prior low and closes back above the midpoint of the prior black body. Bullish reversal
     /// signal. A hit (+100) is a bullish reversal signal.
     ///
-    /// # Notes
-    ///
-    /// * A prior downtrend is not verified.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlpiercing](https://ta-lib.org/functions/cdlpiercing).
     ///
     /// # Arguments
     ///
@@ -340,9 +339,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLDARKCLOUDCOVER`] · [`Core::CDLENGULFING`] · [`Core::CDLMORNINGSTAR`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlpiercing](https://ta-lib.org/functions/cdlpiercing)
     #[doc(alias = "PiercingPattern")]
     #[doc(alias = "PiercingLine")]
     pub fn CDLPIERCING(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
@@ -356,12 +356,8 @@ impl Core {
     /// range. It is a neutral indecision signal, not a directional (bullish/bearish) reversal. A
     /// hit marks market indecision/uncertainty; neutral, neither bullish nor bearish.
     ///
-    /// # Notes
-    ///
-    /// * Bulkowski's verdict: "The rickshaw man candle may look pretty on the chart but it has no
-    ///   investment implications that I have been able to find" — his testing shows it continues
-    ///   only 51% of the time, statistically random.
-    ///   ([thepatternsite.com](https://thepatternsite.com/RickshawMan.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlrickshawman](https://ta-lib.org/functions/cdlrickshawman).
     ///
     /// # Arguments
     ///
@@ -419,9 +415,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLLONGLEGGEDDOJI`] · [`Core::CDLDOJI`] · [`Core::CDLHIGHWAVE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlrickshawman](https://ta-lib.org/functions/cdlrickshawman)
     #[doc(alias = "RickshawMan")]
     pub fn CDLRICKSHAWMAN(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
@@ -394,18 +394,8 @@ impl Core {
     /// stay partly within the first candle's high-low range, then a long same-color candle that
     /// resumes the trend. Bullish (rising) or bearish (falling) continuation signal.
     ///
-    /// # Notes
-    ///
-    /// * Only the three-small-candle variant is detected; the classic pattern allowing two or more
-    ///   small candles is not supported.
-    /// * The middle candles need only partially overlap the first candle's range, not be fully
-    ///   contained within it.
-    /// * The prior trend the continuation reading assumes is not verified.
-    /// * Bulkowski's testing found Rising Three Methods continues 74% of the time (102 examples out
-    ///   of 4.7M candle lines) and Falling Three Methods continues 71% of the time (just 64
-    ///   examples) — both act as classically labeled, but Bulkowski flags the samples as too thin
-    ///   to trust: Falling Three Methods is so rare he omitted its statistics from his book
-    ///   entirely. ([thepatternsite.com](https://thepatternsite.com/Rising3Methods.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlrisefall3methods](https://ta-lib.org/functions/cdlrisefall3methods).
     ///
     /// # Arguments
     ///
@@ -464,9 +454,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLXSIDEGAP3METHODS`] · [`Core::CDL3INSIDE`] · [`Core::CDL3OUTSIDE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlrisefall3methods](https://ta-lib.org/functions/cdlrisefall3methods)
     #[doc(alias = "RisingFallingThreeMethods")]
     #[doc(alias = "RisingThreeMethods")]
     #[doc(alias = "FallingThreeMethods")]

--- a/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
@@ -358,15 +358,8 @@ impl Core {
     /// the same price as the first, and is a long-bodied belt hold. Bullish (white second candle)
     /// or bearish (black second candle) continuation signal.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Two consecutive candles i-1, i: (1) opposite colors: color(i-1) == -color(i); (2) same open: open[i-1]-Equal_avg <= open[i] <= open[i-1]+Equal_avg; (3) long body: realbody(i) > BodyLong_avg; (4) belt hold: if i is white, lowershadow(i) < ShadowVeryShort_avg; if i is black, uppershadow(i) < ShadowVeryShort_avg.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A prior trend is not verified, nor that the pattern aligns with it.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlseparatinglines](https://ta-lib.org/functions/cdlseparatinglines).
     ///
     /// # Arguments
     ///
@@ -424,9 +417,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLBELTHOLD`] · CDLMEETINGLINES
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlseparatinglines](https://ta-lib.org/functions/cdlseparatinglines)
     #[doc(alias = "SeparatingLines")]
     pub fn CDLSEPARATINGLINES(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
@@ -358,12 +358,8 @@ impl Core {
     /// shadow that gaps up from the prior candle's real body. Bearish reversal signal. A hit (-100)
     /// flags a bearish reversal at the top of an uptrend.
     ///
-    /// # Notes
-    ///
-    /// * A preceding uptrend is not verified.
-    /// * Bulkowski found this reverses only 59% of the time — "near random," summarized in his
-    ///   words as "this candle looks better than it performs" — ranking 55th of 103 patterns.
-    ///   ([thepatternsite.com](https://thepatternsite.com/ShootingStar.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlshootingstar](https://ta-lib.org/functions/cdlshootingstar).
     ///
     /// # Arguments
     ///
@@ -422,9 +418,6 @@ impl Core {
     ///
     /// [`Core::CDLINVERTEDHAMMER`] · [`Core::CDLHANGINGMAN`] · [`Core::CDLHAMMER`] ·
     /// [`Core::CDLGRAVESTONEDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlshootingstar](https://ta-lib.org/functions/cdlshootingstar)
     #[doc(alias = "ShootingStar")]
     pub fn CDLSHOOTINGSTAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
@@ -283,15 +283,8 @@ impl Core {
     /// candle). Not a directional signal — the output sign encodes candle color, not
     /// bullish/bearish sentiment.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle at i, all three:
-    /// - short real body: real body < the BodyShort average
-    /// - short upper shadow: upper shadow < the ShadowShort average
-    /// - short lower shadow: lower shadow < the ShadowShort average
-    /// If matched: output = candle color * 100 (+100 white, -100 black); else 0.
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlshortline](https://ta-lib.org/functions/cdlshortline).
     ///
     /// # Arguments
     ///
@@ -346,9 +339,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLLONGLINE`] · [`Core::CDLSPINNINGTOP`] · [`Core::CDLDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlshortline](https://ta-lib.org/functions/cdlshortline)
     #[doc(alias = "ShortLineCandle")]
     #[doc(alias = "ShortLine")]
     pub fn CDLSHORTLINE(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
@@ -214,11 +214,8 @@ impl Core {
     /// Single-candle pattern: a small real body with both an upper and a lower shadow longer than
     /// the body. Signals indecision; the code does not classify it as bullish or bearish.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// One candle where: upper shadow > real body AND lower shadow > real body AND real body < the BodyShort average. The BodyShort average is the factor-scaled mean body over the prior avgPeriod candles.
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlspinningtop](https://ta-lib.org/functions/cdlspinningtop).
     ///
     /// # Arguments
     ///
@@ -276,9 +273,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLDOJI`] · [`Core::CDLHIGHWAVE`] · [`Core::CDLLONGLEGGEDDOJI`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlspinningtop](https://ta-lib.org/functions/cdlspinningtop)
     #[doc(alias = "SpinningTop")]
     pub fn CDLSPINNINGTOP(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
@@ -481,14 +481,8 @@ impl Core {
     /// a bearish reversal signal of a stalling advance. A hit (-100) is bearish: the uptrend is
     /// stalling and may reverse.
     ///
-    /// # Notes
-    ///
-    /// * The pattern classically appears in an uptrend, but this function does not verify a prior
-    ///   uptrend; the caller must confirm it.
-    /// * Bulkowski's testing shows this classically-bearish pattern actually acts as a bullish
-    ///   continuation 77% of the time — the reverse of the label — because price tends to close
-    ///   above the pattern's top rather than turning down.
-    ///   ([thepatternsite.com](https://thepatternsite.com/Deliberation.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlstalledpattern](https://ta-lib.org/functions/cdlstalledpattern).
     ///
     /// # Arguments
     ///
@@ -546,9 +540,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLADVANCEBLOCK`] · [`Core::CDL3WHITESOLDIERS`] · [`Core::CDLXSIDEGAP3METHODS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlstalledpattern](https://ta-lib.org/functions/cdlstalledpattern)
     #[doc(alias = "StalledPattern")]
     #[doc(alias = "DeliberationPattern")]
     pub fn CDLSTALLEDPATTERN(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
@@ -225,12 +225,8 @@ impl Core {
     /// signals a bullish reversal (code comment notes it is significant in a downtrend, which the
     /// function does not verify).
     ///
-    /// # Notes
-    ///
-    /// * Although classically a bullish reversal (and TA-Lib only emits +100), Bulkowski's testing
-    ///   found it actually acts as a bearish continuation 62% of the time — despite that, it
-    ///   still ranks a respectable 14th of 103 patterns for overall performance.
-    ///   ([thepatternsite.com](https://thepatternsite.com/StickSandwich.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlsticksandwich](https://ta-lib.org/functions/cdlsticksandwich).
     ///
     /// # Arguments
     ///
@@ -288,9 +284,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLMATCHINGLOW`] · [`Core::CDLHOMINGPIGEON`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlsticksandwich](https://ta-lib.org/functions/cdlsticksandwich)
     #[doc(alias = "StickSandwich")]
     pub fn CDLSTICKSANDWICH(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
@@ -356,6 +356,9 @@ impl Core {
     /// a potential reversal only when read against the trend (typically a bottom/bullish reversal
     /// after a downtrend), which the code itself does not verify.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdltakuri](https://ta-lib.org/functions/cdltakuri).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -410,8 +413,6 @@ impl Core {
     ///
     /// [`Core::CDLDRAGONFLYDOJI`] · [`Core::CDLDOJI`] · [`Core::CDLHAMMER`] ·
     /// [`Core::CDLGRAVESTONEDOJI`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdltakuri](https://ta-lib.org/functions/cdltakuri)
     #[doc(alias = "Takuri")]
     #[doc(alias = "Takuriline")]
     pub fn CDLTAKURI(

--- a/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
@@ -234,14 +234,8 @@ impl Core {
     /// opens inside its body and closes back into the gap without filling it. An upside gap is a
     /// bullish continuation signal; a downside gap is a bearish continuation signal.
     ///
-    /// # Notes
-    ///
-    /// * This continuation pattern does not verify the prior trend it classically assumes; the
-    ///   caller must confirm the trend.
-    /// * Bulkowski's testing found the downside Tasuki Gap actually acts as a bullish REVERSAL 54%
-    ///   of the time — opposite its textbook bearish-continuation label — while the upside
-    ///   variant does continue as labeled, but only 57% of the time ("near random").
-    ///   ([thepatternsite.com](https://thepatternsite.com/DownsideTasukiGap.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdltasukigap](https://ta-lib.org/functions/cdltasukigap).
     ///
     /// # Arguments
     ///
@@ -297,9 +291,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLGAPSIDESIDEWHITE`] · [`Core::CDLXSIDEGAP3METHODS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdltasukigap](https://ta-lib.org/functions/cdltasukigap)
     #[doc(alias = "TasukiGap")]
     #[doc(alias = "UpsideDownsideTasukiGap")]
     pub fn CDLTASUKIGAP(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
@@ -328,16 +328,8 @@ impl Core {
     /// continuation signal. A hit is bearish: the failed white push back into the black body
     /// signals continuation of the down move.
     ///
-    /// # Notes
-    ///
-    /// * The pattern is classically meaningful only in a downtrend, but this function does not
-    ///   verify any prior trend.
-    /// * Although the pattern can be read as bullish in an uptrend or when it recurs, this function
-    ///   ignores trend and always reports it as bearish.
-    /// * Bulkowski's testing found this classically-bearish continuation pattern actually acts as a
-    ///   bullish reversal 57% of the time — "near random" — though it ranks a strong 15th of
-    ///   103 patterns for overall performance.
-    ///   ([thepatternsite.com](https://www.thepatternsite.com/Thrusting.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlthrusting](https://ta-lib.org/functions/cdlthrusting).
     ///
     /// # Arguments
     ///
@@ -392,9 +384,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLINNECK`] · [`Core::CDLONNECK`] · [`Core::CDLPIERCING`] · CDLMEETINGLINES
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlthrusting](https://ta-lib.org/functions/cdlthrusting)
     #[doc(alias = "ThrustingPattern")]
     #[doc(alias = "ThrustingLine")]
     pub fn CDLTHRUSTING(

--- a/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
@@ -229,14 +229,8 @@ impl Core {
     /// A three-candle pattern of three consecutive doji where the middle doji is a star (its body
     /// gaps away from the first). Bullish or bearish reversal signal.
     ///
-    /// # Notes
-    ///
-    /// * This reversal pattern does not verify the prior trend it classically assumes.
-    /// * Bulkowski's testing found both Tristar variants reverse only marginally better than chance
-    ///   — bullish 60% of the time (rank 28/103 overall, but rare: frequency rank 79/103) and
-    ///   bearish just 52% of the time (rank 76/103) — despite the "exhaustion signal" framing,
-    ///   one of the weaker reversal signals in his candlestick set.
-    ///   ([thepatternsite.com](https://thepatternsite.com/TriStarBull.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdltristar](https://ta-lib.org/functions/cdltristar).
     ///
     /// # Arguments
     ///
@@ -292,8 +286,6 @@ impl Core {
     ///
     /// [`Core::CDLDOJI`] · [`Core::CDLDOJISTAR`] · [`Core::CDLMORNINGDOJISTAR`] ·
     /// [`Core::CDLEVENINGDOJISTAR`]
-    ///
-    /// Further reading: [ta-lib.org/functions/cdltristar](https://ta-lib.org/functions/cdltristar)
     #[doc(alias = "TristarPattern")]
     #[doc(alias = "Tri-Star")]
     pub fn CDLTRISTAR(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
@@ -296,12 +296,8 @@ impl Core {
     /// ideally in a downtrend (trend not checked by the code). A hit (+100) marks a bullish
     /// reversal; significant in a downtrend, which the function does not verify.
     ///
-    /// # Notes
-    ///
-    /// * Although classically a bullish reversal (and TA-Lib only emits +100), Bulkowski's testing
-    ///   found the opposite: it acts as a bearish continuation 60% of the time, ranking 60th of 103
-    ///   patterns overall.
-    ///   ([thepatternsite.com](https://thepatternsite.com/Unique3RiverBottom.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlunique3river](https://ta-lib.org/functions/cdlunique3river).
     ///
     /// # Arguments
     ///
@@ -359,9 +355,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLHARAMI`] · [`Core::CDLHOMINGPIGEON`] · [`Core::CDL3INSIDE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlunique3river](https://ta-lib.org/functions/cdlunique3river)
     #[doc(alias = "Unique3River")]
     #[doc(alias = "UniqueThreeRiverBottom")]
     pub fn CDLUNIQUE3RIVER(

--- a/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
@@ -298,13 +298,8 @@ impl Core {
     /// candle's real body but still closes above the first candle's close. Signals a bearish
     /// reversal. A hit (-100) is a bearish reversal signal, most meaningful in an uptrend.
     ///
-    /// # Notes
-    ///
-    /// * The pattern classically assumes a prior uptrend, but this function does not verify any
-    ///   trend.
-    /// * Although classically a bearish reversal, Bulkowski's testing found this actually acts as a
-    ///   bullish continuation 60% of the time, and even when it does work "the price move is often
-    ///   lousy." ([thepatternsite.com](https://www.thepatternsite.com/UpGapTwoCrows.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlupsidegap2crows](https://ta-lib.org/functions/cdlupsidegap2crows).
     ///
     /// # Arguments
     ///
@@ -362,9 +357,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDL2CROWS`] · [`Core::CDLGAPSIDESIDEWHITE`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlupsidegap2crows](https://ta-lib.org/functions/cdlupsidegap2crows)
     #[doc(alias = "UpsideGapTwoCrows")]
     pub fn CDLUPSIDEGAP2CROWS(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
@@ -157,14 +157,8 @@ impl Core {
     /// followed by an opposite-color candle that fills into the gap. Bullish (upside) when the
     /// first two candles are white, bearish (downside) when they are black.
     ///
-    /// # Notes
-    ///
-    /// * This continuation pattern does not verify the prior trend it classically assumes; the
-    ///   caller must confirm the trend.
-    /// * Bulkowski's testing found BOTH directions of this pattern actually act as reversals more
-    ///   often than not, opposite the classic continuation label: the upside variant reverses
-    ///   bearish 59% of the time, the downside variant reverses bullish 62% of the time.
-    ///   ([thepatternsite.com](https://thepatternsite.com/UpGap3Methods.html))
+    /// Formula and more info at
+    /// [ta-lib.org/functions/cdlxsidegap3methods](https://ta-lib.org/functions/cdlxsidegap3methods).
     ///
     /// # Arguments
     ///
@@ -223,9 +217,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::CDLGAPSIDESIDEWHITE`] · [`Core::CDLTASUKIGAP`] · [`Core::CDLRISEFALL3METHODS`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/cdlxsidegap3methods](https://ta-lib.org/functions/cdlxsidegap3methods)
     #[doc(alias = "UpsideDownsideGapThreeMethods")]
     #[doc(alias = "UpsideGapThreeMethods")]
     #[doc(alias = "DownsideGapThreeMethods")]

--- a/ta_codegen/output/rust/library/src/ta_func/ceil.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ceil.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise ceiling (round up to the nearest integer) of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = ceil(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/ceil](https://ta-lib.org/functions/ceil).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Floor and ceiling functions*:
     ///   [en.wikipedia.org/wiki/Floor_and_ceiling_functions](https://en.wikipedia.org/wiki/Floor_and_ceiling_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/ceil](https://ta-lib.org/functions/ceil)
     #[doc(alias = "VectorCeil")]
     #[doc(alias = "Ceiling")]
     pub fn CEIL(

--- a/ta_codegen/output/rust/library/src/ta_func/cmf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmf.rs
@@ -257,35 +257,7 @@ impl Core {
     /// that same multiplier summed over a fixed window and normalised, where AD accumulates it from
     /// the start of the series without bound.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// t = high[i] - low[i]
-    ///
-    /// mfv[i] = ((close[i] - low[i]) - (high[i] - close[i])) / t * volume[i], or 0 when t is not positive
-    ///
-    /// CMF[i] = ( sum_{k=i-N+1..i} mfv[k] ) / ( sum_{k=i-N+1..i} volume[k] ), N = optInTimePeriod
-    ///
-    /// There is no seeding and no recursion, hence no unstable period. Each output depends only on the N bars in its own window.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The output is the raw ratio in `[-1, +1]`, matching every published definition. Some
-    ///   retail platforms display it multiplied by 100; that is a presentation choice, not a
-    ///   different indicator.
-    /// * Each bar's close is expected to lie within its own `[low, high]`, and its volume to be
-    ///   finite and non-negative. A close outside its bar makes the multiplier exceed ±1 and is
-    ///   passed through unclamped, exactly as [`AD`](https://ta-lib.org/functions/ad) does.
-    /// * A bar whose high equals its low has no range for the close to sit inside, so it
-    ///   contributes exactly zero money flow volume rather than dividing by zero. Its volume still
-    ///   counts toward the divisor.
-    /// * A window whose volume is entirely zero has no money flow to distribute and reports 0.0.
-    ///   Published references are silent here and other implementations divide by zero; TA-Lib does
-    ///   not return NaN from a successful call.
-    /// * Bars where the low exceeds the high are malformed rather than degenerate, and also
-    ///   contribute zero.
-    /// * The default period of 20 follows the original write-up, which describes 20 or 21 bars.
+    /// Formula and more info at [ta-lib.org/functions/cmf](https://ta-lib.org/functions/cmf).
     ///
     /// # Arguments
     ///
@@ -353,8 +325,6 @@ impl Core {
     ///   example.
     /// * Kirkpatrick and Dahlquist, *Technical Analysis: The Complete Resource for Financial Market
     ///   Technicians*, 2nd edition, pages 419 and 421.
-    ///
-    /// Further reading: [ta-lib.org/functions/cmf](https://ta-lib.org/functions/cmf)
     #[doc(alias = "ChaikinMoneyFlow")]
     pub fn CMF(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cmo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmo.rs
@@ -337,16 +337,7 @@ impl Core {
     /// and down-moves. Identical to RSI except the numerator uses (gain-loss) instead of gain.
     /// Bounded in \[-100,+100]; positive = net upward momentum, negative = net downward.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// d = P[t]-P[t-1]; over the initial period accumulate gain = sum of positive d, loss = sum of -d for negative d. Wilder-smooth each: prevGain = (prevGain*(period-1) + gain_today)/period (same for loss). CMO = 100 * (prevGain-prevLoss)/(prevGain+prevLoss); 0 when prevGain+prevLoss == 0.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Gains and losses are smoothed with Wilder's method (as in RSI) rather than the simple
-    ///   period sums of Chande's original definition.
+    /// Formula and more info at [ta-lib.org/functions/cmo](https://ta-lib.org/functions/cmo).
     ///
     /// # Arguments
     ///
@@ -400,8 +391,6 @@ impl Core {
     /// # References
     ///
     /// * Tushar S. Chande, *The New Technical Trader*, John Wiley & Sons (ISBN 0471597805)
-    ///
-    /// Further reading: [ta-lib.org/functions/cmo](https://ta-lib.org/functions/cmo)
     #[doc(alias = "ChandeMomentumOscillator")]
     pub fn CMO(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/cmou.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmou.rs
@@ -271,11 +271,7 @@ impl Core {
     /// implementation used by TradingView (`ta.cmo`), QuantConnect and pandas-ta's default. See
     /// [`CMO`](https://ta-lib.org/functions/cmo) for a smoothed variant of CMOU.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// d = P[t]-P[t-1]; over the trailing `optInTimePeriod` changes accumulate Su = sum of the positive d, Sd = sum of -d for negative d. CMOU = 100 * (Su-Sd)/(Su+Sd); 0 when Su+Sd == 0 (an exactly flat window). Unlike CMO, the sums are the plain period totals (a moving-window sum), not Wilder-smoothed averages, so there is no unstable period.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/cmou](https://ta-lib.org/functions/cmou).
     ///
     /// # Arguments
     ///
@@ -329,8 +325,6 @@ impl Core {
     /// # References
     ///
     /// * Tushar S. Chande, *The New Technical Trader*, John Wiley & Sons (ISBN 0471597805)
-    ///
-    /// Further reading: [ta-lib.org/functions/cmou](https://ta-lib.org/functions/cmou)
     #[doc(alias = "ChandeMomentumOscillatorUnsmoothed")]
     pub fn CMOU(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -354,16 +354,7 @@ impl Core {
     /// optInTimePeriod bars. Measures how linearly the two series move together. r near +1: strong
     /// positive co-movement; near -1: strong inverse; near 0: no linear relationship.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// r = (sumXY - sumX*sumY/n) / sqrt((sumX2 - sumX^2/n) * (sumY2 - sumY^2/n)),  n = optInTimePeriod, sums over the window
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When the correlation is undefined for a window (for example a constant series), the output
-    ///   is 0 rather than an error or NaN.
+    /// Formula and more info at [ta-lib.org/functions/correl](https://ta-lib.org/functions/correl).
     ///
     /// # Arguments
     ///
@@ -420,8 +411,6 @@ impl Core {
     /// # References
     ///
     /// * Karl Pearson
-    ///
-    /// Further reading: [ta-lib.org/functions/correl](https://ta-lib.org/functions/correl)
     #[doc(alias = "PearsonCorrelation")]
     #[doc(alias = "CorrelationCoefficient")]
     #[doc(alias = "r")]

--- a/ta_codegen/output/rust/library/src/ta_func/cos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cos.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise cosine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = cos(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/cos](https://ta-lib.org/functions/cos).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Trigonometric_functions](https://en.wikipedia.org/wiki/Trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/cos](https://ta-lib.org/functions/cos)
     #[doc(alias = "Cosine")]
     #[doc(alias = "VectorTrigonometricCos")]
     pub fn COS(

--- a/ta_codegen/output/rust/library/src/ta_func/cosh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cosh.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise hyperbolic cosine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = cosh(inReal[i]) = (e^{inReal[i]} + e^{-inReal[i]}) / 2
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/cosh](https://ta-lib.org/functions/cosh).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Hyperbolic functions*:
     ///   [en.wikipedia.org/wiki/Hyperbolic_functions](https://en.wikipedia.org/wiki/Hyperbolic_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/cosh](https://ta-lib.org/functions/cosh)
     #[doc(alias = "HyperbolicCosine")]
     pub fn COSH(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/dema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dema.rs
@@ -293,16 +293,7 @@ impl Core {
     /// Double Exponential Moving Average: an EMA combined with an EMA-of-EMA to reduce lag versus a
     /// plain EMA. Overlap Studies overlay on price.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// EMA1 = EMA(inReal, period); EMA2 = EMA(EMA1, period); DEMA = 2*EMA1 - EMA2
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/dema](https://ta-lib.org/functions/dema).
     ///
     /// # Arguments
     ///
@@ -356,8 +347,6 @@ impl Core {
     ///
     /// * Patrick G. Mulloy, *Smoothing Data with Faster Moving Averages*, Technical Analysis of
     ///   Stocks & Commodities, V.12:1 (January 1994)
-    ///
-    /// Further reading: [ta-lib.org/functions/dema](https://ta-lib.org/functions/dema)
     #[doc(alias = "DoubleExponentialMovingAverage")]
     pub fn DEMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/div.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/div.rs
@@ -109,16 +109,7 @@ impl Core {
     }
     /// Element-wise division of two input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = inReal0[i] / inReal1[i]
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Zero divided by zero gives NaN; anything else divided by zero gives positive or negative
-    ///   infinity. Neither is reported as an error.
+    /// Formula and more info at [ta-lib.org/functions/div](https://ta-lib.org/functions/div).
     ///
     /// # Arguments
     ///
@@ -167,8 +158,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MULT`] · [`Core::ADD`] · [`Core::SUB`]
-    ///
-    /// Further reading: [ta-lib.org/functions/div](https://ta-lib.org/functions/div)
     #[doc(alias = "VectorArithmeticDivide")]
     #[doc(alias = "Divide")]
     pub fn DIV(

--- a/ta_codegen/output/rust/library/src/ta_func/dx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dx.rs
@@ -424,18 +424,7 @@ impl Core {
     /// strength of directional (trending) movement, irrespective of direction. Higher DX = stronger
     /// trend (either direction); low DX = ranging market.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Seed +DM14, -DM14, TR14 as sums of the first (period-1) one-period values, then Wilder-smooth each: X = X - X/period + today. +DI = 100*(+DM14/TR14), -DI = 100*(-DM14/TR14). DX = 100 * |(-DI) - (+DI)| / ((-DI) + (+DI)).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Wilder's original integer rounding is not applied (it can be unreliable when values are
-    ///   near 1).
-    /// * When +DI and -DI sum to zero the value is undefined; the previous bar's DX is carried
-    ///   forward instead (the first such bar outputs zero).
+    /// Formula and more info at [ta-lib.org/functions/dx](https://ta-lib.org/functions/dx).
     ///
     /// # Arguments
     ///
@@ -497,8 +486,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/dx](https://ta-lib.org/functions/dx)
     #[doc(alias = "DirectionalMovementIndex")]
     #[doc(alias = "DMI")]
     pub fn DX(

--- a/ta_codegen/output/rust/library/src/ta_func/efi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/efi.rs
@@ -274,13 +274,7 @@ impl Core {
     /// the result, so it scales with the instrument's own volume: read its sign and its shape over
     /// time, not its level against another instrument.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// force_t = ( close_t - close_{t-1} ) * volume_t; EFI = EMA( force, optInTimePeriod )
-    ///
-    /// The EMA is TA-Lib's, seeded with a simple average of the first `optInTimePeriod` force values. A period of 1 leaves the raw one-bar Force Index.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/efi](https://ta-lib.org/functions/efi).
     ///
     /// # Arguments
     ///
@@ -345,8 +339,6 @@ impl Core {
     ///   `Force Index(13) = 13-period EMA of Force Index(1)`.
     /// * MotiveWave, *Elder's Force Index*: `rawForce = vol * (price - prevP)`, smoothed by a
     ///   moving average whose default method is EMA, at 2 and 13. No competing formula was found.
-    ///
-    /// Further reading: [ta-lib.org/functions/efi](https://ta-lib.org/functions/efi)
     pub fn EFI(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/ema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ema.rs
@@ -237,16 +237,7 @@ impl Core {
     /// factor. A core building block seeding or composing many other indicators. Reacts faster than
     /// SMA; price above/below EMA suggests up/down trend.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// k = 2 / (period + 1); EMA_t = (price_t - EMA_{t-1}) * k + EMA_{t-1}. Seed: EMA = SMA of first `period` bars.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/ema](https://ta-lib.org/functions/ema).
     ///
     /// # Arguments
     ///
@@ -297,8 +288,6 @@ impl Core {
     ///
     /// [`Core::SMA`] · [`Core::DEMA`] · [`Core::TEMA`] · [`Core::MA`] · [`Core::MACD`] ·
     /// [`Core::T3`]
-    ///
-    /// Further reading: [ta-lib.org/functions/ema](https://ta-lib.org/functions/ema)
     #[doc(alias = "ExponentialMovingAverage")]
     #[doc(alias = "ExponentiallyWeightedMovingAverage")]
     #[doc(alias = "EWMA")]

--- a/ta_codegen/output/rust/library/src/ta_func/exp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/exp.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise base-e exponential of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = exp(inReal[i]) = e^{inReal[i]}
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/exp](https://ta-lib.org/functions/exp).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Exponential function*:
     ///   [en.wikipedia.org/wiki/Exponential_function](https://en.wikipedia.org/wiki/Exponential_function)
-    ///
-    /// Further reading: [ta-lib.org/functions/exp](https://ta-lib.org/functions/exp)
     #[doc(alias = "exponential")]
     #[doc(alias = "ex")]
     pub fn EXP(

--- a/ta_codegen/output/rust/library/src/ta_func/floor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/floor.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise floor (round down to the nearest integer) of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = floor(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/floor](https://ta-lib.org/functions/floor).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Floor and ceiling functions*:
     ///   [en.wikipedia.org/wiki/Floor_and_ceiling_functions](https://en.wikipedia.org/wiki/Floor_and_ceiling_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/floor](https://ta-lib.org/functions/floor)
     pub fn FLOOR(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/hma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/hma.rs
@@ -473,26 +473,7 @@ impl Core {
     /// [`STOCH`](https://ta-lib.org/functions/stoch),
     /// [`MACDEXT`](https://ta-lib.org/functions/macdext), ...).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// HMA(n) = WMA( 2 * WMA(price, Integer(n/2)) - WMA(price, n), Integer(SquareRoot(n)) )
-    ///
-    /// All three averages are the standard linearly-weighted moving average (TA-Lib's WMA). Every output is a closed-form weighted sum of the input window: there is no seeding, no recursion, hence no unstable period.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The two derived periods `n/2` and `sqrt(n)` are **truncated** to integers, exactly as in
-    ///   Alan Hull's own statement of the formula (`Integer()`); Tulip Indicators and pandas-ta do
-    ///   the same. Some other published descriptions round to nearest instead, which changes both
-    ///   the values and, for the square root, the lookback — a visibly different line, not a
-    ///   tolerance-level difference. TA-Lib follows the author.
-    /// * The default period of 20 is Alan Hull's own default. It is also a period on which the
-    ///   truncate and round-to-nearest conventions coincide (20/2 is exact; sqrt(20) = 4.47
-    ///   truncates and rounds to 4), so at the default a charting platform using the other
-    ///   convention still lands on TA-Lib's values.
-    /// * A period of 1 performs no smoothing: the output is a copy of the input.
+    /// Formula and more info at [ta-lib.org/functions/hma](https://ta-lib.org/functions/hma).
     ///
     /// # Arguments
     ///
@@ -548,8 +529,6 @@ impl Core {
     /// * Alan Hull, *How to reduce lag in a moving average* — the original definition, including
     ///   the `Integer()` truncation of both derived periods:
     ///   [alanhull.com/hull-moving-average](https://alanhull.com/hull-moving-average)
-    ///
-    /// Further reading: [ta-lib.org/functions/hma](https://ta-lib.org/functions/hma)
     #[doc(alias = "HullMovingAverage")]
     pub fn HMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
@@ -446,6 +446,9 @@ impl Core {
     /// Outputs the smoothed instantaneous cycle period. Output is the estimated dominant cycle
     /// length in bars (clamped to 6-50).
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_dcperiod](https://ta-lib.org/functions/ht_dcperiod).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -495,9 +498,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/ht_dcperiod](https://ta-lib.org/functions/ht_dcperiod)
     #[doc(alias = "HilbertTransformDominantCyclePeriod")]
     #[doc(alias = "DominantCyclePeriod")]
     pub fn HT_DCPERIOD(

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
@@ -526,6 +526,9 @@ impl Core {
     /// price. One real output per bar. Output is degrees, in the range −45 to 315 (a full 360°
     /// span).
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_dcphase](https://ta-lib.org/functions/ht_dcphase).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -575,8 +578,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading: [ta-lib.org/functions/ht_dcphase](https://ta-lib.org/functions/ht_dcphase)
     #[doc(alias = "HilbertTransformDominantCyclePhase")]
     pub fn HT_DCPHASE(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
@@ -458,11 +458,8 @@ impl Core {
     /// HT_* cycle functions. This function is meant for building your own cycle analysis on top of
     /// the raw phasor, not as a ready-made signal.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Smooth price with a 4-bar WMA (weights 1,2,3,4 /10). Apply the Hilbert Transform (a=0.0962, b=0.5769, scaled per bar by adjustedPrevPeriod = 0.075*period + 0.54) to get detrender = HT(smoothed) and Q1 = HT(detrender). Output: outInPhase = detrender delayed 3 price bars; outQuadrature = Q1.
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_phasor](https://ta-lib.org/functions/ht_phasor).
     ///
     /// # Arguments
     ///
@@ -515,8 +512,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading: [ta-lib.org/functions/ht_phasor](https://ta-lib.org/functions/ht_phasor)
     #[doc(alias = "HilbertTransformPhasor")]
     #[doc(alias = "InPhaseQuadrature")]
     pub fn HT_PHASOR(

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -535,6 +535,9 @@ impl Core {
     /// plus a 45-degree-lead sine. The two curves cross near cycle turning points. outSine and
     /// outLeadSine crossing marks cycle turning points.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_sine](https://ta-lib.org/functions/ht_sine).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -586,8 +589,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading: [ta-lib.org/functions/ht_sine](https://ta-lib.org/functions/ht_sine)
     #[doc(alias = "HilbertTransformSineWave")]
     #[doc(alias = "EhlersSineWave")]
     #[doc(alias = "SineWaveIndicator")]

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
@@ -504,6 +504,9 @@ impl Core {
     /// averaging window adapts to the dominant cycle period measured via Hilbert-transform
     /// quadrature (I/Q) analysis of price.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_trendline](https://ta-lib.org/functions/ht_trendline).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -552,9 +555,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/ht_trendline](https://ta-lib.org/functions/ht_trendline)
     #[doc(alias = "HilbertTransformInstantaneousTrendline")]
     #[doc(alias = "InstantaneousTrendline")]
     pub fn HT_TRENDLINE(

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -613,6 +613,9 @@ impl Core {
     /// 0 (cycling — favor mean-reversion). Built from the same MAMA dominant-cycle/phase DSP plus
     /// a SineWave/trendline test used across the other HT_* functions.
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/ht_trendmode](https://ta-lib.org/functions/ht_trendmode).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -661,9 +664,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/ht_trendmode](https://ta-lib.org/functions/ht_trendmode)
     #[doc(alias = "HilbertTransformTrendvsCycleMode")]
     #[doc(alias = "TrendMode")]
     pub fn HT_TRENDMODE(

--- a/ta_codegen/output/rust/library/src/ta_func/imi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/imi.rs
@@ -167,11 +167,7 @@ impl Core {
     /// each bar. Over a rolling window it ratios cumulative up-body moves against total up+down
     /// body moves.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// upsum = Σ(close-open) for bars with close>open; downsum = Σ(open-close) for bars with close<=open, over window [i-lookback, i]; IMI = 100 * upsum/(upsum+downsum)
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/imi](https://ta-lib.org/functions/imi).
     ///
     /// # Arguments
     ///
@@ -227,8 +223,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::RSI`]
-    ///
-    /// Further reading: [ta-lib.org/functions/imi](https://ta-lib.org/functions/imi)
     #[doc(alias = "IntradayMomentumIndex")]
     pub fn IMI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -365,20 +365,7 @@ impl Core {
     /// in ranging markets. Flat KAMA = non-trending/ranging market. KAMA tracking price closely =
     /// efficient trend.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ER = |price[t] - price[t-period]| / sum(|price[i]-price[i-1]|, last period bars)
-    /// SC = (ER*(2/3 - 2/31) + 2/31)^2
-    /// KAMA[t] = KAMA[t-1] + SC*(price[t] - KAMA[t-1])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input, consistent with
-    ///   `MA(period=1)` for every MAType. (The natural KAMA math at period 1 would degenerate to a
-    ///   fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.)
-    ///   Allowed since 0.6.5.
+    /// Formula and more info at [ta-lib.org/functions/kama](https://ta-lib.org/functions/kama).
     ///
     /// # Arguments
     ///
@@ -433,8 +420,6 @@ impl Core {
     ///
     /// * Perry J. Kaufman, *Smarter Trading: Improving Performance in Changing Markets*,
     ///   McGraw-Hill (1995)
-    ///
-    /// Further reading: [ta-lib.org/functions/kama](https://ta-lib.org/functions/kama)
     #[doc(alias = "KaufmanAdaptiveMovingAverage")]
     #[doc(alias = "KaufmansAdaptiveMovingAverage")]
     pub fn KAMA(

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
@@ -329,6 +329,9 @@ impl Core {
     /// Least-squares straight-line fit over the last optInTimePeriod bars, reported as the fitted
     /// line value at the window endpoint (b + m*(period-1)).
     ///
+    /// Formula and more info at
+    /// [ta-lib.org/functions/linearreg](https://ta-lib.org/functions/linearreg).
+    ///
     /// # Arguments
     ///
     /// * `startIdx` — Start index of the requested calculation range.
@@ -378,8 +381,6 @@ impl Core {
     ///
     /// [`Core::LINEARREG_SLOPE`] · [`Core::LINEARREG_ANGLE`] · [`Core::LINEARREG_INTERCEPT`] ·
     /// [`Core::TSF`]
-    ///
-    /// Further reading: [ta-lib.org/functions/linearreg](https://ta-lib.org/functions/linearreg)
     #[doc(alias = "LinearRegression")]
     #[doc(alias = "LeastSquares")]
     #[doc(alias = "BestFitLine")]

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
@@ -300,11 +300,8 @@ impl Core {
     /// LINEARREG_SLOPE value passed through atan and converted to degrees. Positive angle = rising
     /// fit line, negative = falling; magnitude reflects steepness.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// m = (N·SumXY − SumX·SumY) / (SumX² − N·SumXSqr), with SumX=N(N−1)/2, SumXSqr=N(N−1)(2N−1)/6; angle = atan(m)·(180/π)
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/linearreg_angle](https://ta-lib.org/functions/linearreg_angle).
     ///
     /// # Arguments
     ///
@@ -355,9 +352,6 @@ impl Core {
     ///
     /// [`Core::LINEARREG`] · [`Core::LINEARREG_SLOPE`] · [`Core::LINEARREG_INTERCEPT`] ·
     /// [`Core::TSF`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/linearreg_angle](https://ta-lib.org/functions/linearreg_angle)
     #[doc(alias = "LinearRegressionAngle")]
     #[doc(alias = "LeastSquaresAngle")]
     pub fn LINEARREG_ANGLE(

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
@@ -295,13 +295,8 @@ impl Core {
     /// Returns the y-intercept (b) of the least-squares regression line fitted over the last
     /// optInTimePeriod values. Part of the linear-regression family (LINEARREG, SLOPE, ANGLE, TSF).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Fit y = b + m·x over the window with x = bars-ago (x=0 is the current bar, x=period-1 the oldest). With SumX = period(period-1)/2, SumXSqr = period(period-1)(2·period-1)/6, Divisor = SumX² − period·SumXSqr:
-    /// m = (period·SumXY − SumX·SumY) / Divisor
-    /// b = (SumY − m·SumX) / period   ← output
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/linearreg_intercept](https://ta-lib.org/functions/linearreg_intercept).
     ///
     /// # Arguments
     ///
@@ -351,9 +346,6 @@ impl Core {
     ///
     /// [`Core::LINEARREG`] · [`Core::LINEARREG_SLOPE`] · [`Core::LINEARREG_ANGLE`] ·
     /// [`Core::TSF`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/linearreg_intercept](https://ta-lib.org/functions/linearreg_intercept)
     #[doc(alias = "LinearRegressionIntercept")]
     pub fn LINEARREG_INTERCEPT(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
@@ -294,13 +294,8 @@ impl Core {
     /// bars. Reports the per-bar rate of change of the fitted trend line. Positive slope = rising
     /// trend, negative = falling; magnitude is price change per bar.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// m = (n·SumXY − SumX·SumY) / Divisor
-    /// SumX = n(n−1)/2,  SumXSqr = n(n−1)(2n−1)/6,  Divisor = SumX² − n·SumXSqr
-    /// SumXY = Σ i·y[today−i],  SumY = Σ y[today−i],  i=0..n−1,  n=period,  y=inReal
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/linearreg_slope](https://ta-lib.org/functions/linearreg_slope).
     ///
     /// # Arguments
     ///
@@ -351,9 +346,6 @@ impl Core {
     ///
     /// [`Core::LINEARREG`] · [`Core::LINEARREG_INTERCEPT`] · [`Core::LINEARREG_ANGLE`] ·
     /// [`Core::TSF`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/linearreg_slope](https://ta-lib.org/functions/linearreg_slope)
     #[doc(alias = "LinearRegressionSlope")]
     #[doc(alias = "LSMAslope")]
     #[doc(alias = "leastsquaresslope")]

--- a/ta_codegen/output/rust/library/src/ta_func/ln.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ln.rs
@@ -107,16 +107,7 @@ impl Core {
     }
     /// Element-wise natural logarithm of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = log(inReal[i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The logarithm is defined only for positive values: a negative input gives NaN, and a zero
-    ///   input gives negative infinity.
+    /// Formula and more info at [ta-lib.org/functions/ln](https://ta-lib.org/functions/ln).
     ///
     /// # Arguments
     ///
@@ -166,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Natural logarithm*:
     ///   [en.wikipedia.org/wiki/Natural_logarithm](https://en.wikipedia.org/wiki/Natural_logarithm)
-    ///
-    /// Further reading: [ta-lib.org/functions/ln](https://ta-lib.org/functions/ln)
     #[doc(alias = "NaturalLog")]
     #[doc(alias = "VectorLogNatural")]
     #[doc(alias = "Log")]

--- a/ta_codegen/output/rust/library/src/ta_func/log10.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/log10.rs
@@ -107,16 +107,7 @@ impl Core {
     }
     /// Element-wise base-10 logarithm of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = log10(inReal[i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The logarithm is defined only for positive values: a negative input gives NaN, and a zero
-    ///   input gives negative infinity.
+    /// Formula and more info at [ta-lib.org/functions/log10](https://ta-lib.org/functions/log10).
     ///
     /// # Arguments
     ///
@@ -166,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Common logarithm*:
     ///   [en.wikipedia.org/wiki/Common_logarithm](https://en.wikipedia.org/wiki/Common_logarithm)
-    ///
-    /// Further reading: [ta-lib.org/functions/log10](https://ta-lib.org/functions/log10)
     #[doc(alias = "LogBase10")]
     #[doc(alias = "CommonLogarithm")]
     pub fn LOG10(

--- a/ta_codegen/output/rust/library/src/ta_func/ma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ma.rs
@@ -291,21 +291,7 @@ impl Core {
     /// Generic moving-average dispatcher that forwards the job to the MA implementation selected by
     /// optInMAType. Single uniform interface over all TA-Lib moving averages.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal = MA_of_type(optInMAType)(inReal, optInTimePeriod); default type = SMA
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing for every MAType: the output is a copy of the input.
-    /// * `TA_MAType_DISABLED` bypasses smoothing explicitly, for any period: the output is a copy
-    ///   of the input with a lookback of 0. Every function that takes an MAType parameter accepts
-    ///   it.
-    /// * `TA_MAType_DEFAULT` selects the documented default of the parameter it is passed to —
-    ///   SMA here, EMA for APO, PPO and PVO. Every function that takes an MAType parameter accepts
-    ///   it.
+    /// Formula and more info at [ta-lib.org/functions/ma](https://ta-lib.org/functions/ma).
     ///
     /// # Arguments
     ///
@@ -358,8 +344,6 @@ impl Core {
     ///
     /// [`Core::SMA`] · [`Core::EMA`] · [`Core::WMA`] · [`Core::DEMA`] · [`Core::TEMA`] ·
     /// [`Core::TRIMA`] · [`Core::KAMA`] · [`Core::MAMA`] · [`Core::T3`] · [`Core::HMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/ma](https://ta-lib.org/functions/ma)
     #[doc(alias = "MovingAverage")]
     pub fn MA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/macd.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macd.rs
@@ -383,19 +383,7 @@ impl Core {
     /// input, plus an EMA-smoothed signal line and their histogram. MACD crossing its signal line
     /// and histogram sign changes flag momentum shifts.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MACD = EMA_fast - EMA_slow;  Signal = EMA(MACD, signalPeriod);  Hist = MACD - Signal
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * If the slow period is set smaller than the fast period, the two are swapped so the slow
-    ///   EMA is always the longer one.
-    /// * A signal period of 1 disables signal-line smoothing: the signal equals the MACD line and
-    ///   the histogram is zero. Before 0.6.5 this parameter value produced misaligned output
-    ///   (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/macd](https://ta-lib.org/functions/macd).
     ///
     /// # Arguments
     ///
@@ -457,8 +445,6 @@ impl Core {
     /// # References
     ///
     /// * Gerald Appel, *Stock Market Trading Systems*, Traders Pr (ISBN 0934380163)
-    ///
-    /// Further reading: [ta-lib.org/functions/macd](https://ta-lib.org/functions/macd)
     #[doc(alias = "movingaverageconvergencedivergence")]
     pub fn MACD(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/macdext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdext.rs
@@ -311,25 +311,8 @@ impl Core {
     /// type. Outputs the MACD line, its signal line, and their difference (histogram). Hist sign
     /// change (MACD crossing its signal line) flags momentum shifts.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MACD = MA_fast(inReal) - MA_slow(inReal)
-    /// Signal = MA_signal(MACD)
-    /// Hist = MACD - Signal
-    /// (each MA_* uses its own MA type and period)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * If the slow period is set smaller than the fast period, the fast and slow periods and
-    ///   their MA types are swapped so the slow moving average is always the longer one.
-    /// * A signal period of 1 disables signal-line smoothing for every signal MAType: the signal
-    ///   equals the MACD line and the histogram is zero.
-    /// * `TA_MAType_MAMA` ignores its period argument, so it always produces the same series
-    ///   regardless of the period requested. If both `optInFastMAType` and `optInSlowMAType` are
-    ///   set to MAMA, the fast and slow lines are therefore identical and MACD, Signal, and Hist
-    ///   are all zero at every bar. Select MAMA for only one side to get a meaningful spread.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/macdext](https://ta-lib.org/functions/macdext).
     ///
     /// # Arguments
     ///
@@ -397,8 +380,6 @@ impl Core {
     ///
     /// [`Core::MACD`] · [`Core::MACDFIX`] · [`Core::MA`] · [`Core::EMA`] · [`Core::APO`] ·
     /// [`Core::PPO`]
-    ///
-    /// Further reading: [ta-lib.org/functions/macdext](https://ta-lib.org/functions/macdext)
     #[doc(alias = "MACDExtended")]
     #[doc(alias = "MACDwithcontrollableMAtype")]
     pub fn MACDEXT(

--- a/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
@@ -331,19 +331,8 @@ impl Core {
     /// smoothing factors 0.15 and 0.075), exposing only the signal period. Signal-line crossovers
     /// and histogram sign flag momentum shifts.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MACD = EMA_12 - EMA_26   (fixed k: 0.15 for 12, 0.075 for 26)
-    /// Signal = EMA(MACD, signalPeriod),  k = 2/(signalPeriod+1)
-    /// Hist = MACD - Signal
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A signal period of 1 disables signal-line smoothing: the signal equals the MACD line and
-    ///   the histogram is zero. Before 0.6.5 this parameter value produced misaligned output
-    ///   (issues #48/#59).
+    /// Formula and more info at
+    /// [ta-lib.org/functions/macdfix](https://ta-lib.org/functions/macdfix).
     ///
     /// # Arguments
     ///
@@ -399,8 +388,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MACD`] · [`Core::MACDEXT`] · [`Core::EMA`] · [`Core::APO`]
-    ///
-    /// Further reading: [ta-lib.org/functions/macdfix](https://ta-lib.org/functions/macdfix)
     #[doc(alias = "MovingAverageConvergenceDivergenceFix")]
     pub fn MACDFIX(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -550,14 +550,7 @@ impl Core {
     /// dominant-cycle phase rate measured with a Hilbert transform. Emits two lines, MAMA and its
     /// slower follower FAMA. MAMA crossing above FAMA is bullish; crossing below is bearish.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// phase = atan(Q1/I1) in degrees; deltaPhase = max(1, prevPhase - phase)
-    /// alpha = max(fastLimit/deltaPhase, slowLimit) if deltaPhase>1 else fastLimit
-    /// MAMA = alpha*price + (1-alpha)*MAMA_prev
-    /// FAMA = (alpha/2)*MAMA + (1-alpha/2)*FAMA_prev
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/mama](https://ta-lib.org/functions/mama).
     ///
     /// # Arguments
     ///
@@ -618,8 +611,6 @@ impl Core {
     ///
     /// * John F. Ehlers, *Rocket Science for Traders: Digital Signal Processing Applications*, John
     ///   Wiley & Sons (ISBN 0471405671)
-    ///
-    /// Further reading: [ta-lib.org/functions/mama](https://ta-lib.org/functions/mama)
     #[doc(alias = "MESAAdaptiveMovingAverage")]
     #[doc(alias = "EhlersMAMA")]
     pub fn MAMA(

--- a/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
@@ -146,13 +146,8 @@ impl Core {
     /// this index and in volume. That is an interpretive layer on top of the series, not part of
     /// it; `outReal` is the scalar only.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MARKETFI_t = (high_t - low_t) / volume_t
-    ///
-    /// A bar with zero volume reports 0 rather than dividing: it facilitated no movement, and a successful call never emits NaN or ±Inf.
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/marketfi](https://ta-lib.org/functions/marketfi).
     ///
     /// # Arguments
     ///
@@ -213,8 +208,6 @@ impl Core {
     /// * The four-state green/fade/fake/squat colour code charting packages overlay is derived from
     ///   the signs of the bar-to-bar change in this index and in volume. It is an interpretive
     ///   layer, not part of the series; `outReal` is the scalar only.
-    ///
-    /// Further reading: [ta-lib.org/functions/marketfi](https://ta-lib.org/functions/marketfi)
     pub fn MARKETFI(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/mavp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mavp.rs
@@ -405,18 +405,7 @@ impl Core {
     /// Moving average whose period varies per bar, driven by a companion period series. For each
     /// bar it computes an MA of the selected type over the (clamped) period given by inPeriods.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// p_i = clamp((int)inPeriods[startIdx+i], optInMinPeriod, optInMaxPeriod); outReal[i] = MA(inReal, p_i, optInMAType) at bar startIdx+i
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Fractional per-bar periods are truncated to whole numbers before being clamped to the
-    ///   minimum and maximum period.
-    /// * Period values of 1 perform no smoothing (the bar's output equals its input); the minimum
-    ///   allowed period is 1 since 0.6.5.
+    /// Formula and more info at [ta-lib.org/functions/mavp](https://ta-lib.org/functions/mavp).
     ///
     /// # Arguments
     ///
@@ -474,8 +463,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MA`] · [`Core::SMA`] · [`Core::MAMA`] · [`Core::T3`]
-    ///
-    /// Further reading: [ta-lib.org/functions/mavp](https://ta-lib.org/functions/mavp)
     #[doc(alias = "MovingAverageVariablePeriod")]
     #[doc(alias = "VariablePeriodMovingAverage")]
     pub fn MAVP(

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -257,11 +257,7 @@ impl Core {
     /// Highest input value over a rolling window of the last optInTimePeriod bars. A moving-window
     /// maximum.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = max(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/max](https://ta-lib.org/functions/max).
     ///
     /// # Arguments
     ///
@@ -310,8 +306,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MIN`] · [`Core::MAXINDEX`] · [`Core::MINMAX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/max](https://ta-lib.org/functions/max)
     #[doc(alias = "Highest")]
     #[doc(alias = "HighestHigh")]
     #[doc(alias = "RollingMaximum")]

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -175,16 +175,8 @@ impl Core {
     /// Returns the index of the highest input value within a rolling window of optInTimePeriod
     /// bars. Same as MAX but outputs the location instead of the value.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outInteger[i] = index of max(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When several bars in a window share the highest value, the index of one of them is
-    ///   returned — not necessarily the first or the last.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/maxindex](https://ta-lib.org/functions/maxindex).
     ///
     /// # Arguments
     ///
@@ -233,8 +225,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MAX`] · [`Core::MININDEX`] · [`Core::MIN`] · [`Core::MINMAXINDEX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/maxindex](https://ta-lib.org/functions/maxindex)
     #[doc(alias = "IndexofHighestValue")]
     #[doc(alias = "HighestValueIndex")]
     #[doc(alias = "argmax")]

--- a/ta_codegen/output/rust/library/src/ta_func/medprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/medprice.rs
@@ -116,11 +116,8 @@ impl Core {
     }
     /// Median Price: the midpoint of each bar's high and low. A price-transform overlay.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $MEDPRICE_i = (High_i + Low_i) / 2$
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/medprice](https://ta-lib.org/functions/medprice).
     ///
     /// # Arguments
     ///
@@ -167,8 +164,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MIDPRICE`] · [`Core::AVGPRICE`] · [`Core::TYPPRICE`] · [`Core::WCLPRICE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/medprice](https://ta-lib.org/functions/medprice)
     #[doc(alias = "MedianPrice")]
     pub fn MEDPRICE(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/mfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mfi.rs
@@ -312,20 +312,7 @@ impl Core {
     /// negative money flow over a period. A volume-based analog of RSI. >80 overbought, \<20
     /// oversold.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// TP = (High+Low+Close)/3; MF = TP*Volume, classed positive if TP>prevTP, negative if TP<prevTP, neither if equal. MFI = 100 * posSumMF/(posSumMF+negSumMF).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When the typical price is unchanged from the prior bar, that bar's money flow is counted
-    ///   as neither positive nor negative.
-    /// * A window in which no bar contributed any money flow — every typical price unchanged, or
-    ///   no volume traded — leaves the index undefined (0/0); 0 is returned. The result does not
-    ///   otherwise depend on the size of the money flow: scaling every volume, or quoting the
-    ///   instrument in a different unit, leaves the index unchanged.
+    /// Formula and more info at [ta-lib.org/functions/mfi](https://ta-lib.org/functions/mfi).
     ///
     /// # Arguments
     ///
@@ -390,8 +377,6 @@ impl Core {
     ///
     /// * Gene Quong & Avrum Soudack, *Volume-Weighted RSI: Money Flow*, Technical Analysis of
     ///   Stocks & Commodities, V.7:3 (March 1989)
-    ///
-    /// Further reading: [ta-lib.org/functions/mfi](https://ta-lib.org/functions/mfi)
     #[doc(alias = "MoneyFlowIndex")]
     pub fn MFI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -312,11 +312,8 @@ impl Core {
     /// lookback window. A single-series overlap smoother (use MIDPRICE for separate high/low price
     /// bars).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MIDPOINT = (Highest(inReal, period) + Lowest(inReal, period)) / 2
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/midpoint](https://ta-lib.org/functions/midpoint).
     ///
     /// # Arguments
     ///
@@ -365,8 +362,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MIDPRICE`] · [`Core::MAX`] · [`Core::MIN`]
-    ///
-    /// Further reading: [ta-lib.org/functions/midpoint](https://ta-lib.org/functions/midpoint)
     pub fn MIDPOINT(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -318,11 +318,8 @@ impl Core {
     /// Midpoint of the price range over a rolling window: the average of the highest high and
     /// lowest low across the last optInTimePeriod bars. An overlap-study line plotted on price.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MIDPRICE = (Highest(High, N) + Lowest(Low, N)) / 2, over the N=optInTimePeriod bars ending at each index
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/midprice](https://ta-lib.org/functions/midprice).
     ///
     /// # Arguments
     ///
@@ -374,8 +371,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MIDPOINT`] · [`Core::MEDPRICE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/midprice](https://ta-lib.org/functions/midprice)
     #[doc(alias = "MidpointPrice")]
     pub fn MIDPRICE(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -255,11 +255,7 @@ impl Core {
     }
     /// Rolling minimum: the lowest input value over the trailing period.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = min(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/min](https://ta-lib.org/functions/min).
     ///
     /// # Arguments
     ///
@@ -308,8 +304,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MAX`] · [`Core::MININDEX`] · [`Core::MINMAX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/min](https://ta-lib.org/functions/min)
     #[doc(alias = "Lowest")]
     #[doc(alias = "RollingMin")]
     #[doc(alias = "MinValue")]

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -175,16 +175,8 @@ impl Core {
     /// Returns the absolute index of the lowest value within a rolling window of the given period.
     /// Same scan as MIN but outputs the position of the minimum rather than its value.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outInteger[i] = index of min(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When several bars in a window share the lowest value, the index of one of them is returned
-    ///   — not necessarily the first or the last.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/minindex](https://ta-lib.org/functions/minindex).
     ///
     /// # Arguments
     ///
@@ -233,8 +225,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MIN`] · [`Core::MAXINDEX`] · [`Core::MINMAXINDEX`] · [`Core::MINMAX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/minindex](https://ta-lib.org/functions/minindex)
     #[doc(alias = "IndexofLowestValue")]
     #[doc(alias = "LowestValueIndex")]
     #[doc(alias = "RollingArgmin")]

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -308,12 +308,7 @@ impl Core {
     /// optInTimePeriod bars. An overlap-study companion to MIN and MAX that computes both extrema
     /// in one pass.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outMin[i] = min(inReal[i-optInTimePeriod+1 .. i])  
-    /// outMax[i] = max(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/minmax](https://ta-lib.org/functions/minmax).
     ///
     /// # Arguments
     ///
@@ -365,8 +360,6 @@ impl Core {
     ///
     /// [`Core::MIN`] · [`Core::MAX`] · [`Core::MINMAXINDEX`] · [`Core::MININDEX`] ·
     /// [`Core::MAXINDEX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/minmax](https://ta-lib.org/functions/minmax)
     #[doc(alias = "HighestLowest")]
     pub fn MINMAX(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -201,17 +201,8 @@ impl Core {
     /// Returns the absolute input indices of the lowest and highest values within each rolling
     /// window of optInTimePeriod bars. Index variant of MINMAX.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outMinIdx[i] = index of min(inReal[i-optInTimePeriod+1 .. i])  
-    /// outMaxIdx[i] = index of max(inReal[i-optInTimePeriod+1 .. i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When several bars in a window share the extreme value, the index of one of them is
-    ///   returned — not necessarily the first or the last.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/minmaxindex](https://ta-lib.org/functions/minmaxindex).
     ///
     /// # Arguments
     ///
@@ -262,9 +253,6 @@ impl Core {
     ///
     /// [`Core::MINMAX`] · [`Core::MIN`] · [`Core::MAX`] · [`Core::MININDEX`] ·
     /// [`Core::MAXINDEX`]
-    ///
-    /// Further reading:
-    /// [ta-lib.org/functions/minmaxindex](https://ta-lib.org/functions/minmaxindex)
     #[doc(alias = "LowestHighestIndex")]
     pub fn MINMAXINDEX(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
@@ -446,16 +446,8 @@ impl Core {
     /// Higher -DI indicates a stronger downtrend; compared against +DI to gauge directional
     /// dominance.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// -DM1 = (prevLow - low) if (prevLow-low)>0 and (high-prevHigh)<(prevLow-low), else 0. Seed -DM/TR = sum of first (period-1) -DM1/TR1, then Wilder-smooth each: X = X - X/period + today. -DI = 100 * (-DM / TR); TR from ta_true_range. If period<=1: -DI1 = -DM1/TR1 (no ×100).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Wilder's original integer rounding is not applied (it was removed as unreliable when
-    ///   values are near 1).
+    /// Formula and more info at
+    /// [ta-lib.org/functions/minus_di](https://ta-lib.org/functions/minus_di).
     ///
     /// # Arguments
     ///
@@ -517,8 +509,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/minus_di](https://ta-lib.org/functions/minus_di)
     #[doc(alias = "-DI")]
     #[doc(alias = "NegativeDirectionalIndicator")]
     pub fn MINUS_DI(

--- a/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
@@ -316,15 +316,8 @@ impl Core {
     /// Measures Wilder-smoothed downward price motion over the period. Higher -DM indicates
     /// stronger downward directional movement.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// diffP = high - prevHigh; diffM = prevLow - low
-    /// -DM1 = diffM if (diffM > 0 and diffP < diffM) else 0
-    /// period<=1: output raw -DM1 per bar.
-    /// period>1: seed = sum of first (period-1) -DM1; then Wilder smooth each bar:
-    /// -DM = prevMinusDM - prevMinusDM/period (+ -DM1 when the bar qualifies)
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/minus_dm](https://ta-lib.org/functions/minus_dm).
     ///
     /// # Arguments
     ///
@@ -381,8 +374,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/minus_dm](https://ta-lib.org/functions/minus_dm)
     #[doc(alias = "MinusDirectionalMovement")]
     #[doc(alias = "-DM")]
     pub fn MINUS_DM(

--- a/ta_codegen/output/rust/library/src/ta_func/mom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mom.rs
@@ -177,11 +177,7 @@ impl Core {
     /// (unnormalized) rate of change. Positive = price rose over the period, negative = fell;
     /// centered at zero.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// MOM[i] = inReal[i] - inReal[i - optInTimePeriod]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/mom](https://ta-lib.org/functions/mom).
     ///
     /// # Arguments
     ///
@@ -230,8 +226,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ROC`] · [`Core::ROCP`] · [`Core::ROCR`] · [`Core::ROCR100`]
-    ///
-    /// Further reading: [ta-lib.org/functions/mom](https://ta-lib.org/functions/mom)
     #[doc(alias = "Momentum")]
     pub fn MOM(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/mult.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mult.rs
@@ -108,11 +108,7 @@ impl Core {
     }
     /// Element-wise multiplication of two input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = inReal0[i] * inReal1[i]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/mult](https://ta-lib.org/functions/mult).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ADD`] · [`Core::SUB`] · [`Core::DIV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/mult](https://ta-lib.org/functions/mult)
     #[doc(alias = "VectorMultiply")]
     #[doc(alias = "VectorArithmeticMult")]
     #[doc(alias = "Element-wiseProduct")]

--- a/ta_codegen/output/rust/library/src/ta_func/natr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/natr.rs
@@ -318,12 +318,7 @@ impl Core {
     /// comparable across price levels and securities. Same computation as ATR, then normalized by
     /// close. Higher values mean greater relative volatility; unit is percent of price.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// NATR = (ATR / Close) * 100
-    /// ATR: first value = SMA of TRANGE over period; then Wilder smoothing ATR_t = (ATR_{t-1}*(period-1) + TR_t) / period
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/natr](https://ta-lib.org/functions/natr).
     ///
     /// # Arguments
     ///
@@ -383,8 +378,6 @@ impl Core {
     /// # References
     ///
     /// * John Forman
-    ///
-    /// Further reading: [ta-lib.org/functions/natr](https://ta-lib.org/functions/natr)
     #[doc(alias = "NormalizedAverageTrueRange")]
     pub fn NATR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/nvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/nvi.rs
@@ -148,26 +148,7 @@ impl Core {
     /// that quiet, low-volume days reflect the actions of well-informed "smart money", so NVI is
     /// read as a proxy for that cohort's positioning.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// NVI[startIdx] = 1000
-    ///
-    /// For each subsequent bar i:
-    ///
-    ///     NVI[i] = NVI[i-1] + ( inVolume[i] < inVolume[i-1]
-    ///                           ? ((inClose[i] - inClose[i-1]) / inClose[i-1]) * NVI[i-1]
-    ///                           : 0 )
-    ///
-    /// The index carries forward unchanged on bars whose volume did not fall (and on the
-    /// degenerate case of a zero previous close, which would otherwise divide by zero).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The index compounds, so it has no upper bound. If a run of large rises ever pushes it past
-    ///   the largest representable number, the last representable value is carried forward instead
-    ///   of returning infinity. Real price series stay far away from that.
+    /// Formula and more info at [ta-lib.org/functions/nvi](https://ta-lib.org/functions/nvi).
     ///
     /// # Arguments
     ///
@@ -219,8 +200,6 @@ impl Core {
     ///
     /// * Norman G. Fosback, *Stock Market Logic*, The Institute for Econometric Research (ISBN
     ///   0917604482)
-    ///
-    /// Further reading: [ta-lib.org/functions/nvi](https://ta-lib.org/functions/nvi)
     #[doc(alias = "NegativeVolumeIndex")]
     pub fn NVI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/obv.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/obv.rs
@@ -125,11 +125,7 @@ impl Core {
     /// On Balance Volume: a running cumulative total of volume, added on up-price bars and
     /// subtracted on down-price bars. Relates volume flow to price direction.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// OBV[i] = OBV[i-1] + (inReal[i] > inReal[i-1] ? V[i] : inReal[i] < inReal[i-1] ? -V[i] : 0); seed OBV[startIdx] = V[startIdx]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/obv](https://ta-lib.org/functions/obv).
     ///
     /// # Arguments
     ///
@@ -179,8 +175,6 @@ impl Core {
     ///
     /// * Joseph Ensign Granville, B. Granville, *Granville's New Strategy of Daily Stock Market
     ///   Timing for Maximum Profit*, Simon & Schuster (ISBN 0133634329)
-    ///
-    /// Further reading: [ta-lib.org/functions/obv](https://ta-lib.org/functions/obv)
     #[doc(alias = "OnBalanceVolume")]
     pub fn OBV(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
@@ -444,20 +444,8 @@ impl Core {
     /// percentage of the true range. Measures the strength of upward price movement. Rising +DI
     /// signals strengthening upward direction; compared against MINUS_DI to judge trend direction.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// +DM1 = (H-Hprev) if (H-Hprev) > 0 and (H-Hprev) > (Lprev-L), else 0.
-    /// TR1 = true range = max(H-L, |H-Cprev|, |L-Cprev|).
-    /// Seed +DM/TR = sum of first (period-1) one-period values; then Wilder smooth: X = X - X/period + X1.
-    /// +DI = 100 * (+DM / TR); if TR = 0, +DI = 0.
-    /// When period <= 1: +DI = +DM1 / TR1 (no *100).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Wilder's original integer rounding of intermediate values is not applied (it was
-    ///   unreliable when values are near 1).
+    /// Formula and more info at
+    /// [ta-lib.org/functions/plus_di](https://ta-lib.org/functions/plus_di).
     ///
     /// # Arguments
     ///
@@ -518,8 +506,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/plus_di](https://ta-lib.org/functions/plus_di)
     #[doc(alias = "DI")]
     #[doc(alias = "PlusDirectionalIndicator")]
     #[doc(alias = "PDI")]

--- a/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
@@ -316,14 +316,8 @@ impl Core {
     /// Plus Directional Movement: the Wilder-smoothed accumulation of upward directional movement
     /// (+DM1). A component of the Directional Movement System used to build +DI/DX/ADX.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// +DM1 = (high - prevHigh) if (high-prevHigh) > 0 and > (prevLow-low), else 0.
-    /// period<=1: output = +DM1 per bar.
-    /// period>1: seed = sum of first (period-1) +DM1; then Wilder smoothing:
-    /// +DM = prevPlusDM - prevPlusDM/period + +DM1(today)
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/plus_dm](https://ta-lib.org/functions/plus_dm).
     ///
     /// # Arguments
     ///
@@ -380,8 +374,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/plus_dm](https://ta-lib.org/functions/plus_dm)
     #[doc(alias = "DM")]
     #[doc(alias = "PlusDirectionalMovement")]
     pub fn PLUS_DM(

--- a/ta_codegen/output/rust/library/src/ta_func/ppo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ppo.rs
@@ -209,19 +209,7 @@ impl Core {
     /// the fast MA is above the slow MA (upward momentum), negative otherwise; magnitude is the %
     /// deviation.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// PPO = ((fastMA(inReal) - slowMA(inReal)) / slowMA(inReal)) * 100, both MAs of type optInMAType; output = 0 when slowMA == 0
-    ///
-    /// The standard form is exponential with periods 12 and 26 — ((12-day EMA - 26-day EMA) / 26-day EMA) * 100, i.e. the MACD oscillator expressed as a percentage. `optInMAType` therefore **defaults to EMA** — the moving average Gerald Appel used for the original PPO/MACD; pass another type (e.g. `TA_MAType_SMA`) to override.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * `optInMAType` applies to both the fast and slow moving average. `TA_MAType_MAMA` ignores
-    ///   its period argument, so with `optInMAType = TA_MAType_MAMA` the fast and slow MAs are
-    ///   identical, making the numerator — and therefore the output — zero at every bar.
+    /// Formula and more info at [ta-lib.org/functions/ppo](https://ta-lib.org/functions/ppo).
     ///
     /// # Arguments
     ///
@@ -281,8 +269,6 @@ impl Core {
     ///   Forecasts* newsletter). The PPO is the MACD expressed as a percentage of the slow moving
     ///   average. Appel's original definition uses **exponential** moving averages (periods 12,
     ///   26).
-    ///
-    /// Further reading: [ta-lib.org/functions/ppo](https://ta-lib.org/functions/ppo)
     #[doc(alias = "PercentagePriceOscillator")]
     pub fn PPO(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/pvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvi.rs
@@ -148,26 +148,7 @@ impl Core {
     /// that active, high-volume days reflect the actions of the less-informed "crowd", so PVI is
     /// read as a proxy for that cohort's positioning.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// PVI[startIdx] = 1000
-    ///
-    /// For each subsequent bar i:
-    ///
-    ///     PVI[i] = PVI[i-1] + ( inVolume[i] > inVolume[i-1]
-    ///                           ? ((inClose[i] - inClose[i-1]) / inClose[i-1]) * PVI[i-1]
-    ///                           : 0 )
-    ///
-    /// The index carries forward unchanged on bars whose volume did not rise (and on the
-    /// degenerate case of a zero previous close, which would otherwise divide by zero).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The index compounds, so it has no upper bound. If a run of large rises ever pushes it past
-    ///   the largest representable number, the last representable value is carried forward instead
-    ///   of returning infinity. Real price series stay far away from that.
+    /// Formula and more info at [ta-lib.org/functions/pvi](https://ta-lib.org/functions/pvi).
     ///
     /// # Arguments
     ///
@@ -219,8 +200,6 @@ impl Core {
     ///
     /// * Norman G. Fosback, *Stock Market Logic*, The Institute for Econometric Research (ISBN
     ///   0917604482)
-    ///
-    /// Further reading: [ta-lib.org/functions/pvi](https://ta-lib.org/functions/pvi)
     #[doc(alias = "PositiveVolumeIndex")]
     pub fn PVI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/pvo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvo.rs
@@ -205,19 +205,7 @@ impl Core {
     /// is above its longer-term average (rising participation), negative when below. The default
     /// periods (12, 26) match MACD and PPO.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// PVO = ((fastMA(inVolume) - slowMA(inVolume)) / slowMA(inVolume)) * 100, both MAs of type optInMAType; output = 0 when slowMA == 0
-    ///
-    /// The standard form is exponential with periods 12 and 26 — ((12-day EMA of Volume - 26-day EMA of Volume) / 26-day EMA of Volume) * 100, i.e. the PPO/MACD oscillator computed on volume. `optInMAType` therefore **defaults to EMA** — the moving average Gerald Appel used for the original PPO/MACD; pass another type (e.g. `TA_MAType_SMA`) to override.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * `optInMAType` applies to both the fast and slow moving average. `TA_MAType_MAMA` ignores
-    ///   its period argument, so with `optInMAType = TA_MAType_MAMA` the fast and slow MAs are
-    ///   identical, making the numerator — and therefore the output — zero at every bar.
+    /// Formula and more info at [ta-lib.org/functions/pvo](https://ta-lib.org/functions/pvo).
     ///
     /// # Arguments
     ///
@@ -281,8 +269,6 @@ impl Core {
     ///   (PVO)](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/percentage-volume-oscillator-pvo),
     ///   StockCharts ChartSchool; also documented by
     ///   [TradingView](https://www.tradingview.com/support/solutions/43000591350-percentage-volume-oscillator-pvo/).
-    ///
-    /// Further reading: [ta-lib.org/functions/pvo](https://ta-lib.org/functions/pvo)
     #[doc(alias = "PercentageVolumeOscillator")]
     pub fn PVO(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/qstick.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/qstick.rs
@@ -187,13 +187,7 @@ impl Core {
     /// have been over the window, independently of the wicks — above zero the bodies closed up on
     /// balance, below zero they closed down, and the zero-line crossings are the signal.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// body_t = close_t - open_t; QSTICK_t = ( Σ body over the last `optInTimePeriod` bars ) / optInTimePeriod
-    ///
-    /// The moving average is a plain SMA, so there is no seeding convention and none of the cross-library divergence that comes with one. `optInTimePeriod` of 1 leaves the raw body.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/qstick](https://ta-lib.org/functions/qstick).
     ///
     /// # Arguments
     ///
@@ -263,8 +257,6 @@ impl Core {
     /// * TraderEvolution documents a default period of 1 and offers a choice of moving average;
     ///   AmiBroker community code commonly cites 8. Neither is verifiable against the book, and
     ///   this ships the SMA-only form the authors define.
-    ///
-    /// Further reading: [ta-lib.org/functions/qstick](https://ta-lib.org/functions/qstick)
     pub fn QSTICK(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/roc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/roc.rs
@@ -183,11 +183,7 @@ impl Core {
     /// optInTimePeriod bars earlier. Centered at zero with positive and negative values. Positive
     /// when price rose over the period, negative when it fell; magnitude scales the move.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ROC = ((price / prevPrice) - 1) * 100, where prevPrice = inReal[i - optInTimePeriod]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/roc](https://ta-lib.org/functions/roc).
     ///
     /// # Arguments
     ///
@@ -236,8 +232,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MOM`] · [`Core::ROCP`] · [`Core::ROCR`] · [`Core::ROCR100`]
-    ///
-    /// Further reading: [ta-lib.org/functions/roc](https://ta-lib.org/functions/roc)
     #[doc(alias = "RateofChange")]
     #[doc(alias = "PriceRateofChange")]
     pub fn ROC(

--- a/ta_codegen/output/rust/library/src/ta_func/rocp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocp.rs
@@ -184,11 +184,7 @@ impl Core {
     /// centered at zero (positive or negative). >0 rising vs N bars ago, \<0 falling; equals
     /// ROC/100.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ROCP = (price - prevPrice) / prevPrice, prevPrice = inReal[i - optInTimePeriod]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/rocp](https://ta-lib.org/functions/rocp).
     ///
     /// # Arguments
     ///
@@ -238,8 +234,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ROC`] · [`Core::ROCR`] · [`Core::ROCR100`] · [`Core::MOM`]
-    ///
-    /// Further reading: [ta-lib.org/functions/rocp](https://ta-lib.org/functions/rocp)
     #[doc(alias = "RateofChangePercentage")]
     #[doc(alias = "PercentChange")]
     pub fn ROCP(

--- a/ta_codegen/output/rust/library/src/ta_func/rocr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr.rs
@@ -183,11 +183,7 @@ impl Core {
     /// Rate of Change Ratio: the ratio of the current price to the price optInTimePeriod bars ago.
     /// A momentum measure centered at 1. Always positive, centered at 1: >1 rising, \<1 falling.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// ROCR = price / price[t - optInTimePeriod]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/rocr](https://ta-lib.org/functions/rocr).
     ///
     /// # Arguments
     ///
@@ -237,8 +233,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ROC`] · [`Core::ROCP`] · [`Core::ROCR100`] · [`Core::MOM`]
-    ///
-    /// Further reading: [ta-lib.org/functions/rocr](https://ta-lib.org/functions/rocr)
     #[doc(alias = "RateofChangeRatio")]
     pub fn ROCR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
@@ -184,11 +184,8 @@ impl Core {
     /// optInTimePeriod bars ago. Momentum measure centered at 100 and always positive. Above 100 =
     /// price rose vs n bars ago; below 100 = price fell.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $ROCR100_t = \dfrac{price_t}{price_{t-n}} \times 100$, where $n$ = optInTimePeriod
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/rocr100](https://ta-lib.org/functions/rocr100).
     ///
     /// # Arguments
     ///
@@ -238,8 +235,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ROCR`] · [`Core::ROC`] · [`Core::ROCP`] · [`Core::MOM`]
-    ///
-    /// Further reading: [ta-lib.org/functions/rocr100](https://ta-lib.org/functions/rocr100)
     #[doc(alias = "RateofChangeRatio100Scale")]
     #[doc(alias = "MO")]
     pub fn ROCR100(

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -338,28 +338,7 @@ impl Core {
     /// average gains to average losses over the period. Used to gauge overbought/oversold
     /// conditions. >70 overbought, \<30 oversold.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $$
-    /// \begin{aligned}
-    /// U_t &= \max(X_t - X_{t-1},\ 0)
-    ///    &  D_t &= \max(X_{t-1} - X_t,\ 0) \\[4pt]
-    /// \overline{U}_t &= \begin{cases}
-    ///     \operatorname{SMA}(U, n)_t                 & \text{if } t = n \\[4pt]
-    ///     \dfrac{(n-1)\,\overline{U}_{t-1} + U_t}{n} & \text{if } t > n
-    ///   \end{cases}
-    ///    &  \overline{D}_t &= \begin{cases}
-    ///     \operatorname{SMA}(D, n)_t                 & \text{if } t = n \\[4pt]
-    ///     \dfrac{(n-1)\,\overline{D}_{t-1} + D_t}{n} & \text{if } t > n
-    ///   \end{cases} \\[4pt]
-    /// \mathrm{RS}_t &= \frac{\overline{U}_t}{\overline{D}_t}
-    ///    &  \mathrm{RSI}_t &= 100 - \frac{100}{1 + \mathrm{RS}_t}
-    /// \end{aligned}
-    /// $$
-    /// ```
-    ///
-    /// where $X$ is the input series and $n$ the period.
+    /// Formula and more info at [ta-lib.org/functions/rsi](https://ta-lib.org/functions/rsi).
     ///
     /// # Arguments
     ///
@@ -413,8 +392,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/rsi](https://ta-lib.org/functions/rsi)
     #[doc(alias = "relativestrengthindex")]
     pub fn RSI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/sar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sar.rs
@@ -393,13 +393,7 @@ impl Core {
     /// SAR below price = uptrend (long); SAR above price = downtrend (short). Price crossing SAR
     /// flips direction.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// SAR_next = SAR + af * (EP - SAR)
-    /// EP = extreme point (highest high in long / lowest low in short); af starts at Acceleration, += Acceleration each new EP, capped at Maximum.
-    /// On penetration: reverse, SAR := prior EP, reset af = Acceleration. SAR clamped each bar so it does not penetrate the prior/current bar's range.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sar](https://ta-lib.org/functions/sar).
     ///
     /// # Arguments
     ///
@@ -457,8 +451,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/sar](https://ta-lib.org/functions/sar)
     #[doc(alias = "ParabolicSAR")]
     #[doc(alias = "PSAR")]
     #[doc(alias = "StopandReverse")]

--- a/ta_codegen/output/rust/library/src/ta_func/sarext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sarext.rs
@@ -542,11 +542,7 @@ impl Core {
     /// negative values while short so reversals are distinguishable. Sign flip of the output marks
     /// a trend reversal (positive=long stop, negative=short stop).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// SAR_next = SAR + AF*(EP - SAR), then clamped within the prior and current bar's range. On penetration, reverse: set SAR=EP (clamped), reset AF to its Init value, EP=extreme of the new direction. Output is +SAR when long, -SAR when short. On reversal an optional offset is applied: long->short SAR*(1+offset), short->long SAR*(1-offset).
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sarext](https://ta-lib.org/functions/sarext).
     ///
     /// # Arguments
     ///
@@ -613,8 +609,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SAR`] · [`Core::MINUS_DM`]
-    ///
-    /// Further reading: [ta-lib.org/functions/sarext](https://ta-lib.org/functions/sarext)
     #[doc(alias = "ParabolicSARExtended")]
     #[doc(alias = "ExtendedParabolicStopandReverse")]
     pub fn SAREXT(

--- a/ta_codegen/output/rust/library/src/ta_func/sin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sin.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise sine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = sin(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sin](https://ta-lib.org/functions/sin).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Trigonometric_functions](https://en.wikipedia.org/wiki/Trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/sin](https://ta-lib.org/functions/sin)
     #[doc(alias = "sine")]
     pub fn SIN(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/sinh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sinh.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise hyperbolic sine of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = sinh(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sinh](https://ta-lib.org/functions/sinh).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Hyperbolic functions*:
     ///   [en.wikipedia.org/wiki/Hyperbolic_functions](https://en.wikipedia.org/wiki/Hyperbolic_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/sinh](https://ta-lib.org/functions/sinh)
     #[doc(alias = "HyperbolicSine")]
     pub fn SINH(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/sma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sma.rs
@@ -167,16 +167,7 @@ impl Core {
     /// Simple Moving Average: the unweighted arithmetic mean of the last N input values. Used to
     /// smooth a series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// SMA_t = (1/N) * sum_{i=t-N+1}^{t} inReal_i
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/sma](https://ta-lib.org/functions/sma).
     ///
     /// # Arguments
     ///
@@ -226,8 +217,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::EMA`] · [`Core::WMA`] · [`Core::MA`] · [`Core::DEMA`] · [`Core::TEMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/sma](https://ta-lib.org/functions/sma)
     #[doc(alias = "simplemovingaverage")]
     pub fn SMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/smi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/smi.rs
@@ -473,31 +473,7 @@ impl Core {
     /// below. Extreme readings mark overbought and oversold conditions, and crossings of the signal
     /// line are the usual trade trigger.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// HH = MAX(high, timePeriod);  LL = MIN(low, timePeriod)
-    ///
-    /// num = close - 0.5 * (HH + LL);  den = HH - LL
-    ///
-    /// SMI = 100 * EMA(EMA(num, slowPeriod), fastPeriod) / (0.5 * EMA(EMA(den, slowPeriod), fastPeriod))
-    ///
-    /// Signal = EMA(SMI, signalPeriod)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A window whose bars are all flat (every high equal to its low) leaves both the numerator
-    ///   and the denominator at zero. Rather than divide, SMI emits 0 there — the same convention
-    ///   as CCI and IMI. Some implementations divide unguarded and return a non-finite value.
-    /// * Each exponential average is seeded with a simple average of its own first inputs, the same
-    ///   seeding TA-Lib's EMA uses, so the first published values converge toward an
-    ///   unlimited-history result rather than reproducing it exactly.
-    ///   `TA_SetUnstablePeriod(TA_FUNC_UNST_EMA, ...)` discards more of that warm-up.
-    ///   Implementations seeding from a single first sample — Tulip and TradingView among them
-    ///   — differ over the transient and agree once it decays.
-    /// * One output range covers both outputs, so the SMI values consumed by the signal line's own
-    ///   warm-up are not published.
+    /// Formula and more info at [ta-lib.org/functions/smi](https://ta-lib.org/functions/smi).
     ///
     /// # Arguments
     ///
@@ -568,8 +544,6 @@ impl Core {
     /// * William Blau, "Stochastic Momentum", *Technical Analysis of Stocks & Commodities*, v11:1
     ///   (January 1993), pp. 11-18
     /// * William Blau, *Momentum, Direction and Divergence*, Wiley 1995 (ISBN 0471027294)
-    ///
-    /// Further reading: [ta-lib.org/functions/smi](https://ta-lib.org/functions/smi)
     #[doc(alias = "stochasticmomentumindex")]
     #[doc(alias = "Blaustochasticmomentum")]
     pub fn SMI(

--- a/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
@@ -107,15 +107,7 @@ impl Core {
     }
     /// Element-wise square root of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = sqrt(inReal[i])
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A negative input has no real square root, so those elements come out NaN.
+    /// Formula and more info at [ta-lib.org/functions/sqrt](https://ta-lib.org/functions/sqrt).
     ///
     /// # Arguments
     ///
@@ -161,8 +153,6 @@ impl Core {
     ///
     /// * Wikipedia, *Square root*:
     ///   [en.wikipedia.org/wiki/Square_root](https://en.wikipedia.org/wiki/Square_root)
-    ///
-    /// Further reading: [ta-lib.org/functions/sqrt](https://ta-lib.org/functions/sqrt)
     #[doc(alias = "SquareRoot")]
     pub fn SQRT(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/stddev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stddev.rs
@@ -185,16 +185,7 @@ impl Core {
     /// Rolling standard deviation of a series over a window, scaled by a deviations multiplier.
     /// Delegates to VAR, then takes the square root.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $\sigma_i = \sqrt{\mathrm{VAR}_i}\cdot nbDev$, where $\mathrm{VAR}_i = \frac{1}{N}\sum x^2 - \left(\frac{1}{N}\sum x\right)^2$ (population variance, $N=$ timePeriod)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Uses population variance (divides by the period, not period minus one), so results differ
-    ///   slightly from the sample standard deviation used by some tools.
+    /// Formula and more info at [ta-lib.org/functions/stddev](https://ta-lib.org/functions/stddev).
     ///
     /// # Arguments
     ///
@@ -245,8 +236,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::VAR`] · [`Core::BBANDS`] · [`Core::SMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/stddev](https://ta-lib.org/functions/stddev)
     #[doc(alias = "StandardDeviation")]
     #[doc(alias = "SD")]
     #[doc(alias = "sigma")]

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -385,18 +385,7 @@ impl Core {
     /// period, then double-smooths it. Returns the Slow-%K and Slow-%D lines. SlowK/SlowD > 80
     /// overbought, \< 20 oversold; %K crossing %D signals momentum shifts.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// FastK = 100*(Close - LL_n)/(HH_n - LL_n), n = FastK_Period (LL/HH = lowest low / highest high over n)
-    /// SlowK = MA(FastK, SlowK_Period, SlowK_MAType)
-    /// SlowD = MA(SlowK, SlowD_Period, SlowD_MAType)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When the high-low range over the window is zero, the raw stochastic is set to 0 instead of
-    ///   being undefined.
+    /// Formula and more info at [ta-lib.org/functions/stoch](https://ta-lib.org/functions/stoch).
     ///
     /// # Arguments
     ///
@@ -467,8 +456,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::STOCHF`] · [`Core::STOCHRSI`] · [`Core::MA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/stoch](https://ta-lib.org/functions/stoch)
     #[doc(alias = "Stochastic")]
     #[doc(alias = "StochasticOscillator")]
     #[doc(alias = "SlowStochastic")]

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -351,17 +351,7 @@ impl Core {
     /// STOCH (which slows both lines), STOCHF returns the unsmoothed FastK and FastD. Oscillates
     /// 0-100; >80 overbought, \<20 oversold.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// FastK = 100 * (Close - LowestLow) / (HighestHigh - LowestLow), over the last FastK_Period bars (incl. today)
-    /// FastD = MA(FastK, FastD_Period, FastD_MAType)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * When the high-low range over the window is zero, %K is set to 0 instead of being
-    ///   undefined.
+    /// Formula and more info at [ta-lib.org/functions/stochf](https://ta-lib.org/functions/stochf).
     ///
     /// # Arguments
     ///
@@ -426,8 +416,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::STOCH`] · [`Core::STOCHRSI`] · [`Core::MA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/stochf](https://ta-lib.org/functions/stochf)
     #[doc(alias = "StochasticFast")]
     #[doc(alias = "FastStochasticOscillator")]
     pub fn STOCHF(

--- a/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
@@ -231,19 +231,8 @@ impl Core {
     /// where RSI sits within its recent min/max range. Oscillates 0-100; high = RSI near its recent
     /// top, low = near its recent bottom.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// rsi = RSI(inReal, optInTimePeriod)
-    /// FastK = 100 * (rsi_t - min(rsi, FastK_Period)) / (max(rsi, FastK_Period) - min(rsi, FastK_Period))
-    /// FastD = MA(FastK, FastD_Period, FastD_MAType)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * To reproduce the original article's unsmoothed Stochastic RSI, set the RSI period equal to
-    ///   the %K period and read the raw %K output.
-    /// * When the RSI's recent range is zero, %K is set to 0 instead of being undefined.
+    /// Formula and more info at
+    /// [ta-lib.org/functions/stochrsi](https://ta-lib.org/functions/stochrsi).
     ///
     /// # Arguments
     ///
@@ -308,8 +297,6 @@ impl Core {
     ///
     /// * Tushar S. Chande, Stanley Kroll, *The New Technical Trader*, John Wiley & Sons (ISBN
     ///   0471597805)
-    ///
-    /// Further reading: [ta-lib.org/functions/stochrsi](https://ta-lib.org/functions/stochrsi)
     #[doc(alias = "StochasticRSI")]
     pub fn STOCHRSI(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/sub.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sub.rs
@@ -110,11 +110,7 @@ impl Core {
     }
     /// Element-wise subtraction of two input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = inReal0[i] - inReal1[i]
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sub](https://ta-lib.org/functions/sub).
     ///
     /// # Arguments
     ///
@@ -163,8 +159,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::ADD`] · [`Core::MULT`] · [`Core::DIV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/sub](https://ta-lib.org/functions/sub)
     #[doc(alias = "Subtract")]
     #[doc(alias = "VectorSubtraction")]
     pub fn SUB(

--- a/ta_codegen/output/rust/library/src/ta_func/sum.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sum.rs
@@ -163,11 +163,7 @@ impl Core {
     /// Rolling sum of the input over a fixed period. Each output is the sum of the most recent
     /// optInTimePeriod input values.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $out_i = \sum_{j=i-(N-1)}^{i} inReal_j$, N = optInTimePeriod
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/sum](https://ta-lib.org/functions/sum).
     ///
     /// # Arguments
     ///
@@ -216,8 +212,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/sum](https://ta-lib.org/functions/sum)
     #[doc(alias = "Summation")]
     #[doc(alias = "RollingSum")]
     #[doc(alias = "MovingSum")]

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -340,18 +340,7 @@ impl Core {
     /// volume-factor-weighted coefficients. Not the same as EMA3, despite both being called "triple
     /// EMA".
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// k = 2/(period+1); e1=EMA(x), e2=EMA(e1), ... e6=EMA(e5) (six chained EMAs).
-    /// v = vFactor: c1 = -v^3; c2 = 3(v^2 - c1); c3 = -6v^2 - 3(v - c1); c4 = 1 + 3v - c1 + 3v^2.
-    /// T3 = c1*e6 + c2*e5 + c3*e4 + c4*e3
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/t3](https://ta-lib.org/functions/t3).
     ///
     /// # Arguments
     ///
@@ -408,8 +397,6 @@ impl Core {
     ///
     /// * Tim Tillson, *Smoothing Techniques for More Accurate Signals*, Technical Analysis of
     ///   Stocks & Commodities, V.16:1 (January 1998)
-    ///
-    /// Further reading: [ta-lib.org/functions/t3](https://ta-lib.org/functions/t3)
     #[doc(alias = "TillsonT3")]
     #[doc(alias = "TripleExponentialMovingAverage")]
     pub fn T3(

--- a/ta_codegen/output/rust/library/src/ta_func/tan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tan.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise tangent of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = tan(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/tan](https://ta-lib.org/functions/tan).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Trigonometric functions*:
     ///   [en.wikipedia.org/wiki/Trigonometric_functions](https://en.wikipedia.org/wiki/Trigonometric_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/tan](https://ta-lib.org/functions/tan)
     #[doc(alias = "tangent")]
     pub fn TAN(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/tanh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tanh.rs
@@ -107,11 +107,7 @@ impl Core {
     }
     /// Element-wise hyperbolic tangent of the input series.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// outReal[i] = tanh(inReal[i])
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/tanh](https://ta-lib.org/functions/tanh).
     ///
     /// # Arguments
     ///
@@ -161,8 +157,6 @@ impl Core {
     ///
     /// * Wikipedia, *Hyperbolic functions*:
     ///   [en.wikipedia.org/wiki/Hyperbolic_functions](https://en.wikipedia.org/wiki/Hyperbolic_functions)
-    ///
-    /// Further reading: [ta-lib.org/functions/tanh](https://ta-lib.org/functions/tanh)
     #[doc(alias = "HyperbolicTangent")]
     pub fn TANH(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/tema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tema.rs
@@ -321,16 +321,7 @@ impl Core {
     /// successively-applied EMAs to reduce lag versus a plain EMA. Distinct from EMA3, also called
     /// "triple EMA" in the literature.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// EMA1=EMA(t,period); EMA2=EMA(EMA1,period); EMA3=EMA(EMA2,period); TEMA = 3*EMA1 - 3*EMA2 + EMA3
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/tema](https://ta-lib.org/functions/tema).
     ///
     /// # Arguments
     ///
@@ -384,8 +375,6 @@ impl Core {
     ///
     /// * Patrick G. Mulloy, *Smoothing Data with Faster Moving Averages*, Technical Analysis of
     ///   Stocks & Commodities, V.12:1 (January 1994)
-    ///
-    /// Further reading: [ta-lib.org/functions/tema](https://ta-lib.org/functions/tema)
     #[doc(alias = "TripleExponentialMovingAverage")]
     pub fn TEMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/trange.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trange.rs
@@ -157,16 +157,7 @@ impl Core {
     /// and today's high/low. Base volatility measure used to build ATR/NATR. Larger values mean
     /// wider or gappier bars (higher volatility).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// TR = max( high - low, |prevClose - high|, |prevClose - low| )
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The first bar produces no value because it has no prior close; unlike some definitions, it
-    ///   does not fall back to the high-low range for that bar.
+    /// Formula and more info at [ta-lib.org/functions/trange](https://ta-lib.org/functions/trange).
     ///
     /// # Arguments
     ///
@@ -222,8 +213,6 @@ impl Core {
     ///
     /// * J. Welles Wilder, *New Concepts in Technical Trading Systems*, Trend Research (ISBN
     ///   0894590278)
-    ///
-    /// Further reading: [ta-lib.org/functions/trange](https://ta-lib.org/functions/trange)
     #[doc(alias = "TrueRange")]
     #[doc(alias = "TR")]
     pub fn TRANGE(

--- a/ta_codegen/output/rust/library/src/ta_func/trima.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trima.rs
@@ -392,18 +392,7 @@ impl Core {
     /// middle of the window most heavily. Equivalent to an SMA of an SMA, computed here via an
     /// incremental triangular-weighted running numerator.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Weights rise then fall (4-period: (1a+2b+2c+1d)/6; 5-period: (1a+2b+3c+2d+1e)/9). With n = period>>1: odd divides by (n+1)^2, even by n(n+1). Equivalent to odd: SMA(SMA(x,(period+1)/2),(period+1)/2); even: SMA(SMA(x,period/2),period/2+1).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Follows the generally accepted (Metastock) definition rather than the TradeStation
-    ///   variant.
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/trima](https://ta-lib.org/functions/trima).
     ///
     /// # Arguments
     ///
@@ -453,8 +442,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SMA`] · [`Core::WMA`] · [`Core::MA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/trima](https://ta-lib.org/functions/trima)
     #[doc(alias = "TriangularMovingAverage")]
     pub fn TRIMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/trix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trix.rs
@@ -275,16 +275,7 @@ impl Core {
     /// out price moves shorter than the chosen period. Oscillates around zero; sign, zero-crossings
     /// and slope signal momentum direction.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// E1 = EMA(inReal, n); E2 = EMA(E1, n); E3 = EMA(E2, n); TRIX = ROC_1(E3) = 100 * (E3_today/E3_yesterday - 1)
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The final rate-of-change step yields 0 when the previous smoothed value is exactly zero,
-    ///   rather than being undefined.
+    /// Formula and more info at [ta-lib.org/functions/trix](https://ta-lib.org/functions/trix).
     ///
     /// # Arguments
     ///
@@ -338,8 +329,6 @@ impl Core {
     /// # References
     ///
     /// * Jack K. Hutson, Technical Analysis of Stocks & Commodities (1980s)
-    ///
-    /// Further reading: [ta-lib.org/functions/trix](https://ta-lib.org/functions/trix)
     #[doc(alias = "TripleExponentialAverage")]
     pub fn TRIX(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/tsf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tsf.rs
@@ -330,11 +330,7 @@ impl Core {
     /// projects it one x-step beyond LINEARREG. Same regression as LINEARREG but evaluated at
     /// x=period instead of x=period-1.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// Fit y=b+m*x over window (x=0..N-1): m = (N*SumXY - SumX*SumY)/(SumX^2 - N*SumXSqr), b = (SumY - m*SumX)/N; output = b + m*N. With SumX=N(N-1)/2, SumXSqr=N(N-1)(2N-1)/6.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/tsf](https://ta-lib.org/functions/tsf).
     ///
     /// # Arguments
     ///
@@ -385,8 +381,6 @@ impl Core {
     ///
     /// [`Core::LINEARREG`] · [`Core::LINEARREG_SLOPE`] · [`Core::LINEARREG_INTERCEPT`] ·
     /// [`Core::LINEARREG_ANGLE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/tsf](https://ta-lib.org/functions/tsf)
     #[doc(alias = "TimeSeriesForecast")]
     pub fn TSF(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/typprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/typprice.rs
@@ -115,11 +115,8 @@ impl Core {
     /// Typical Price: the average of the high, low, and close of each bar. A single representative
     /// price per period.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// out[i] = (High[i] + Low[i] + Close[i]) / 3
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/typprice](https://ta-lib.org/functions/typprice).
     ///
     /// # Arguments
     ///
@@ -170,8 +167,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::MEDPRICE`] · [`Core::WCLPRICE`] · [`Core::AVGPRICE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/typprice](https://ta-lib.org/functions/typprice)
     #[doc(alias = "TypicalPrice")]
     pub fn TYPPRICE(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -422,19 +422,7 @@ impl Core {
     /// momentum to damp single-period noise. Ranges 0-100; conventionally >70 overbought, \<30
     /// oversold.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// trueLow = min(low, prevClose);  BP = close - trueLow
-    /// TR = max(high-low, |prevClose-high|, |prevClose-low|)
-    /// avg_n = (sum BP over n bars) / (sum TR over n bars)
-    /// ULTOSC = 100 * (4*avg_short + 2*avg_mid + avg_long) / 7
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The three periods are sorted internally, so the 4/2/1 weighting always applies to the
-    ///   shortest, middle, and longest period regardless of the order in which you pass them.
+    /// Formula and more info at [ta-lib.org/functions/ultosc](https://ta-lib.org/functions/ultosc).
     ///
     /// # Arguments
     ///
@@ -496,8 +484,6 @@ impl Core {
     ///
     /// * Larry Williams, *The Ultimate Oscillator*, Technical Analysis of Stocks & Commodities,
     ///   V.3:4 (1985)
-    ///
-    /// Further reading: [ta-lib.org/functions/ultosc](https://ta-lib.org/functions/ultosc)
     #[doc(alias = "UltimateOscillator")]
     #[doc(alias = "UO")]
     pub fn ULTOSC(

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -301,17 +301,7 @@ impl Core {
     /// Rolling population variance of a real series over a given period. Measures dispersion of
     /// values around their mean. Higher values indicate greater dispersion; 0 means constant input.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $\mathrm{VAR} = \frac{1}{n}\sum x_i^2 - \left(\frac{1}{n}\sum x_i\right)^2$, over the last $n$ = optInTimePeriod values (population, divides by $n$).
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * Computes population variance (divides by the period), not the sample variance (n-1) used
-    ///   by some definitions.
-    /// * The deviation-count parameter is accepted but has no effect on the result.
+    /// Formula and more info at [ta-lib.org/functions/var](https://ta-lib.org/functions/var).
     ///
     /// # Arguments
     ///
@@ -363,8 +353,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::STDDEV`]
-    ///
-    /// Further reading: [ta-lib.org/functions/var](https://ta-lib.org/functions/var)
     #[doc(alias = "Variance")]
     pub fn VAR(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/vwap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwap.rs
@@ -223,30 +223,7 @@ impl Core {
     /// sluggish the further it runs from its anchor. It stays within the range of the typical
     /// prices it averages, but over a long trending range it can sit far from the current price.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// TP_t = ( High_t + Low_t + Close_t ) / 3; VWAP_t = ( Σ TP · Volume ) / ( Σ Volume ), both sums running from the first bar of the range
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * The sums run from the first bar of the range and are never reset. Charting packages anchor
-    ///   VWAP to a trading session and restart it at each session boundary; no TA-Lib function
-    ///   takes a timestamp or a session boundary, so the anchor is the range the caller asks for
-    ///   — pass one session's bars to get that session's VWAP. This is how AD and OBV, the other
-    ///   cumulative volume functions, are already used across sessions.
-    /// * Volume is expected to be non-negative. A zero-volume bar carries no weight, so one
-    ///   occurring after volume has traded leaves the average exactly where it was. Before *any*
-    ///   volume has traded there are no weights at all and the weighted mean is undefined; those
-    ///   bars carry the previous value forward, which is 0 until the first bar with volume. A
-    ///   successful call never emits NaN or ±Inf. Other implementations differ here:
-    ///   pandas-ta-classic divides through and emits NaN, and trading-signals emits no value for
-    ///   the bar at all.
-    /// * A bar whose price or volume is not a finite number cannot be weighted, so it is left out
-    ///   of the average entirely and repeats the previous value. It is skipped, not absorbed: the
-    ///   running average stays usable and resumes on the next bar that can be weighted, rather than
-    ///   being held at one stale value for the remainder of the range.
+    /// Formula and more info at [ta-lib.org/functions/vwap](https://ta-lib.org/functions/vwap).
     ///
     /// # Arguments
     ///
@@ -319,8 +296,6 @@ impl Core {
     ///   `VWAP = tpv.cumsum() / volume.cumsum()`, and reaches the session reset only by grouping on
     ///   a `DatetimeIndex`. trading-signals `trend/VWAP` implements the cumulative form with no
     ///   anchor at all.
-    ///
-    /// Further reading: [ta-lib.org/functions/vwap](https://ta-lib.org/functions/vwap)
     #[doc(alias = "VolumeWeightedAveragePrice")]
     pub fn VWAP(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/vwma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwma.rs
@@ -211,25 +211,7 @@ impl Core {
     /// charting-package folklore — and every published definition agrees, so there is no
     /// competing variant.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// VWMA = ( sum_{k=t-N+1..t} P[k] * V[k] ) / ( sum_{k=t-N+1..t} V[k] ), N = optInTimePeriod
-    ///
-    /// Equivalently, and bit-identically so in TA-Lib for N of 2 or more, SMA(P * V, N) / SMA(V, N) — the composition TradingView documents for `ta.vwma`. There is no seeding and no recursion, hence no unstable period.
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input, whatever the
-    ///   volume.
-    /// * Volume is expected to be non-negative. Individual zero-volume bars are fine: a bar that
-    ///   did not trade simply carries no weight, and the average stays well defined as long as some
-    ///   bar in the window has volume. At a period of 2 or more, a window in which *every* volume
-    ///   is zero has no weights at all; the weighted mean is then undefined and that element is
-    ///   NaN, as it is in every other implementation. Series carrying no volume on any bar, such as
-    ///   cash-index feeds, are outside what a volume-weighted average can describe — use SMA or
-    ///   WMA there.
+    /// Formula and more info at [ta-lib.org/functions/vwma](https://ta-lib.org/functions/vwma).
     ///
     /// # Arguments
     ///
@@ -292,8 +274,6 @@ impl Core {
     ///   a primary definition.
     /// * TradingView, *Volume Weighted Moving Average (VWMA)* — documents the equivalence with
     ///   SMA(price * volume) / SMA(volume).
-    ///
-    /// Further reading: [ta-lib.org/functions/vwma](https://ta-lib.org/functions/vwma)
     #[doc(alias = "VolumeWeightedMovingAverage")]
     pub fn VWMA(
         &self,

--- a/ta_codegen/output/rust/library/src/ta_func/wad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wad.rs
@@ -182,22 +182,7 @@ impl Core {
     /// signed close-to-close move measured on the true range, so it is grouped as a momentum
     /// indicator, not a volume one.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// For each bar t:
-    ///
-    ///     TRH_t = max(close_{t-1}, high_t)
-    ///     TRL_t = min(close_{t-1}, low_t)
-    ///
-    ///     if close_t > close_{t-1} then AD_t = close_t - TRL_t
-    ///     if close_t < close_{t-1} then AD_t = close_t - TRH_t
-    ///     otherwise                     AD_t = 0
-    ///
-    ///     WAD_t = WAD_{t-1} + AD_t
-    ///
-    /// The first bar of the requested range has no previous close, so the first output is always AD_t = 0. A different `startIdx` shifts WAD's whole line by a constant.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/wad](https://ta-lib.org/functions/wad).
     ///
     /// # Arguments
     ///
@@ -262,8 +247,6 @@ impl Core {
     ///   Distribute*](https://www.incrediblecharts.com/indicators/williams_accumulate_distribute.php)
     ///   — the Achelis form under its disambiguating name, "not a volume indicator despite the
     ///   name".
-    ///
-    /// Further reading: [ta-lib.org/functions/wad](https://ta-lib.org/functions/wad)
     pub fn WAD(
         &self,
         startIdx: usize,

--- a/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
@@ -147,11 +147,8 @@ impl Core {
     /// Weighted Close Price: a per-bar price average giving the close double weight relative to
     /// high and low.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// $\text{WCLPRICE} = \dfrac{\text{High} + \text{Low} + 2\cdot\text{Close}}{4}$
-    /// ```
+    /// Formula and more info at
+    /// [ta-lib.org/functions/wclprice](https://ta-lib.org/functions/wclprice).
     ///
     /// # Arguments
     ///
@@ -202,8 +199,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::TYPPRICE`] · [`Core::MEDPRICE`] · [`Core::AVGPRICE`]
-    ///
-    /// Further reading: [ta-lib.org/functions/wclprice](https://ta-lib.org/functions/wclprice)
     #[doc(alias = "WeightedClosePrice")]
     #[doc(alias = "WeightedClose")]
     pub fn WCLPRICE(

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -328,11 +328,7 @@ impl Core {
     /// where the current close sits relative to the high-low range of the last N bars. Near 0 =
     /// close at period high (overbought); near -100 = close at period low (oversold).
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// %R = -100 * (highestHigh - close) / (highestHigh - lowestLow) over the trailing optInTimePeriod bars; if highestHigh == lowestLow, output 0.
-    /// ```
+    /// Formula and more info at [ta-lib.org/functions/willr](https://ta-lib.org/functions/willr).
     ///
     /// # Arguments
     ///
@@ -387,8 +383,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::STOCH`] · [`Core::STOCHF`] · [`Core::MINMAX`]
-    ///
-    /// Further reading: [ta-lib.org/functions/willr](https://ta-lib.org/functions/willr)
     #[doc(alias = "WilliamsR")]
     #[doc(alias = "WilliamsPercentR")]
     #[doc(alias = "R")]

--- a/ta_codegen/output/rust/library/src/ta_func/wma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wma.rs
@@ -293,16 +293,7 @@ impl Core {
     /// Linearly weighted moving average: each of the last N prices is weighted by its position,
     /// oldest getting weight 1 and newest weight N. Smooths price while emphasizing recent bars.
     ///
-    /// # Formula
-    ///
-    /// ```text
-    /// WMA = ( sum_{k=1..N} k * P_k ) / (N(N+1)/2), where P_N is the most recent bar
-    /// ```
-    ///
-    /// # Notes
-    ///
-    /// * A period of 1 performs no smoothing: the output is a copy of the input. Allowed since
-    ///   0.6.5 (issues #48/#59).
+    /// Formula and more info at [ta-lib.org/functions/wma](https://ta-lib.org/functions/wma).
     ///
     /// # Arguments
     ///
@@ -352,8 +343,6 @@ impl Core {
     /// # See also
     ///
     /// [`Core::SMA`] · [`Core::EMA`] · [`Core::MA`] · [`Core::DEMA`] · [`Core::TEMA`]
-    ///
-    /// Further reading: [ta-lib.org/functions/wma](https://ta-lib.org/functions/wma)
     #[doc(alias = "WeightedMovingAverage")]
     #[doc(alias = "LinearlyWeightedMovingAverage")]
     #[doc(alias = "LWMA")]


### PR DESCRIPTION
Follow-up to #288 (#179 D6). Rustdoc's per-function Summary/Formula/Notes were
identical text to ta-lib.org's, both rendered from the same
\`ta_codegen/input/<name>/<name>.md\` -- not hand-duplicated, but a rendering-format
ceiling waiting to happen: the website already carries a KaTeX dependency, and
Formula/Notes are the fields most likely to need real math notation or images as
they grow, which rustdoc's plain-CommonMark renderer has no path to match.

This keeps rustdoc to Summary (short, plain prose, not at that risk) plus a
single link where Formula/Notes used to be:

\`\`\`
Formula and more info at [ta-lib.org/functions/sma](https://ta-lib.org/functions/sma).
\`\`\`

Drops the now-redundant trailing "Further reading" line (same URL, now
restated) and \`fenced_text()\`, the \`DocWriter\` helper that only the removed
Formula block called.

Arguments, Returns, Errors, Examples and See Also are untouched -- this only
trims the two ta-lib.org-owned prose sections.

## Verification

- \`cargo run -- generate\` -- 177 files changed (\`rust_doc.rs\` + all 176
  \`ta_func/*.rs\`), nothing outside that scope
- \`cargo clippy --all-targets -D warnings\` -- generator and generated crate, clean
- \`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ta-lib\` -- clean
- \`cargo test --doc -p ta-lib\` -- 536 passed (unchanged; Examples untouched)
- \`cargo test --tests -p ta-lib\` -- 85 passed
- generator's own suite -- all green