### PR TITLE
fix(java): the published pom still advertises 174 indicators; 176 ship

### DIFF
--- a/ta_codegen/output/java/library/pom.xml
+++ b/ta_codegen/output/java/library/pom.xml
@@ -34,11 +34,11 @@
   <packaging>jar</packaging>
 
   <name>TA-Lib</name>
-  <!-- The count is published to Central and is immutable per version. It drifted from
-       168 to 174 unnoticed, so it is no longer kept in step by hand: check_java_jars
-       (the generator) asserts this description carries the number of function
-       directories under ta_codegen/input/. -->
-  <description>Technical analysis library: 174 indicators (SMA, EMA, RSI, MACD, Bollinger Bands, ATR, Stochastic, candlestick patterns) - the official Java port of TA-Lib, verified against the C reference.</description>
+  <!-- The count is published to Central and is immutable per version, so a stale
+       number cannot be corrected after release. It is hand-maintained: nothing in
+       `ta_codegen build` asserts it, and the only guard is
+       scripts/pre-release-checks.py, which fires at release time. -->
+  <description>Technical analysis library: 176 indicators (SMA, EMA, RSI, MACD, Bollinger Bands, ATR, Stochastic, candlestick patterns) - the official Java port of TA-Lib, verified against the C reference.</description>
   <url>https://ta-lib.org</url>
   <inceptionYear>1999</inceptionYear>
 


### PR DESCRIPTION
`scripts/pre-release-checks.py` fails on a clean `dev` checkout (`69284b1d`), at its own indicator-count gate:

    Running pre-release checks
    Error: ta_codegen/output/java/library/pom.xml <description> does not say '176 indicators'.
           It is published to Maven Central and is immutable per version.

The pom says 174. The tree ships 176 — `Core.java` carries 176 stream handle classes, `scripts/build.py generate` reports `java metadata registry … (176 functions)`, and `include/ta_func.h` declares 176 `TA_<N>_Stream` types. The check derives its expectation the same way, by counting `ta_codegen/input/<d>/<d>.yaml`.

## Why it went stale rather than being caught

Nothing regenerates `pom.xml` — it is hand-maintained, unlike the Rust manifest, where `main.rs:2467` interpolates `{n_funcs}` into the crate description and `Cargo.toml`/`README.md` therefore already read 176. And the check deliberately runs only at release (the script's own comment explains why: the synth gate adds synthetic indicators to `ta_codegen/input/`, so a per-build assertion is wrong by construction there).

So the field drifts silently and the release is the first thing that looks — which is what the script's comment already records happening once: *"it had already drifted from 168 to 174 before anything checked it."* This is the same drift a third time.

## Control

The gate is sensitive to the value, not merely present. Same probe, three contents of the field:

    dev as it stands (174)   expected=176   MISMATCH
    this change      (176)   expected=176   OK
    deliberately     (175)   expected=176   MISMATCH

With this commit, `pre-release-checks.py` gets past the pom gate.

## What this does not fix

**The next drift.** A durable fix is to derive the count the way Rust does — either have `ta_codegen` own the pom's `<description>`, or have `sync.py` rewrite the number so it moves with the corpus. I did not do either here: making the pom a generated artifact is a larger change than a release-blocking one-liner should carry, and which of the two you want is your call. Happy to send it as a follow-up if you name the shape.

## Not part of this, and not a defect

While confirming the above I noticed `pre-release-checks.py`'s *next* gate also fails on clean `dev` — `TA_LIB_SOURCES_DIGEST` in `ta_common.h` (`e8740f93`) against a calculated `55daa1fa`. That one is the designed transient, not a bug: the digest covers `src/**/*.c`, six commits have touched those since `9c53c98e` last synced it, and `merge.py` says as much in its own refusal message ("wait for the dev-nightly job to regenerate and commit the digest + dist assets"). Mentioning it only so it is not mistaken for something this PR should have cleared.
