### PR TITLE
ci(nightly): compile the publishable crates off x86-64 (#179 E3)

### DIFF
--- a/.github/workflows/dev-nightly-tests.yml
+++ b/.github/workflows/dev-nightly-tests.yml
@@ -583,6 +583,83 @@ jobs:
             exit 1
           fi
 
+  # Every Rust step in this tree compiles for the runner's own host triple,
+  # x86_64-unknown-linux-gnu, and that is the only machine shape the crate has
+  # ever been compiled in (#179 E3). Two assumptions rustc can see are invisible
+  # from there: a pointer width of 64 -- the crate indexes with `usize` end to
+  # end -- and an x86 ISA. Neither has a symptom here; the first sign is a
+  # compile error in a consumer's build, on a platform nobody in this repo
+  # builds for, in a published version that cannot be edited.
+  #
+  # Measured on this tree, by injecting each defect into the generated crate and
+  # re-running all three legs:
+  #
+  #   injected into library/src/lib.rs                  host   i686   aarch64
+  #   const _: () = assert!(size_of::<usize>() == 8)    green   RED    green
+  #   use core::arch::x86_64::_mm_pause;                green   RED    RED
+  #
+  # So i686 is the leg that does the work: it is the only one of the three that
+  # sees a pointer-width assumption. aarch64 earns its place on a different
+  # argument -- it is a platform consumers actually run on (Apple Silicon,
+  # Graviton), not a defect class i686 misses. No defect was found that aarch64
+  # catches and i686 does not.
+  #
+  # `check`, not `test`: running the crate on either target needs an emulator and
+  # a cross linker, and this job deliberately buys neither. A 32-bit arithmetic
+  # overflow that only appears at run time is therefore NOT covered here -- this
+  # gate is about what the compiler can see.
+  #
+  # Nightly, not the PR gate, for the same reason as msrv above: two rust-std
+  # downloads of unmeasured time do not belong in every contributor's
+  # merge-blocking path. Rust-only and self-contained, so also not gated on the
+  # C hero 'test' job.
+  cross-target:
+    name: Rust cross-target check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout dev Branch
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      # The list is the job's non-vacuity guard. An empty list, or one that named
+      # the host again, would leave every step below green while compiling
+      # nothing the other Rust jobs do not already compile -- so both are a hard
+      # failure here rather than a silently weaker gate.
+      - name: Install the cross targets
+        id: targets
+        shell: bash
+        run: |
+          host=$(rustc -vV | sed -n 's/^host: //p')
+          targets="i686-unknown-linux-gnu aarch64-unknown-linux-gnu"
+          if [ -z "${targets// /}" ]; then
+            echo "::error::No cross targets are listed, so this job would pass without compiling anything the host jobs do not. Restore the list in .github/workflows/dev-nightly-tests.yml or delete the job."
+            exit 1
+          fi
+          for t in $targets; do
+            if [ "$t" = "$host" ]; then
+              echo "::error::Cross target '$t' is the runner's own host triple, so that leg re-checks what every other Rust job here already checks. Name a target that differs from the host, or drop it from the list."
+              exit 1
+            fi
+          done
+          echo "Host: $host"
+          echo "Cross targets: $targets"
+          rustup target add $targets
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+
+      - name: Compile the publishable crates for each cross target
+        shell: bash
+        run: |
+          for t in ${{ steps.targets.outputs.targets }}; do
+            echo "--- $t ---"
+            if ! cargo check -p ta-lib -p ta-lib-dispatch --all-targets --target "$t" --manifest-path ta_codegen/output/rust/Cargo.toml; then
+              echo "::error::The publishable crates do not compile for $t. The crate is pure Rust with no platform-specific code, so this is a portability assumption that reached the generated output -- a pointer width (anything that assumes usize is 64 bits), an x86-only intrinsic, or a type too large for a 32-bit address space. Fix the generator that emits it in ta_codegen/generator/ and re-run 'scripts/build.py generate'; do not edit ta_codegen/output/. Reproduce locally: rustup target add $t && cargo check -p ta-lib -p ta-lib-dispatch --all-targets --target $t --manifest-path ta_codegen/output/rust/Cargo.toml"
+              exit 1
+            fi
+          done
+
   # Bit-exact regression gate vs the last release (v0.6.4): diff every function
   # at period>=2, fail on any real divergence. C-only, gated on 'test'.
   # fetch-depth: 0 so the v0.6.4 tag is available. See ta_regtest/CLAUDE.md.


### PR DESCRIPTION
Closes the E3 line of #179: *"No non-x86-64 `cargo check`"*.

## What was missing

Every Rust step in this tree compiles for the runner's own host triple,
`x86_64-unknown-linux-gnu` — clippy, `cargo doc`, the 534 doctests, the
`--tests` suites, the MSRV floor job and `rust_package_check.py` all run there.
So the crate has only ever been compiled in **one machine shape**, and two
assumptions rustc can see are invisible from it:

- a **pointer width of 64** — the crate indexes with `usize` end to end;
- an **x86 ISA**.

Neither has a symptom in this repo. The first sign is a compile error in a
consumer's build, on a platform nobody here builds for, in a published version
that cannot be edited.

## The change

One nightly job, `cross-target`, compiling `ta-lib` and `ta-lib-dispatch`
with `--all-targets` for `i686-unknown-linux-gnu` and
`aarch64-unknown-linux-gnu`. **Both are green on this tree today** — nothing in
the generated output is currently unportable; this is a regression gate, not a
bug fix.

## Every gate needs a control

Each defect was injected into `ta_codegen/output/rust/library/src/lib.rs` and
all three legs re-run:

| injected | host x86-64 | i686 | aarch64 |
|---|---|---|---|
| `const _: () = assert!(size_of::<usize>() == 8);` | green | **RED** | green |
| `use core::arch::x86_64::_mm_pause;` | green | **RED** | **RED** |

So **i686 is the leg that does the work**: it is the only one of the three that
sees a pointer-width assumption, and the host — where every other Rust job in
this tree runs — sees neither defect.

**aarch64 earns its place on a different argument, and a weaker one.** It is a
platform consumers actually run on (Apple Silicon, Graviton), not a defect class
i686 misses: I looked for a defect that aarch64 catches and i686 does not, and
did not find one. If you would rather not pay for a leg that is justified by
audience rather than by coverage, dropping the second entry from the `targets`
list is the whole edit — the guard below keeps the job honest at one target.

The target list is also the job's **non-vacuity guard**. An empty list, or one
naming the host triple again, would leave the job green while compiling nothing
the host jobs do not already compile, so both are a hard failure. Both refusals
were exercised:

```
$ guard ""                         → ::error::No cross targets are listed…      exit 1
$ guard "x86_64-unknown-linux-gnu" → ::error::…is the runner's own host triple… exit 1
$ guard "i686… aarch64…"           → exit 0
```

## What this does not cover

- **`check`, not `test`.** Running the crate on either target needs an emulator
  and a cross linker, and this job buys neither. A 32-bit arithmetic overflow
  that only appears at run time is **not** covered — the gate is about what the
  compiler can see. Making it a real `test` leg is a separate, much larger job
  (qemu + cross linkers) and is not proposed here.
- I did **not** check Windows or macOS (that is E6, still open), and did not
  touch E7 (`cargo-semver-checks`).

## Cost

- Two `rust-std` components: **131 MB** (i686) + **163 MB** (aarch64) on disk
  after install. I did not measure the compressed download size or the download
  time on a GitHub runner.
- Compile time on my box, from a cold `CARGO_TARGET_DIR`: **9 s** per target
  (`check`, so no codegen). A GitHub runner will be slower; I did not measure it
  there.

Nightly rather than the PR gate, for the reason the MSRV job (#298) already
records: two toolchain-component installs of unmeasured download time do not
belong in every contributor's merge-blocking path, and dev takes direct pushes
that `on: pull_request` never sees. Rust-only and self-contained, so like
`clippy` and `msrv` it is deliberately not gated on the C hero `test` job.
