### PR TITLE
ci(main-nightly): the release branch never compiled the crate it publishes (#179 E5)

### DIFF
--- a/.github/workflows/main-nightly-tests.yml
+++ b/.github/workflows/main-nightly-tests.yml
@@ -246,35 +246,13 @@ jobs:
         shell: bash
         run: python3 scripts/build.py xlang-hash
 
-  # Rust on the release branch (#179 E5). dev-nightly lints, documents, tests and
-  # packages the crate on dev; main had none of it -- of the three jobs above, one
-  # builds the C dist assets, one fuzzes C against v0.6.4 and one diffs the language
-  # servers, so nothing on this branch ever compiled the crate, ran a doctest or
-  # built a .crate.
-  #
-  # main is where a release is cut FROM: release-step-1/2 check out main, and the
-  # only thing they run before tagging and publishing is scripts/pre-release-checks.py
-  # -- versions, the CHANGELOG entry, the pom's indicator count and the dist digests.
-  # It compiles no Rust and executes no test. So between "main is tagged" and "the
-  # crate is published" there was no step that had ever built what gets published.
-  #
-  # Honest about the overlap: main's tip is normally an ancestor of dev, so its
-  # content has usually already been through dev-nightly. What this adds is the
-  # window where it has not -- the dist bot commits land on main first (they also
-  # rewrite include/ta_common.h's digest) and reach dev only on the next
-  # "Merged main into dev" -- plus any hotfix pushed straight to main, plus the
-  # release cut itself. It is coverage of the branch that publishes, not of a
-  # defect known to be there today: every step below passes on main as of
-  # 12987063d.
-  #
-  # A mirror of dev-nightly's `clippy` job with `ref: main`. The MSRV floor is
-  # deliberately not duplicated (it is its own job there, and it reads the floor
-  # out of the manifests, which regen-check below already pins).
-  #
-  # Rust-only and self-contained: no C build, no dist asset, no JDK/.NET -- and,
-  # like its dev twin, deliberately NOT gated on the C hero 'test' job, so an
-  # unrelated Windows or dist-pool failure cannot skip the release branch's only
-  # Rust coverage.
+  # Rust on the release branch (#179 E5): dev-nightly's `clippy` job with
+  # `ref: main`, plus rust_package_check.py because main is the branch a .crate
+  # publishes from and nothing here ever compiled the crate. Content merged from
+  # dev has already been through dev-nightly; what this covers is the commits
+  # only main sees -- the dist bot's, hotfixes, and the release cut itself.
+  # Not gated on 'test': no C build is needed, so a dist-pool failure must not
+  # skip the release branch's only Rust coverage. MSRV stays dev-only.
   rust:
     name: Rust clippy + docs + tests (release branch)
     runs-on: ubuntu-latest
@@ -286,8 +264,6 @@ jobs:
         with:
           ref: main
 
-      # Rust is preinstalled on ubuntu-latest; add the component defensively
-      # (idempotent — a no-op when clippy is already present).
       - name: Ensure clippy component
         shell: bash
         run: rustup component add clippy
@@ -296,63 +272,36 @@ jobs:
         shell: bash
         run: cargo clippy --all-targets --manifest-path ta_codegen/generator/Cargo.toml -- -D warnings
 
-      # `-D warnings` is load-bearing beyond clippy's own lints: the crate sets
-      # #![warn(missing_docs)] (#179 D7), so this is what turns an undocumented
-      # public item into a failure rather than a warning nobody reads.
       - name: Clippy the generated crate
         shell: bash
         run: cargo clippy --all-targets --manifest-path ta_codegen/output/rust/Cargo.toml -- -D warnings
 
-      # Rustdoc's own lints are a set clippy never reaches, and docs.rs is the
-      # first place rustdoc runs on a release: a broken intra-doc link renders
-      # there as literal text (#179 E4).
       - name: Rustdoc the generated crate
         shell: bash
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --no-deps -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
 
-      # --no-fail-fast: cargo stops at the first failing test binary, which once
-      # hid a second real failure (#238).
       - name: Test the generator tool
         shell: bash
         run: cargo test --no-fail-fast --manifest-path ta_codegen/generator/Cargo.toml
 
-      # clippy --all-targets does not build doctests, so without this step the
-      # crate's public-facing examples are compiled by nothing on this branch.
       - name: Run the generated crate's doctests
         shell: bash
         run: cargo test --doc -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
 
-      # `--tests`, not `--lib`: the latter excludes tests/, and --all-targets
-      # above only COMPILES the test target while --doc skips it.
       - name: Run the generated crate's unit and integration tests
         shell: bash
         run: cargo test --tests -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
 
-      # Beyond E5's list, and the one step here that is about publishing rather
-      # than about parity with dev: every step above compiles the crate IN the
-      # workspace, where a file on disk is reachable whether or not it would
-      # ship. This builds the actual .crate tarball and verification-builds it
-      # (#179 E1). main is the branch that tarball would be published from.
       - name: Package the publishable crates and check what ships
         shell: bash
         run: python3 scripts/rust_package_check.py
 
-  # regen-check on the release branch (#179 E5). Same command the PR gate and
-  # dev-nightly run: the ta_regtest source lists agree, ta_codegen/input is
-  # formatted, and regenerating every backend changes nothing committed.
-  #
-  # The weakest of the two jobs added here, and stated as such: content that
-  # arrives on main by merging dev has already been regen-checked there. It earns
-  # its place on the branch that ships for the same reason the dev copy earns its
-  # place next to the PR gate -- main also takes commits that no pull_request
-  # trigger and no dev-nightly run ever saw (the dist bot's, which rewrite a
-  # tracked header, and hotfixes pushed straight to main).
-  #
-  # Not gated on 'test': that job builds the C dist assets, and a source-level
-  # check that regenerates the tree needs nothing from it. Making it wait would
-  # only let a dist-pool failure skip it.
+  # regen-check on the release branch (#179 E5): the same command the PR gate and
+  # dev-nightly run, here for the commits only main sees (the dist bot's, which
+  # rewrite a tracked header, and hotfixes). Not gated on 'test' -- it regenerates
+  # source and needs nothing the C build produces.
   regen-check:
     name: ta_codegen output up-to-date (release branch)
     runs-on: ubuntu-latest
@@ -377,8 +326,6 @@ jobs:
             exit 1
           fi
 
-      # Static text check, sub-second, so it is free next to the regenerate
-      # above — the same pairing dev-nightly uses.
       - name: Candle trailing-total wiring (read AND write side)
         shell: bash
         run: |

--- a/.github/workflows/main-nightly-tests.yml
+++ b/.github/workflows/main-nightly-tests.yml
@@ -245,3 +245,144 @@ jobs:
       - name: Bitwise-diff each language server vs the in-process C library
         shell: bash
         run: python3 scripts/build.py xlang-hash
+
+  # Rust on the release branch (#179 E5). dev-nightly lints, documents, tests and
+  # packages the crate on dev; main had none of it -- of the three jobs above, one
+  # builds the C dist assets, one fuzzes C against v0.6.4 and one diffs the language
+  # servers, so nothing on this branch ever compiled the crate, ran a doctest or
+  # built a .crate.
+  #
+  # main is where a release is cut FROM: release-step-1/2 check out main, and the
+  # only thing they run before tagging and publishing is scripts/pre-release-checks.py
+  # -- versions, the CHANGELOG entry, the pom's indicator count and the dist digests.
+  # It compiles no Rust and executes no test. So between "main is tagged" and "the
+  # crate is published" there was no step that had ever built what gets published.
+  #
+  # Honest about the overlap: main's tip is normally an ancestor of dev, so its
+  # content has usually already been through dev-nightly. What this adds is the
+  # window where it has not -- the dist bot commits land on main first (they also
+  # rewrite include/ta_common.h's digest) and reach dev only on the next
+  # "Merged main into dev" -- plus any hotfix pushed straight to main, plus the
+  # release cut itself. It is coverage of the branch that publishes, not of a
+  # defect known to be there today: every step below passes on main as of
+  # 12987063d.
+  #
+  # A mirror of dev-nightly's `clippy` job with `ref: main`. The MSRV floor is
+  # deliberately not duplicated (it is its own job there, and it reads the floor
+  # out of the manifests, which regen-check below already pins).
+  #
+  # Rust-only and self-contained: no C build, no dist asset, no JDK/.NET -- and,
+  # like its dev twin, deliberately NOT gated on the C hero 'test' job, so an
+  # unrelated Windows or dist-pool failure cannot skip the release branch's only
+  # Rust coverage.
+  rust:
+    name: Rust clippy + docs + tests (release branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      # Rust is preinstalled on ubuntu-latest; add the component defensively
+      # (idempotent — a no-op when clippy is already present).
+      - name: Ensure clippy component
+        shell: bash
+        run: rustup component add clippy
+
+      - name: Clippy the generator tool
+        shell: bash
+        run: cargo clippy --all-targets --manifest-path ta_codegen/generator/Cargo.toml -- -D warnings
+
+      # `-D warnings` is load-bearing beyond clippy's own lints: the crate sets
+      # #![warn(missing_docs)] (#179 D7), so this is what turns an undocumented
+      # public item into a failure rather than a warning nobody reads.
+      - name: Clippy the generated crate
+        shell: bash
+        run: cargo clippy --all-targets --manifest-path ta_codegen/output/rust/Cargo.toml -- -D warnings
+
+      # Rustdoc's own lints are a set clippy never reaches, and docs.rs is the
+      # first place rustdoc runs on a release: a broken intra-doc link renders
+      # there as literal text (#179 E4).
+      - name: Rustdoc the generated crate
+        shell: bash
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
+
+      # --no-fail-fast: cargo stops at the first failing test binary, which once
+      # hid a second real failure (#238).
+      - name: Test the generator tool
+        shell: bash
+        run: cargo test --no-fail-fast --manifest-path ta_codegen/generator/Cargo.toml
+
+      # clippy --all-targets does not build doctests, so without this step the
+      # crate's public-facing examples are compiled by nothing on this branch.
+      - name: Run the generated crate's doctests
+        shell: bash
+        run: cargo test --doc -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
+
+      # `--tests`, not `--lib`: the latter excludes tests/, and --all-targets
+      # above only COMPILES the test target while --doc skips it.
+      - name: Run the generated crate's unit and integration tests
+        shell: bash
+        run: cargo test --tests -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
+
+      # Beyond E5's list, and the one step here that is about publishing rather
+      # than about parity with dev: every step above compiles the crate IN the
+      # workspace, where a file on disk is reachable whether or not it would
+      # ship. This builds the actual .crate tarball and verification-builds it
+      # (#179 E1). main is the branch that tarball would be published from.
+      - name: Package the publishable crates and check what ships
+        shell: bash
+        run: python3 scripts/rust_package_check.py
+
+  # regen-check on the release branch (#179 E5). Same command the PR gate and
+  # dev-nightly run: the ta_regtest source lists agree, ta_codegen/input is
+  # formatted, and regenerating every backend changes nothing committed.
+  #
+  # The weakest of the two jobs added here, and stated as such: content that
+  # arrives on main by merging dev has already been regen-checked there. It earns
+  # its place on the branch that ships for the same reason the dev copy earns its
+  # place next to the PR gate -- main also takes commits that no pull_request
+  # trigger and no dev-nightly run ever saw (the dist bot's, which rewrite a
+  # tracked header, and hotfixes pushed straight to main).
+  #
+  # Not gated on 'test': that job builds the C dist assets, and a source-level
+  # check that regenerates the tree needs nothing from it. Making it wait would
+  # only let a dist-pool failure skip it.
+  regen-check:
+    name: ta_codegen output up-to-date (release branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Regenerate all backends and verify committed output matches
+        shell: bash
+        run: |
+          if ! python3 scripts/build.py regen-check; then
+            echo "::error::ta_codegen output on main is out of date. Run 'scripts/build.py generate' and commit the result — see the log above for which files drifted."
+            exit 1
+          fi
+
+      # Static text check, sub-second, so it is free next to the regenerate
+      # above — the same pairing dev-nightly uses.
+      - name: Candle trailing-total wiring (read AND write side)
+        shell: bash
+        run: |
+          if ! python3 scripts/build.py check-candle-windows; then
+            echo "::error::A candlestick's trailing total is wired to the wrong bar — see the log above."
+            exit 1
+          fi

--- a/docs/rust-publish-runbook.md
+++ b/docs/rust-publish-runbook.md
@@ -63,6 +63,13 @@ into 0.1.2. Get the contents right before publishing, not after.
 
 ## 4. Pre-flight
 
+The `main nightly tests` workflow now runs these same gates against the release branch
+every night — the `rust` and `regen-check` jobs, both `ref: main` (#179 E5). On an
+unchanged `main` this section therefore confirms a result CI already has. Run it anyway
+at the moment of publishing: the nightly's last run can predate the commit being tagged,
+and the release path itself (`release-step-1/2` → `scripts/pre-release-checks.py`)
+compiles no Rust and executes no test.
+
 From the repo root:
 
 ```bash

--- a/docs/rust-publish-runbook.md
+++ b/docs/rust-publish-runbook.md
@@ -63,12 +63,9 @@ into 0.1.2. Get the contents right before publishing, not after.
 
 ## 4. Pre-flight
 
-The `main nightly tests` workflow now runs these same gates against the release branch
-every night — the `rust` and `regen-check` jobs, both `ref: main` (#179 E5). On an
-unchanged `main` this section therefore confirms a result CI already has. Run it anyway
-at the moment of publishing: the nightly's last run can predate the commit being tagged,
-and the release path itself (`release-step-1/2` → `scripts/pre-release-checks.py`)
-compiles no Rust and executes no test.
+`main nightly tests` runs these same gates against `main` every night (#179 E5). Run
+them here anyway: the nightly can predate the commit being tagged, and the release path
+itself compiles no Rust.
 
 From the repo root:
 


### PR DESCRIPTION
E5 asks for clippy, doc tests, lib tests, arm64 and regen-check on the release
branch. This adds all of them except arm64 (below), plus one step E5 does not
list — `rust_package_check.py` — because `main` is the branch a `.crate` would
be published from.

## What main had

`main-nightly-tests.yml` ran three jobs, and no Rust among them:

| job | what it does |
|---|---|
| `test` (ubuntu + windows) | builds the C dist assets, verifies the pool, warns on a stale website |
| `fuzz-vs-064` | bit-exact C fuzz against released v0.6.4 |
| `xlang-hash` | diffs the four language servers against the in-process C library |

Nothing there compiles the crate, runs a doctest, executes the crate's own test
modules, regenerates, or builds a `.crate`.

The release path does not either. `release-step-1.yml` and `-2.yml` check out
`main` and run exactly one check before tagging and publishing —
`scripts/pre-release-checks.py` — which verifies versions, the CHANGELOG entry
and date, the pom's indicator count and the `dist/digests` files. It compiles no
Rust and executes no test. Between "main is tagged" and "the crate is published"
there was no step that had ever built what gets published.

## What is added

Two jobs, both `ref: main`, mirroring their dev-nightly twins:

- **`rust`** — clippy on the generator and on the crate (`-D warnings`, which is
  also what turns the crate's `#![warn(missing_docs)]` into a failure), rustdoc
  under `RUSTDOCFLAGS=-D warnings`, the generator's own tests (`--no-fail-fast`),
  the crate's doctests, the crate's unit/integration tests (`--tests`, not
  `--lib`), then `scripts/rust_package_check.py`.
- **`regen-check`** — `scripts/build.py regen-check` plus the candle
  trailing-total wiring check, the same pairing dev-nightly uses.

Neither is gated on the C hero `test` job: they need no C build and no dist
asset, so a Windows or dist-pool failure cannot skip the release branch's only
Rust coverage. That matches how dev-nightly treats its `clippy` and `msrv` jobs;
it differs from dev's `regen-check`, which is `needs: test` there — on main that
would only let a dist-pool failure take the source check with it.

`docs/rust-publish-runbook.md` §4 now says the nightly runs these, so a release
is not the first time anyone runs them.

## Where the overlap is, stated plainly

`main`'s tip is normally an ancestor of `dev` (today `12987063d`, 35 commits
behind `6d7851137`), so its content has usually already been through
dev-nightly. This is not new coverage of that content. What it does cover:

- the window where main is *ahead*: the `Update dist package` bot commits land
  on main first and rewrite a tracked header (`include/ta_common.h`), reaching
  dev only at the next "Merged main into dev";
- any hotfix pushed straight to main;
- the release cut itself, on the branch the publish happens from.

Every step passes on main as of `12987063d`. This is coverage of the publishing
branch, not a defect known to be there today.

## Verification

All runs below are on a fresh worktree of `upstream/main` (`12987063d`), on a
4-vCPU / 15 GB Linux container with a warm `~/.cargo` registry and cold cargo
target directories.

**Green on main today:**

| step | result |
|---|---|
| clippy generator | exit 0 |
| clippy crate | exit 0 |
| rustdoc `-D warnings` | exit 0 |
| generator tests | all suites pass |
| crate doctests | 534 passed, 0 failed |
| crate `--tests` | 72 + 6 + 7 passed, 0 failed |
| `build.py regen-check` | "ta_codegen output matches the committed source. OK." |
| candle trailing-total wiring | 57 files, 567 batch + 187 streaming reads, OK |

**Each gate broken on purpose, and watched go red** (sabotage reverted after
each):

| step | sabotage | observed |
|---|---|---|
| regen-check | committed an extra line into `src/ta_func/ta_SMA.c`, clean tree | rc=1, prints the drifted hunk |
| clippy generator | added an unused fn with `return x;` | exit 101, `needless_return` + never-used |
| clippy crate | added an undocumented `pub struct` to `lib.rs` | exit 101, "missing documentation for a struct" |
| rustdoc | `[Core::NO_SUCH_METHOD_AT_ALL]` in the crate docs | exit 101, "unresolved link" |
| crate doctests | `assert!(false)` in one generated SMA example | FAILED, 533 passed 1 failed |
| crate `--tests` | added a failing `#[test]` to `tests/stream_open_contract.rs` | exit 101, 7 passed 1 failed |
| candle wiring | read `ShadowVeryShortPeriodTotal[2]` at `i-3` in CDL3BLACKCROWS | rc=1, names the file, the total and the bar |

Two steps I did **not** break myself, and do not claim a control for: the
generator's `cargo test` step (same runner as the two cargo-test controls above,
and it is dev-nightly's step verbatim) and `rust_package_check.py` (its control
is the one recorded in dev-nightly's own comment — excluding LICENSE from the
manifest reddens it alone).

I did not run these as an actual GitHub Actions job — I cannot dispatch one on
this repo. What is verified is the commands, on main's tree, plus the YAML
parsing into the five expected jobs.

## Cost, and the one thing worth your call

Measured wall-clock, same machine, cold target dirs:

| | |
|---|---|
| `rust` job | 22 + 20 + 4 + 149 + 58 + 22 s ≈ **4 min 35 s**, plus `rust_package_check.py` (4 s warm on dev's tree) |
| `regen-check` job | **64 s** (cold generator build included) + 0 s for the candle check |

So roughly six minutes of added runner time per night, in two jobs that run in
parallel with the existing three, and neither extends the critical path past the
90-minute `test` job.

**The README badge.** `README.md` line 3 carries the `main nightly tests` badge.
Both new jobs fail hard, so a red crate on the release branch now turns that
public badge red. The workflow deliberately keeps the website check soft for
exactly this reason ("never fail — keep the main badge green"). I think a crate
that does not compile on the branch it publishes from *should* be loud, but that
is a judgement about a badge on the front page, so it is yours: say the word and
either job can become a warning, or move to dev-nightly with `ref: main`.

**arm64 is deliberately not here.** E5 lists it, and it is the one item with a
real cost: `arm64-linux` is a native-runner job that builds C and runs the
reference suite, and its value on main is a second execution of what dev already
gated pre-merge. It is a separate decision from the cheap Rust ones, so I left it
for you rather than bundling it.

## Sequencing note

Scheduled workflows run from the default branch, which is `main`, so these jobs
start firing only after this reaches main in the next dev→main merge.
`scripts/rust_package_check.py` (#179 E1, merged into dev as #292) is not on main
yet either — it arrives in that same merge, so the step and the script land
together. Nothing here works or breaks in between.
