### PR TITLE
perf(java): a multi-output stream `update` returns its `Value` unstored (#310)

### DIFF
--- a/docs/streaming-api-design.md
+++ b/docs/streaming-api-design.md
@@ -50,8 +50,11 @@ Every stream, in every language, is the same lifecycle:
    true.
 2. **`update(handle, bar) → value` — once per closed bar.** Takes the handle
    and the new input(s) (OHLCV for multi-input functions) and always produces
-   the new current value. `update` performs **no allocation** — the handle is
-   sized at open.
+   the new current value. `update` allocates **no handle state** — the handle is
+   sized at open. On the managed backends a multi-output `update` also returns a
+   `Value`; C#'s is a record struct and costs nothing, and Java's is a record
+   *returned unstored*, which is what leaves it eligible for scalar replacement
+   rather than a guaranteed per-bar heap allocation (#310).
 3. **`close(handle)`.** Releases the stream — explicit in C, implicit
    in managed languages (Rust/Java).
 
@@ -492,8 +495,11 @@ OutRange r = s2.outRange();                      // the bars this handle has an
   `"<NAME> peek:"`), leaving the handle's *state* untouched
   (`docs/error-handling-spec.md` §2.4).
 - `value()` re-reads the value(s) at the last bar the stream counted — the bar
-  `outRange()` ends on — without recomputing; multi-output `update`
-  caches the immutable `Value` it returns, so `value()` is allocation-free.
+  `outRange()` ends on — without recomputing. Multi-output `value()` builds its
+  `Value` from those committed fields on each call rather than returning a
+  cached instance: the cache cost a guaranteed heap allocation on every
+  `update`, to make an accessor free that a caller invokes at most once a bar
+  and usually not at all (#310).
 - `clone()` is the universal deep copy (arrays cloned, sub-handles copied
   recursively, the `Core` reference shared), and it is spelled the same in all
   four backends: `TA_<N>_Clone`, `.clone()`, `clone()`, `Clone()`. It is the
@@ -536,9 +542,10 @@ emitter and accepted the later delivery date.
 One place the C# tier deliberately departs from the Java one, because the
 language offers something Java does not:
 
-- **Multi-output values are a `readonly record struct`, not a class.** Java
-  caches the boxed `Value` so that `value()` allocates nothing; a struct is
-  allocation-free by construction, so C# has no `cachedValue` field at all.
+- **Multi-output values are a `readonly record struct`, not a class.** A struct
+  is allocation-free by construction; Java's `Value` is a real object, so the
+  best Java can do is never store it (#310) and leave the JIT free to
+  scalar-replace it — a JIT decision, where C#'s is a language guarantee.
   The consequence for callers is that C# equality is .NET's `double` equality
   — `NaN` equals `NaN` **and** `+0.0` equals `-0.0` — where Java's record
   compares bitwise and disagrees on the second. Compare

--- a/ta_codegen/generator/src/backends/csharp_stream.rs
+++ b/ta_codegen/generator/src/backends/csharp_stream.rs
@@ -33,11 +33,12 @@
 //!   `Core` instance method. Measured, `core.Step(sp, x)` versus
 //!   `this.Step(x)` is 3.44–3.54 against 3.39–3.47 ns/bar — indistinguishable.
 //!
-//! - **No `cachedValue` field.** Java caches the boxed multi-output `Value` so
-//!   that `value()` allocates nothing; a `readonly record struct` return is
-//!   0 B/update by construction (measured against 40 B/update for the
-//!   Java-shaped class). One fewer field, one fewer store per bar, and one
-//!   fewer thing the copy path can get wrong.
+//! - **No `cachedValue` field.** A `readonly record struct` return is
+//!   0 B/update by construction, where a class return is 0 B only if the JIT
+//!   proves it does not escape. Java once cached the boxed multi-output
+//!   `Value` in a field so that `value()` was a field read, and paid 40 B per
+//!   `update` for it; #310 dropped that field and brought Java to this shape,
+//!   so the two managed backends now agree here rather than differing.
 //!
 //! - **The `NameMap` prefixes are Java's, verbatim** (`sp.x`, `sp.cur_y`,
 //!   `sp.ring_v_a`, ...). This is load-bearing, not cosmetic:
@@ -286,7 +287,8 @@ fn field_type_and_default(ty: &VarType) -> (String, String) {
 ///
 /// There is no `cachedValue`: the C# `Value` is a `readonly record struct`
 /// returned by value, so caching it would cost a field and a store per bar and
-/// buy nothing.
+/// buy nothing. Java reached the same conclusion the other way round, by
+/// measuring what the store cost it (#310).
 fn base_fields(func: &FuncDef) -> Vec<Field> {
     let mut fields: Vec<Field> = Vec::new();
     for p in &func.optional_inputs {
@@ -975,10 +977,10 @@ fn emit_handle_class_with_members(
 /// after the outputs (`outSlowK` → `SlowK`).
 ///
 /// A record struct, not Java's record class: the return is copied to the
-/// caller's frame, so `Update` allocates nothing at all (measured 0 B/update
-/// against 40 B/update for the Java-shaped cached class), which is also why
-/// there is no `cachedValue` field to keep it free. `Deconstruct` comes free —
-/// `var (up, mid, low) = s.Update(bar);`.
+/// caller's frame, so `Update` allocates nothing at all — unconditionally,
+/// where Java's unstored record class relies on the JIT to scalar-replace it
+/// (#310). That is why there is no `cachedValue` field here to keep it free.
+/// `Deconstruct` comes free — `var (up, mid, low) = s.Update(bar);`.
 fn emit_value_type(o: &mut String, func: &FuncDef) {
     if !has_value_type(func) {
         return;

--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -43,10 +43,11 @@
 //!   indicator, never by the period. `clone()` exposes the copy constructor as
 //!   an independent stream — arrays clone, sub-streams clone recursively, and
 //!   only the `Core` reference is shared (settings identity is the contract).
-//! - Multi-output functions return a per-function immutable `Value` class
-//!   (public final fields, batch output order, generated toString/equals/
-//!   hashCode); `update` caches the instance so `value()` is a pure field
-//!   read. Single-output functions return the primitive directly.
+//! - Multi-output functions return a per-function immutable `Value` record
+//!   (batch output order); `update` returns it WITHOUT storing it, and
+//!   `value()` builds an equal one from the same committed fields — a store
+//!   made it escape, which cost a heap allocation on every bar (#310).
+//!   Single-output functions return the primitive directly.
 //! - Candle settings are SNAPSHOTTED into the handle at open (primitive
 //!   fields), matching Rust's frozen-by-copy observable semantics — the step
 //!   never reads the live (mutable, torn-read-prone) `CandleSetting` objects.
@@ -247,7 +248,7 @@ fn field_type_and_default(ty: &VarType) -> (String, String) {
     }
 }
 
-/// The params + `cur_<out>` (+ cachedValue) fields every tier's handle carries
+/// The params + `cur_<out>` fields every tier's handle carries
 /// (dispatch/period-bank/loopless-composed build on exactly this base).
 fn base_fields(func: &FuncDef) -> Vec<Field> {
     let mut fields: Vec<Field> = Vec::new();
@@ -259,9 +260,6 @@ fn base_fields(func: &FuncDef) -> Vec<Field> {
     }
     for out in &func.outputs {
         fields.push((format!("cur_{}", out.name), out_java_type(func, &out.name).to_string(), "0".into()));
-    }
-    if has_value_class(func) {
-        fields.push(("cachedValue".into(), "Value".into(), "null".into()));
     }
     fields
 }
@@ -385,9 +383,6 @@ fn state_fields_from(
     for out in &func.outputs {
         let t = out_java_type(func, &out.name);
         fields.push((format!("cur_{}", out.name), t.to_string(), "0".to_string()));
-    }
-    if has_value_class(func) {
-        fields.push(("cachedValue".into(), "Value".into(), "null".into()));
     }
     fields
 }
@@ -903,12 +898,11 @@ fn emit_update_method(o: &mut String, func: &FuncDef) {
     // finite-bar reject above counts its own bar and is the only rejection that
     // does; `peek` runs a frame that commits nothing and reaches neither.
     let _ = writeln!(o, "         {}", advance_out_range());
-    if has_value_class(func) {
-        let _ = writeln!(o, "         this.cachedValue = {};", fresh_value_expr(func, "this"));
-        let _ = writeln!(o, "         return this.cachedValue;");
-    } else {
-        let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
-    }
+    // Multi-output: the `Value` is returned WITHOUT being stored on the handle.
+    // Storing it made it escape, which is a guaranteed heap allocation on every
+    // bar (issue #310); unstored it is a candidate for scalar replacement, the
+    // same shape `peek` already had.
+    let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
     let _ = writeln!(o, "      }}");
 }
 
@@ -1018,28 +1012,16 @@ fn emit_update_and_fill_method(o: &mut String, func: &FuncDef) {
         let _ = writeln!(o, "            {reject}");
     }
     // `value()` must name the last COMMITTED bar on EVERY exit, the throwing
-    // ones included, so the multi-output cache is refreshed in a `finally`.
-    //
-    // That is sound because of an invariant of the step, not by luck: a
-    // composed `<base>StepImpl` writes its `sp.cur_<out>` fields as its LAST
-    // statements, after every sub-stream call — so the one thing that can throw
-    // out of the middle of a bar (a sub rejecting a non-finite intermediate,
-    // the documented composed hole) leaves `cur_*` still holding bar `i-1`,
-    // which is exactly the bar `done` counts. `no_throwing_call_follows_the_cur_capture`
-    // pins it, because without that ordering the `finally` would publish a
-    // half-written bar.
-    //
-    // C# needs none of this: its `Value` is a record struct built fresh from
-    // the same fields, so it is correct at every exit by construction. Leaving
-    // Java's cache stale would make the two backends disagree on an observable
-    // the streaming design says they agree on. Single-output handles read
-    // `cur_<out>` directly and have no cache at all.
-    let cached = has_value_class(func);
-    if cached {
-        let _ = writeln!(o, "         int done = 0;");
-        let _ = writeln!(o, "         try {{");
-    }
-    let pad = if cached { "            " } else { "         " };
+    // ones included. Since #310 that holds by construction in both managed
+    // backends alike: `value()` builds its `Value` from the `cur_<out>` fields
+    // when it is called, so there is no cache to leave stale here and no
+    // `try`/`finally` to keep one fresh. What makes those fields name the last
+    // COMMITTED bar rather than a half-written one is an invariant of the step —
+    // a composed `<base>StepImpl` writes `sp.cur_<out>` as its LAST statements,
+    // after every sub-stream call, so a sub rejecting a non-finite intermediate
+    // mid-bar (the documented composed hole) leaves them holding bar `i-1`.
+    // `no_throwing_call_follows_the_cur_capture` pins that ordering.
+    let pad = "         ";
     let _ = writeln!(o, "{pad}for( int i = 0; i < barCount; i++ ) {{");
     let idx_bars: Vec<String> = inputs.iter().map(|a| format!("{a}[i]")).collect();
     if !inputs.is_empty() {
@@ -1063,19 +1045,7 @@ fn emit_update_and_fill_method(o: &mut String, func: &FuncDef) {
         let _ = writeln!(o, "{pad}   {guard}{name}[i] = this.cur_{name};");
     }
     let _ = writeln!(o, "{pad}   {}", advance_out_range());
-    if cached {
-        let _ = writeln!(o, "{pad}   done = i + 1;");
-    }
     let _ = writeln!(o, "{pad}}}");
-    if cached {
-        let _ = writeln!(o, "         }} finally {{");
-        let _ = writeln!(
-            o,
-            "            if( done > 0 ) this.cachedValue = {};",
-            fresh_value_expr(func, "this")
-        );
-        let _ = writeln!(o, "         }}");
-    }
     let _ = writeln!(o, "      }}");
 }
 
@@ -1140,14 +1110,17 @@ fn emit_value_method(o: &mut String, func: &FuncDef) {
          \x20      * {{@link #outRange()}} ends on. The last history bar right after open,\n\
          \x20      * then whatever the latest accepted {{@code update}} returned.\n\
          \x20      * A pure field read; {{@code peek}} does not change it.\n\
-         \x20      */"
+         \x20      * {tail}\n\
+         \x20      */",
+        tail = if has_value_class(func) {
+            "Built from the committed fields on each call, as the C# tier does —\n\
+             \x20      * nothing is cached between calls, and {@code peek} does not change them."
+        } else {
+            "A pure field read; {@code peek} does not change it."
+        }
     );
     let _ = writeln!(o, "      public {vt} value() {{");
-    if has_value_class(func) {
-        let _ = writeln!(o, "         return this.cachedValue;");
-    } else {
-        let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
-    }
+    let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
     let _ = writeln!(o, "      }}");
 }
 
@@ -2079,7 +2052,7 @@ fn emit_identity_fast_path(
     // Identity state: params captured, everything else deterministic defaults
     // (1-slot buffers keep the transition's cap-0 guard well-defined).
     for (name, _, default) in fields {
-        if name == "cachedValue" || name.starts_with("cur_") {
+        if name.starts_with("cur_") {
             continue;
         }
         if model.parity.as_ref().is_some_and(|p| &p.field == name) {
@@ -2108,23 +2081,8 @@ fn emit_identity_fast_path(
     for (out, _inp) in &idp.pairs {
         let _ = writeln!(o, "         sp.cur_{out} = {out}[(outNBElement.value - 1) * outStride];");
     }
-    if has_value_class(func) {
-        let _ = writeln!(o, "         sp.cachedValue = {};", capture_value_expr(func));
-    }
     let _ = writeln!(o, "         return RetCode.Success;");
     let _ = writeln!(o, "      }}");
-}
-
-/// `new Value(sp.cur_a, ...)` for the capture sites (Value resolves inside the
-/// nested handle class; from Core scope it needs the class qualifier).
-fn capture_value_expr(func: &FuncDef) -> String {
-    let class = stream_class_name(func);
-    let args: Vec<String> = func
-        .outputs
-        .iter()
-        .map(|out| format!("sp.cur_{}", out.name))
-        .collect();
-    format!("new {class}.Value({})", args.join(", "))
 }
 
 // ---------------------------------------------------------------------------
@@ -2366,7 +2324,7 @@ enum CurSource {
     Scratch,
 }
 
-/// Seed `sp.cur_*` (+ the cached Value) at the end of an open body.
+/// Seed `sp.cur_*` at the end of an open body.
 fn emit_cur_capture(o: &mut String, func: &FuncDef, outputs: &[String], source: CurSource) {
     let nullable = super::common::nullable_output_names(func);
     assert!(
@@ -2385,9 +2343,6 @@ fn emit_cur_capture(o: &mut String, func: &FuncDef, outputs: &[String], source: 
             }
         };
         let _ = writeln!(o, "      sp.cur_{out} = {expr};");
-    }
-    if has_value_class(func) {
-        let _ = writeln!(o, "      sp.cachedValue = {};", capture_value_expr(func));
     }
 }
 
@@ -3183,9 +3138,6 @@ fn emit_dispatch(
                     }
                 }
             }
-            if has_value_class(func) {
-                let _ = writeln!(o, "         sp.cachedValue = {};", capture_value_expr(func));
-            }
             let _ = writeln!(o, "         return RetCode.Success;");
             let _ = writeln!(o, "      }}");
         }
@@ -3280,9 +3232,6 @@ fn emit_dispatch(
         let _ = writeln!(o, "      }}");
         for p in &func.optional_inputs {
             let _ = writeln!(o, "      sp.{0} = {0};", p.name);
-        }
-        if has_value_class(func) {
-            let _ = writeln!(o, "      sp.cachedValue = {};", capture_value_expr(func));
         }
         let _ = writeln!(o, "      return RetCode.Success;");
         let _ = writeln!(o, "   }}");

--- a/ta_codegen/generator/tests/java_stream_suite.rs
+++ b/ta_codegen/generator/tests/java_stream_suite.rs
@@ -184,9 +184,11 @@ fn test_java_mama_value_class_protocol() {
     // one output reads the same in both tiers.
     assert!(s.contains("@param mama "));
     assert!(s.contains("@param fama "));
-    // update caches the instance so value() is a pure field read.
-    assert!(s.contains("this.cachedValue ="));
-    assert!(s.contains("return this.cachedValue;"));
+    // #310: the record `update` returns is never STORED — a store makes it
+    // escape, which is a guaranteed heap allocation on every bar. `value()`
+    // builds its own from the same committed fields, as C# does.
+    assert!(!s.contains("cachedValue"));
+    assert!(s.contains("         return new Value(this.cur_outMAMA, this.cur_outFAMA);\n"));
 }
 
 #[test]

--- a/ta_codegen/generator/tests/update_and_fill_suite.rs
+++ b/ta_codegen/generator/tests/update_and_fill_suite.rs
@@ -281,44 +281,43 @@ fn the_check_is_inside_the_loop_and_not_a_pre_scan() {
     }
 }
 
-/// Java caches the multi-output `Value` so `value()` allocates nothing, so the
-/// cache has to be refreshed on the way out of a PARTIAL fill too — otherwise
-/// `value()` names a bar before the ones the call committed, and disagrees with
-/// `outRange()` by exactly the committed bars.
+/// `value()` must name the last COMMITTED bar on every exit of a PARTIAL fill —
+/// otherwise it names a bar before the ones the call committed, and disagrees
+/// with `outRange()` by exactly the committed bars.
 ///
-/// It is refreshed in a `finally`, which covers every exit including the two
-/// throwing ones (a non-finite bar, and a sub-stream rejecting a computed
-/// intermediate mid-step). That is sound only because a step writes its `cur_*`
-/// fields last — pinned separately by
+/// Since #310 that holds in both managed backends for the same reason: neither
+/// stores the multi-output `Value`, so `value()` builds it from the `cur_*`
+/// fields when it is called and there is nothing to leave stale. The `try` /
+/// `finally` Java used to need to keep a cache fresh is gone with the cache,
+/// and this test is what stops one growing back.
+///
+/// What makes those fields name the last COMMITTED bar and not a half-written
+/// one is that a step writes its `cur_*` fields last — pinned separately by
 /// `no_throwing_sub_call_follows_the_cur_capture_in_a_java_step`.
-///
-/// C# has no cache (a record struct built fresh from the fields), so it must NOT
-/// grow one here — and is already correct at every exit for the same reason.
 #[test]
-fn the_java_value_cache_is_refreshed_on_every_exit() {
-    let multi = body_of(&section("bbands", "java"), "public void updateAndFill(");
-    assert!(
-        multi.contains("} finally {"),
-        "a multi-output updateAndFill refreshes the cache in a finally:\n{multi}"
-    );
-    assert_eq!(
-        multi.matches("if( done > 0 ) this.cachedValue =").count(),
-        1,
-        "one refresh, in the finally — not repeated per exit:\n{multi}"
-    );
-    let fin = multi.find("} finally {").expect("the finally");
-    let refresh = multi.find("if( done > 0 ) this.cachedValue =").expect("the refresh");
-    assert!(refresh > fin, "the refresh belongs inside the finally:\n{multi}");
-    let single = body_of(&section("sma", "java"), "public void updateAndFill(");
-    assert!(
-        !single.contains("cachedValue") && !single.contains("finally"),
-        "a single-output handle has no cache to refresh:\n{single}"
-    );
-    let cs = body_of(&section("bbands", "csharp"), "public void UpdateAndFill(");
-    assert!(
-        !cs.contains("cachedValue") && !cs.contains("finally"),
-        "C#'s Value is a fresh record struct and needs no refresh:\n{cs}"
-    );
+fn no_managed_update_and_fill_caches_the_multi_output_value() {
+    for (lang, sig) in [("java", "public void updateAndFill("), ("csharp", "public void UpdateAndFill(")] {
+        for func in ["bbands", "sma"] {
+            let body = body_of(&section(func, lang), sig);
+            assert!(
+                !body.to_lowercase().contains("cachedvalue"),
+                "{lang}/{func} updateAndFill must cache no Value:\n{body}"
+            );
+            assert!(
+                !body.contains("finally"),
+                "{lang}/{func} updateAndFill has no cache to refresh, so no finally:\n{body}"
+            );
+        }
+    }
+    // The whole handle, not just this method: a cache re-added anywhere else
+    // (open's capture, update) would put the staleness back.
+    for lang in ["java", "csharp"] {
+        let whole = section("bbands", lang);
+        assert!(
+            !whole.to_lowercase().contains("cachedvalue"),
+            "{lang}'s multi-output handle carries no cached Value field"
+        );
+    }
 }
 
 /// C is the only backend with a bar count and the only one that has to reject

--- a/ta_codegen/output/java/fragments/Core_AC.java
+++ b/ta_codegen/output/java/fragments/Core_AC.java
@@ -755,6 +755,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ACCBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_ACCBANDS.java
@@ -465,7 +465,6 @@
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -498,7 +497,6 @@
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -540,8 +538,7 @@
          }
          core.accbandsStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -567,22 +564,16 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -667,9 +658,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -895,7 +888,6 @@
       sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_ACOS.java
+++ b/ta_codegen/output/java/fragments/Core_ACOS.java
@@ -311,6 +311,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_AD.java
+++ b/ta_codegen/output/java/fragments/Core_AD.java
@@ -405,6 +405,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ADD.java
+++ b/ta_codegen/output/java/fragments/Core_ADD.java
@@ -312,6 +312,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ADOSC.java
+++ b/ta_codegen/output/java/fragments/Core_ADOSC.java
@@ -607,6 +607,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ADX.java
+++ b/ta_codegen/output/java/fragments/Core_ADX.java
@@ -990,6 +990,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ADXR.java
+++ b/ta_codegen/output/java/fragments/Core_ADXR.java
@@ -451,6 +451,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_AO.java
+++ b/ta_codegen/output/java/fragments/Core_AO.java
@@ -600,6 +600,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_APO.java
+++ b/ta_codegen/output/java/fragments/Core_APO.java
@@ -494,6 +494,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_AROON.java
+++ b/ta_codegen/output/java/fragments/Core_AROON.java
@@ -420,7 +420,6 @@
       double[] x_inLow;
       double cur_outAroonDown;
       double cur_outAroonUp;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -455,7 +454,6 @@
          this.x_inLow = other.x_inLow.clone();
          this.cur_outAroonDown = other.cur_outAroonDown;
          this.cur_outAroonUp = other.cur_outAroonUp;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -496,8 +494,7 @@
          }
          core.aroonStepImpl(this, inHigh, inLow);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-         return this.cachedValue;
+         return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
       }
 
       /**
@@ -521,21 +518,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
             throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.aroonStepImpl(this, inHigh[i], inLow[i]);
-               outAroonDown[i] = this.cur_outAroonDown;
-               outAroonUp[i] = this.cur_outAroonUp;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+            core.aroonStepImpl(this, inHigh[i], inLow[i]);
+            outAroonDown[i] = this.cur_outAroonDown;
+            outAroonUp[i] = this.cur_outAroonUp;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -628,9 +619,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
       }
 
       /**
@@ -845,7 +838,6 @@
       sp.x_inLow = capX_inLow;
       sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
       sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
       return RetCode.Success;
    }
    /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_AROONOSC.java
+++ b/ta_codegen/output/java/fragments/Core_AROONOSC.java
@@ -611,6 +611,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ASIN.java
+++ b/ta_codegen/output/java/fragments/Core_ASIN.java
@@ -313,6 +313,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ATAN.java
+++ b/ta_codegen/output/java/fragments/Core_ATAN.java
@@ -304,6 +304,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ATR.java
+++ b/ta_codegen/output/java/fragments/Core_ATR.java
@@ -617,6 +617,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_AVGDEV.java
+++ b/ta_codegen/output/java/fragments/Core_AVGDEV.java
@@ -414,6 +414,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_AVGPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_AVGPRICE.java
@@ -341,6 +341,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_BBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_BBANDS.java
@@ -811,7 +811,6 @@
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       MaStream sub0;
       StddevStream sub1;
       int outRangeBegIdx;
@@ -841,7 +840,6 @@
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new StddevStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -885,8 +883,7 @@
          }
          core.bbandsStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -910,22 +907,16 @@
          final int barCount = inReal.length;
          if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.bbandsStepImpl(this, inReal[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.bbandsStepImpl(this, inReal[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -973,9 +964,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -1153,7 +1146,6 @@
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_BETA.java
+++ b/ta_codegen/output/java/fragments/Core_BETA.java
@@ -1130,6 +1130,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_BOP.java
+++ b/ta_codegen/output/java/fragments/Core_BOP.java
@@ -365,6 +365,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CCI.java
+++ b/ta_codegen/output/java/fragments/Core_CCI.java
@@ -576,6 +576,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CDL2CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL2CROWS.java
@@ -517,6 +517,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
@@ -553,6 +553,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3INSIDE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3INSIDE.java
@@ -573,6 +573,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
@@ -549,6 +549,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3OUTSIDE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3OUTSIDE.java
@@ -424,6 +424,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
@@ -732,6 +732,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
@@ -750,6 +750,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLABANDONEDBABY.java
+++ b/ta_codegen/output/java/fragments/Core_CDLABANDONEDBABY.java
@@ -665,6 +665,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
@@ -814,6 +814,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLBELTHOLD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLBELTHOLD.java
@@ -536,6 +536,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLBREAKAWAY.java
+++ b/ta_codegen/output/java/fragments/Core_CDLBREAKAWAY.java
@@ -544,6 +544,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLCLOSINGMARUBOZU.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCLOSINGMARUBOZU.java
@@ -532,6 +532,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
@@ -555,6 +555,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
@@ -565,6 +565,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLDARKCLOUDCOVER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDARKCLOUDCOVER.java
@@ -523,6 +523,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDOJI.java
@@ -458,6 +458,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDOJISTAR.java
@@ -566,6 +566,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLDRAGONFLYDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDRAGONFLYDOJI.java
@@ -539,6 +539,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLENGULFING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLENGULFING.java
@@ -430,6 +430,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLEVENINGDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLEVENINGDOJISTAR.java
@@ -667,6 +667,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLEVENINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLEVENINGSTAR.java
@@ -616,6 +616,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLGAPSIDESIDEWHITE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLGAPSIDESIDEWHITE.java
@@ -569,6 +569,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLGRAVESTONEDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLGRAVESTONEDOJI.java
@@ -539,6 +539,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHAMMER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHAMMER.java
@@ -671,6 +671,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHANGINGMAN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHANGINGMAN.java
@@ -673,6 +673,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHARAMI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHARAMI.java
@@ -589,6 +589,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHARAMICROSS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHARAMICROSS.java
@@ -588,6 +588,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHIGHWAVE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIGHWAVE.java
@@ -535,6 +535,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHIKKAKE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIKKAKE.java
@@ -523,6 +523,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHIKKAKEMOD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIKKAKEMOD.java
@@ -626,6 +626,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLHOMINGPIGEON.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHOMINGPIGEON.java
@@ -558,6 +558,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
@@ -612,6 +612,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLINNECK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLINNECK.java
@@ -562,6 +562,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLINVERTEDHAMMER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLINVERTEDHAMMER.java
@@ -602,6 +602,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLKICKING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKING.java
@@ -571,6 +571,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
@@ -566,6 +566,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLLADDERBOTTOM.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLADDERBOTTOM.java
@@ -533,6 +533,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLLONGLEGGEDDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLONGLEGGEDDOJI.java
@@ -531,6 +531,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLLONGLINE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLONGLINE.java
@@ -514,6 +514,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLMARUBOZU.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMARUBOZU.java
@@ -526,6 +526,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLMATCHINGLOW.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMATCHINGLOW.java
@@ -491,6 +491,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
@@ -673,6 +673,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLMORNINGDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMORNINGDOJISTAR.java
@@ -674,6 +674,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLMORNINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMORNINGSTAR.java
@@ -624,6 +624,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLONNECK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLONNECK.java
@@ -560,6 +560,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
@@ -508,6 +508,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLRICKSHAWMAN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLRICKSHAWMAN.java
@@ -591,6 +591,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
@@ -656,6 +656,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSEPARATINGLINES.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSEPARATINGLINES.java
@@ -615,6 +615,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSHOOTINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSHOOTINGSTAR.java
@@ -606,6 +606,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSHORTLINE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSHORTLINE.java
@@ -529,6 +529,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSPINNINGTOP.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSPINNINGTOP.java
@@ -458,6 +458,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
@@ -730,6 +730,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLSTICKSANDWICH.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSTICKSANDWICH.java
@@ -508,6 +508,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLTAKURI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTAKURI.java
@@ -588,6 +588,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLTASUKIGAP.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTASUKIGAP.java
@@ -520,6 +520,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLTHRUSTING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTHRUSTING.java
@@ -560,6 +560,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLTRISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTRISTAR.java
@@ -532,6 +532,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLUNIQUE3RIVER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLUNIQUE3RIVER.java
@@ -577,6 +577,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLUPSIDEGAP2CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLUPSIDEGAP2CROWS.java
@@ -579,6 +579,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CDLXSIDEGAP3METHODS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLXSIDEGAP3METHODS.java
@@ -437,6 +437,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_CEIL.java
+++ b/ta_codegen/output/java/fragments/Core_CEIL.java
@@ -301,6 +301,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CMF.java
+++ b/ta_codegen/output/java/fragments/Core_CMF.java
@@ -635,6 +635,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CMO.java
+++ b/ta_codegen/output/java/fragments/Core_CMO.java
@@ -618,6 +618,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CMOU.java
+++ b/ta_codegen/output/java/fragments/Core_CMOU.java
@@ -644,6 +644,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_CORREL.java
+++ b/ta_codegen/output/java/fragments/Core_CORREL.java
@@ -921,6 +921,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_COS.java
+++ b/ta_codegen/output/java/fragments/Core_COS.java
@@ -305,6 +305,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_COSH.java
+++ b/ta_codegen/output/java/fragments/Core_COSH.java
@@ -303,6 +303,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_DEMA.java
+++ b/ta_codegen/output/java/fragments/Core_DEMA.java
@@ -543,6 +543,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_DIV.java
+++ b/ta_codegen/output/java/fragments/Core_DIV.java
@@ -320,6 +320,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_DX.java
+++ b/ta_codegen/output/java/fragments/Core_DX.java
@@ -896,6 +896,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_EFI.java
+++ b/ta_codegen/output/java/fragments/Core_EFI.java
@@ -558,6 +558,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_EMA.java
+++ b/ta_codegen/output/java/fragments/Core_EMA.java
@@ -482,6 +482,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_EXP.java
+++ b/ta_codegen/output/java/fragments/Core_EXP.java
@@ -301,6 +301,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_FLOOR.java
+++ b/ta_codegen/output/java/fragments/Core_FLOOR.java
@@ -301,6 +301,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_HMA.java
+++ b/ta_codegen/output/java/fragments/Core_HMA.java
@@ -1221,6 +1221,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
@@ -1165,6 +1165,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
@@ -1368,6 +1368,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
+++ b/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
@@ -869,7 +869,6 @@
       double[] ring_trailingWMAIdx_inReal;
       double cur_outInPhase;
       double cur_outQuadrature;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -936,7 +935,6 @@
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outInPhase = other.cur_outInPhase;
          this.cur_outQuadrature = other.cur_outQuadrature;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -977,8 +975,7 @@
          }
          core.htPhasorStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-         return this.cachedValue;
+         return new Value(this.cur_outInPhase, this.cur_outQuadrature);
       }
 
       /**
@@ -1001,21 +998,15 @@
          final int barCount = inReal.length;
          if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
             throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htPhasorStepImpl(this, inReal[i]);
-               outInPhase[i] = this.cur_outInPhase;
-               outQuadrature[i] = this.cur_outQuadrature;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+            core.htPhasorStepImpl(this, inReal[i]);
+            outInPhase[i] = this.cur_outInPhase;
+            outQuadrature[i] = this.cur_outQuadrature;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1225,9 +1216,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outInPhase, this.cur_outQuadrature);
       }
 
       /**
@@ -1803,7 +1796,6 @@
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
       sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
       return RetCode.Success;
    }
    /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_HT_SINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_SINE.java
@@ -995,7 +995,6 @@
       double[] cb_smoothPrice;
       double cur_outSine;
       double cur_outLeadSine;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -1070,7 +1069,6 @@
          this.cb_smoothPrice = other.cb_smoothPrice.clone();
          this.cur_outSine = other.cur_outSine;
          this.cur_outLeadSine = other.cur_outLeadSine;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -1111,8 +1109,7 @@
          }
          core.htSineStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-         return this.cachedValue;
+         return new Value(this.cur_outSine, this.cur_outLeadSine);
       }
 
       /**
@@ -1135,21 +1132,15 @@
          final int barCount = inReal.length;
          if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
             throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htSineStepImpl(this, inReal[i]);
-               outSine[i] = this.cur_outSine;
-               outLeadSine[i] = this.cur_outLeadSine;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+            core.htSineStepImpl(this, inReal[i]);
+            outSine[i] = this.cur_outSine;
+            outLeadSine[i] = this.cur_outLeadSine;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1417,9 +1408,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSine, this.cur_outLeadSine);
       }
 
       /**
@@ -2127,7 +2120,6 @@
       sp.cb_smoothPrice = smoothPrice;
       sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
       sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
       return RetCode.Success;
    }
    /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
@@ -1298,6 +1298,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
@@ -1606,6 +1606,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_IMI.java
+++ b/ta_codegen/output/java/fragments/Core_IMI.java
@@ -446,6 +446,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_KAMA.java
+++ b/ta_codegen/output/java/fragments/Core_KAMA.java
@@ -783,6 +783,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG.java
@@ -709,6 +709,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_ANGLE.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_ANGLE.java
@@ -714,6 +714,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_INTERCEPT.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_INTERCEPT.java
@@ -713,6 +713,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_SLOPE.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_SLOPE.java
@@ -707,6 +707,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LN.java
+++ b/ta_codegen/output/java/fragments/Core_LN.java
@@ -311,6 +311,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_LOG10.java
+++ b/ta_codegen/output/java/fragments/Core_LOG10.java
@@ -309,6 +309,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MA.java
+++ b/ta_codegen/output/java/fragments/Core_MA.java
@@ -713,6 +713,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MACD.java
+++ b/ta_codegen/output/java/fragments/Core_MACD.java
@@ -612,7 +612,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -645,7 +644,6 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -687,8 +685,7 @@
          }
          core.macdStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -712,22 +709,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -773,9 +764,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -1022,7 +1015,6 @@
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MACDEXT.java
+++ b/ta_codegen/output/java/fragments/Core_MACDEXT.java
@@ -597,7 +597,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       MaStream sub2;
@@ -630,7 +629,6 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.sub2 = new MaStream(other.sub2);
@@ -675,8 +673,7 @@
          }
          core.macdextStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -700,22 +697,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdextStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdextStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -755,9 +746,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -950,7 +943,6 @@
       sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
       sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
       sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-      sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MACDFIX.java
+++ b/ta_codegen/output/java/fragments/Core_MACDFIX.java
@@ -522,7 +522,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -553,7 +552,6 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -595,8 +593,7 @@
          }
          core.macdfixStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -620,22 +617,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdfixStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdfixStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -681,9 +672,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -905,7 +898,6 @@
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MAMA.java
+++ b/ta_codegen/output/java/fragments/Core_MAMA.java
@@ -1012,7 +1012,6 @@
       double[] ring_trailingWMAIdx_inReal;
       double cur_outMAMA;
       double cur_outFAMA;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -1084,7 +1083,6 @@
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outMAMA = other.cur_outMAMA;
          this.cur_outFAMA = other.cur_outFAMA;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -1125,8 +1123,7 @@
          }
          core.mamaStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-         return this.cachedValue;
+         return new Value(this.cur_outMAMA, this.cur_outFAMA);
       }
 
       /**
@@ -1151,21 +1148,15 @@
          final int barCount = inReal.length;
          if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
             throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.mamaStepImpl(this, inReal[i]);
-               outMAMA[i] = this.cur_outMAMA;
-               if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+            core.mamaStepImpl(this, inReal[i]);
+            outMAMA[i] = this.cur_outMAMA;
+            if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1410,9 +1401,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMAMA, this.cur_outFAMA);
       }
 
       /**
@@ -2074,7 +2067,6 @@
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
       sp.cur_outFAMA = lastCur_outFAMA;
-      sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
       return RetCode.Success;
    }
    /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MARKETFI.java
+++ b/ta_codegen/output/java/fragments/Core_MARKETFI.java
@@ -398,6 +398,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MAVP.java
+++ b/ta_codegen/output/java/fragments/Core_MAVP.java
@@ -801,6 +801,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MAX.java
+++ b/ta_codegen/output/java/fragments/Core_MAX.java
@@ -587,6 +587,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MAXINDEX.java
@@ -487,6 +487,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_MEDPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_MEDPRICE.java
@@ -328,6 +328,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MFI.java
+++ b/ta_codegen/output/java/fragments/Core_MFI.java
@@ -697,6 +697,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MIDPOINT.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPOINT.java
@@ -686,6 +686,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MIDPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPRICE.java
@@ -709,6 +709,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MIN.java
+++ b/ta_codegen/output/java/fragments/Core_MIN.java
@@ -584,6 +584,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MININDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MININDEX.java
@@ -487,6 +487,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;

--- a/ta_codegen/output/java/fragments/Core_MINMAX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAX.java
@@ -536,7 +536,6 @@
       double[] x_inReal;
       double cur_outMin;
       double cur_outMax;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -569,7 +568,6 @@
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMin = other.cur_outMin;
          this.cur_outMax = other.cur_outMax;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -610,8 +608,7 @@
          }
          core.minmaxStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-         return this.cachedValue;
+         return new Value(this.cur_outMin, this.cur_outMax);
       }
 
       /**
@@ -634,21 +631,15 @@
          final int barCount = inReal.length;
          if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
             throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxStepImpl(this, inReal[i]);
-               outMin[i] = this.cur_outMin;
-               outMax[i] = this.cur_outMax;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+            core.minmaxStepImpl(this, inReal[i]);
+            outMin[i] = this.cur_outMin;
+            outMax[i] = this.cur_outMax;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -733,9 +724,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMin, this.cur_outMax);
       }
 
       /**
@@ -949,7 +942,6 @@
       sp.x_inReal = capX_inReal;
       sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
       sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
       return RetCode.Success;
    }
    /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
@@ -404,7 +404,6 @@
       double[] x_inReal;
       int cur_outMinIdx;
       int cur_outMaxIdx;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -437,7 +436,6 @@
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMinIdx = other.cur_outMinIdx;
          this.cur_outMaxIdx = other.cur_outMaxIdx;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -478,8 +476,7 @@
          }
          core.minmaxindexStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-         return this.cachedValue;
+         return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
       }
 
       /**
@@ -502,21 +499,15 @@
          final int barCount = inReal.length;
          if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
             throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxindexStepImpl(this, inReal[i]);
-               outMinIdx[i] = this.cur_outMinIdx;
-               outMaxIdx[i] = this.cur_outMaxIdx;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+            core.minmaxindexStepImpl(this, inReal[i]);
+            outMinIdx[i] = this.cur_outMinIdx;
+            outMaxIdx[i] = this.cur_outMaxIdx;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -601,9 +592,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
       }
 
       /**
@@ -800,7 +793,6 @@
       sp.x_inReal = capX_inReal;
       sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
       sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
       return RetCode.Success;
    }
    /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MINUS_DI.java
+++ b/ta_codegen/output/java/fragments/Core_MINUS_DI.java
@@ -946,6 +946,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MINUS_DM.java
+++ b/ta_codegen/output/java/fragments/Core_MINUS_DM.java
@@ -689,6 +689,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MOM.java
+++ b/ta_codegen/output/java/fragments/Core_MOM.java
@@ -419,6 +419,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_MULT.java
+++ b/ta_codegen/output/java/fragments/Core_MULT.java
@@ -320,6 +320,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_NATR.java
+++ b/ta_codegen/output/java/fragments/Core_NATR.java
@@ -700,6 +700,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_NVI.java
+++ b/ta_codegen/output/java/fragments/Core_NVI.java
@@ -433,6 +433,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_OBV.java
+++ b/ta_codegen/output/java/fragments/Core_OBV.java
@@ -353,6 +353,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_PLUS_DI.java
+++ b/ta_codegen/output/java/fragments/Core_PLUS_DI.java
@@ -954,6 +954,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_PLUS_DM.java
+++ b/ta_codegen/output/java/fragments/Core_PLUS_DM.java
@@ -688,6 +688,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_PPO.java
+++ b/ta_codegen/output/java/fragments/Core_PPO.java
@@ -509,6 +509,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_PVI.java
+++ b/ta_codegen/output/java/fragments/Core_PVI.java
@@ -433,6 +433,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_PVO.java
+++ b/ta_codegen/output/java/fragments/Core_PVO.java
@@ -507,6 +507,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_QSTICK.java
+++ b/ta_codegen/output/java/fragments/Core_QSTICK.java
@@ -471,6 +471,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ROC.java
+++ b/ta_codegen/output/java/fragments/Core_ROC.java
@@ -438,6 +438,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ROCP.java
+++ b/ta_codegen/output/java/fragments/Core_ROCP.java
@@ -436,6 +436,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ROCR.java
+++ b/ta_codegen/output/java/fragments/Core_ROCR.java
@@ -439,6 +439,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ROCR100.java
+++ b/ta_codegen/output/java/fragments/Core_ROCR100.java
@@ -441,6 +441,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_RSI.java
+++ b/ta_codegen/output/java/fragments/Core_RSI.java
@@ -653,6 +653,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SAR.java
+++ b/ta_codegen/output/java/fragments/Core_SAR.java
@@ -860,6 +860,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SAREXT.java
+++ b/ta_codegen/output/java/fragments/Core_SAREXT.java
@@ -1120,6 +1120,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SIN.java
+++ b/ta_codegen/output/java/fragments/Core_SIN.java
@@ -303,6 +303,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SINH.java
+++ b/ta_codegen/output/java/fragments/Core_SINH.java
@@ -301,6 +301,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SMA.java
+++ b/ta_codegen/output/java/fragments/Core_SMA.java
@@ -442,6 +442,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SMI.java
+++ b/ta_codegen/output/java/fragments/Core_SMI.java
@@ -853,7 +853,6 @@
       double[] x_inClose;
       double cur_outSMI;
       double cur_outSMISignal;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -899,7 +898,6 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSMI = other.cur_outSMI;
          this.cur_outSMISignal = other.cur_outSMISignal;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -940,8 +938,7 @@
          }
          core.smiStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-         return this.cachedValue;
+         return new Value(this.cur_outSMI, this.cur_outSMISignal);
       }
 
       /**
@@ -966,21 +963,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
             throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSMI[i] = this.cur_outSMI;
-               outSMISignal[i] = this.cur_outSMISignal;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+            core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSMI[i] = this.cur_outSMI;
+            outSMISignal[i] = this.cur_outSMISignal;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1107,9 +1098,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSMI, this.cur_outSMISignal);
       }
 
       /**
@@ -1545,7 +1538,6 @@
       sp.x_inClose = capX_inClose;
       sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
       sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
       return RetCode.Success;
    }
    /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_SQRT.java
+++ b/ta_codegen/output/java/fragments/Core_SQRT.java
@@ -303,6 +303,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_STDDEV.java
+++ b/ta_codegen/output/java/fragments/Core_STDDEV.java
@@ -433,6 +433,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_STOCH.java
+++ b/ta_codegen/output/java/fragments/Core_STOCH.java
@@ -711,7 +711,6 @@
       double[] x_inClose;
       double cur_outSlowK;
       double cur_outSlowD;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       int outRangeBegIdx;
@@ -753,7 +752,6 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSlowK = other.cur_outSlowK;
          this.cur_outSlowD = other.cur_outSlowD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -796,8 +794,7 @@
          }
          core.stochStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-         return this.cachedValue;
+         return new Value(this.cur_outSlowK, this.cur_outSlowD);
       }
 
       /**
@@ -822,21 +819,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
             throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSlowK[i] = this.cur_outSlowK;
-               outSlowD[i] = this.cur_outSlowD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+            core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSlowK[i] = this.cur_outSlowK;
+            outSlowD[i] = this.cur_outSlowD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -951,9 +942,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSlowK, this.cur_outSlowD);
       }
 
       /**
@@ -1333,7 +1326,6 @@
       sp.sub1 = sub1;
       sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
       sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-      sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
       return RetCode.Success;
    }
    /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_STOCHF.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHF.java
@@ -632,7 +632,6 @@
       double[] x_inClose;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       MaStream sub0;
       int outRangeBegIdx;
       int outRangeCount;
@@ -671,7 +670,6 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
@@ -713,8 +711,7 @@
          }
          core.stochfStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -739,21 +736,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -867,9 +858,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -1223,7 +1216,6 @@
       sp.sub0 = sub0;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_STOCHRSI.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHRSI.java
@@ -448,7 +448,6 @@
       MAType optInFastD_MAType;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       RsiStream sub0;
       StochfStream sub1;
       int outRangeBegIdx;
@@ -477,7 +476,6 @@
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new RsiStream(other.sub0);
          this.sub1 = new StochfStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -520,8 +518,7 @@
          }
          core.stochrsiStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -544,21 +541,15 @@
          final int barCount = inReal.length;
          if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochrsiStepImpl(this, inReal[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochrsiStepImpl(this, inReal[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -594,9 +585,11 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -747,7 +740,6 @@
       sp.sub1 = sub1;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_SUB.java
+++ b/ta_codegen/output/java/fragments/Core_SUB.java
@@ -313,6 +313,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_SUM.java
+++ b/ta_codegen/output/java/fragments/Core_SUM.java
@@ -417,6 +417,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_T3.java
+++ b/ta_codegen/output/java/fragments/Core_T3.java
@@ -675,6 +675,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TAN.java
+++ b/ta_codegen/output/java/fragments/Core_TAN.java
@@ -305,6 +305,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TANH.java
+++ b/ta_codegen/output/java/fragments/Core_TANH.java
@@ -303,6 +303,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TEMA.java
+++ b/ta_codegen/output/java/fragments/Core_TEMA.java
@@ -587,6 +587,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TRANGE.java
+++ b/ta_codegen/output/java/fragments/Core_TRANGE.java
@@ -436,6 +436,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TRIMA.java
+++ b/ta_codegen/output/java/fragments/Core_TRIMA.java
@@ -807,6 +807,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TRIX.java
+++ b/ta_codegen/output/java/fragments/Core_TRIX.java
@@ -542,6 +542,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TSF.java
+++ b/ta_codegen/output/java/fragments/Core_TSF.java
@@ -717,6 +717,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_TYPPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_TYPPRICE.java
@@ -330,6 +330,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_ULTOSC.java
+++ b/ta_codegen/output/java/fragments/Core_ULTOSC.java
@@ -1012,6 +1012,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_VAR.java
+++ b/ta_codegen/output/java/fragments/Core_VAR.java
@@ -755,6 +755,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_VWAP.java
+++ b/ta_codegen/output/java/fragments/Core_VWAP.java
@@ -593,6 +593,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_VWMA.java
+++ b/ta_codegen/output/java/fragments/Core_VWMA.java
@@ -554,6 +554,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_WAD.java
+++ b/ta_codegen/output/java/fragments/Core_WAD.java
@@ -480,6 +480,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_WCLPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_WCLPRICE.java
@@ -330,6 +330,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_WILLR.java
+++ b/ta_codegen/output/java/fragments/Core_WILLR.java
@@ -755,6 +755,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/fragments/Core_WMA.java
+++ b/ta_codegen/output/java/fragments/Core_WMA.java
@@ -712,6 +712,7 @@
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -1240,6 +1240,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -2096,7 +2097,6 @@ public final class Core {
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -2129,7 +2129,6 @@ public final class Core {
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -2171,8 +2170,7 @@ public final class Core {
          }
          core.accbandsStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -2198,22 +2196,16 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -2298,9 +2290,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -2526,7 +2520,6 @@ public final class Core {
       sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -2935,6 +2928,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -3476,6 +3470,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -3983,6 +3978,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -4732,6 +4728,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -6012,6 +6009,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -7019,6 +7017,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -7837,6 +7836,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -8642,6 +8642,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -9278,7 +9279,6 @@ public final class Core {
       double[] x_inLow;
       double cur_outAroonDown;
       double cur_outAroonUp;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -9313,7 +9313,6 @@ public final class Core {
          this.x_inLow = other.x_inLow.clone();
          this.cur_outAroonDown = other.cur_outAroonDown;
          this.cur_outAroonUp = other.cur_outAroonUp;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -9354,8 +9353,7 @@ public final class Core {
          }
          core.aroonStepImpl(this, inHigh, inLow);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-         return this.cachedValue;
+         return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
       }
 
       /**
@@ -9379,21 +9377,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
             throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.aroonStepImpl(this, inHigh[i], inLow[i]);
-               outAroonDown[i] = this.cur_outAroonDown;
-               outAroonUp[i] = this.cur_outAroonUp;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+            core.aroonStepImpl(this, inHigh[i], inLow[i]);
+            outAroonDown[i] = this.cur_outAroonDown;
+            outAroonUp[i] = this.cur_outAroonUp;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -9486,9 +9478,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
       }
 
       /**
@@ -9703,7 +9697,6 @@ public final class Core {
       sp.x_inLow = capX_inLow;
       sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
       sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
       return RetCode.Success;
    }
    /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -10407,6 +10400,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -11050,6 +11044,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -11488,6 +11483,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -12242,6 +12238,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -12970,6 +12967,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -13503,6 +13501,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -14467,7 +14466,6 @@ public final class Core {
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       MaStream sub0;
       StddevStream sub1;
       int outRangeBegIdx;
@@ -14497,7 +14495,6 @@ public final class Core {
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new StddevStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -14541,8 +14538,7 @@ public final class Core {
          }
          core.bbandsStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -14566,22 +14562,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.bbandsStepImpl(this, inReal[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.bbandsStepImpl(this, inReal[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -14629,9 +14619,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
       }
 
       /**
@@ -14809,7 +14801,6 @@ public final class Core {
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -16032,6 +16023,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -17090,6 +17082,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -17841,6 +17834,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -18653,6 +18647,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -19480,6 +19475,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -20353,6 +20349,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -21209,6 +21206,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -21919,6 +21917,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -22857,6 +22856,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -24027,6 +24027,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -25122,6 +25123,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -26295,6 +26297,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -27301,6 +27304,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -28126,6 +28130,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -28939,6 +28944,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -29775,6 +29781,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -30640,6 +30647,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -31466,6 +31474,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -32188,6 +32197,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -32990,6 +33000,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -33825,6 +33836,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -34534,6 +34546,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -35409,6 +35422,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -36388,6 +36402,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -37282,6 +37297,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -38127,6 +38143,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -39078,6 +39095,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -40133,6 +40151,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -41103,6 +41122,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -42016,6 +42036,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -42873,6 +42894,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -43673,6 +43695,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -44564,6 +44587,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -45454,6 +45478,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -46366,6 +46391,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -47264,6 +47290,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -48164,6 +48191,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -49072,6 +49100,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -49949,6 +49978,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -50794,6 +50824,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -51607,6 +51638,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -52398,6 +52430,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -53202,6 +53235,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -53969,6 +54003,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -54893,6 +54928,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -55931,6 +55967,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -56917,6 +56954,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -57802,6 +57840,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -58607,6 +58646,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -59466,6 +59506,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -60452,6 +60493,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -61429,6 +61471,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -62374,6 +62417,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -63239,6 +63283,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -63974,6 +64019,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -64941,6 +64987,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -65866,6 +65913,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -66720,6 +66768,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -67562,6 +67611,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -68402,6 +68452,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -69233,6 +69284,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -70091,6 +70143,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -70986,6 +71039,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -71740,6 +71794,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -72259,6 +72314,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -73029,6 +73085,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -73944,6 +74001,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -74904,6 +74962,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -76164,6 +76223,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -77034,6 +77094,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -77471,6 +77532,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -78150,6 +78212,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -78748,6 +78811,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -79786,6 +79850,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -80842,6 +80907,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -81655,6 +81721,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -82181,6 +82248,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -82616,6 +82684,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -83972,6 +84041,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -86015,6 +86085,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -88042,6 +88113,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -89701,7 +89773,6 @@ public final class Core {
       double[] ring_trailingWMAIdx_inReal;
       double cur_outInPhase;
       double cur_outQuadrature;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -89768,7 +89839,6 @@ public final class Core {
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outInPhase = other.cur_outInPhase;
          this.cur_outQuadrature = other.cur_outQuadrature;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -89809,8 +89879,7 @@ public final class Core {
          }
          core.htPhasorStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-         return this.cachedValue;
+         return new Value(this.cur_outInPhase, this.cur_outQuadrature);
       }
 
       /**
@@ -89833,21 +89902,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
             throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htPhasorStepImpl(this, inReal[i]);
-               outInPhase[i] = this.cur_outInPhase;
-               outQuadrature[i] = this.cur_outQuadrature;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+            core.htPhasorStepImpl(this, inReal[i]);
+            outInPhase[i] = this.cur_outInPhase;
+            outQuadrature[i] = this.cur_outQuadrature;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -90057,9 +90120,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outInPhase, this.cur_outQuadrature);
       }
 
       /**
@@ -90635,7 +90700,6 @@ public final class Core {
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
       sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
       return RetCode.Success;
    }
    /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -91719,7 +91783,6 @@ public final class Core {
       double[] cb_smoothPrice;
       double cur_outSine;
       double cur_outLeadSine;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -91794,7 +91857,6 @@ public final class Core {
          this.cb_smoothPrice = other.cb_smoothPrice.clone();
          this.cur_outSine = other.cur_outSine;
          this.cur_outLeadSine = other.cur_outLeadSine;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -91835,8 +91897,7 @@ public final class Core {
          }
          core.htSineStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-         return this.cachedValue;
+         return new Value(this.cur_outSine, this.cur_outLeadSine);
       }
 
       /**
@@ -91859,21 +91920,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
             throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htSineStepImpl(this, inReal[i]);
-               outSine[i] = this.cur_outSine;
-               outLeadSine[i] = this.cur_outLeadSine;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+            core.htSineStepImpl(this, inReal[i]);
+            outSine[i] = this.cur_outSine;
+            outLeadSine[i] = this.cur_outLeadSine;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -92141,9 +92196,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSine, this.cur_outLeadSine);
       }
 
       /**
@@ -92851,7 +92908,6 @@ public final class Core {
       sp.cb_smoothPrice = smoothPrice;
       sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
       sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
       return RetCode.Success;
    }
    /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -94237,6 +94293,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -96591,6 +96648,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -97986,6 +98044,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -98983,6 +99042,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -100123,6 +100183,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -101267,6 +101328,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -102404,6 +102466,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -103535,6 +103598,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -104265,6 +104329,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -104708,6 +104773,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -105556,6 +105622,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -106697,7 +106764,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -106730,7 +106796,6 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -106772,8 +106837,7 @@ public final class Core {
          }
          core.macdStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -106797,22 +106861,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -106858,9 +106916,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -107107,7 +107167,6 @@ public final class Core {
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -107795,7 +107854,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       MaStream sub2;
@@ -107828,7 +107886,6 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.sub2 = new MaStream(other.sub2);
@@ -107873,8 +107930,7 @@ public final class Core {
          }
          core.macdextStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -107898,22 +107954,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdextStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdextStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -107953,9 +108003,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -108148,7 +108200,6 @@ public final class Core {
       sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
       sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
       sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-      sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -108767,7 +108818,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -108798,7 +108848,6 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -108840,8 +108889,7 @@ public final class Core {
          }
          core.macdfixStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -108865,22 +108913,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdfixStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdfixStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -108926,9 +108968,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
       }
 
       /**
@@ -109150,7 +109194,6 @@ public final class Core {
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -110253,7 +110296,6 @@ public final class Core {
       double[] ring_trailingWMAIdx_inReal;
       double cur_outMAMA;
       double cur_outFAMA;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -110325,7 +110367,6 @@ public final class Core {
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outMAMA = other.cur_outMAMA;
          this.cur_outFAMA = other.cur_outFAMA;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -110366,8 +110407,7 @@ public final class Core {
          }
          core.mamaStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-         return this.cachedValue;
+         return new Value(this.cur_outMAMA, this.cur_outFAMA);
       }
 
       /**
@@ -110392,21 +110432,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
             throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.mamaStepImpl(this, inReal[i]);
-               outMAMA[i] = this.cur_outMAMA;
-               if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+            core.mamaStepImpl(this, inReal[i]);
+            outMAMA[i] = this.cur_outMAMA;
+            if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -110651,9 +110685,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMAMA, this.cur_outFAMA);
       }
 
       /**
@@ -111315,7 +111351,6 @@ public final class Core {
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
       sp.cur_outFAMA = lastCur_outFAMA;
-      sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
       return RetCode.Success;
    }
    /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -111803,6 +111838,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -112794,6 +112830,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -113632,6 +113669,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -114369,6 +114407,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public int value() {
          return this.cur_outInteger;
@@ -114936,6 +114975,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -115782,6 +115822,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -116832,6 +116873,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -117846,6 +117888,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -118744,6 +118787,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -119478,6 +119522,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public int value() {
@@ -120255,7 +120300,6 @@ public final class Core {
       double[] x_inReal;
       double cur_outMin;
       double cur_outMax;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -120288,7 +120332,6 @@ public final class Core {
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMin = other.cur_outMin;
          this.cur_outMax = other.cur_outMax;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -120329,8 +120372,7 @@ public final class Core {
          }
          core.minmaxStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-         return this.cachedValue;
+         return new Value(this.cur_outMin, this.cur_outMax);
       }
 
       /**
@@ -120353,21 +120395,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
             throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxStepImpl(this, inReal[i]);
-               outMin[i] = this.cur_outMin;
-               outMax[i] = this.cur_outMax;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+            core.minmaxStepImpl(this, inReal[i]);
+            outMin[i] = this.cur_outMin;
+            outMax[i] = this.cur_outMax;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -120452,9 +120488,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMin, this.cur_outMax);
       }
 
       /**
@@ -120668,7 +120706,6 @@ public final class Core {
       sp.x_inReal = capX_inReal;
       sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
       sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
       return RetCode.Success;
    }
    /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -121161,7 +121198,6 @@ public final class Core {
       double[] x_inReal;
       int cur_outMinIdx;
       int cur_outMaxIdx;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -121194,7 +121230,6 @@ public final class Core {
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMinIdx = other.cur_outMinIdx;
          this.cur_outMaxIdx = other.cur_outMaxIdx;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -121235,8 +121270,7 @@ public final class Core {
          }
          core.minmaxindexStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-         return this.cachedValue;
+         return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
       }
 
       /**
@@ -121259,21 +121293,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
             throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxindexStepImpl(this, inReal[i]);
-               outMinIdx[i] = this.cur_outMinIdx;
-               outMaxIdx[i] = this.cur_outMaxIdx;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+            core.minmaxindexStepImpl(this, inReal[i]);
+            outMinIdx[i] = this.cur_outMinIdx;
+            outMaxIdx[i] = this.cur_outMaxIdx;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -121358,9 +121386,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
       }
 
       /**
@@ -121557,7 +121587,6 @@ public final class Core {
       sp.x_inReal = capX_inReal;
       sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
       sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
       return RetCode.Success;
    }
    /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -122591,6 +122620,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -123945,6 +123975,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -124834,6 +124865,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -125364,6 +125396,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -126211,6 +126244,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -127016,6 +127050,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -127581,6 +127616,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -128700,6 +128736,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -130053,6 +130090,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -131032,6 +131070,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -131692,6 +131731,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -132413,6 +132453,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -133112,6 +133153,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -133784,6 +133826,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -134440,6 +134483,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -135100,6 +135144,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -135762,6 +135807,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -136636,6 +136682,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -137819,6 +137866,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -139432,6 +139480,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -140328,6 +140377,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -140763,6 +140813,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -141340,6 +141391,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -142401,7 +142453,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outSMI;
       double cur_outSMISignal;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -142447,7 +142498,6 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSMI = other.cur_outSMI;
          this.cur_outSMISignal = other.cur_outSMISignal;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
@@ -142488,8 +142538,7 @@ public final class Core {
          }
          core.smiStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-         return this.cachedValue;
+         return new Value(this.cur_outSMI, this.cur_outSMISignal);
       }
 
       /**
@@ -142514,21 +142563,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
             throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSMI[i] = this.cur_outSMI;
-               outSMISignal[i] = this.cur_outSMISignal;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+            core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSMI[i] = this.cur_outSMI;
+            outSMISignal[i] = this.cur_outSMISignal;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -142655,9 +142698,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSMI, this.cur_outSMISignal);
       }
 
       /**
@@ -143093,7 +143138,6 @@ public final class Core {
       sp.x_inClose = capX_inClose;
       sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
       sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
       return RetCode.Success;
    }
    /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -143492,6 +143536,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -144060,6 +144105,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -144974,7 +145020,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outSlowK;
       double cur_outSlowD;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       int outRangeBegIdx;
@@ -145016,7 +145061,6 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSlowK = other.cur_outSlowK;
          this.cur_outSlowD = other.cur_outSlowD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -145059,8 +145103,7 @@ public final class Core {
          }
          core.stochStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-         return this.cachedValue;
+         return new Value(this.cur_outSlowK, this.cur_outSlowD);
       }
 
       /**
@@ -145085,21 +145128,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
             throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSlowK[i] = this.cur_outSlowK;
-               outSlowD[i] = this.cur_outSlowD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+            core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSlowK[i] = this.cur_outSlowK;
+            outSlowD[i] = this.cur_outSlowD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -145214,9 +145251,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outSlowK, this.cur_outSlowD);
       }
 
       /**
@@ -145596,7 +145635,6 @@ public final class Core {
       sp.sub1 = sub1;
       sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
       sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-      sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
       return RetCode.Success;
    }
    /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -146329,7 +146367,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       MaStream sub0;
       int outRangeBegIdx;
       int outRangeCount;
@@ -146368,7 +146405,6 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
@@ -146410,8 +146446,7 @@ public final class Core {
          }
          core.stochfStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -146436,21 +146471,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -146564,9 +146593,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -146920,7 +146951,6 @@ public final class Core {
       sp.sub0 = sub0;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -147467,7 +147497,6 @@ public final class Core {
       MAType optInFastD_MAType;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       RsiStream sub0;
       StochfStream sub1;
       int outRangeBegIdx;
@@ -147496,7 +147525,6 @@ public final class Core {
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new RsiStream(other.sub0);
          this.sub1 = new StochfStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
@@ -147539,8 +147567,7 @@ public final class Core {
          }
          core.stochrsiStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -147563,21 +147590,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochrsiStepImpl(this, inReal[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochrsiStepImpl(this, inReal[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -147613,9 +147634,11 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * Built from the committed fields on each call, as the C# tier does —
+       * nothing is cached between calls, and {@code peek} does not change them.
        */
       public Value value() {
-         return this.cachedValue;
+         return new Value(this.cur_outFastK, this.cur_outFastD);
       }
 
       /**
@@ -147766,7 +147789,6 @@ public final class Core {
       sp.sub1 = sub1;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -148169,6 +148191,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -148729,6 +148752,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -149608,6 +149632,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -150238,6 +150263,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -150675,6 +150701,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -151397,6 +151424,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -152140,6 +152168,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -153163,6 +153192,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -154328,6 +154358,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -155299,6 +155330,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -156057,6 +156089,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -157217,6 +157250,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -158499,6 +158533,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -159536,6 +159571,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -160436,6 +160472,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -161202,6 +161239,7 @@ public final class Core {
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
+       * A pure field read; {@code peek} does not change it.
        */
       public double value() {
          return this.cur_outReal;
@@ -161757,6 +161795,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -162660,6 +162699,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {
@@ -163712,6 +163752,7 @@ public final class Core {
        * The value at the last bar this stream counted — the bar
        * {@link #outRange()} ends on. The last history bar right after open,
        * then whatever the latest accepted {@code update} returned.
+       * A pure field read; {@code peek} does not change it.
        * A pure field read; {@code peek} does not change it.
        */
       public double value() {

--- a/ta_codegen/output/java/library/src/test/java/io/github/talib/test/StreamSmokeTest.java
+++ b/ta_codegen/output/java/library/src/test/java/io/github/talib/test/StreamSmokeTest.java
@@ -453,8 +453,11 @@ public class StreamSmokeTest {
                 ufUntouched("BBANDS.lower", bl[i], UF_CANARY);
             }
             /* value() must name the last COMMITTED bar, not the one before the
-             * call: the multi-output cache is refreshed on the throwing path
-             * too. */
+             * call, on the throwing path too. Before #310 that took a `finally`
+             * refreshing a cached Value; now it holds because `value()` reads
+             * the `cur_*` fields the loop already advanced, and nothing else
+             * stands between them and the caller. This check is what says the
+             * `finally` was removable rather than load-bearing. */
             check(bitEq(ba.value().realUpperBand(), wantB[UF_BAD - 1].realUpperBand()),
                   "BBANDS: value() must name the last committed bar after a partial fill");
             ufValues++;
@@ -1427,12 +1430,21 @@ public class StreamSmokeTest {
         /* Multi-output Value: named components, equals/hashCode/toString. */
         Core.MacdStream m = core.macdOpen(close, 12, 26, 9);
         Core.MacdStream.Value v1 = m.update(close[n - 1]);
-        check(m.value() == v1, "multi-output value() returns the cached instance");
+        /* #310: the handle caches no Value. `value()` builds one from the same
+         * committed fields, so it is EQUAL to what `update` returned and is a
+         * DISTINCT instance. Both halves are asserted: equality alone would
+         * still pass against a cache, and distinctness alone would pass against
+         * a stale one. Java therefore reads here exactly as C# does, where a
+         * record struct makes both true by construction. */
+        check(v1.equals(m.value()), "multi-output value() equals what update returned");
+        check(m.value() != v1, "multi-output value() is not a cached instance");
         Core.MacdStream.Value v2 = m.peek(close[n - 1] + 1.0);
         check(!v1.equals(v2), "distinct bars produce non-equal Values");
         check(v1.toString().contains("macdSignal="), "Value toString names fields");
         java.util.HashSet<Core.MacdStream.Value> set = new java.util.HashSet<Core.MacdStream.Value>();
         set.add(v1);
+        /* Now a real test of the record's equals/hashCode: the instance looked
+         * up is not the instance inserted, where before #310 it was. */
         check(set.contains(m.value()), "Value hashCode/equals contract");
 
         /* Components are readable by name, in batch output order, and carry the

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -914,6 +914,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -1770,7 +1771,6 @@ class Core {
           double cur_outRealUpperBand;
           double cur_outRealMiddleBand;
           double cur_outRealLowerBand;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -1803,7 +1803,6 @@ class Core {
              this.cur_outRealUpperBand = other.cur_outRealUpperBand;
              this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
              this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -1845,8 +1844,7 @@ class Core {
              }
              core.accbandsStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-             return this.cachedValue;
+             return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
           }
 
           /**
@@ -1872,22 +1870,16 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
                 throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outRealUpperBand[i] = this.cur_outRealUpperBand;
-                   outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-                   outRealLowerBand[i] = this.cur_outRealLowerBand;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+                core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outRealUpperBand[i] = this.cur_outRealUpperBand;
+                outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+                outRealLowerBand[i] = this.cur_outRealLowerBand;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -1972,9 +1964,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
           }
 
           /**
@@ -2200,7 +2194,6 @@ class Core {
           sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
           sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
           sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
           return RetCode.Success;
        }
        /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -2609,6 +2602,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -3150,6 +3144,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -3657,6 +3652,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -4406,6 +4402,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -5686,6 +5683,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -6693,6 +6691,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -7511,6 +7510,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -8316,6 +8316,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -8952,7 +8953,6 @@ class Core {
           double[] x_inLow;
           double cur_outAroonDown;
           double cur_outAroonUp;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -8987,7 +8987,6 @@ class Core {
              this.x_inLow = other.x_inLow.clone();
              this.cur_outAroonDown = other.cur_outAroonDown;
              this.cur_outAroonUp = other.cur_outAroonUp;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -9028,8 +9027,7 @@ class Core {
              }
              core.aroonStepImpl(this, inHigh, inLow);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-             return this.cachedValue;
+             return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
           }
 
           /**
@@ -9053,21 +9051,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
                 throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.aroonStepImpl(this, inHigh[i], inLow[i]);
-                   outAroonDown[i] = this.cur_outAroonDown;
-                   outAroonUp[i] = this.cur_outAroonUp;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+                core.aroonStepImpl(this, inHigh[i], inLow[i]);
+                outAroonDown[i] = this.cur_outAroonDown;
+                outAroonUp[i] = this.cur_outAroonUp;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -9160,9 +9152,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outAroonDown, this.cur_outAroonUp);
           }
 
           /**
@@ -9377,7 +9371,6 @@ class Core {
           sp.x_inLow = capX_inLow;
           sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
           sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
           return RetCode.Success;
        }
        /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -10081,6 +10074,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -10724,6 +10718,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -11162,6 +11157,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -11916,6 +11912,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -12644,6 +12641,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -13177,6 +13175,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -14141,7 +14140,6 @@ class Core {
           double cur_outRealUpperBand;
           double cur_outRealMiddleBand;
           double cur_outRealLowerBand;
-          Value cachedValue;
           MaStream sub0;
           StddevStream sub1;
           int outRangeBegIdx;
@@ -14171,7 +14169,6 @@ class Core {
              this.cur_outRealUpperBand = other.cur_outRealUpperBand;
              this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
              this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new StddevStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
@@ -14215,8 +14212,7 @@ class Core {
              }
              core.bbandsStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-             return this.cachedValue;
+             return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
           }
 
           /**
@@ -14240,22 +14236,16 @@ class Core {
              final int barCount = inReal.length;
              if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
                 throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.bbandsStepImpl(this, inReal[i]);
-                   outRealUpperBand[i] = this.cur_outRealUpperBand;
-                   outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-                   outRealLowerBand[i] = this.cur_outRealLowerBand;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+                core.bbandsStepImpl(this, inReal[i]);
+                outRealUpperBand[i] = this.cur_outRealUpperBand;
+                outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+                outRealLowerBand[i] = this.cur_outRealLowerBand;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -14303,9 +14293,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
           }
 
           /**
@@ -14483,7 +14475,6 @@ class Core {
           sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
           sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
           sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-          sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
           return RetCode.Success;
        }
        /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -15706,6 +15697,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -16764,6 +16756,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -17515,6 +17508,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -18327,6 +18321,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -19154,6 +19149,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -20027,6 +20023,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -20883,6 +20880,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -21593,6 +21591,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -22531,6 +22530,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -23701,6 +23701,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -24796,6 +24797,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -25969,6 +25971,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -26975,6 +26978,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -27800,6 +27804,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -28613,6 +28618,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -29449,6 +29455,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -30314,6 +30321,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -31140,6 +31148,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -31862,6 +31871,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -32664,6 +32674,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -33499,6 +33510,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -34208,6 +34220,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -35083,6 +35096,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -36062,6 +36076,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -36956,6 +36971,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -37801,6 +37817,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -38752,6 +38769,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -39807,6 +39825,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -40777,6 +40796,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -41690,6 +41710,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -42547,6 +42568,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -43347,6 +43369,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -44238,6 +44261,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -45128,6 +45152,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -46040,6 +46065,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -46938,6 +46964,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -47838,6 +47865,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -48746,6 +48774,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -49623,6 +49652,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -50468,6 +50498,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -51281,6 +51312,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -52072,6 +52104,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -52876,6 +52909,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -53643,6 +53677,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -54567,6 +54602,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -55605,6 +55641,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -56591,6 +56628,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -57476,6 +57514,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -58281,6 +58320,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -59140,6 +59180,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -60126,6 +60167,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -61103,6 +61145,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -62048,6 +62091,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -62913,6 +62957,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -63648,6 +63693,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -64615,6 +64661,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -65540,6 +65587,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -66394,6 +66442,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -67236,6 +67285,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -68076,6 +68126,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -68907,6 +68958,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -69765,6 +69817,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -70660,6 +70713,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -71414,6 +71468,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -71933,6 +71988,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -72703,6 +72759,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -73618,6 +73675,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -74578,6 +74636,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -75838,6 +75897,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -76708,6 +76768,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -77145,6 +77206,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -77824,6 +77886,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -78422,6 +78485,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -79460,6 +79524,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -80516,6 +80581,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -81329,6 +81395,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -81855,6 +81922,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -82290,6 +82358,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -83646,6 +83715,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -85689,6 +85759,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -87716,6 +87787,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -89375,7 +89447,6 @@ class Core {
           double[] ring_trailingWMAIdx_inReal;
           double cur_outInPhase;
           double cur_outQuadrature;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -89442,7 +89513,6 @@ class Core {
              this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
              this.cur_outInPhase = other.cur_outInPhase;
              this.cur_outQuadrature = other.cur_outQuadrature;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -89483,8 +89553,7 @@ class Core {
              }
              core.htPhasorStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-             return this.cachedValue;
+             return new Value(this.cur_outInPhase, this.cur_outQuadrature);
           }
 
           /**
@@ -89507,21 +89576,15 @@ class Core {
              final int barCount = inReal.length;
              if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
                 throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.htPhasorStepImpl(this, inReal[i]);
-                   outInPhase[i] = this.cur_outInPhase;
-                   outQuadrature[i] = this.cur_outQuadrature;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+                core.htPhasorStepImpl(this, inReal[i]);
+                outInPhase[i] = this.cur_outInPhase;
+                outQuadrature[i] = this.cur_outQuadrature;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -89731,9 +89794,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outInPhase, this.cur_outQuadrature);
           }
 
           /**
@@ -90309,7 +90374,6 @@ class Core {
           sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
           sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
           sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
           return RetCode.Success;
        }
        /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -91393,7 +91457,6 @@ class Core {
           double[] cb_smoothPrice;
           double cur_outSine;
           double cur_outLeadSine;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -91468,7 +91531,6 @@ class Core {
              this.cb_smoothPrice = other.cb_smoothPrice.clone();
              this.cur_outSine = other.cur_outSine;
              this.cur_outLeadSine = other.cur_outLeadSine;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -91509,8 +91571,7 @@ class Core {
              }
              core.htSineStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-             return this.cachedValue;
+             return new Value(this.cur_outSine, this.cur_outLeadSine);
           }
 
           /**
@@ -91533,21 +91594,15 @@ class Core {
              final int barCount = inReal.length;
              if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
                 throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.htSineStepImpl(this, inReal[i]);
-                   outSine[i] = this.cur_outSine;
-                   outLeadSine[i] = this.cur_outLeadSine;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+                core.htSineStepImpl(this, inReal[i]);
+                outSine[i] = this.cur_outSine;
+                outLeadSine[i] = this.cur_outLeadSine;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -91815,9 +91870,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outSine, this.cur_outLeadSine);
           }
 
           /**
@@ -92525,7 +92582,6 @@ class Core {
           sp.cb_smoothPrice = smoothPrice;
           sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
           sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
           return RetCode.Success;
        }
        /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -93911,6 +93967,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -96265,6 +96322,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -97660,6 +97718,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -98657,6 +98716,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -99797,6 +99857,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -100941,6 +101002,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -102078,6 +102140,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -103209,6 +103272,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -103939,6 +104003,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -104382,6 +104447,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -105230,6 +105296,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -106371,7 +106438,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -106404,7 +106470,6 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -106446,8 +106511,7 @@ class Core {
              }
              core.macdStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -106471,22 +106535,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -106532,9 +106590,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -106781,7 +106841,6 @@ class Core {
           sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -107469,7 +107528,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           MaStream sub0;
           MaStream sub1;
           MaStream sub2;
@@ -107502,7 +107560,6 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new MaStream(other.sub1);
              this.sub2 = new MaStream(other.sub2);
@@ -107547,8 +107604,7 @@ class Core {
              }
              core.macdextStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -107572,22 +107628,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdextStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdextStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -107627,9 +107677,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -107822,7 +107874,6 @@ class Core {
           sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
           sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
           sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-          sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -108441,7 +108492,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -108472,7 +108522,6 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -108514,8 +108563,7 @@ class Core {
              }
              core.macdfixStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -108539,22 +108587,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdfixStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdfixStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -108600,9 +108642,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
           }
 
           /**
@@ -108824,7 +108868,6 @@ class Core {
           sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -109927,7 +109970,6 @@ class Core {
           double[] ring_trailingWMAIdx_inReal;
           double cur_outMAMA;
           double cur_outFAMA;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -109999,7 +110041,6 @@ class Core {
              this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
              this.cur_outMAMA = other.cur_outMAMA;
              this.cur_outFAMA = other.cur_outFAMA;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -110040,8 +110081,7 @@ class Core {
              }
              core.mamaStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-             return this.cachedValue;
+             return new Value(this.cur_outMAMA, this.cur_outFAMA);
           }
 
           /**
@@ -110066,21 +110106,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
                 throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.mamaStepImpl(this, inReal[i]);
-                   outMAMA[i] = this.cur_outMAMA;
-                   if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+                core.mamaStepImpl(this, inReal[i]);
+                outMAMA[i] = this.cur_outMAMA;
+                if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -110325,9 +110359,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMAMA, this.cur_outFAMA);
           }
 
           /**
@@ -110989,7 +111025,6 @@ class Core {
           sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
           sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
           sp.cur_outFAMA = lastCur_outFAMA;
-          sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
           return RetCode.Success;
        }
        /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -111477,6 +111512,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -112468,6 +112504,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -113306,6 +113343,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -114043,6 +114081,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public int value() {
              return this.cur_outInteger;
@@ -114610,6 +114649,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -115456,6 +115496,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -116506,6 +116547,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -117520,6 +117562,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -118418,6 +118461,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -119152,6 +119196,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public int value() {
@@ -119929,7 +119974,6 @@ class Core {
           double[] x_inReal;
           double cur_outMin;
           double cur_outMax;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -119962,7 +120006,6 @@ class Core {
              this.x_inReal = other.x_inReal.clone();
              this.cur_outMin = other.cur_outMin;
              this.cur_outMax = other.cur_outMax;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -120003,8 +120046,7 @@ class Core {
              }
              core.minmaxStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-             return this.cachedValue;
+             return new Value(this.cur_outMin, this.cur_outMax);
           }
 
           /**
@@ -120027,21 +120069,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
                 throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.minmaxStepImpl(this, inReal[i]);
-                   outMin[i] = this.cur_outMin;
-                   outMax[i] = this.cur_outMax;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+                core.minmaxStepImpl(this, inReal[i]);
+                outMin[i] = this.cur_outMin;
+                outMax[i] = this.cur_outMax;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -120126,9 +120162,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMin, this.cur_outMax);
           }
 
           /**
@@ -120342,7 +120380,6 @@ class Core {
           sp.x_inReal = capX_inReal;
           sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
           sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
           return RetCode.Success;
        }
        /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -120835,7 +120872,6 @@ class Core {
           double[] x_inReal;
           int cur_outMinIdx;
           int cur_outMaxIdx;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -120868,7 +120904,6 @@ class Core {
              this.x_inReal = other.x_inReal.clone();
              this.cur_outMinIdx = other.cur_outMinIdx;
              this.cur_outMaxIdx = other.cur_outMaxIdx;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -120909,8 +120944,7 @@ class Core {
              }
              core.minmaxindexStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-             return this.cachedValue;
+             return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
           }
 
           /**
@@ -120933,21 +120967,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
                 throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.minmaxindexStepImpl(this, inReal[i]);
-                   outMinIdx[i] = this.cur_outMinIdx;
-                   outMaxIdx[i] = this.cur_outMaxIdx;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+                core.minmaxindexStepImpl(this, inReal[i]);
+                outMinIdx[i] = this.cur_outMinIdx;
+                outMaxIdx[i] = this.cur_outMaxIdx;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -121032,9 +121060,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
           }
 
           /**
@@ -121231,7 +121261,6 @@ class Core {
           sp.x_inReal = capX_inReal;
           sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
           sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
           return RetCode.Success;
        }
        /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -122265,6 +122294,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -123619,6 +123649,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -124508,6 +124539,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -125038,6 +125070,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -125885,6 +125918,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -126690,6 +126724,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -127255,6 +127290,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -128374,6 +128410,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -129727,6 +129764,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -130706,6 +130744,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -131366,6 +131405,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -132087,6 +132127,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -132786,6 +132827,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -133458,6 +133500,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -134114,6 +134157,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -134774,6 +134818,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -135436,6 +135481,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -136310,6 +136356,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -137493,6 +137540,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -139106,6 +139154,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -140002,6 +140051,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -140437,6 +140487,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -141014,6 +141065,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -142075,7 +142127,6 @@ class Core {
           double[] x_inClose;
           double cur_outSMI;
           double cur_outSMISignal;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -142121,7 +142172,6 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outSMI = other.cur_outSMI;
              this.cur_outSMISignal = other.cur_outSMISignal;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
@@ -142162,8 +142212,7 @@ class Core {
              }
              core.smiStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-             return this.cachedValue;
+             return new Value(this.cur_outSMI, this.cur_outSMISignal);
           }
 
           /**
@@ -142188,21 +142237,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
                 throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outSMI[i] = this.cur_outSMI;
-                   outSMISignal[i] = this.cur_outSMISignal;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+                core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outSMI[i] = this.cur_outSMI;
+                outSMISignal[i] = this.cur_outSMISignal;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -142329,9 +142372,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outSMI, this.cur_outSMISignal);
           }
 
           /**
@@ -142767,7 +142812,6 @@ class Core {
           sp.x_inClose = capX_inClose;
           sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
           sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
           return RetCode.Success;
        }
        /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -143166,6 +143210,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -143734,6 +143779,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -144648,7 +144694,6 @@ class Core {
           double[] x_inClose;
           double cur_outSlowK;
           double cur_outSlowD;
-          Value cachedValue;
           MaStream sub0;
           MaStream sub1;
           int outRangeBegIdx;
@@ -144690,7 +144735,6 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outSlowK = other.cur_outSlowK;
              this.cur_outSlowD = other.cur_outSlowD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new MaStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
@@ -144733,8 +144777,7 @@ class Core {
              }
              core.stochStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-             return this.cachedValue;
+             return new Value(this.cur_outSlowK, this.cur_outSlowD);
           }
 
           /**
@@ -144759,21 +144802,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
                 throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outSlowK[i] = this.cur_outSlowK;
-                   outSlowD[i] = this.cur_outSlowD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+                core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outSlowK[i] = this.cur_outSlowK;
+                outSlowD[i] = this.cur_outSlowD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -144888,9 +144925,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outSlowK, this.cur_outSlowD);
           }
 
           /**
@@ -145270,7 +145309,6 @@ class Core {
           sp.sub1 = sub1;
           sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
           sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-          sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
           return RetCode.Success;
        }
        /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -146003,7 +146041,6 @@ class Core {
           double[] x_inClose;
           double cur_outFastK;
           double cur_outFastD;
-          Value cachedValue;
           MaStream sub0;
           int outRangeBegIdx;
           int outRangeCount;
@@ -146042,7 +146079,6 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outFastK = other.cur_outFastK;
              this.cur_outFastD = other.cur_outFastD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
@@ -146084,8 +146120,7 @@ class Core {
              }
              core.stochfStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-             return this.cachedValue;
+             return new Value(this.cur_outFastK, this.cur_outFastD);
           }
 
           /**
@@ -146110,21 +146145,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
                 throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outFastK[i] = this.cur_outFastK;
-                   outFastD[i] = this.cur_outFastD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+                core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outFastK[i] = this.cur_outFastK;
+                outFastD[i] = this.cur_outFastD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -146238,9 +146267,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outFastK, this.cur_outFastD);
           }
 
           /**
@@ -146594,7 +146625,6 @@ class Core {
           sp.sub0 = sub0;
           sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
           sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-          sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
           return RetCode.Success;
        }
        /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -147141,7 +147171,6 @@ class Core {
           MAType optInFastD_MAType;
           double cur_outFastK;
           double cur_outFastD;
-          Value cachedValue;
           RsiStream sub0;
           StochfStream sub1;
           int outRangeBegIdx;
@@ -147170,7 +147199,6 @@ class Core {
              this.optInFastD_MAType = other.optInFastD_MAType;
              this.cur_outFastK = other.cur_outFastK;
              this.cur_outFastD = other.cur_outFastD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new RsiStream(other.sub0);
              this.sub1 = new StochfStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
@@ -147213,8 +147241,7 @@ class Core {
              }
              core.stochrsiStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-             return this.cachedValue;
+             return new Value(this.cur_outFastK, this.cur_outFastD);
           }
 
           /**
@@ -147237,21 +147264,15 @@ class Core {
              final int barCount = inReal.length;
              if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
                 throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochrsiStepImpl(this, inReal[i]);
-                   outFastK[i] = this.cur_outFastK;
-                   outFastD[i] = this.cur_outFastD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+                core.stochrsiStepImpl(this, inReal[i]);
+                outFastK[i] = this.cur_outFastK;
+                outFastD[i] = this.cur_outFastD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -147287,9 +147308,11 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * Built from the committed fields on each call, as the C# tier does —
+           * nothing is cached between calls, and {@code peek} does not change them.
            */
           public Value value() {
-             return this.cachedValue;
+             return new Value(this.cur_outFastK, this.cur_outFastD);
           }
 
           /**
@@ -147440,7 +147463,6 @@ class Core {
           sp.sub1 = sub1;
           sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
           sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-          sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
           return RetCode.Success;
        }
        /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -147843,6 +147865,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -148403,6 +148426,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -149282,6 +149306,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -149912,6 +149937,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -150349,6 +150375,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -151071,6 +151098,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -151814,6 +151842,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -152837,6 +152866,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -154002,6 +154032,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -154973,6 +155004,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -155731,6 +155763,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -156891,6 +156924,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -158173,6 +158207,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -159210,6 +159245,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -160110,6 +160146,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -160876,6 +160913,7 @@ class Core {
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
+           * A pure field read; {@code peek} does not change it.
            */
           public double value() {
              return this.cur_outReal;
@@ -161431,6 +161469,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -162334,6 +162373,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {
@@ -163386,6 +163426,7 @@ class Core {
            * The value at the last bar this stream counted — the bar
            * {@link #outRange()} ends on. The last history bar right after open,
            * then whatever the latest accepted {@code update} returned.
+           * A pure field read; {@code peek} does not change it.
            * A pure field read; {@code peek} does not change it.
            */
           public double value() {


### PR DESCRIPTION
Closes the investigation #310 asked for, and implements what it proposed. The
allocation claim replicates exactly. The **cost** claim does not go the way the
issue expected, and that is the part worth reading before merging.

## The change

One generator file. `backends/java_stream.rs` no longer emits the
`cachedValue` field on a multi-output stream handle:

- `update` returns `new Value(...)` **without storing it**. The store was what
  made the record escape, and an escaping record is a heap allocation the JIT
  cannot remove.
- `value()` builds its `Value` from the same `cur_<out>` fields when it is
  called — which is exactly what the C# tier already does.
- `updateAndFill` loses the `int done` / `try` / `finally` that existed only to
  keep the cache fresh on a partial fill. `value()` now names the last committed
  bar by construction, for the same reason C# always did.
- `copy()` copies one fewer field; the three open-capture sites seed one fewer.

Regenerating touches the 15 multi-output streamable functions and nothing else:
`ACCBANDS AROON BBANDS HT_PHASOR HT_SINE MACD MACDEXT MACDFIX MAMA MINMAX
MINMAXINDEX SMI STOCH STOCHF STOCHRSI`. **C, Rust and C# output is byte-identical**
(`generate` then `git status`: only `output/java/` moved). Net −135 lines of
generated Java.

## Allocation: the mechanism claim, confirmed

Throwaway probe, `ThreadMXBean.getThreadAllocatedBytes`, two arms compiled from
the same probe source against two copies of the generated library (this branch
vs `dev` at `f5909c8`), min-of-N, 3 interleaved rounds with alternating arm
order, 1M updates per timed block.

| | base B/update | this B/update | base ns | this ns | chg |
|---|---:|---:|---:|---:|---:|
| MACD (3 out) | 40.00 | **0.00** | 7.62 | 4.19 | −45.0% |
| BBANDS (3 out) | 40.00 | **0.00** | 16.95 | 13.18 | −22.2% |
| STOCH (2 out) | 32.00 | **0.00** | 25.25 | 21.42 | −15.2% |
| AROON (2 out) | 32.00 | **0.00** | 16.59 | 13.75 | −17.1% |
| MINMAX (2 out) | 32.00 | **0.00** | 15.27 | 12.31 | −19.4% |
| MAMA (2 out) | 32.00 | **0.00** | 59.25 | 57.37 | −3.2% |
| *SMA (control)* | *0.00* | *0.00* | *4.21* | *4.19* | *−0.4%* |
| *RSI (control)* | *0.00* | *0.00* | *8.24* | *8.22* | *−0.2%* |

The two single-output controls read 0 B in **both** arms and move −0.4% / −0.2%,
which is what says the probe itself allocates nothing and the box was quiet.

## Timing across the whole tier, with 161 functions as the control

`scripts/stream_ab.py --base=f5909c8 --lang=java --call=update --rounds=7`
(500k iters/pass, interleaved, alternating arm order):

| group | n | median | p05 | p95 |
|---|---:|---:|---:|---:|
| multi-output | 15 | **−1.90%** | −3.84% | −0.13% |
| everything else (control) | 161 | −0.13% | −1.17% | +0.73% |

14 of the 15 sit below the control's p05; the 15th (HT_SINE, +0.4%) costs ~1000
ns/bar in this harness and would not notice 40 B either way.

Two caveats on the magnitudes, stated rather than buried:

- The **absolute** ns here are not the issue's. #310 measured MACD `update` at
  ~30 ns; this box reads 51.8 ns through `stream_ab` and 7.6 ns through the
  isolated probe. `stream_ab` compiles all 176 functions into one class, and the
  per-block inflation is what the gap is. Both arms get it identically, so the
  change column is unaffected — but do not read a ns column here against #310's.
- I could not reproduce the issue's ~26 ns saving on MACD. On this hardware the
  saving is 3.4 ns isolated and ~1 ns in the crowded harness. The direction and
  the control separation replicate; the size does not.

## The cost, which is larger than the issue expected

The issue's reasoning was that `value()` is *"an accessor that most callers never
call, and callers who do call it call it at most once per bar."* The first half
holds. The second half does not survive measurement.

| caller shape, MACD | base B/bar | this B/bar | base ns | this ns | chg |
|---|---:|---:|---:|---:|---:|
| `update` only | 40 | **0** | 7.62 | 4.19 | −45.0% |
| `update` + `value()` **1×/bar** | 40 | **0 or 80** | see below | | |
| `update` + `value()` **4×/bar** | 40 | **200** | 9.13 | 33.01 | **+261.6%** |
| `update` + `value()` **1 bar in 8** | 40 | 45 | 8.57 | 8.03 | −6.3% |
| `value()` polled, no update | 0 | **40** | 1.20 | 5.59 | **+366.4%** |
| *`SMA` + `value()` (control)* | *0* | *0* | *4.60* | *4.54* | *−1.4%* |

Two things there need naming:

- **`value()` is no longer free.** Polled on its own it goes 0 B → 40 B and
  1.20 ns → 5.59 ns. That is the trade, not a surprise — but it is a 4.7x on
  that accessor, not a rounding error.
- **At exactly one `value()` per bar the result is not stable.** I measured that
  row twice, from runs differing only in what *else* was compiled into the same
  probe class: once at **0 B / −61.6%**, once at **80 B / +50.8%**. Escape
  analysis fired in one and not the other. The issue already flagged that EA is
  a JIT decision; this is what that looks like in practice, and it means the
  1×/bar caller can land either side of today's behaviour.

So the honest summary of the trade: strictly better for a caller that reads
`update`'s return (the shape the API is built around), strictly worse for a
caller that polls `value()`, and JIT-dependent in between. Whether that is the
right trade is a maintainer's call, not mine.

**A third option I did not implement**, in case it is preferred: keep the field
but populate it lazily — `update` writes `cachedValue = null` (a null store does
not make the returned record escape) and `value()` fills it on first read per
bar. That would be 0 B/update *and* at most 40 B/bar for any number of `value()`
calls, i.e. better than both this branch and `dev` on every row above. It costs
the field back on `copy()`, a store per bar, and a benign race on `value()`
(safe under JLS 17.5 final-field publication, which the design doc already
leans on). Say the word and I will build and measure it.

## One observable API change

`value()` no longer returns the *same instance* `update` returned. It returns an
**equal** one — `Value` is a record, so `equals`/`hashCode`/`toString` and every
component read are unchanged. Only reference identity moved, and it moved to
match C#, where a record struct never had identity to share.

`StreamSmokeTest` asserted the old identity (`m.value() == v1`) and now asserts
both halves of the new contract: equal to what `update` returned, and a distinct
instance. Its `HashSet` check becomes a real test of the record's
`equals`/`hashCode` — before, identity satisfied it.

## Gates, and which of them I watched go red

- `tests/java_stream_suite.rs::test_java_mama_value_class_protocol` — asserts no
  `cachedValue` and the exact unstored return. **Verified red** against the
  unfixed generator (`assertion failed: !s.contains("cachedValue")`).
- `tests/update_and_fill_suite.rs::no_managed_update_and_fill_caches_the_multi_output_value`
  — replaces `the_java_value_cache_is_refreshed_on_every_exit`; sweeps Java and
  C#, `updateAndFill` and the whole handle, for any cache or `finally`.
  **Verified red** against the unfixed generator.
- `StreamSmokeTest`'s partial-fill check (`value()` must name the last committed
  bar after `updateAndFill` throws) is what says the `finally` was removable
  rather than load-bearing. It passes here unchanged.
- `StreamSmokeTest`'s new identity assertions — **verified red** by compiling
  this branch's test against the `dev` library: `FAIL: multi-output value() is
  not a cached instance`.

Green here:

- `cargo test` in `ta_codegen/generator` — every suite, 0 failed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- The shipped Java suites, on the jar: `StreamSmokeTest` 3860 checks,
  `MetadataTest` 1722, `BatchApiTest` 181, `CoreApiTest` 66, `DivZeroTest` 91,
  `SMathOverflowTest` 4 — all ALL PASS.
- `ta_regtest --xlang-hash --language=java` — **PASS**, 176 functions,
  276,983 Java cases, 0 mismatches, bit-identical against the in-process C
  library (batch, `Open` and `OpenAndFill` tiers, plus the L2/L3 tier-agreement
  and golden legs).
- `ta_regtest`'s own C reference suite — all groups pass, including the
  streaming finite-input gate and the `UpdateAndFill` partial-commit gate.

Two things I did **not** check, named rather than implied:

- **The `--codegen` leg.** It needs `bin/ta_ref_serve`, built from the pinned
  `reference-pre-cutover` worktree, which this box does not have; the run stops
  at "cannot start ta_ref_serve". So the `Stream verify: N legs bit-exact vs
  batch` line is not in evidence here. `--xlang-hash --language=java` and
  `StreamSmokeTest`'s own stream-vs-batch sweeps are what stand in its place.
- **Anything .NET.** No `dotnet` SDK on this box, so the C# half of the new
  `updateAndFill` sweep was exercised only through the generator's in-process
  rendering, and no C# was compiled. The generated C# is byte-identical to
  `dev`, so there is nothing new for it to break — but I did not compile it.
