### PR TITLE
docs(changelog): 0.8.1 never mentions the crate it publishes (#179 D10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See [github commits](https://github.com/TA-Lib/ta-lib/commits) for complete list
 ## [0.8.1] Not Released Yet
 ### Added
 - New Streaming API. See https://ta-lib.org/api/stream/
+- The Rust library is published on crates.io for the first time: `cargo add ta-lib`. See https://ta-lib.org/api/rust/
+  - It carries the C library's version, so the first release from this project is 0.8.1, not 0.1.0. Versions 0.1.0 to 0.1.2 of the `ta-lib` crate name (2021-2023) are an unrelated third-party binding from https://github.com/virtualritz/ta-lib-rs and are not part of this project.
+  - `ta-lib` depends on `ta-lib-dispatch`, which is versioned separately.
 - (#81) Microsoft VCPKG support. Thanks @greenTableWork !
 - (#78) CMake can now opt out of building the static or the shared library (both built by default). Thanks @BwL1289 !
 - (#75) More docs for DEMA, TEMA, T3, MFI, ULTOSC, KAMA and TRIX. Thanks @nehemiah888 !


### PR DESCRIPTION
Closes the D10 line of #179: *"CHANGELOG 0.8.1 never mentions the crate."*

The 0.8.1 section lists the streaming API and fifteen new indicators, and says nothing about the Rust library reaching crates.io. `grep -iE 'crates\.io|cargo add' CHANGELOG.md` → 0 hits. The section is still `Not Released Yet`, so it is editable now and immutable afterwards.

## The entry

Two bullets under `### Added`, in the terse style the section already uses:

- the publish itself, with `cargo add ta-lib` and the site link;
- the version discontinuity, because the crate *name* is not new to crates.io.

## The discontinuity, verified rather than recalled

    GET https://crates.io/api/v1/crates/ta-lib
      max_version 0.1.2   repository https://github.com/virtualritz/ta-lib-rs/
      0.1.0  2021-09-27
      0.1.1  2021-10-25
      0.1.2  2023-01-16      (none yanked)

    GET https://crates.io/api/v1/crates/ta-lib-dispatch
      0.1.0  2026-08-03      0.1.1  2026-08-05      0.1.2  2026-08-12

So a reader who runs `cargo add ta-lib` and gets 0.8.1, or who finds the 2021–2023 versions first, currently has nothing in the CHANGELOG telling them which are this project's. The wording says only that those versions are not ours — **it does not presuppose the B2 decision** on whether they get yanked, so it stays correct either way.

The "carries the C library's version" half is the B1 lockstep decision (2026-08-12), and the separate `ta-lib-dispatch` versioning is what `library/Cargo.toml:29` pins (`= "0.1.2"`) against `dispatch/Cargo.toml:3` (`0.1.2`) while the library itself is `0.8.1`.

Both links resolve: `https://ta-lib.org/api/rust/` → 200, and the ta-lib-rs repo → 200.

## Two things to flag

- **The entry describes a publish that has not happened yet** (B3, gated on A6). That is normal for a `Not Released Yet` section — it describes what the release will contain — but if you would rather it say "will be published" until the credential exists and `cargo publish` has run, say so and I will reword.
- **The same gap exists for Java and C#.** `grep -iE 'maven|nuget|crates' CHANGELOG.md` was 0 hits before this commit: the CHANGELOG has never mentioned any package-distribution channel. D10 names the crate, so that is all this changes. Whether Maven Central and NuGet deserve the same sentence is yours to decide — I did not widen the scope on my own.
