### PR TITLE
perf(streaming): peek deletes its dead accumulator stores instead of cloning around them (#303)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,22 +145,29 @@ Assume the reader is an AI that can read the code faster than the prose about
 it. A comment or a `.md` earns its place only by saying something the code
 cannot:
 
-- **Guidance, not description.** Why this shape, what breaks if you change it,
-  which invariant is load-bearing. Not what the lines below do.
+- **Default to none.** Code shows *how*. Write a comment only for a *why* a
+  careful reader would not reach from the code in a minute.
+- **Guidance, not description.** Which invariant is load-bearing, what breaks if
+  you change it. Not what the lines below do.
+- **Never write these.** A restatement of the lines below. The reasoning that
+  led here. An alternative that was rejected. What the code used to be. "Fixed
+  X", "per review". A pointer to a doc instead of the fact itself. All of it
+  belongs in the issue and the commit message, which are timestamped and do not
+  pretend to be current.
 - **Never re-explain another file.** That copy goes stale the moment the
-  original moves, and a stale description costs a reader either a wrong belief
-  or a re-verification. When you find one that has drifted, delete it — do not
-  re-sync it. Drift is the symptom; the duplication is the defect.
-- **Delete the scaffolding of solved problems.** A workaround that is gone, a
-  bug that is fixed, a tier that was retired: the post-mortem belongs in the
-  issue and the commit message, which are timestamped and do not pretend to be
-  current.
-- **A real pitfall is worth writing down** — but state the rule, not the
-  history. "Keep every `(int)` cast the whole right-hand side" beats a paragraph
-  naming the emitter function that used to get it wrong.
+  original moves, and costs a reader either a wrong belief or a re-verification.
+  When you find one that has drifted, delete it — do not re-sync it. Drift is
+  the symptom; the duplication is the defect.
+- **A pitfall earns a sentence only if it fails SILENTLY** — and state the rule,
+  not the history. "Keep every `(int)` cast the whole right-hand side" beats a
+  paragraph naming the emitter that used to get it wrong. Loud failures get
+  rediscovered in minutes and need nothing.
 - **Named internals are the tell** — a function, a struct field, a symbol out of
-  a compiler error. They are the part most likely to be renamed out from under
-  the comment, and naming them is usually description wearing a rule's clothes.
+  a compiler error. Most likely to be renamed out from under the comment, and
+  naming them is usually description wearing a rule's clothes.
+- **Doc lines outnumbering the code they describe means cut, not balance.**
+  Writing less is the weaker half; re-reading and deleting before you commit is
+  the half that works.
 
 Applies to `ta_codegen/input/**` headers and `.md` files as much as to the
 generator's own source. `ta_codegen/generator/input_synth/README.md` states the

--- a/docs/streaming-api-design.md
+++ b/docs/streaming-api-design.md
@@ -94,9 +94,10 @@ handle buffer becomes two locals — the slot it targeted and the value it held 
 and every load that could land on that slot selects them back; a store no load
 can reach this bar is deleted outright. Nothing else about the body changes, so
 `peek` is still the same numbers in the same order. What it buys is the cost
-model: peek copies the handle's SCALARS onto the stack and nothing else, so its
-overhead is a fixed number of bytes where the buffers are a function of the
-period. Measured on this box, WMA's peek was 9 ns at period 30, 31 ns at 200 and
+model: peek copies the handle's fixed-size part onto the stack — the scalars
+and the in-struct accumulators — and never a buffer, so its overhead is a fixed
+number of bytes where the buffers are a function of the period. Measured on
+this box, WMA's peek was 9 ns at period 30, 31 ns at 200 and
 474 ns at 2000 against a flat 4.4 ns update; it is now flat with it. The
 per-handle mirror buffers are gone with it — they were ~38% of every handle.
 
@@ -120,28 +121,38 @@ as `usize`; and the outputs are rebound as `&mut` inside a block so the body
 keeps the `(*out) = …` spelling and every cast with it.
 
 **Java and .NET run the same frame**, tier for tier, with two differences that
-are theirs alone. A managed array field is a *reference*, so a localized one is
-cloned rather than aliased — always a fixed-size per-bar accumulator, two to
-five elements, never a period-sized buffer, which the frame only reads. And
-`cur_<out>` is itself a handle field, so localizing the stores is what turns the
-cached output into the local `peek` returns.
+are theirs alone. A managed array field is a *reference*, so localizing one
+means cloning it, and that clone is a per-call allocation the other two
+backends do not pay. So the accumulators are offered to the shadow rewrite
+alongside the handle's buffers, and a store no load reaches is deleted outright
+instead — leaving a clone only where the rewrite refuses, which today is an
+accumulator the batch body sums inside a loop. The offer is made from all four
+backends or from none, for the bit-identity reason
+`transition_buffers_with_state_arrays` states. And `cur_<out>` is itself a
+handle field, so localizing the stores is what turns the cached output into the
+local `peek` returns.
 
-Nothing copies a handle in any backend now. Java's `copyFrom`, both backends'
-per-thread scratch and the predicate that chose between a reused scratch and a
-throwaway are all deleted; the shipped `Core.java` lost ~14,000 lines with them.
+No backend copies a handle's BUFFERS to peek it any more. Java's `copyFrom`,
+both backends' per-thread scratch and the predicate that chose between a reused
+scratch and a throwaway are all deleted; the shipped `Core.java` lost ~14,000
+lines with them. C still copies the struct itself, which is the fixed-size part
+and nothing behind a pointer.
 
 No form writes the handle, which is what keeps Rust's `peek` a `&self` method
 and every backend's handles concurrently peekable — including two threads
 peeking the same handle, which a per-thread scratch could not serve. `update`
-never allocates (that is the hard constraint, not peek's), and now neither does
-`peek`, in any of the four.
+never allocates (that is the hard constraint, not peek's). Neither does `peek`
+in C or Rust; in Java and .NET it allocates only where the surviving clone
+above is, and the generated doc comment on each `peek` says which of the two it
+is rather than claiming the stronger one everywhere.
 
 The property is structural, not observable: a peek that copied and then wrote
 the copy would still answer correctly, so no value gate can see the difference.
 Each backend therefore carries its own sweep over every streamable function —
 `peek_suite` for C, `no_rust_peek_copies_the_handle`,
 `no_java_peek_copies_the_handle`, `no_csharp_peek_copies_the_handle` — asserting
-a frame is what runs and that nothing in it allocates.
+a frame is what runs, that it allocates nothing that grows with the period, and
+that the accumulators it still copies are the ones the shadow rewrite refused.
 
 ### Full-history output at open (`OpenAndFill`)
 

--- a/src/ta_func/ta_HT_DCPERIOD.c
+++ b/src/ta_func/ta_HT_DCPERIOD.c
@@ -1482,7 +1482,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1491,7 +1490,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1500,7 +1498,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1509,7 +1506,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1535,7 +1531,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1544,7 +1539,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1553,7 +1547,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1562,7 +1555,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPERIOD_Peek( const TA_HT_DCPERIOD_Stream *stream, 
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_HT_DCPHASE.c
+++ b/src/ta_func/ta_HT_DCPHASE.c
@@ -1811,7 +1811,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1820,7 +1819,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1829,7 +1827,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1838,7 +1835,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1864,7 +1860,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1873,7 +1868,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1882,7 +1876,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1891,7 +1884,6 @@ TA_LIB_API TA_RetCode TA_HT_DCPHASE_Peek( const TA_HT_DCPHASE_Stream *stream, do
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_HT_PHASOR.c
+++ b/src/ta_func/ta_HT_PHASOR.c
@@ -1505,7 +1505,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1514,7 +1513,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1525,7 +1523,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       *outInPhase= sp->I1ForEvenPrev3;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1534,7 +1531,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1560,7 +1556,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1569,7 +1564,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1580,7 +1574,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       *outInPhase= sp->I1ForOddPrev3;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1589,7 +1582,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_HT_SINE.c
+++ b/src/ta_func/ta_HT_SINE.c
@@ -1840,7 +1840,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1849,7 +1848,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1858,7 +1856,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1867,7 +1864,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1893,7 +1889,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1902,7 +1897,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1911,7 +1905,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1920,7 +1913,6 @@ TA_LIB_API TA_RetCode TA_HT_SINE_Peek( const TA_HT_SINE_Stream *stream, double i
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_HT_TRENDLINE.c
+++ b/src/ta_func/ta_HT_TRENDLINE.c
@@ -1676,7 +1676,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1685,7 +1684,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1694,7 +1692,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1703,7 +1700,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1729,7 +1725,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1738,7 +1733,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1747,7 +1741,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1756,7 +1749,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDLINE_Peek( const TA_HT_TRENDLINE_Stream *stream
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_HT_TRENDMODE.c
+++ b/src/ta_func/ta_HT_TRENDMODE.c
@@ -2165,7 +2165,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -2174,7 +2173,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -2183,7 +2181,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -2192,7 +2189,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -2218,7 +2214,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -2227,7 +2222,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -2236,7 +2230,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -2245,7 +2238,6 @@ TA_LIB_API TA_RetCode TA_HT_TRENDMODE_Peek( const TA_HT_TRENDMODE_Stream *stream
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/ta_func/ta_MAMA.c
+++ b/src/ta_func/ta_MAMA.c
@@ -1737,7 +1737,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       /* Do the Hilbert Transforms for even price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Even[sp->hilbertIdx];
-      sp->detrender_Even[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Even;
       sp->prev_detrender_Even = sp->b * sp->prev_detrender_input_Even;
@@ -1746,7 +1745,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Even[sp->hilbertIdx];
-      sp->Q1_Even[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Even;
       sp->prev_Q1_Even = sp->b * sp->prev_Q1_input_Even;
@@ -1755,7 +1753,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
       jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      sp->jI_Even[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
@@ -1764,7 +1761,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      sp->jQ_Even[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
@@ -1798,7 +1794,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       /* Do the Hilbert Transforms for odd price bar */
       hilbertTempReal = sp->a * smoothedValue;
       detrender = 0 - sp->detrender_Odd[sp->hilbertIdx];
-      sp->detrender_Odd[sp->hilbertIdx] = hilbertTempReal;
       detrender += hilbertTempReal;
       detrender -= sp->prev_detrender_Odd;
       sp->prev_detrender_Odd = sp->b * sp->prev_detrender_input_Odd;
@@ -1807,7 +1802,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       detrender *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * detrender;
       Q1 = 0 - sp->Q1_Odd[sp->hilbertIdx];
-      sp->Q1_Odd[sp->hilbertIdx] = hilbertTempReal;
       Q1 += hilbertTempReal;
       Q1 -= sp->prev_Q1_Odd;
       sp->prev_Q1_Odd = sp->b * sp->prev_Q1_input_Odd;
@@ -1816,7 +1810,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
       jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      sp->jI_Odd[sp->hilbertIdx] = hilbertTempReal;
       jI += hilbertTempReal;
       jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
@@ -1825,7 +1818,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
       jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      sp->jQ_Odd[sp->hilbertIdx] = hilbertTempReal;
       jQ += hilbertTempReal;
       jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;

--- a/src/tools/ta_regtest/test_codegen.c
+++ b/src/tools/ta_regtest/test_codegen.c
@@ -125,9 +125,11 @@ static int codegen_lang_has_stream_state_probe(const char *lang)
  * inert. The TOTAL gate for the property is structural, in the generator:
  * tests/peek_suite.rs asserts no peek frame stores into a handle buffer at all.
  *
- * C only: its peek runs a frame that commits nothing, where the other three
- * peek a copy of the handle and the property is structural. Widen this the
- * moment one of them converts. */
+ * C only, for the same structural reason the state-equivalence leg above is:
+ * the probe compares the handle field-by-field around a peek, and only the C
+ * server has the struct as a complete type. All four backends run a
+ * non-committing frame, so what is C-only here is the OBSERVER, not the
+ * property — which is why each backend also carries its own generator sweep. */
 static int codegen_lang_has_peek_probe(const char *lang)
 {
     return lang && strcmp(lang, "c") == 0;

--- a/ta_codegen/generator/src/backends/c_stream.rs
+++ b/ta_codegen/generator/src/backends/c_stream.rs
@@ -4,10 +4,11 @@
 //! `src/ta_func/ta_<NAME>.c` gains a stream section after the batch variants:
 //!
 //! - `struct TA_<NAME>_Stream` — params, carried scalars, lag slots;
-//! - `static void TA_<NAME>_StepImpl(...)` — the ONE transition function
-//!   (the batch steady-loop body on rewritten IR); `Update` runs it on the
-//!   live state and `Peek` on a stack copy, so peek == update bit-for-bit by
-//!   construction;
+//! - `static void TA_<NAME>_StepImpl(...)` — the transition function (the batch
+//!   steady-loop body on rewritten IR) that `Update` runs on the live state;
+//!   `Peek` inlines the same transition rewritten to commit nothing into the
+//!   handle's BUFFERS, over a stack copy of the struct that carries the scalars
+//!   and the in-struct arrays;
 //! - `TA_LIB_API TA_RetCode TA_<NAME>_Open/Update/Peek/Close` — the public
 //!   lifecycle (proposal §"API shape per backend").
 //!
@@ -1207,12 +1208,8 @@ fn emit_composed_frame_body(
         let transition = match frame {
             StepFrame::Commit => transition,
             StepFrame::Peek => {
-                let pt = streaming::peek_transition(
-                    &transition,
-                    &streaming::transition_buffers(model, &names),
-                    None,
-                )
-                .unwrap_or_else(|e| panic!("{}: {e}", func.name));
+                let pt = streaming::peek_transition_widest(model, &names, &transition, None)
+                    .unwrap_or_else(|e| panic!("{}: {e}", func.name));
                 decls.push_str(&peek_shadow_decls(&pt.shadows, &pt.slot_temps, 3));
                 answer_bare_returns(&pt.body)
             }
@@ -3526,12 +3523,8 @@ fn emit_step_inner(
     let (transition, shadows, slot_temps) = match frame {
         StepFrame::Commit => (transition, Vec::new(), Vec::new()),
         StepFrame::Peek => {
-            let pt = streaming::peek_transition(
-                &transition,
-                &streaming::transition_buffers(model, &CNames),
-                None,
-            )
-            .unwrap_or_else(|e| panic!("{}: {e}", model.func.name));
+            let pt = streaming::peek_transition_widest(model, &CNames, &transition, None)
+                .unwrap_or_else(|e| panic!("{}: {e}", model.func.name));
             (answer_bare_returns(&pt.body), pt.shadows, pt.slot_temps)
         }
     };

--- a/ta_codegen/generator/src/backends/csharp_stream.rs
+++ b/ta_codegen/generator/src/backends/csharp_stream.rs
@@ -69,7 +69,7 @@
 //! - Rings stay `double[]`/`int[]` fields. `Span<T>` cannot be a field (CS8345)
 //!   and `Memory<T>` costs a span materialization per access.
 //! - The copy constructor uses `new T[n]` + `Array.Copy`, never
-//!   `(double[])x.Clone()` — 2.3x, and it is on `Peek`'s path for ~86 functions.
+//!   `(double[])x.Clone()` — 2.3x.
 //! - Dispatch is a `switch` + cast, but *not* because virtual calls are slow:
 //!   an interface call measured 4.41–4.74 against the switch's 5.55–5.72
 //!   ns/bar. The switch wins on cross-language parity and on not adding a type
@@ -944,9 +944,9 @@ fn emit_handle_class_with_members(
     );
 
     // Deep-copy constructor: scalars assign, arrays are allocated and copied
-    // (never `(double[])x.Clone()` — 2.3x slower, and this is on Peek's path),
-    // sub-handles copy recursively; the Core reference is shared (settings
-    // identity is the contract).
+    // (never `(double[])x.Clone()` — 2.3x slower), sub-handles copy
+    // recursively; the Core reference is shared (settings identity is the
+    // contract).
     let _ = writeln!(o, "\n      internal {class}( {class} other )");
     let _ = writeln!(o, "      {{");
     let _ = writeln!(o, "         this.core = other.core;");
@@ -1138,11 +1138,11 @@ fn emit_peek_method(o: &mut String, func: &FuncDef, frame: Option<&str>) {
          return — the same transition, with every store it would make carried in a local \
          instead. Never writes this handle, so peeks may run concurrently with each other.",
     );
-    // Conditional, because for 21 handles the unconditional claim was false: a
-    // C# array field is a reference, so a frame that writes a fixed-size
-    // accumulator has to copy it, and that copy is a real per-call allocation.
-    // The flat-in-period cost — the claim the frame exists to keep — holds
-    // either way, and is what both sentences lead with.
+    // Conditional, because for the handles whose accumulator the frame still
+    // copies the unconditional claim was false: a C# array field is a
+    // reference, so a frame that writes one has to copy it, and that copy is a
+    // real per-call allocation. The flat-in-period cost — the claim the frame
+    // exists to keep — holds either way, and is what both sentences lead with.
     if frame.is_some_and(|f| f.contains("Array.Copy(")) {
         d.para(
             "It copies no buffer: the frame runs against this handle, reading its buffers \
@@ -1585,7 +1585,8 @@ fn peek_frame_arm(
 }
 
 /// One model's peek frame: the transition rewritten to commit nothing, run
-/// against the live handle at `indent`.
+/// against the live handle at `indent`. `None` where it cannot be built, which
+/// the caller turns into a panic — every tier emits a frame.
 #[allow(clippy::too_many_arguments)]
 fn peek_frame_arm_named(
     func: &FuncDef,
@@ -1603,8 +1604,7 @@ fn peek_frame_arm_named(
 ) -> Option<String> {
     let pad = " ".repeat(indent);
     let transition = streaming::build_transition(model, names).ok()?;
-    let bufs = streaming::transition_buffers(model, names);
-    let pt = streaming::peek_transition(&transition, &bufs, None).ok()?;
+    let pt = streaming::peek_transition_widest(model, names, &transition, None).ok()?;
     // The extrema rebase moves the cursor before the first store, so its
     // targets localize with the transition's own.
     let mut rebased: Vec<String> = Vec::new();
@@ -1613,6 +1613,7 @@ fn peek_frame_arm_named(
         rebased.push(ex.trailing.clone());
         rebased.extend(ex.index_vars.iter().cloned());
     }
+    let bufs = streaming::transition_buffers(model, names);
     let (locals, body_ir) = localize_state_writes(func, &pt.body, &rebased, &bufs)?;
     // The transition's own early exit — the param-degenerate identity
     // short-circuit — is valueless, because a step returns `void`. Inline in
@@ -1638,10 +1639,11 @@ fn peek_frame_arm_named(
         }
         let cty = types.get(name.as_str()).copied()?;
         // A C# array field is a reference: taking it plain would write the
-        // handle through it. These are the fixed-size per-bar accumulators —
-        // two to five elements — never a period-sized buffer, which the frame
-        // only ever reads. Allocate and `Array.Copy` rather than `Clone()`, the
-        // same shape the copy constructor states its case for.
+        // handle through it. Only the accumulators `peek_transition_widest`
+        // refused reach here — two to five elements, never a period-sized
+        // buffer, which the frame only ever reads. Allocate and `Array.Copy`
+        // rather than `Clone()`, the same shape the copy constructor states its
+        // case for.
         if let Some(elem) = cty.strip_suffix("[]") {
             let _ = writeln!(out, "{pad}{cty} {name} = new {elem}[sp.{name}.Length];");
             let _ = writeln!(out, "{pad}Array.Copy( sp.{name}, {name}, sp.{name}.Length );");
@@ -3884,8 +3886,8 @@ fn emit_period_bank(
 // sub-handles, mirroring java_stream's emit_composed with the same managed
 // simplifications: GC replaces every cleanup ladder and series-free replay,
 // `free()` renders as a no-op so lag-ring seeding reads the still-live
-// intermediate array, and copy-peek needs no sub-call routing at all (sub handles
-// deep-copy through their copy constructors).
+// intermediate array, and the peek frame drives each sub-stream's own public
+// peek rather than committing anything.
 // ---------------------------------------------------------------------------
 
 /// Composed producer name map: identical to [`CsStreamNames`] except the

--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -38,11 +38,12 @@
 //! - There is no `close`: a handle is ordinary heap state — GC suffices (no
 //!   AutoCloseable, no finalizer). Handles are deliberately NOT serializable;
 //!   the sanctioned checkpoint story is re-opening from retained history.
-//! - `peek` = deep-copy constructor + step on the throwaway copy (the design
-//!   doc's stated cost model); `copy()` exposes the same constructor as an
-//!   independent stream. The copy is deep:
-//!   arrays clone, sub-handles copy recursively; only the `Core` reference is
-//!   shared (settings identity is the contract).
+//! - `peek` runs its own non-committing frame against the live handle, so its
+//!   cost is flat in the period; what it still clones is a fixed-size
+//!   accumulator the shadow rewrite refused. `copy()` is the deep-copy
+//!   constructor exposed as an independent stream: arrays clone, sub-handles
+//!   copy recursively; only the `Core` reference is shared (settings identity
+//!   is the contract).
 //! - Multi-output functions return a per-function immutable `Value` class
 //!   (public final fields, batch output order, generated toString/equals/
 //!   hashCode); `update` caches the instance so `value()` is a pure field
@@ -1057,19 +1058,16 @@ fn emit_peek_method(o: &mut String, func: &FuncDef, frame: Option<&str>) {
     };
     let (sig_bars, _) = bar_params(func);
 
-    // The allocation sentence is CONDITIONAL, because for 21 handles the
-    // unconditional one was false: a Java array field is a reference, so a
-    // frame that writes a fixed-size accumulator has to clone it, and that
-    // clone is a real per-call allocation. Both sentences say the thing that is
-    // actually true of THIS frame — the flat-in-period cost, which is the claim
-    // the frame exists to keep, holds either way.
-    let cost = if frame.is_some_and(|f| f.contains(".clone()")) {
+    // Two things allocate here and both are per call: an accumulator the frame
+    // had to clone, and the `Value` a multi-output peek returns. Neither grows
+    // with the period, which is the claim the frame exists to keep.
+    let allocates =
+        frame.is_some_and(|f| f.contains(".clone()")) || func.outputs.len() > 1;
+    let cost = if allocates {
         "It copies no buffer: the frame runs against this handle, reading its\n\
          \x20      * buffers and storing what the step would commit into locals, so the cost\n\
-         \x20      * does not grow with the period. It does clone this indicator's fixed-size\n\
-         \x20      * per-bar accumulators — a few elements, a count fixed by the indicator and\n\
-         \x20      * not by the period — so {@code peek} allocates a small bounded amount per\n\
-         \x20      * call."
+         \x20      * does not grow with the period. It does allocate a small bounded amount\n\
+         \x20      * per call — a size fixed by the indicator, never by the period."
     } else {
         "It copies nothing: the frame runs against this handle, reading its\n\
          \x20      * buffers and storing what the step would commit into locals, so the cost\n\
@@ -1385,8 +1383,8 @@ fn peek_frame_arm(
 }
 
 /// One model's peek frame: the transition rewritten to commit nothing, run
-/// against the live handle at `indent`. `None` where it cannot be built and the
-/// caller falls back to peeking a copy.
+/// against the live handle at `indent`. `None` where it cannot be built, which
+/// the caller turns into a panic — every tier emits a frame.
 #[allow(clippy::too_many_arguments)]
 fn peek_frame_arm_named(
     func: &FuncDef,
@@ -1404,8 +1402,7 @@ fn peek_frame_arm_named(
 ) -> Option<String> {
     let pad = " ".repeat(indent);
     let transition = streaming::build_transition(model, names).ok()?;
-    let bufs = streaming::transition_buffers(model, names);
-    let pt = streaming::peek_transition(&transition, &bufs, None).ok()?;
+    let pt = streaming::peek_transition_widest(model, names, &transition, None).ok()?;
     // The extrema rebase moves the cursor before the first store, so its
     // targets localize with the transition's own.
     let mut rebased: Vec<String> = Vec::new();
@@ -1414,6 +1411,7 @@ fn peek_frame_arm_named(
         rebased.push(ex.trailing.clone());
         rebased.extend(ex.index_vars.iter().cloned());
     }
+    let bufs = streaming::transition_buffers(model, names);
     let (locals, body_ir) = localize_state_writes(func, &pt.body, &rebased, &bufs)?;
     // The transition's own early exit — the param-degenerate identity
     // short-circuit — is valueless, because a step returns `void`. Inline in
@@ -1439,9 +1437,9 @@ fn peek_frame_arm_named(
         }
         let jty = types.get(name.as_str()).copied()?;
         // A Java array field is a reference: taking it plain would write the
-        // handle through it. These are the fixed-size per-bar accumulators —
-        // two to five elements — never a period-sized buffer, which the frame
-        // only ever reads.
+        // handle through it. Only the accumulators `peek_transition_widest`
+        // refused reach here — two to five elements, never a period-sized
+        // buffer, which the frame only ever reads.
         let init = if jty.ends_with("[]") {
             format!("sp.{name}.clone()")
         } else {
@@ -3463,8 +3461,8 @@ fn emit_period_bank(
 // sub-handles, mirroring rust_stream's emit_composed with the managed-language
 // simplifications: GC replaces every cleanup ladder and series-free replay,
 // `free()` renders as a no-op so lag-ring seeding reads the still-live
-// intermediate array, and copy-peek needs no sub-call routing at all (sub handles
-// deep-copy through their copy constructors).
+// intermediate array, and the peek frame drives each sub-stream's own public
+// peek rather than committing anything.
 // ---------------------------------------------------------------------------
 
 /// Composed producer name map: identical to [`JavaStreamNames`] except the

--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -19,8 +19,8 @@
 //! Deliberate simplifications vs the C emitter (see design spec):
 //! - `peek(&self)` runs a second frame of the transition that commits nothing,
 //!   as C does. The handle is never written — which is what keeps the signature
-//!   `&self` and the handle `Sync` — and nothing is copied, so the cost is flat
-//!   in the period.
+//!   `&self` and the handle `Sync` — and no buffer is copied, so the cost is
+//!   flat in the period.
 //! - Drop replaces Close; RAII replaces every OOM-unwind ladder.
 //! - `historyLen` is the FIRST input slice's length: empty is
 //!   `Err(OutOfRangeStartIndex)` (rule S1), and a multi-input open additionally
@@ -1153,8 +1153,8 @@ fn answer_bare_returns_rust(func: &FuncDef, body: &[Statement]) -> Vec<Statement
 }
 
 /// One model's peek frame: the transition rewritten to commit nothing, against
-/// `&self.state`, at `indent`. `None` where the frame cannot be built, and the
-/// caller falls back to peeking a copy of the handle.
+/// `&self.state`, at `indent`. `None` where the frame cannot be built, which
+/// the caller turns into a panic — every tier emits a frame.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn peek_frame_arm(
     func: &FuncDef,
@@ -1170,12 +1170,8 @@ fn peek_frame_arm(
 ) -> Option<String> {
     let pad = " ".repeat(indent);
     let transition = streaming::build_transition(model, names).ok()?;
-    let pt = streaming::peek_transition(
-        &transition,
-        &streaming::transition_buffers(model, names),
-        Some(VarType::Index),
-    )
-    .ok()?;
+    let pt =
+        streaming::peek_transition_widest(model, names, &transition, Some(VarType::Index)).ok()?;
     // The extrema rebase moves the cursor before the first store, so its
     // targets are localized with the transition's own.
     let mut rebased: Vec<String> = Vec::new();
@@ -2986,8 +2982,8 @@ fn emit_update_and_peek(
         "    /// Evaluate a forming bar without committing — bit-identical to what the\n\
          \x20   /// next `update` with the same bar would return: the same transition,\n\
          \x20   /// rewritten so every store it would make lives in a local instead. It\n\
-         \x20   /// copies nothing and never allocates, so its cost does not grow with the\n\
-         \x20   /// period, and it writes no part of the handle — peeks may run\n\
+         \x20   /// allocates nothing and copies no buffer, so its cost does not grow with\n\
+         \x20   /// the period, and it writes no part of the handle — peeks may run\n\
          \x20   /// concurrently with each other.\n\
          \x20   ///\n\
          \x20   /// # Errors\n\

--- a/ta_codegen/generator/src/bench_gen.rs
+++ b/ta_codegen/generator/src/bench_gen.rs
@@ -256,9 +256,9 @@ pub fn write_c_bench(funcs: &[FuncDef], output_dir: &Path) {
 //   (opened over the full history once, outside timing). Input scalars rotate
 //   over the first MASK+1 bars — CSE-proof; write-plus-compute per call, an
 //   apples-to-apples throughput comparison with batch@last.
-// - peek_ns       : one `TA_XXX_Peek` (deep-copy of the handle + one transition,
-//   never commits) — the same rotating feed and index cost as update, so the
-//   peek-minus-update delta is exactly the throwaway-copy overhead.
+// - peek_ns       : one `TA_XXX_Peek` (the same transition, rewritten to commit
+//   nothing) — the same rotating feed and index cost as update, so the
+//   peek-minus-update delta is what running it non-committing costs.
 // - lookback      : `TA_XXX_Lookback(defaults)` — contextualises batch_last.
 // - handle_bytes  : retained bytes of the open handle, measured by overriding
 //   TA_Malloc/TA_Free with a registry and taking the net-live delta across

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -7245,9 +7245,11 @@ pub struct PeekTransition {
     pub slot_temps: Vec<String>,
 }
 
-/// Every handle buffer a transition can index, with `true` for integer
-/// elements. Composed lag rings are absent by design: the composed tier emits
-/// its own push as text and drops it in peek mode.
+/// The handle's HEAP buffers a transition can index, with `true` for integer
+/// elements. Fixed-size array state fields are not here — see
+/// [`transition_buffers_with_state_arrays`]. Composed lag rings are absent by
+/// design: the composed tier emits its own push as text and drops it in peek
+/// mode.
 #[must_use]
 pub fn transition_buffers(model: &StreamModel, names: &dyn NameMap) -> Vec<(String, bool)> {
     let mut out: Vec<(String, bool)> = Vec::new();
@@ -7274,6 +7276,51 @@ pub fn transition_buffers(model: &StreamModel, names: &dyn NameMap) -> Vec<(Stri
     out.sort();
     out.dedup();
     out
+}
+
+/// [`transition_buffers`] plus the fixed-size REAL array state fields, so a
+/// peek frame can drop a dead store into one instead of cloning the field.
+///
+/// Offer it from every backend or from none: shadowing rewrites a store's
+/// target, which `canonicalize_accumulator_add` matches by string equality, so
+/// one backend shadowing where another does not can move an FMA site — a ~1 ULP
+/// cross-language divergence nothing points at.
+///
+/// Integer arrays are excluded deliberately: none exist in the corpus, so an
+/// integer shadow would be ungated.
+#[must_use]
+pub fn transition_buffers_with_state_arrays(
+    model: &StreamModel,
+    names: &dyn NameMap,
+) -> Vec<(String, bool)> {
+    let mut out = transition_buffers(model, names);
+    for (name, ty) in &model.state {
+        if matches!(ty, VarType::RealArray(_)) {
+            out.push((names.state(name), false));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// [`peek_transition`] against the widest buffer set that accepts it. The retry
+/// is all-or-nothing: one refusing accumulator takes the whole function back to
+/// [`transition_buffers`].
+///
+/// # Errors
+/// Only when [`transition_buffers`] itself is refused; see [`peek_transition`].
+pub fn peek_transition_widest(
+    model: &StreamModel,
+    names: &dyn NameMap,
+    transition: &[Statement],
+    slot_cast: Option<VarType>,
+) -> Result<PeekTransition, String> {
+    let wide = transition_buffers_with_state_arrays(model, names);
+    if let Ok(pt) = peek_transition(transition, &wide, slot_cast.clone()) {
+        return Ok(pt);
+    }
+    peek_transition(transition, &transition_buffers(model, names), slot_cast)
 }
 
 /// The statement lists nested inside `s`, and whether entering them crosses a

--- a/ta_codegen/generator/tests/backend_suite.rs
+++ b/ta_codegen/generator/tests/backend_suite.rs
@@ -13325,6 +13325,48 @@ fn a_stream_step_reads_candle_settings_from_its_parameters() {
 }
 
 
+/// A store `validate_peekable` refuses: a compound one, which renders as a
+/// store reading its own target. A refusal drops the whole function back to the
+/// narrow set, so one such store justifies every copy in it. The other two
+/// refusals (a store in a loop, a counter-moving index) have no instance here;
+/// one would surface as an offender below rather than be waved through.
+fn csharp_refused_accumulator_store(body: &str, fields: &BTreeSet<String>) -> bool {
+    body.lines().any(|l| {
+        l.split_once('=').is_some_and(|(lhs, rhs)| {
+            // `!rhs.starts_with('=')`: `X[i] == X[j]` splits the same way a store
+            // does, and comparing two slots is not a store into either.
+            lhs.trim_end().ends_with(']')
+                && !rhs.starts_with('=')
+                && fields.iter().any(|f| {
+                    let sub = format!("{f}[");
+                    lhs.contains(&sub) && rhs.contains(&sub)
+                })
+        })
+    })
+}
+
+/// The handle's fixed-size accumulator fields: an array the BATCH body declares
+/// with a literal size. Off the emitted code, never a name list.
+fn csharp_accumulator_fields(section: &str, batch: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in section.lines() {
+        let Some(d) = line.trim().strip_prefix("internal ") else { continue };
+        let Some((ty, rest)) = d.split_once(' ') else { continue };
+        // A field carries its initializer (`internal double[] x = [];`).
+        let name = rest.trim_end_matches(';').split(" =").next().unwrap_or(rest);
+        if !ty.ends_with("[]") || !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            continue;
+        }
+        let decl = format!("{ty} {name} = new {}[", ty.trim_end_matches("[]"));
+        if batch.match_indices(&decl).any(|(i, _)| {
+            batch[i + decl.len()..].split_once(']').is_some_and(|(n, _)| n.parse::<u32>().is_ok())
+        }) {
+            out.insert(name.to_string());
+        }
+    }
+    out
+}
+
 /// No C# `Peek` copies the handle: every one runs a frame against `this`, and
 /// what it allocates never grows with the period.
 ///
@@ -13372,6 +13414,7 @@ fn no_csharp_peek_copies_the_handle() {
     let registry = make_registry();
     let helpers = HelperRegistry::empty();
     let (mut swept, mut frames, mut clones, mut writes) = (0usize, 0usize, 0usize, 0usize);
+    let mut fully_shadowed: BTreeSet<String> = BTreeSet::new();
     let mut offenders: Vec<String> = Vec::new();
 
     for name in discover_indicators() {
@@ -13391,6 +13434,7 @@ fn no_csharp_peek_copies_the_handle() {
             }
             let end = s[start..].find("\n      }").map_or(s.len(), |e| start + e);
             let peek = &s[start..end];
+            let mut copying: BTreeSet<String> = BTreeSet::new();
             swept += 1;
             if peek.contains("Stream sp = this;") {
                 frames += 1;
@@ -13433,28 +13477,50 @@ fn no_csharp_peek_copies_the_handle() {
                     .split_once("= new ")
                     .and_then(|(_, rhs)| rhs.split_once("[sp."))
                     .and_then(|(elem, tail)| tail.split_once(".Length];").map(|(f, _)| (elem, f)))
-                    .is_some_and(|(elem, f)| {
+                    .filter(|(elem, f)| {
                         let decl = format!("{elem}[] {f} = new {elem}[");
                         batch.match_indices(&decl).any(|(i, _)| {
                             batch[i + decl.len()..]
                                 .split_once(']')
                                 .is_some_and(|(n, _)| n.parse::<u32>().is_ok())
                         })
-                    });
-                if ok {
-                    clones += 1;
-                } else {
-                    offenders.push(format!("{name}: {l}"));
+                    })
+                    .map(|(_, f)| f);
+                match ok {
+                    Some(f) => {
+                        clones += 1;
+                        copying.insert(f.to_string());
+                    }
+                    None => offenders.push(format!("{name}: {l}")),
                 }
+            }
+            // A frame that copies with nothing refused was never offered the
+            // wide set, and allocates per Peek for nothing.
+            let accs = csharp_accumulator_fields(&s, &batch);
+            if !copying.is_empty() && !csharp_refused_accumulator_store(peek, &accs) {
+                offenders.push(format!(
+                    "{name}: copies {copying:?} but no accumulator store is refusable"
+                ));
+            }
+            // The other half of the split. The frame must TOUCH an accumulator:
+            // a field it never names is evidence either way.
+            if copying.is_empty() && accs.iter().any(|f| peek.contains(&format!("{f}["))) {
+                fully_shadowed.insert(name.clone());
             }
         }
     }
 
     assert!(swept > 170, "only {swept} Peek(s) swept");
     assert_eq!(frames, swept, "{frames} of {swept} Peek(s) run a frame");
-    // A floor on the exemption itself: if the clone shape stopped being emitted
-    // the branch above would be dead and would stop discriminating.
-    assert!(clones >= 20, "only {clones} accumulator clones seen — the exemption is untested");
+    // Both sides of the split are floored, because the corpus has both and a
+    // sweep that stopped finding either would read green while measuring one.
+    assert!(clones >= 1, "no accumulator copy seen — the exemption is untested");
+    assert!(
+        fully_shadowed.len() >= 7,
+        "only {} handle(s) hold an accumulator the frame copies nothing of — the widened \
+         buffer set is no longer reaching them and Peek allocates again",
+        fully_shadowed.len()
+    );
     assert!(writes >= 500, "only {writes} local writes seen — the store sweep found nothing");
     assert!(offenders.is_empty(), "a Peek copies:\n{}", offenders.join("\n"));
 }

--- a/ta_codegen/generator/tests/java_stream_suite.rs
+++ b/ta_codegen/generator/tests/java_stream_suite.rs
@@ -622,6 +622,49 @@ fn java_composed_copy_out_is_stride_guarded() {
     );
 }
 
+/// A store `validate_peekable` refuses: a compound one, which renders as a
+/// store reading its own target. A refusal drops the whole function back to the
+/// narrow set, so one such store justifies every copy in it. The other two
+/// refusals (a store in a loop, a counter-moving index) have no instance here;
+/// one would surface as an offender below rather than be waved through.
+fn refused_accumulator_store(body: &str, fields: &BTreeSet<String>) -> bool {
+    body.lines().any(|l| {
+        l.split_once('=').is_some_and(|(lhs, rhs)| {
+            // `!rhs.starts_with('=')`: `X[i] == X[j]` splits the same way a store
+            // does, and comparing two slots is not a store into either.
+            lhs.trim_end().ends_with(']')
+                && !rhs.starts_with('=')
+                && fields.iter().any(|f| {
+                    let sub = format!("{f}[");
+                    lhs.contains(&sub) && rhs.contains(&sub)
+                })
+        })
+    })
+}
+
+/// The handle's fixed-size accumulator fields: an array the BATCH body declares
+/// with a literal size. Off the emitted code, never a name list.
+fn accumulator_fields(section: &str, batch: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in section.lines() {
+        if !line.starts_with("      ") || line.starts_with("       ") {
+            continue;
+        }
+        let Some(d) = line.trim().strip_suffix(';') else { continue };
+        let Some((ty, name)) = d.split_once(' ') else { continue };
+        if !ty.ends_with("[]") || !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            continue;
+        }
+        let decl = format!("{ty} {name} = new {}[", ty.trim_end_matches("[]"));
+        if batch.match_indices(&decl).any(|(i, _)| {
+            batch[i + decl.len()..].split_once(']').is_some_and(|(n, _)| n.parse::<u32>().is_ok())
+        }) {
+            out.insert(name.to_string());
+        }
+    }
+    out
+}
+
 /// No tier copies a handle to peek it — swept over the whole corpus.
 ///
 /// Structural, because no value gate can see it: a peek that copied and then
@@ -664,8 +707,10 @@ fn no_java_peek_copies_the_handle() {
     let mut frames = 0usize;
     let mut writes = 0usize;
     let mut clones = 0usize;
+    let mut fully_shadowed: BTreeSet<String> = BTreeSet::new();
     let mut offenders: Vec<String> = Vec::new();
     for name in streaming_indicators() {
+        let mut cloning: BTreeSet<String> = BTreeSet::new();
         let (func, enums) = load_indicator(&name);
         let registry = Registry::from_dir(&input_dir());
         let helpers = HelperRegistry::from_dir(&input_dir().join("helpers"));
@@ -728,6 +773,7 @@ fn no_java_peek_copies_the_handle() {
                 });
                 if literal {
                     clones += 1;
+                    cloning.insert(f.to_string());
                 } else {
                     offenders.push(format!("{name}: clones a non-fixed-size array: {l}"));
                 }
@@ -735,13 +781,32 @@ fn no_java_peek_copies_the_handle() {
                 offenders.push(format!("{name}: {l}"));
             }
         }
+        // A frame that clones with nothing refused was never offered the wide
+        // set, and allocates per peek for nothing.
+        let accs = accumulator_fields(&s, &batch);
+        if !cloning.is_empty() && !refused_accumulator_store(peek, &accs) {
+            offenders.push(format!(
+                "{name}: clones {cloning:?} but no accumulator store is refusable"
+            ));
+        }
+        // The other half of the split. The frame must TOUCH an accumulator: a
+        // field it never names is evidence either way.
+        if cloning.is_empty() && accs.iter().any(|f| peek.contains(&format!("{f}["))) {
+            fully_shadowed.insert(name.clone());
+        }
     }
     assert!(swept > 170, "only {swept} peek(s) swept");
     assert_eq!(frames, swept, "{frames} of {swept} peek(s) run a frame");
     assert!(writes >= 500, "only {writes} local writes seen — the store sweep found nothing");
-    // A floor on the exemption itself: if the clone shape stopped being emitted
-    // the branch above would be dead and would stop discriminating.
-    assert!(clones >= 20, "only {clones} accumulator clones seen — the exemption is untested");
+    // Both sides of the split are floored, because the corpus has both and a
+    // sweep that stopped finding either would read green while measuring one.
+    assert!(clones >= 1, "no accumulator clone seen — the exemption is untested");
+    assert!(
+        fully_shadowed.len() >= 7,
+        "only {} handle(s) hold an accumulator the frame clones nothing of — the widened \
+         buffer set is no longer reaching them and peek allocates again",
+        fully_shadowed.len()
+    );
     assert!(offenders.is_empty(), "a peek copies:\n{}", offenders.join("\n"));
 }
 

--- a/ta_codegen/generator/tests/peek_suite.rs
+++ b/ta_codegen/generator/tests/peek_suite.rs
@@ -550,3 +550,129 @@ fn sma_shadows_the_store_its_own_bar_reads_and_deletes_the_one_it_does_not() {
         "exactly one load survives, and it is a load: {peek}"
     );
 }
+
+/// The handle's fixed-size REAL accumulator fields — the set
+/// `transition_buffers_with_state_arrays` offers. `handle_buffers` above cannot
+/// see them: it keys on `*`, and these are in the struct.
+fn handle_accumulators(src: &str, upper: &str) -> BTreeSet<String> {
+    let Some(body) = body_of(src, &format!("struct TA_{upper}_Stream {{")) else {
+        return BTreeSet::new();
+    };
+    let mut out = BTreeSet::new();
+    for line in body.lines() {
+        let l = line.trim().trim_end_matches(';');
+        if l.contains('*') || !l.ends_with(']') || !l.starts_with("double ") {
+            continue;
+        }
+        let Some((decl, size)) = l.rsplit_once('[') else { continue };
+        if !size.trim_end_matches(']').chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let Some((_, name)) = decl.rsplit_once(' ') else { continue };
+        if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            out.insert(name.to_string());
+        }
+    }
+    out
+}
+
+/// A store `validate_peekable` refuses: a compound one, which renders as a
+/// store reading its own target. A refusal drops the whole function back to the
+/// narrow set, so one such store justifies every copy in it. The other two
+/// refusals (a store in a loop, a counter-moving index) have no instance here;
+/// one would surface as an offender below rather than be waved through.
+fn refused_accumulator_store(body: &str, fields: &BTreeSet<String>) -> bool {
+    body.lines().any(|l| {
+        l.split_once('=').is_some_and(|(lhs, rhs)| {
+            // `!rhs.starts_with('=')`: `X[i] == X[j]` splits the same way a store
+            // does, and comparing two slots is not a store into either.
+            lhs.trim_end().ends_with(']')
+                && !rhs.starts_with('=')
+                && fields.iter().any(|f| {
+                    let sub = format!("{f}[");
+                    lhs.contains(&sub) && rhs.contains(&sub)
+                })
+        })
+    })
+}
+
+/// A peek frame deletes every accumulator store it can, and one that keeps a
+/// store shows why.
+///
+/// The refusal is per function, so ONE surviving store must be a refused shape,
+/// not each. Both floors guard a real split; `kept_by_refusal` shrinking is an
+/// improvement, so lower it rather than working around it.
+#[test]
+fn a_peek_frame_deletes_every_accumulator_store_it_can() {
+    let mut with_accumulators = 0usize;
+    let mut fully_deleted = 0usize;
+    let mut kept_by_refusal = 0usize;
+    let mut step_stores = 0usize;
+    let mut unhandled: Vec<String> = Vec::new();
+    let mut offenders: Vec<String> = Vec::new();
+
+    for name in indicators() {
+        let Some((func, enums)) = load(&name) else { continue };
+        let src = stream_c(&func, &enums);
+        let upper = func.name.to_uppercase();
+        let accs = handle_accumulators(&src, &upper);
+        if accs.is_empty() {
+            continue;
+        }
+        let Some(peek) = body_of(&src, &format!("TA_RetCode TA_{upper}_Peek(")) else {
+            unhandled.push(format!("{upper}: holds an accumulator but emits no Peek"));
+            continue;
+        };
+        // Reported, not skipped: no such handle exists today.
+        let Some(step) = body_of(&src, &format!("TA_{upper}_StepImpl(")) else {
+            unhandled.push(format!("{upper}: holds an accumulator but emits no StepImpl"));
+            continue;
+        };
+        let stored = buffer_stores(&step, &accs).len();
+        if stored == 0 {
+            continue; // nothing for the frame to delete: neither side of the split
+        }
+        with_accumulators += 1;
+        step_stores += stored;
+        if buffer_stores(&peek, &accs).is_empty() {
+            fully_deleted += 1;
+            continue;
+        }
+        kept_by_refusal += 1;
+        if !refused_accumulator_store(&peek, &accs) {
+            offenders.push(format!(
+                "{upper}: keeps {} accumulator store(s), none of them a shape \
+                 `validate_peekable` refuses",
+                buffer_stores(&peek, &accs).len()
+            ));
+        }
+    }
+
+    assert!(unhandled.is_empty(), "unswept handle(s):\n{}", unhandled.join("\n"));
+    assert!(
+        with_accumulators >= 21,
+        "only {with_accumulators} function(s) store into a fixed-size accumulator, so this \
+         sweep is looking for something that is not there"
+    );
+    assert!(
+        step_stores >= 60,
+        "the update frames carry only {step_stores} accumulator store(s), so the peek \
+         sweep proves nothing"
+    );
+    assert!(
+        fully_deleted >= 7,
+        "only {fully_deleted} function(s) had every accumulator store deleted — the \
+         widened buffer set is no longer reaching them, and Java/C# are cloning again"
+    );
+    assert!(
+        kept_by_refusal >= 1,
+        "no function keeps an accumulator store, so the refusal arm below is untested"
+    );
+    assert!(
+        offenders.is_empty(),
+        "a peek frame keeps an accumulator store with no refusal to justify it, so the \
+         widened buffer set was not offered for it ({} site(s)):\n{}",
+        offenders.len(),
+        offenders.join("\n")
+    );
+}

--- a/ta_codegen/generator/tests/rust_stream_suite.rs
+++ b/ta_codegen/generator/tests/rust_stream_suite.rs
@@ -6,7 +6,7 @@
 //! check: the transition build panics on a cursor/startIdx leak, so a clean
 //! render proves the analyzer normalizations fired.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use ta_codegen_lib::helper_registry::HelperRegistry;
 use ta_codegen_lib::registry::Registry;
@@ -481,16 +481,55 @@ fn rust_composed_copy_out_is_stride_guarded() {
     );
 }
 
+/// The handle's fixed-size accumulator fields: a `[f64; N]` member.
+fn rust_accumulator_fields(section: &str) -> BTreeSet<String> {
+    section
+        .lines()
+        .filter_map(|l| l.trim_end().strip_suffix(','))
+        .filter_map(|d| d.trim().split_once(": "))
+        .filter(|(n, t)| {
+            t.starts_with("[f64;") && n.chars().all(|c| c.is_alphanumeric() || c == '_')
+        })
+        .map(|(n, _)| n.to_string())
+        .collect()
+}
+
+/// A store `validate_peekable` refuses: a compound one, which renders as a
+/// store reading its own target. A refusal drops the whole function back to the
+/// narrow set, so one such store justifies every copy in it. The other two
+/// refusals (a store in a loop, a counter-moving index) have no instance here;
+/// one would surface as an offender below rather than be waved through.
+fn rust_refused_accumulator_store(body: &str, fields: &BTreeSet<String>) -> bool {
+    body.lines().any(|l| {
+        l.split_once('=').is_some_and(|(lhs, rhs)| {
+            // `!rhs.starts_with('=')`: `X[i] == X[j]` splits the same way a store
+            // does, and comparing two slots is not a store into either.
+            lhs.trim_end().ends_with(']')
+                && !rhs.starts_with('=')
+                && fields.iter().any(|f| {
+                    let sub = format!("{f}[");
+                    lhs.contains(&sub) && rhs.contains(&sub)
+                })
+        })
+    })
+}
+
 /// No tier copies a handle to peek it — swept over the whole corpus.
 ///
 /// The property is structural, not a value one: a peek that copied and then
 /// wrote the copy would still answer correctly, so no value gate can see it.
 /// What it costs is the thing the frame exists to buy — a peek whose cost does
 /// not grow with the period — and the only place that is visible is here.
+///
+/// The accumulator half pins Rust's share of a decision that must be identical
+/// in all four backends; the other three sweeps cannot see a Rust-only
+/// regression, and no runtime gate can (the stores are dead).
 #[test]
 fn no_rust_peek_copies_the_handle() {
     let mut swept = 0usize;
     let mut frames = 0usize;
+    let mut localized = 0usize;
+    let mut fully_shadowed: BTreeSet<String> = BTreeSet::new();
     let mut offenders: Vec<String> = Vec::new();
     for name in streaming_indicators() {
         let s = rust_stream_section(&name);
@@ -506,12 +545,42 @@ fn no_rust_peek_copies_the_handle() {
                 offenders.push(format!("{name}: {needle}"));
             }
         }
+        let accs = rust_accumulator_fields(&s);
+        let held: BTreeSet<String> = accs
+            .iter()
+            .filter(|f| peek.contains(&format!("let mut {f} = sp.{f};")))
+            .cloned()
+            .collect();
+        localized += held.len();
+        if !held.is_empty() && !rust_refused_accumulator_store(peek, &accs) {
+            offenders.push(format!(
+                "{name}: localizes {held:?} but no accumulator store is refusable"
+            ));
+        }
+        // The frame must TOUCH an accumulator: a field it never names is
+        // evidence either way.
+        if held.is_empty() && accs.iter().any(|f| peek.contains(&format!("{f}["))) {
+            fully_shadowed.insert(name.clone());
+        }
     }
     assert!(swept > 170, "only {swept} peek(s) swept");
     assert!(
         frames == swept,
         "{} of {swept} peek(s) run a frame — the rest copy something",
         frames
+    );
+    // Both sides of the split are floored, because the corpus has both and a
+    // sweep that stopped finding either would read green while measuring one.
+    assert!(
+        localized >= 1,
+        "no accumulator is still localized, so the refusal arm above is untested"
+    );
+    assert!(
+        fully_shadowed.len() >= 7,
+        "only {} handle(s) hold an accumulator the frame localizes none of — Rust has \
+         fallen back to the narrow buffer set while the other three did not, which is \
+         exactly the per-backend divergence the widened set must never have",
+        fully_shadowed.len()
     );
     assert!(
         offenders.is_empty(),

--- a/ta_codegen/output/csharp/library/src/Core_HT_DCPERIOD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_DCPERIOD.cs
@@ -996,11 +996,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1025,25 +1023,9 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1086,8 +1068,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1095,8 +1076,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1104,8 +1084,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1113,8 +1092,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1137,8 +1115,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1146,8 +1123,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1155,8 +1131,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1164,8 +1139,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_HT_DCPHASE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_DCPHASE.cs
@@ -1140,11 +1140,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1176,25 +1174,9 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1245,8 +1227,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1254,8 +1235,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1263,8 +1243,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1272,8 +1251,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1296,8 +1274,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1305,8 +1282,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1314,8 +1290,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1323,8 +1298,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
@@ -1042,11 +1042,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1071,26 +1069,10 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outInPhase = sp.cur_outInPhase;
          double cur_outQuadrature = sp.cur_outQuadrature;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1132,8 +1114,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1141,8 +1122,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1152,8 +1132,7 @@ public partial class Core
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1161,8 +1140,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1185,8 +1163,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1194,8 +1171,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1205,8 +1181,7 @@ public partial class Core
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1214,8 +1189,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_HT_SINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_SINE.cs
@@ -1179,11 +1179,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1215,26 +1213,10 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outLeadSine = sp.cur_outLeadSine;
          double cur_outSine = sp.cur_outSine;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1285,8 +1267,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1294,8 +1275,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1303,8 +1283,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1312,8 +1291,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1336,8 +1314,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1345,8 +1322,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1354,8 +1330,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1363,8 +1338,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_HT_TRENDLINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_TRENDLINE.cs
@@ -1091,11 +1091,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1123,28 +1121,12 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1192,8 +1174,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1201,8 +1182,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1210,8 +1190,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1219,8 +1198,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1243,8 +1221,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1252,8 +1229,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1261,8 +1237,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1270,8 +1245,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_HT_TRENDMODE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_TRENDMODE.cs
@@ -1306,11 +1306,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1348,29 +1346,13 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          int cur_outInteger = sp.cur_outInteger;
          int daysInTrend = sp.daysInTrend;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double leadSine = sp.leadSine;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -1428,8 +1410,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1437,8 +1418,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1446,8 +1426,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1455,8 +1434,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1479,8 +1457,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1488,8 +1465,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1497,8 +1473,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1506,8 +1481,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/src/Core_MAMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAMA.cs
@@ -1195,11 +1195,9 @@ public partial class Core
       /// would return — the same transition, with every store it would make carried
       /// in a local instead. Never writes this handle, so peeks may run
       /// concurrently with each other.</para>
-      /// <para>It copies no buffer: the frame runs against this handle, reading its
-      /// buffers and holding what the step would commit in locals, so the cost does
-      /// not grow with the period. It does copy this indicator's fixed-size per-bar
-      /// accumulators — a few elements, a count fixed by the indicator and not by
-      /// the period — so <c>Peek</c> allocates a small bounded amount per call.</para>
+      /// <para>It copies nothing: the frame runs against this handle, reading its buffers
+      /// and holding what the step would commit in locals. The cost does not grow
+      /// with the period, and <c>Peek</c> never allocates.</para>
       /// </remarks>
       /// <param name="inReal">This bar's value for <c>inReal</c>.</param>
       /// <returns>What <see cref="Update"/> would return for this bar.</returns>
@@ -1224,27 +1222,11 @@ public partial class Core
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = new double[sp.Q1_Even.Length];
-         Array.Copy( sp.Q1_Even, Q1_Even, sp.Q1_Even.Length );
-         double[] Q1_Odd = new double[sp.Q1_Odd.Length];
-         Array.Copy( sp.Q1_Odd, Q1_Odd, sp.Q1_Odd.Length );
          double Re = sp.Re;
          double cur_outFAMA = sp.cur_outFAMA;
          double cur_outMAMA = sp.cur_outMAMA;
-         double[] detrender_Even = new double[sp.detrender_Even.Length];
-         Array.Copy( sp.detrender_Even, detrender_Even, sp.detrender_Even.Length );
-         double[] detrender_Odd = new double[sp.detrender_Odd.Length];
-         Array.Copy( sp.detrender_Odd, detrender_Odd, sp.detrender_Odd.Length );
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = new double[sp.jI_Even.Length];
-         Array.Copy( sp.jI_Even, jI_Even, sp.jI_Even.Length );
-         double[] jI_Odd = new double[sp.jI_Odd.Length];
-         Array.Copy( sp.jI_Odd, jI_Odd, sp.jI_Odd.Length );
-         double[] jQ_Even = new double[sp.jQ_Even.Length];
-         Array.Copy( sp.jQ_Even, jQ_Even, sp.jQ_Even.Length );
-         double[] jQ_Odd = new double[sp.jQ_Odd.Length];
-         Array.Copy( sp.jQ_Odd, jQ_Odd, sp.jQ_Odd.Length );
          double mama = sp.mama;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -1288,8 +1270,7 @@ public partial class Core
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1297,8 +1278,7 @@ public partial class Core
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1306,8 +1286,7 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1315,8 +1294,7 @@ public partial class Core
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1345,8 +1323,7 @@ public partial class Core
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1354,8 +1331,7 @@ public partial class Core
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1363,8 +1339,7 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1372,8 +1347,7 @@ public partial class Core
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/csharp/library/test/StreamApiTest.cs
+++ b/ta_codegen/output/csharp/library/test/StreamApiTest.cs
@@ -887,6 +887,56 @@ public static class StreamApiTest
         Check(after == before, $"Update allocates nothing ({after - before} bytes over {closes.Length - 400} bars)");
     }
 
+    /// <summary>
+    /// Peek allocates nothing on a handle whose accumulator stores the frame
+    /// could delete.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the C# half of a property no value gate can see, and the
+    /// only backend where it is worth measuring at runtime: a C# array field is
+    /// a reference, so a frame that copied one would allocate — and RyuJIT does
+    /// not stack-allocate arrays, so the bytes are real. Java's escape analysis
+    /// can hide the same copy, and C and Rust never had it.</para>
+    /// <para>HT_DCPERIOD is the sharpest case in the corpus, with eight
+    /// <c>double[3]</c> accumulators — 384 B per call when they are copied. SMA
+    /// is the control: no accumulator, so it reads zero either way, and a run
+    /// that reported zero for both would still fail if the sweep stopped
+    /// running.</para>
+    /// </remarks>
+    private static void PeekDoesNotAllocate()
+    {
+        var core = new Core();
+        double[] closes = Closes(4000);
+
+        Core.HtDcperiodStream ht = core.HtDcperiodOpen(closes[..200]);
+        Core.SmaStream sma = core.SmaOpen(closes[..40], 30);
+
+        // Warm up: first-call JIT and any lazy init must not be attributed.
+        double sink = 0;
+        int calls = 0;
+        for (int t = 200; t < 600; t++)
+        {
+            sink += ht.Peek(closes[t]) + sma.Peek(closes[t]);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int t = 600; t < closes.Length; t++)
+        {
+            sink += ht.Peek(closes[t]) + sma.Peek(closes[t]);
+            calls += 2;
+        }
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        // A byte count of zero reads the same whether the sweep ran or not, so
+        // both are asserted: the call count, and a sink no run of these two
+        // functions can leave at its initial value.
+        Check(calls >= 6000, $"the Peek sweep ran ({calls} calls)");
+        Check(sink != 0 && !double.IsNaN(sink), "the Peek sweep produced values");
+        Check(after == before,
+              $"Peek allocates nothing ({after - before} bytes over {calls} calls, half "
+              + "of them HT_DCPERIOD's eight fixed-size accumulators)");
+    }
+
     /// <summary>Multi-output handles return a value type, not a fresh object.</summary>
     private static void MultiOutputValueIsAStruct()
     {
@@ -1479,6 +1529,7 @@ public static class StreamApiTest
         IntegerSentinelSelectsTheDocumentedDefault();
         SettingsAreCapturedFromTheOpeningCore();
         UpdateDoesNotAllocate();
+        PeekDoesNotAllocate();
         MultiOutputValueIsAStruct();
         CatalogueAgreesWithTheEmittedSurface();
         NonFiniteInputsAreRejected();

--- a/ta_codegen/output/java/fragments/Core_ACCBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_ACCBANDS.java
@@ -581,9 +581,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_AROON.java
+++ b/ta_codegen/output/java/fragments/Core_AROON.java
@@ -534,9 +534,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )

--- a/ta_codegen/output/java/fragments/Core_BBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_BBANDS.java
@@ -924,9 +924,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
@@ -466,10 +466,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
@@ -466,10 +466,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
@@ -605,10 +605,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
@@ -622,10 +622,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
@@ -675,10 +675,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
@@ -467,10 +467,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
@@ -487,10 +487,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
@@ -517,10 +517,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLKICKING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKING.java
@@ -490,10 +490,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
@@ -485,10 +485,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
@@ -561,10 +561,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
@@ -442,10 +442,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
@@ -540,10 +540,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
@@ -607,10 +607,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
@@ -957,12 +957,9 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -985,17 +982,9 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1038,8 +1027,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1047,8 +1035,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1056,8 +1043,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1065,8 +1051,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1089,8 +1074,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1098,8 +1082,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1107,8 +1090,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1116,8 +1098,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
@@ -1102,12 +1102,9 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1137,17 +1134,9 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1198,8 +1187,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1207,8 +1195,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1216,8 +1203,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1225,8 +1211,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1249,8 +1234,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1258,8 +1242,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1267,8 +1250,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1276,8 +1258,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
+++ b/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
@@ -1016,10 +1016,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1042,18 +1040,10 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outInPhase = sp.cur_outInPhase;
          double cur_outQuadrature = sp.cur_outQuadrature;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1095,8 +1085,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1104,8 +1093,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1115,8 +1103,7 @@
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1124,8 +1111,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1148,8 +1134,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1157,8 +1142,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1168,8 +1152,7 @@
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1177,8 +1160,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_HT_SINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_SINE.java
@@ -1150,10 +1150,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1183,18 +1181,10 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outLeadSine = sp.cur_outLeadSine;
          double cur_outSine = sp.cur_outSine;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1245,8 +1235,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1254,8 +1243,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1263,8 +1251,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1272,8 +1259,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1296,8 +1282,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1305,8 +1290,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1314,8 +1298,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1323,8 +1306,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
@@ -1047,12 +1047,9 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1078,20 +1075,12 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -1139,8 +1128,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1148,8 +1136,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1157,8 +1144,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1166,8 +1152,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1190,8 +1175,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1199,8 +1183,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1208,8 +1191,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1217,8 +1199,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
@@ -1266,12 +1266,9 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public int peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1307,21 +1304,13 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          int cur_outInteger = sp.cur_outInteger;
          int daysInTrend = sp.daysInTrend;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double leadSine = sp.leadSine;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -1379,8 +1368,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1388,8 +1376,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1397,8 +1384,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1406,8 +1392,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1430,8 +1415,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1439,8 +1423,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1448,8 +1431,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1457,8 +1439,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_MACD.java
+++ b/ta_codegen/output/java/fragments/Core_MACD.java
@@ -726,9 +726,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_MACDEXT.java
+++ b/ta_codegen/output/java/fragments/Core_MACDEXT.java
@@ -714,9 +714,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_MACDFIX.java
+++ b/ta_codegen/output/java/fragments/Core_MACDFIX.java
@@ -634,9 +634,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_MAMA.java
+++ b/ta_codegen/output/java/fragments/Core_MAMA.java
@@ -1166,10 +1166,8 @@
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -1192,19 +1190,11 @@
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outFAMA = sp.cur_outFAMA;
          double cur_outMAMA = sp.cur_outMAMA;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double mama = sp.mama;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -1248,8 +1238,7 @@
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1257,8 +1246,7 @@
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1266,8 +1254,7 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1275,8 +1262,7 @@
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1305,8 +1291,7 @@
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1314,8 +1299,7 @@
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1323,8 +1307,7 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1332,8 +1315,7 @@
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/java/fragments/Core_MINMAX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAX.java
@@ -647,9 +647,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
@@ -515,9 +515,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/fragments/Core_SMI.java
+++ b/ta_codegen/output/java/fragments/Core_SMI.java
@@ -979,9 +979,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_STOCH.java
+++ b/ta_codegen/output/java/fragments/Core_STOCH.java
@@ -835,9 +835,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_STOCHF.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHF.java
@@ -752,9 +752,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )

--- a/ta_codegen/output/java/fragments/Core_STOCHRSI.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHRSI.java
@@ -557,9 +557,10 @@
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -2193,9 +2193,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -9201,9 +9202,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
@@ -14255,9 +14257,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -18973,10 +18976,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -20669,10 +20670,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -22238,10 +22237,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -23389,10 +23386,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -25610,10 +25605,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -29068,10 +29061,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -29925,10 +29916,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -45294,10 +45283,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -47959,10 +47946,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -48819,10 +48804,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -53621,10 +53604,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -57307,10 +57288,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -59065,10 +59044,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -63454,10 +63431,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -83989,12 +83964,9 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -84017,17 +83989,9 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -84070,8 +84034,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -84079,8 +84042,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -84088,8 +84050,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -84097,8 +84058,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -84121,8 +84081,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -84130,8 +84089,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -84139,8 +84097,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -84148,8 +84105,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -85958,12 +85914,9 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -85993,17 +85946,9 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -86054,8 +85999,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -86063,8 +86007,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -86072,8 +86015,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -86081,8 +86023,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -86105,8 +86046,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -86114,8 +86054,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -86123,8 +86062,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -86132,8 +86070,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -88030,10 +87967,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -88056,18 +87991,10 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outInPhase = sp.cur_outInPhase;
          double cur_outQuadrature = sp.cur_outQuadrature;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -88109,8 +88036,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -88118,8 +88044,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -88129,8 +88054,7 @@ public final class Core {
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -88138,8 +88062,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -88162,8 +88085,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -88171,8 +88093,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -88182,8 +88103,7 @@ public final class Core {
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -88191,8 +88111,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -90055,10 +89974,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -90088,18 +90005,10 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outLeadSine = sp.cur_outLeadSine;
          double cur_outSine = sp.cur_outSine;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -90150,8 +90059,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -90159,8 +90067,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -90168,8 +90075,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -90177,8 +90083,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -90201,8 +90106,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -90210,8 +90114,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -90219,8 +90122,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -90228,8 +90130,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -92167,12 +92068,9 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public double peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -92198,20 +92096,12 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outReal = sp.cur_outReal;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -92259,8 +92149,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -92268,8 +92157,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -92277,8 +92165,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -92286,8 +92173,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -92310,8 +92196,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -92319,8 +92204,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -92328,8 +92212,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -92337,8 +92220,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -94431,12 +94313,9 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period and {@code peek} never allocates.
        */
       public int peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -94472,21 +94351,13 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          int cur_outInteger = sp.cur_outInteger;
          int daysInTrend = sp.daysInTrend;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
          double iTrend3 = sp.iTrend3;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double leadSine = sp.leadSine;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -94544,8 +94415,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -94553,8 +94423,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -94562,8 +94431,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -94571,8 +94439,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -94595,8 +94462,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -94604,8 +94470,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -94613,8 +94478,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -94622,8 +94486,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -104820,9 +104683,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -105901,9 +105765,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -106848,9 +106713,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -108356,10 +108222,8 @@ public final class Core {
        * Never writes this handle, so peeks may
        * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period. It does clone this indicator's fixed-size
-       * per-bar accumulators — a few elements, a count fixed by the indicator and
-       * not by the period — so {@code peek} allocates a small bounded amount per
-       * call.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -108382,19 +108246,11 @@ public final class Core {
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
-         double[] Q1_Even = sp.Q1_Even.clone();
-         double[] Q1_Odd = sp.Q1_Odd.clone();
          double Re = sp.Re;
          double cur_outFAMA = sp.cur_outFAMA;
          double cur_outMAMA = sp.cur_outMAMA;
-         double[] detrender_Even = sp.detrender_Even.clone();
-         double[] detrender_Odd = sp.detrender_Odd.clone();
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
-         double[] jI_Even = sp.jI_Even.clone();
-         double[] jI_Odd = sp.jI_Odd.clone();
-         double[] jQ_Even = sp.jQ_Even.clone();
-         double[] jQ_Odd = sp.jQ_Odd.clone();
          double mama = sp.mama;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -108438,8 +108294,7 @@ public final class Core {
          if( streamParity == 0 ) {
             /* Do the Hilbert Transforms for even price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Even[hilbertIdx];
-            detrender_Even[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Even[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Even;
             prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -108447,8 +108302,7 @@ public final class Core {
             prev_detrender_input_Even = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Even[hilbertIdx];
-            Q1_Even[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Even[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Even;
             prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -108456,8 +108310,7 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - jI_Even[hilbertIdx];
-            jI_Even[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Even[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -108465,8 +108318,7 @@ public final class Core {
             prev_jI_input_Even = I1ForEvenPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Even[hilbertIdx];
-            jQ_Even[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Even[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -108495,8 +108347,7 @@ public final class Core {
          } else {
             /* Do the Hilbert Transforms for odd price bar */
             hilbertTempReal = sp.a * smoothedValue;
-            detrender = 0 - detrender_Odd[hilbertIdx];
-            detrender_Odd[hilbertIdx] = hilbertTempReal;
+            detrender = 0 - sp.detrender_Odd[hilbertIdx];
             detrender += hilbertTempReal;
             detrender -= prev_detrender_Odd;
             prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -108504,8 +108355,7 @@ public final class Core {
             prev_detrender_input_Odd = smoothedValue;
             detrender *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * detrender;
-            Q1 = 0 - Q1_Odd[hilbertIdx];
-            Q1_Odd[hilbertIdx] = hilbertTempReal;
+            Q1 = 0 - sp.Q1_Odd[hilbertIdx];
             Q1 += hilbertTempReal;
             Q1 -= prev_Q1_Odd;
             prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -108513,8 +108363,7 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - jI_Odd[hilbertIdx];
-            jI_Odd[hilbertIdx] = hilbertTempReal;
+            jI = 0 - sp.jI_Odd[hilbertIdx];
             jI += hilbertTempReal;
             jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -108522,8 +108371,7 @@ public final class Core {
             prev_jI_input_Odd = I1ForOddPrev3;
             jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - jQ_Odd[hilbertIdx];
-            jQ_Odd[hilbertIdx] = hilbertTempReal;
+            jQ = 0 - sp.jQ_Odd[hilbertIdx];
             jQ += hilbertTempReal;
             jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -118124,9 +117972,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -119010,9 +118859,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )
@@ -139808,9 +139658,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -142321,9 +142172,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -143652,9 +143504,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inHigh, double inLow, double inClose ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -144759,9 +144612,10 @@ public final class Core {
        * next {@code update} with the same bar would return — the same
        * transition, with every store it would make carried in a local instead.
        * Never writes this handle, so peeks may
-       * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+       * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
        * buffers and storing what the step would commit into locals, so the cost
-       * does not grow with the period and {@code peek} never allocates.
+       * does not grow with the period. It does allocate a small bounded amount
+       * per call — a size fixed by the indicator, never by the period.
        */
       public Value peek( double inReal ) {
          if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -1867,9 +1867,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -8875,9 +8876,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inHigh, double inLow ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
@@ -13929,9 +13931,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -18647,10 +18650,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -20343,10 +20344,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -21912,10 +21911,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -23063,10 +23060,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -25284,10 +25279,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -28742,10 +28735,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -29599,10 +29590,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -44968,10 +44957,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -47633,10 +47620,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -48493,10 +48478,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -53295,10 +53278,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -56981,10 +56962,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -58739,10 +58718,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -63128,10 +63105,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public int peek( double inOpen, double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -83663,12 +83638,9 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period and {@code peek} never allocates.
            */
           public double peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -83691,17 +83663,9 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outReal = sp.cur_outReal;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -83744,8 +83708,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -83753,8 +83716,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -83762,8 +83724,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -83771,8 +83732,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -83795,8 +83755,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -83804,8 +83763,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -83813,8 +83771,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -83822,8 +83779,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -85632,12 +85588,9 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period and {@code peek} never allocates.
            */
           public double peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -85667,17 +85620,9 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outReal = sp.cur_outReal;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -85728,8 +85673,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -85737,8 +85681,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -85746,8 +85689,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -85755,8 +85697,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -85779,8 +85720,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -85788,8 +85728,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -85797,8 +85736,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -85806,8 +85744,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -87704,10 +87641,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -87730,18 +87665,10 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outInPhase = sp.cur_outInPhase;
              double cur_outQuadrature = sp.cur_outQuadrature;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -87783,8 +87710,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -87792,8 +87718,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -87803,8 +87728,7 @@ class Core {
                 cur_outQuadrature = Q1;
                 cur_outInPhase = I1ForEvenPrev3;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -87812,8 +87736,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -87836,8 +87759,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -87845,8 +87767,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -87856,8 +87777,7 @@ class Core {
                 cur_outQuadrature = Q1;
                 cur_outInPhase = I1ForOddPrev3;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -87865,8 +87785,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -89729,10 +89648,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -89762,18 +89679,10 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outLeadSine = sp.cur_outLeadSine;
              double cur_outSine = sp.cur_outSine;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -89824,8 +89733,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -89833,8 +89741,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -89842,8 +89749,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -89851,8 +89757,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -89875,8 +89780,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -89884,8 +89788,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -89893,8 +89796,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -89902,8 +89804,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -91841,12 +91742,9 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period and {@code peek} never allocates.
            */
           public double peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -91872,20 +91770,12 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outReal = sp.cur_outReal;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
              double iTrend1 = sp.iTrend1;
              double iTrend2 = sp.iTrend2;
              double iTrend3 = sp.iTrend3;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -91933,8 +91823,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -91942,8 +91831,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -91951,8 +91839,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -91960,8 +91847,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -91984,8 +91870,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -91993,8 +91878,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -92002,8 +91886,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -92011,8 +91894,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -94105,12 +93987,9 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period and {@code peek} never allocates.
            */
           public int peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -94146,21 +94025,13 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              int cur_outInteger = sp.cur_outInteger;
              int daysInTrend = sp.daysInTrend;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              int hilbertIdx = sp.hilbertIdx;
              double iTrend1 = sp.iTrend1;
              double iTrend2 = sp.iTrend2;
              double iTrend3 = sp.iTrend3;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double leadSine = sp.leadSine;
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
@@ -94218,8 +94089,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -94227,8 +94097,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -94236,8 +94105,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -94245,8 +94113,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -94269,8 +94136,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -94278,8 +94144,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -94287,8 +94152,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -94296,8 +94160,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -104494,9 +104357,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -105575,9 +105439,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -106522,9 +106387,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -108030,10 +107896,8 @@ class Core {
            * Never writes this handle, so peeks may
            * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period. It does clone this indicator's fixed-size
-           * per-bar accumulators — a few elements, a count fixed by the indicator and
-           * not by the period — so {@code peek} allocates a small bounded amount per
-           * call.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -108056,19 +107920,11 @@ class Core {
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
-             double[] Q1_Even = sp.Q1_Even.clone();
-             double[] Q1_Odd = sp.Q1_Odd.clone();
              double Re = sp.Re;
              double cur_outFAMA = sp.cur_outFAMA;
              double cur_outMAMA = sp.cur_outMAMA;
-             double[] detrender_Even = sp.detrender_Even.clone();
-             double[] detrender_Odd = sp.detrender_Odd.clone();
              double fama = sp.fama;
              int hilbertIdx = sp.hilbertIdx;
-             double[] jI_Even = sp.jI_Even.clone();
-             double[] jI_Odd = sp.jI_Odd.clone();
-             double[] jQ_Even = sp.jQ_Even.clone();
-             double[] jQ_Odd = sp.jQ_Odd.clone();
              double mama = sp.mama;
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
@@ -108112,8 +107968,7 @@ class Core {
              if( streamParity == 0 ) {
                 /* Do the Hilbert Transforms for even price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -108121,8 +107976,7 @@ class Core {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -108130,8 +107984,7 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -108139,8 +107992,7 @@ class Core {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -108169,8 +108021,7 @@ class Core {
              } else {
                 /* Do the Hilbert Transforms for odd price bar */
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -108178,8 +108029,7 @@ class Core {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -108187,8 +108037,7 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -108196,8 +108045,7 @@ class Core {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
@@ -117798,9 +117646,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -118684,9 +118533,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )
@@ -139482,9 +139332,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -141995,9 +141846,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -143326,9 +143178,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inHigh, double inLow, double inClose ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
@@ -144433,9 +144286,10 @@ class Core {
            * next {@code update} with the same bar would return — the same
            * transition, with every store it would make carried in a local instead.
            * Never writes this handle, so peeks may
-           * run concurrently with each other. It copies nothing: the frame runs against this handle, reading its
+           * run concurrently with each other. It copies no buffer: the frame runs against this handle, reading its
            * buffers and storing what the step would commit into locals, so the cost
-           * does not grow with the period and {@code peek} never allocates.
+           * does not grow with the period. It does allocate a small bounded amount
+           * per call — a size fixed by the indicator, never by the period.
            */
           public Value peek( double inReal ) {
              if( !Double.isFinite(inReal) )

--- a/ta_codegen/output/rust/library/src/ta_func/ac.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ac.rs
@@ -936,8 +936,8 @@ impl AcStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/accbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/accbands.rs
@@ -831,8 +831,8 @@ impl AccbandsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/acos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/acos.rs
@@ -439,8 +439,8 @@ impl AcosStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ad.rs
@@ -561,8 +561,8 @@ impl AdStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/add.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/add.rs
@@ -456,8 +456,8 @@ impl AddStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/adosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adosc.rs
@@ -821,8 +821,8 @@ impl AdoscStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/adx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adx.rs
@@ -1264,8 +1264,8 @@ impl AdxStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/adxr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/adxr.rs
@@ -631,8 +631,8 @@ impl AdxrStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ao.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ao.rs
@@ -780,8 +780,8 @@ impl AoStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/apo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/apo.rs
@@ -634,8 +634,8 @@ impl ApoStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/aroon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroon.rs
@@ -756,8 +756,8 @@ impl AroonStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/aroonosc.rs
@@ -764,8 +764,8 @@ impl AroonoscStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/asin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/asin.rs
@@ -438,8 +438,8 @@ impl AsinStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/atan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atan.rs
@@ -441,8 +441,8 @@ impl AtanStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/atr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/atr.rs
@@ -793,8 +793,8 @@ impl AtrStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgdev.rs
@@ -560,8 +560,8 @@ impl AvgdevStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/avgprice.rs
@@ -486,8 +486,8 @@ impl AvgpriceStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/bbands.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bbands.rs
@@ -1035,8 +1035,8 @@ impl BbandsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/beta.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/beta.rs
@@ -1384,8 +1384,8 @@ impl BetaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/bop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/bop.rs
@@ -516,8 +516,8 @@ impl BopStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cci.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cci.rs
@@ -762,8 +762,8 @@ impl CciStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl2crows.rs
@@ -829,8 +829,8 @@ impl Cdl2crowsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3blackcrows.rs
@@ -914,8 +914,8 @@ impl Cdl3blackcrowsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3inside.rs
@@ -1032,8 +1032,8 @@ impl Cdl3insideStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3linestrike.rs
@@ -869,8 +869,8 @@ impl Cdl3linestrikeStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3outside.rs
@@ -579,8 +579,8 @@ impl Cdl3outsideStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3starsinsouth.rs
@@ -1488,8 +1488,8 @@ impl Cdl3starsinsouthStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdl3whitesoldiers.rs
@@ -1582,8 +1582,8 @@ impl Cdl3whitesoldiersStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlabandonedbaby.rs
@@ -1324,8 +1324,8 @@ impl CdlabandonedbabyStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdladvanceblock.rs
@@ -1791,8 +1791,8 @@ impl CdladvanceblockStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbelthold.rs
@@ -988,8 +988,8 @@ impl CdlbeltholdStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlbreakaway.rs
@@ -828,8 +828,8 @@ impl CdlbreakawayStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlclosingmarubozu.rs
@@ -989,8 +989,8 @@ impl CdlclosingmarubozuStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlconcealbabyswall.rs
@@ -914,8 +914,8 @@ impl CdlconcealbabyswallStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlcounterattack.rs
@@ -1026,8 +1026,8 @@ impl CdlcounterattackStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldarkcloudcover.rs
@@ -834,8 +834,8 @@ impl CdldarkcloudcoverStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldoji.rs
@@ -768,8 +768,8 @@ impl CdldojiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldojistar.rs
@@ -1013,8 +1013,8 @@ impl CdldojistarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdldragonflydoji.rs
@@ -992,8 +992,8 @@ impl CdldragonflydojiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlengulfing.rs
@@ -589,8 +589,8 @@ impl CdlengulfingStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningdojistar.rs
@@ -1292,8 +1292,8 @@ impl CdleveningdojistarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdleveningstar.rs
@@ -1179,8 +1179,8 @@ impl CdleveningstarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgapsidesidewhite.rs
@@ -1007,8 +1007,8 @@ impl CdlgapsidesidewhiteStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlgravestonedoji.rs
@@ -992,8 +992,8 @@ impl CdlgravestonedojiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhammer.rs
@@ -1438,8 +1438,8 @@ impl CdlhammerStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhangingman.rs
@@ -1441,8 +1441,8 @@ impl CdlhangingmanStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharami.rs
@@ -1059,8 +1059,8 @@ impl CdlharamiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlharamicross.rs
@@ -1058,8 +1058,8 @@ impl CdlharamicrossStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhighwave.rs
@@ -985,8 +985,8 @@ impl CdlhighwaveStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkake.rs
@@ -690,8 +690,8 @@ impl CdlhikkakeStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhikkakemod.rs
@@ -999,8 +999,8 @@ impl CdlhikkakemodStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlhomingpigeon.rs
@@ -1004,8 +1004,8 @@ impl CdlhomingpigeonStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlidentical3crows.rs
@@ -1136,8 +1136,8 @@ impl Cdlidentical3crowsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinneck.rs
@@ -988,8 +988,8 @@ impl CdlinneckStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlinvertedhammer.rs
@@ -1222,8 +1222,8 @@ impl CdlinvertedhammerStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkicking.rs
@@ -1049,8 +1049,8 @@ impl CdlkickingStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlkickingbylength.rs
@@ -1056,8 +1056,8 @@ impl CdlkickingbylengthStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlladderbottom.rs
@@ -831,8 +831,8 @@ impl CdlladderbottomStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongleggeddoji.rs
@@ -986,8 +986,8 @@ impl CdllongleggeddojiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdllongline.rs
@@ -983,8 +983,8 @@ impl CdllonglineStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmarubozu.rs
@@ -981,8 +981,8 @@ impl CdlmarubozuStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmatchinglow.rs
@@ -781,8 +781,8 @@ impl CdlmatchinglowStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmathold.rs
@@ -1176,8 +1176,8 @@ impl CdlmatholdStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningdojistar.rs
@@ -1331,8 +1331,8 @@ impl CdlmorningdojistarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlmorningstar.rs
@@ -1217,8 +1217,8 @@ impl CdlmorningstarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlonneck.rs
@@ -987,8 +987,8 @@ impl CdlonneckStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlpiercing.rs
@@ -868,8 +868,8 @@ impl CdlpiercingStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrickshawman.rs
@@ -1212,8 +1212,8 @@ impl CdlrickshawmanStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlrisefall3methods.rs
@@ -1253,8 +1253,8 @@ impl Cdlrisefall3methodsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlseparatinglines.rs
@@ -1214,8 +1214,8 @@ impl CdlseparatinglinesStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshootingstar.rs
@@ -1224,8 +1224,8 @@ impl CdlshootingstarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlshortline.rs
@@ -983,8 +983,8 @@ impl CdlshortlineStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlspinningtop.rs
@@ -771,8 +771,8 @@ impl CdlspinningtopStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlstalledpattern.rs
@@ -1503,8 +1503,8 @@ impl CdlstalledpatternStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlsticksandwich.rs
@@ -806,8 +806,8 @@ impl CdlsticksandwichStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltakuri.rs
@@ -1204,8 +1204,8 @@ impl CdltakuriStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltasukigap.rs
@@ -826,8 +826,8 @@ impl CdltasukigapStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlthrusting.rs
@@ -1026,8 +1026,8 @@ impl CdlthrustingStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdltristar.rs
@@ -838,8 +838,8 @@ impl CdltristarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlunique3river.rs
@@ -1044,8 +1044,8 @@ impl Cdlunique3riverStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlupsidegap2crows.rs
@@ -1047,8 +1047,8 @@ impl Cdlupsidegap2crowsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cdlxsidegap3methods.rs
@@ -601,8 +601,8 @@ impl Cdlxsidegap3methodsStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ceil.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ceil.rs
@@ -438,8 +438,8 @@ impl CeilStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cmf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmf.rs
@@ -790,8 +790,8 @@ impl CmfStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cmo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmo.rs
@@ -904,8 +904,8 @@ impl CmoStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cmou.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmou.rs
@@ -810,8 +810,8 @@ impl CmouStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -1150,8 +1150,8 @@ impl CorrelStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cos.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cos.rs
@@ -438,8 +438,8 @@ impl CosStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/cosh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cosh.rs
@@ -437,8 +437,8 @@ impl CoshStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/dema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dema.rs
@@ -779,8 +779,8 @@ impl DemaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/div.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/div.rs
@@ -456,8 +456,8 @@ impl DivStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/dx.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dx.rs
@@ -1142,8 +1142,8 @@ impl DxStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/efi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/efi.rs
@@ -827,8 +827,8 @@ impl EfiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ema.rs
@@ -665,8 +665,8 @@ impl EmaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/exp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/exp.rs
@@ -438,8 +438,8 @@ impl ExpStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/floor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/floor.rs
@@ -436,8 +436,8 @@ impl FloorStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/hma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/hma.rs
@@ -1612,8 +1612,8 @@ impl HmaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcperiod.rs
@@ -1334,8 +1334,8 @@ impl HtDcperiodStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1368,16 +1368,8 @@ impl HtDcperiodStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
             let mut periodWMASum = sp.periodWMASum;
@@ -1420,8 +1412,7 @@ impl HtDcperiodStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1429,8 +1420,7 @@ impl HtDcperiodStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1438,8 +1428,7 @@ impl HtDcperiodStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1447,8 +1436,7 @@ impl HtDcperiodStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1470,8 +1458,7 @@ impl HtDcperiodStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1479,8 +1466,7 @@ impl HtDcperiodStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1488,8 +1474,7 @@ impl HtDcperiodStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1497,8 +1482,7 @@ impl HtDcperiodStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_dcphase.rs
@@ -1555,8 +1555,8 @@ impl HtDcphaseStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1596,16 +1596,8 @@ impl HtDcphaseStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
             let mut periodWMASum = sp.periodWMASum;
@@ -1655,8 +1647,7 @@ impl HtDcphaseStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1664,8 +1655,7 @@ impl HtDcphaseStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1673,8 +1663,7 @@ impl HtDcphaseStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1682,8 +1671,7 @@ impl HtDcphaseStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1705,8 +1693,7 @@ impl HtDcphaseStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1714,8 +1701,7 @@ impl HtDcphaseStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1723,8 +1709,7 @@ impl HtDcphaseStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1732,8 +1717,7 @@ impl HtDcphaseStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
@@ -1369,8 +1369,8 @@ impl HtPhasorStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1405,16 +1405,8 @@ impl HtPhasorStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
             let mut periodWMASum = sp.periodWMASum;
@@ -1456,8 +1448,7 @@ impl HtPhasorStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1465,8 +1456,7 @@ impl HtPhasorStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1476,8 +1466,7 @@ impl HtPhasorStream {
                 (*outQuadrature) = Q1;
                 (*outInPhase) = I1ForEvenPrev3;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1485,8 +1474,7 @@ impl HtPhasorStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1508,8 +1496,7 @@ impl HtPhasorStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1517,8 +1504,7 @@ impl HtPhasorStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1528,8 +1514,7 @@ impl HtPhasorStream {
                 (*outQuadrature) = Q1;
                 (*outInPhase) = I1ForOddPrev3;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1537,8 +1522,7 @@ impl HtPhasorStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_sine.rs
@@ -1592,8 +1592,8 @@ impl HtSineStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1635,16 +1635,8 @@ impl HtSineStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
             let mut periodWMASum = sp.periodWMASum;
@@ -1694,8 +1686,7 @@ impl HtSineStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1703,8 +1694,7 @@ impl HtSineStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1712,8 +1702,7 @@ impl HtSineStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1721,8 +1710,7 @@ impl HtSineStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1744,8 +1732,7 @@ impl HtSineStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1753,8 +1740,7 @@ impl HtSineStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1762,8 +1748,7 @@ impl HtSineStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1771,8 +1756,7 @@ impl HtSineStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendline.rs
@@ -1487,8 +1487,8 @@ impl HtTrendlineStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1524,19 +1524,11 @@ impl HtTrendlineStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
             let mut iTrend1 = sp.iTrend1;
             let mut iTrend2 = sp.iTrend2;
             let mut iTrend3 = sp.iTrend3;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
             let mut periodWMASum = sp.periodWMASum;
@@ -1584,8 +1576,7 @@ impl HtTrendlineStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1593,8 +1584,7 @@ impl HtTrendlineStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1602,8 +1592,7 @@ impl HtTrendlineStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1611,8 +1600,7 @@ impl HtTrendlineStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1634,8 +1622,7 @@ impl HtTrendlineStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1643,8 +1630,7 @@ impl HtTrendlineStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1652,8 +1638,7 @@ impl HtTrendlineStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1661,8 +1646,7 @@ impl HtTrendlineStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_trendmode.rs
@@ -1815,8 +1815,8 @@ impl HtTrendmodeStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1862,20 +1862,12 @@ impl HtTrendmodeStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
             let mut daysInTrend = sp.daysInTrend;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut hilbertIdx = sp.hilbertIdx;
             let mut iTrend1 = sp.iTrend1;
             let mut iTrend2 = sp.iTrend2;
             let mut iTrend3 = sp.iTrend3;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut leadSine = sp.leadSine;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
@@ -1932,8 +1924,7 @@ impl HtTrendmodeStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1941,8 +1932,7 @@ impl HtTrendmodeStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1950,8 +1940,7 @@ impl HtTrendmodeStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1959,8 +1948,7 @@ impl HtTrendmodeStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1982,8 +1970,7 @@ impl HtTrendmodeStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1991,8 +1978,7 @@ impl HtTrendmodeStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -2000,8 +1986,7 @@ impl HtTrendmodeStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -2009,8 +1994,7 @@ impl HtTrendmodeStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/imi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/imi.rs
@@ -602,8 +602,8 @@ impl ImiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -987,8 +987,8 @@ impl KamaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg.rs
@@ -973,8 +973,8 @@ impl LinearregStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_angle.rs
@@ -938,8 +938,8 @@ impl LinearregAngleStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_intercept.rs
@@ -931,8 +931,8 @@ impl LinearregInterceptStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/linearreg_slope.rs
@@ -928,8 +928,8 @@ impl LinearregSlopeStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ln.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ln.rs
@@ -439,8 +439,8 @@ impl LnStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/log10.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/log10.rs
@@ -438,8 +438,8 @@ impl Log10Stream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ma.rs
@@ -855,8 +855,8 @@ impl MaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/macd.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macd.rs
@@ -979,8 +979,8 @@ impl MacdStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/macdext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdext.rs
@@ -887,8 +887,8 @@ impl MacdextStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/macdfix.rs
@@ -892,8 +892,8 @@ impl MacdfixStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -1568,8 +1568,8 @@ impl MamaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors
@@ -1604,17 +1604,9 @@ impl MamaStream {
             let mut I1ForOddPrev2 = sp.I1ForOddPrev2;
             let mut I1ForOddPrev3 = sp.I1ForOddPrev3;
             let mut Im = sp.Im;
-            let mut Q1_Even = sp.Q1_Even;
-            let mut Q1_Odd = sp.Q1_Odd;
             let mut Re = sp.Re;
-            let mut detrender_Even = sp.detrender_Even;
-            let mut detrender_Odd = sp.detrender_Odd;
             let mut fama = sp.fama;
             let mut hilbertIdx = sp.hilbertIdx;
-            let mut jI_Even = sp.jI_Even;
-            let mut jI_Odd = sp.jI_Odd;
-            let mut jQ_Even = sp.jQ_Even;
-            let mut jQ_Odd = sp.jQ_Odd;
             let mut mama = sp.mama;
             let mut period = sp.period;
             let mut periodWMASub = sp.periodWMASub;
@@ -1658,8 +1650,7 @@ impl MamaStream {
             if streamParity == 0 {
                 // Do the Hilbert Transforms for even price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Even[hilbertIdx];
-                detrender_Even[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Even[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Even;
                 prev_detrender_Even = sp.b * prev_detrender_input_Even;
@@ -1667,8 +1658,7 @@ impl MamaStream {
                 prev_detrender_input_Even = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Even[hilbertIdx];
-                Q1_Even[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Even[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Even;
                 prev_Q1_Even = sp.b * prev_Q1_input_Even;
@@ -1676,8 +1666,7 @@ impl MamaStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - jI_Even[hilbertIdx];
-                jI_Even[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Even[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
@@ -1685,8 +1674,7 @@ impl MamaStream {
                 prev_jI_input_Even = I1ForEvenPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Even[hilbertIdx];
-                jQ_Even[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
@@ -1714,8 +1702,7 @@ impl MamaStream {
             } else {
                 // Do the Hilbert Transforms for odd price bar
                 hilbertTempReal = sp.a * smoothedValue;
-                detrender = 0_f64 - detrender_Odd[hilbertIdx];
-                detrender_Odd[hilbertIdx] = hilbertTempReal;
+                detrender = 0_f64 - sp.detrender_Odd[hilbertIdx];
                 detrender += hilbertTempReal;
                 detrender -= prev_detrender_Odd;
                 prev_detrender_Odd = sp.b * prev_detrender_input_Odd;
@@ -1723,8 +1710,7 @@ impl MamaStream {
                 prev_detrender_input_Odd = smoothedValue;
                 detrender *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * detrender;
-                Q1 = 0_f64 - Q1_Odd[hilbertIdx];
-                Q1_Odd[hilbertIdx] = hilbertTempReal;
+                Q1 = 0_f64 - sp.Q1_Odd[hilbertIdx];
                 Q1 += hilbertTempReal;
                 Q1 -= prev_Q1_Odd;
                 prev_Q1_Odd = sp.b * prev_Q1_input_Odd;
@@ -1732,8 +1718,7 @@ impl MamaStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - jI_Odd[hilbertIdx];
-                jI_Odd[hilbertIdx] = hilbertTempReal;
+                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
                 jI += hilbertTempReal;
                 jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
@@ -1741,8 +1726,7 @@ impl MamaStream {
                 prev_jI_input_Odd = I1ForOddPrev3;
                 jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - jQ_Odd[hilbertIdx];
-                jQ_Odd[hilbertIdx] = hilbertTempReal;
+                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
                 jQ += hilbertTempReal;
                 jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;

--- a/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/marketfi.rs
@@ -547,8 +547,8 @@ impl MarketfiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/mavp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mavp.rs
@@ -831,8 +831,8 @@ impl MavpStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/max.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/max.rs
@@ -710,8 +710,8 @@ impl MaxStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/maxindex.rs
@@ -623,8 +623,8 @@ impl MaxindexStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/medprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/medprice.rs
@@ -459,8 +459,8 @@ impl MedpriceStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/mfi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mfi.rs
@@ -906,8 +906,8 @@ impl MfiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midpoint.rs
@@ -819,8 +819,8 @@ impl MidpointStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/midprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/midprice.rs
@@ -845,8 +845,8 @@ impl MidpriceStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/min.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/min.rs
@@ -706,8 +706,8 @@ impl MinStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/minindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minindex.rs
@@ -623,8 +623,8 @@ impl MinindexStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/minmax.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmax.rs
@@ -833,8 +833,8 @@ impl MinmaxStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minmaxindex.rs
@@ -718,8 +718,8 @@ impl MinmaxindexStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_di.rs
@@ -1332,8 +1332,8 @@ impl MinusDiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/minus_dm.rs
@@ -998,8 +998,8 @@ impl MinusDmStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/mom.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mom.rs
@@ -581,8 +581,8 @@ impl MomStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/mult.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mult.rs
@@ -455,8 +455,8 @@ impl MultStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/natr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/natr.rs
@@ -899,8 +899,8 @@ impl NatrStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/nvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/nvi.rs
@@ -566,8 +566,8 @@ impl NviStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/obv.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/obv.rs
@@ -493,8 +493,8 @@ impl ObvStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_di.rs
@@ -1330,8 +1330,8 @@ impl PlusDiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/plus_dm.rs
@@ -998,8 +998,8 @@ impl PlusDmStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ppo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ppo.rs
@@ -652,8 +652,8 @@ impl PpoStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/pvi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvi.rs
@@ -566,8 +566,8 @@ impl PviStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/pvo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/pvo.rs
@@ -656,8 +656,8 @@ impl PvoStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/qstick.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/qstick.rs
@@ -651,8 +651,8 @@ impl QstickStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/roc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/roc.rs
@@ -599,8 +599,8 @@ impl RocStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/rocp.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocp.rs
@@ -601,8 +601,8 @@ impl RocpStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/rocr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr.rs
@@ -599,8 +599,8 @@ impl RocrStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rocr100.rs
@@ -602,8 +602,8 @@ impl Rocr100Stream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -913,8 +913,8 @@ impl RsiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sar.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sar.rs
@@ -1086,8 +1086,8 @@ impl SarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sarext.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sarext.rs
@@ -1362,8 +1362,8 @@ impl SarextStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sin.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sin.rs
@@ -437,8 +437,8 @@ impl SinStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sinh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sinh.rs
@@ -437,8 +437,8 @@ impl SinhStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sma.rs
@@ -569,8 +569,8 @@ impl SmaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/smi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/smi.rs
@@ -1277,8 +1277,8 @@ impl SmiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sqrt.rs
@@ -433,8 +433,8 @@ impl SqrtStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/stddev.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stddev.rs
@@ -597,8 +597,8 @@ impl StddevStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -1143,8 +1143,8 @@ impl StochStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -1070,8 +1070,8 @@ impl StochfStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochrsi.rs
@@ -719,8 +719,8 @@ impl StochrsiStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sub.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sub.rs
@@ -458,8 +458,8 @@ impl SubStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/sum.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/sum.rs
@@ -563,8 +563,8 @@ impl SumStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -900,8 +900,8 @@ impl T3Stream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/tan.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tan.rs
@@ -437,8 +437,8 @@ impl TanStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/tanh.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tanh.rs
@@ -437,8 +437,8 @@ impl TanhStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/tema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tema.rs
@@ -839,8 +839,8 @@ impl TemaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/trange.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trange.rs
@@ -582,8 +582,8 @@ impl TrangeStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/trima.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trima.rs
@@ -1226,8 +1226,8 @@ impl TrimaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/trix.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/trix.rs
@@ -738,8 +738,8 @@ impl TrixStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/tsf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tsf.rs
@@ -971,8 +971,8 @@ impl TsfStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/typprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/typprice.rs
@@ -469,8 +469,8 @@ impl TyppriceStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ultosc.rs
@@ -1183,8 +1183,8 @@ impl UltoscStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/var.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/var.rs
@@ -962,8 +962,8 @@ impl VarStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/vwap.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwap.rs
@@ -797,8 +797,8 @@ impl VwapStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/vwma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwma.rs
@@ -716,8 +716,8 @@ impl VwmaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/wad.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wad.rs
@@ -626,8 +626,8 @@ impl WadStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wclprice.rs
@@ -502,8 +502,8 @@ impl WclpriceStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/willr.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/willr.rs
@@ -895,8 +895,8 @@ impl WillrStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors

--- a/ta_codegen/output/rust/library/src/ta_func/wma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wma.rs
@@ -938,8 +938,8 @@ impl WmaStream {
     /// Evaluate a forming bar without committing — bit-identical to what the
     /// next `update` with the same bar would return: the same transition,
     /// rewritten so every store it would make lives in a local instead. It
-    /// copies nothing and never allocates, so its cost does not grow with the
-    /// period, and it writes no part of the handle — peeks may run
+    /// allocates nothing and copies no buffer, so its cost does not grow with
+    /// the period, and it writes no part of the handle — peeks may run
     /// concurrently with each other.
     ///
     /// # Errors


### PR DESCRIPTION
Closes #303 for the 7 functions the issue's proposed shape reaches; the 14 candlesticks are
argued below to be out of reach of this mechanism rather than merely skipped.

## What changed

`transition_buffers` returns only the model's ring/window/circ/extrema buffers, so a
fixed-size array STATE field never reached `peek_transition` and `localize_state_writes`
picked it up as an ordinary written field — a clone per call in Java and C#, because a
managed array field is a reference.

`transition_buffers_with_state_arrays` adds those fields and `peek_transition_widest`
offers that set first, falling back to the narrow one where `validate_peekable` refuses.
All four backends call it. The stores are dead inside the frame — the bar reads the slot,
writes it, and never reads it back — so every shadow is pruned and the store is deleted;
the frame then reads the field in place.

**7 accept** (HT_DCPERIOD, HT_DCPHASE, HT_PHASOR, HT_SINE, HT_TRENDLINE, HT_TRENDMODE,
MAMA): 8 dead stores each, deleted in all four backends.

**14 candlesticks refuse** and are byte-unchanged. Their accumulator is
`X[totIdx] += E` inside `for( totIdx = N; totIdx >= 0; totIdx -= 1 )`, which
`validate_peekable` rejects twice over (compound, and in a loop). One `pkSlot`/`pkVal`
pair cannot model N iterations' slots, and deleting the stores outright is not open
either: the pattern condition READS `X[2]`, `X[1]`, `X[0]` before the loop, so
`buffer_is_read` is true and the delete arm never fires. The residue is 904 B across all
14 (32-152 B each), against 320 B on each of the 7 now fixed.

## Why all four backends, when only two allocate

Shadowing a store rewrites its TARGET from `X[k]` to a local, and
`canonicalize_accumulator_add` matches an accumulator by raw string equality before
deciding a fusion. A backend that shadowed where another did not could fuse a
multiply-add the other leaves alone, in a value a later select reads back — a ~1 ULP
cross-language divergence with nothing naming the cause. C gains nothing (it peeks a
whole-struct copy that carried these fields by value) and takes the change to keep the
four sets equal.

Integer array state fields are deliberately excluded: no corpus function has one, so an
integer shadow — and the select's `i32`-against-`usize` comparison in Rust — would be a
branch every gate here is blind to.

Measured: no `fma(` / `Math.fma` / `Math.FusedMultiplyAdd` / `mul_add` line moved in any
of the 200 regenerated files.

## Measurement

Java, JDK 21, `ThreadMXBean.getThreadAllocatedBytes`, warmed, per call:

| | before | after |
|---|---|---|
| `HT_DCPERIOD.peek` | 320 B | **0 B** |
| `HT_DCPHASE.peek` | 320 B | **0 B** |
| `HT_TRENDMODE.peek` | 320 B | **0 B** |
| `SMA.peek` (control) | 0 B | 0 B |
| `CDL3BLACKCROWS.peek` | 40 B | 40 B |
| `CDLADVANCEBLOCK.peek` | 152 B | 152 B |

`scripts/stream_ab.py --call=peek`, 6 interleaved rounds, the other 169 functions as the
control:

| lang | the 7 | control |
|---|---|---|
| Java | **-33.0%** median (-109 ns), all 7 negative, worst row -11.5% | +0.7% median, 2/169 past 25% |
| C# | **-55.6%** median (-86 ns), all 7 negative, worst row -20.7% | +2.9% median, 7/169 past 25% |
| Rust | -9.5% median but **2 of 7 positive** — no claim | +1.1% median, 10/169 past 25% |

Rust is a no-change and reads as one: `[f64; N]` is `Copy`, so there was never an
allocation to remove. C is not on this tool; its stores went into a struct copy `Peek`
discards.

## Coverage

None of the existing sweeps could see this class: the C peek gate derives its buffers
from the POINTER fields of the stream struct, and a `double detrender_Even[3]` has no
`*`.

- `peek_suite::a_peek_frame_deletes_every_accumulator_store_it_can` — sweeps the
  fixed-size array fields, floors both sides of the split (>=7 fully deleted, >=14 kept,
  >=60 stores in the update frames), and demands of a frame that still stores that one of
  its stores be a shape `validate_peekable` refuses.
- The Java, C# **and Rust** peek sweeps each carry the same pair of floors. Rust's is
  there specifically because the wide/narrow decision is taken per backend from a
  per-backend transition, and a Rust-only regression is invisible to the other three.
- `StreamApiTest.PeekDoesNotAllocate` — the bytes, at runtime, on HT_DCPERIOD with SMA as
  the control, with a call counter and a sink floor so a sweep that did not run cannot
  read green. C# rather than Java because RyuJIT does not stack-allocate arrays, so the
  copy cannot hide behind escape analysis.

Each of the four gates was sabotage-proven against a generator reverted to the narrow
set; the C# runtime test reads 384 B/call and fails against the pre-change file.

## Stale prose corrected

All of it about peek's cost model, all of it left behind by the non-committing frame:
three backends' `peek_frame_arm*` said a `None` frame makes the caller "fall back to
peeking a copy" (it panics); `java_stream.rs` still defined `peek` as a deep-copy
constructor plus a step on the throwaway; `c_stream.rs` said `Peek` runs `StepImpl` on a
stack copy; `bench_gen.rs` defined `peek_ns` as a deep copy of the handle;
`test_codegen.c` said the other three backends peek a copy; the Java and C# composed-tier
headers described copy-peek; `docs/streaming-api-design.md` said `peek` allocates in none
of the four.

## Gates run

`regen-check`; generator `cargo test` (873); clippy `-D warnings` on both crates; the
generated crate's doctests (536) and tests; the four-language regtest (C 24391 legs
bit-exact + 202223 peeks with the handle bit-identical, Rust/Java/C# 21642 legs each);
`--xlang-hash` (PASS, 176 functions, bit-identical, zero tolerance); the synth gate (14
fixtures x 4 languages, stream + batch bitwise + 1520 hand-derived golden values).
