### PR TITLE
ci(nightly): compile and test the crate on Windows and macOS (#179 E6)

### DIFF
--- a/.github/workflows/dev-nightly-tests.yml
+++ b/.github/workflows/dev-nightly-tests.yml
@@ -517,6 +517,75 @@ jobs:
       - name: Package the publishable crates and check what ships
         shell: bash
         run: python3 scripts/rust_package_check.py
+  # Every Rust step in this workflow runs on ubuntu. The crate has therefore
+  # only ever been compiled on one operating system, and the audit's own
+  # justification for that -- "no build.rs, and `cfg(windows)|cfg(unix)|
+  # cfg(target_os` over library/src dispatch/src is zero hits" -- is a
+  # statement about today's emitted code, not a property the generator is
+  # obliged to preserve. The first `cfg` the emitter grows, or the first
+  # path/line-ending assumption that reaches a doctest, is invisible here and
+  # visible to a consumer on Windows or a Mac, after publish (#179 E6).
+  #
+  # `cargo check` plus the lib and doc tests only: no C build, no server
+  # harness, no dist asset, so the POSIX-only argument that keeps the other
+  # jobs on ubuntu does not reach this one. Split into two `cargo test`
+  # invocations on purpose -- `--lib --doc` together is rejected by cargo
+  # ("can't mix --doc with other target selecting options").
+  #
+  # The OS list is the job's non-vacuity guard: an empty matrix, or one that
+  # names only ubuntu, would leave this green while compiling nothing the
+  # jobs above do not already compile, so both are a hard failure before any
+  # toolchain work.
+  #
+  # Rust-only and self-contained, so like clippy and msrv it is deliberately
+  # NOT gated on the C hero 'test' job.
+  rust-other-os:
+    name: Rust on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, macos-latest]
+
+    steps:
+      - name: Checkout dev Branch
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      - name: Refuse a matrix that adds no operating system
+        shell: bash
+        run: |
+          os='${{ matrix.os }}'
+          if [ -z "$os" ]; then
+            echo "::error::This job ran with an empty 'os', so it compiled nothing. The point of the job is to compile the crate somewhere the other Rust jobs do not — restore the matrix in .github/workflows/dev-nightly-tests.yml."
+            exit 1
+          fi
+          case "$os" in
+            ubuntu*)
+              echo "::error::'$os' is the operating system every other Rust job in this workflow already uses, so this leg would duplicate them instead of covering anything (#179 E6). Name a non-Linux runner, or delete the job rather than leaving it green and vacuous."
+              exit 1
+              ;;
+          esac
+          echo "Covering $os"
+
+      # rustup is preinstalled on both runner images and honours
+      # rust-toolchain.toml, so the pinned 1.97.0 is what compiles here too —
+      # the variable under test is the operating system, not the toolchain.
+      - name: Compile the publishable crates
+        shell: bash
+        run: cargo check -p ta-lib -p ta-lib-dispatch --manifest-path ta_codegen/output/rust/Cargo.toml
+
+      - name: Run the crate's unit tests
+        shell: bash
+        run: cargo test --lib -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
+
+      - name: Run the crate's doctests
+        shell: bash
+        run: cargo test --doc -p ta-lib --manifest-path ta_codegen/output/rust/Cargo.toml
+
 
   # The two publishable crates declare `rust-version = "1.86"`, and nothing
   # else here compiles them at it -- every other Rust step runs on the pinned


### PR DESCRIPTION
Closes the E6 line of #179: *"no Windows/macOS Rust build"*.

## What was missing

Every Rust step in `dev-nightly-tests.yml` runs on `ubuntu-latest`. `test-macos` is the C job. So the crate has only ever been compiled on one operating system.

E6's own argument for why that is safe today holds — I re-checked both halves on `dev` (`69284b1d`):

    grep -rE 'cfg\(windows\)|cfg\(unix\)|cfg\(target_os|cfg\(target_family' \
      ta_codegen/output/rust/{library,dispatch}/src   → 0 hits
    find ta_codegen/output/rust -name build.rs        → none

But that is a statement about what the emitter produces today, not a property it is obliged to preserve. The first `cfg` a backend grows, or the first path- or line-ending assumption that reaches a doctest, is invisible to every job in this tree and visible to a consumer on Windows or a Mac — after publish, in a version that cannot be edited.

## The change

One nightly job, `rust-other-os`, matrixed over `windows-2022` and `macos-latest`: `cargo check -p ta-lib -p ta-lib-dispatch`, then `cargo test --lib -p ta-lib`, then `cargo test --doc -p ta-lib`. No C build, no server harness, no dist asset — so the POSIX-only constraint that keeps the other jobs on ubuntu does not reach this one. `fail-fast: false`, so one OS failing still reports the other.

Two small things worth stating rather than leaving to be rediscovered:

- **The command in E6 does not run as written.** `cargo test --lib --doc` is rejected — `error: can't mix --doc with other target selecting options`. It has to be two invocations, which is what this does.
- **The toolchain is not the variable.** rustup is preinstalled on both images and honours `rust-toolchain.toml`, so all three legs compile on the pinned 1.97.0. What changes across legs is the operating system and nothing else.

## Control

I ran the macOS leg locally — this box is a Mac on the pinned toolchain (`rustc 1.97.0 (2d8144b78)`).

**Green as it stands:**

    cargo check -p ta-lib -p ta-lib-dispatch     9.9 s
    cargo test --lib  -p ta-lib                  73 passed, 0 failed
    cargo test --doc  -p ta-lib                  536 passed, 0 failed

**A defect only a non-Linux leg can see.** I appended one line to `library/src/lib.rs`:

    const _: () = assert!(cfg!(target_os = "linux"));

and re-ran `cargo check` on macOS:

    error[E0080]: evaluation panicked: assertion failed: cfg!(target_os = "linux")
     --> library/src/lib.rs:328
    error: could not compile `ta-lib` (lib) due to 1 previous error

That line is green on every existing job in this workflow, because every one of them is Linux. Sabotage reverted; tree clean.

**The non-vacuity guard, each branch exercised:**

    ""                 rc=1  No cross OS is listed…
    "ubuntu-latest"    rc=1  …is the operating system every other Rust job already uses
    "ubuntu-24.04-arm" rc=1  …same
    "windows-2022"     rc=0  Covering windows-2022
    "macos-latest"     rc=0  Covering macos-latest

An empty matrix or a Linux-only one fails before any toolchain work, rather than passing while compiling nothing the jobs above do not already compile.

## What I did not check

- **Windows was not executed anywhere by me.** No Windows machine here. The Windows leg runs the same three commands as the macOS leg, on the same pinned toolchain, and the control above is a `cfg` defect both legs would catch identically — but the first actual Windows run of this crate will be the CI run on this PR. If it goes red, that is the job doing its job, and I would rather find out here than on a consumer's machine.
- **Runner cost is unmeasured on GitHub.** Locally the three commands are ~10 s + ~4.5 s + ~28 s. Windows and macOS runners are billed at a multiple of Linux minutes; I did not measure the wall-clock there, and if the doctest leg turns out to dominate, dropping `--doc` from the Windows arm and keeping it on macOS would retain most of the coverage. Your call.
- I did not touch `main-nightly-tests.yml`. E5 mirrored the Linux Rust jobs onto the release branch; whether this one belongs there too is a separate decision.
