### PR TITLE
test(abstract): drive both orderings of every integer parameter pair (#322)

### DIFF
--- a/src/tools/ta_regtest/test_abstract.c
+++ b/src/tools/ta_regtest/test_abstract.c
@@ -94,6 +94,8 @@ static long long g_d2Vectors = 0;
 static long long g_d2NonDefault = 0;
 static long long g_d2Sentinel = 0;
 static long long g_d2Reject = 0;
+/* Pairs of integer slots driven at both orderings; see d2_param_vectors step 1b. */
+static long long g_d2Ordering = 0;
 /* Non-finite parameter probes; see d2_nonfinite_params. */
 static long long g_d2NonFinite = 0;
 static long long g_d2NonFiniteFuncs = 0;
@@ -167,6 +169,7 @@ void test_abstract_set_server(CodegenPipe *cp, const char *lang)
    /* Per-server, so the summary line reports the server it names rather than a
       running total across every server tested so far. */
    g_d2Vectors = g_d2NonDefault = g_d2Sentinel = g_d2Reject = 0;
+   g_d2Ordering = 0;
    g_d2NonFinite = g_d2NonFiniteFuncs = 0;
    g_d2OorNotRejected = g_d2SentNotDefault = 0;
    if( cp )
@@ -1462,6 +1465,7 @@ static void d2_set_opts( TA_ParamHolder *paramHolder, const TA_FuncHandle *handl
 #define D2_CLASS_NON_DEFAULT 0
 #define D2_CLASS_SENTINEL     1
 #define D2_CLASS_REJECT       2
+#define D2_CLASS_ORDERING     3
 
 /* The all-defaults C result, captured before the sweep so the sentinel class can
  * assert what it exists to assert. */
@@ -1485,6 +1489,27 @@ static unsigned long long d2_digest( const TA_FuncInfo *funcInfo, const TA_FuncH
         }
     }
     return h;
+}
+
+/* A low and a high in-range value for one integer slot, far enough apart that a
+ * PAIR of them expresses an ordering in both directions. Small on purpose: what
+ * this class tests is the relation between two slots, and a large period only
+ * buys runtime -- but not `min` itself, so a degenerate period is not the only
+ * thing the class ever sees. Returns 0 when the domain has no room for two
+ * distinct values, which is not a failure: the slot simply cannot be ordered. */
+static int d2_lo_hi( const TA_OptInputParameterInfo *oi, double *lo, double *hi )
+{
+    const TA_IntegerRange *r = (const TA_IntegerRange *)oi->dataSet;
+    if( !r || r->max <= r->min ) return 0;
+    int a = r->min + 2;
+    int b = r->min + 9;
+    if( a > r->max ) a = r->max;
+    if( b > r->max ) b = r->max;
+    if( a >= b ) { a = r->min; b = r->max; }
+    if( a >= b ) return 0;
+    *lo = (double)a;
+    *hi = (double)b;
+    return 1;
 }
 
 static ErrorNumber d2_drive( const char *funcName, const TA_FuncHandle *handle,
@@ -1680,6 +1705,48 @@ static ErrorNumber d2_param_vectors( const char *funcName, const TA_FuncHandle *
     ErrorNumber e = d2_drive(funcName, handle, funcInfo, paramHolder, input, size,
                              vec, "non-default", relaxValues, D2_CLASS_NON_DEFAULT, NULL);
     if( e != TA_TEST_PASS ) return e;
+
+    /* 1b. Parameter INTERACTION. Steps 1-3 each move ONE slot away from the
+     *     default, or move every slot by a fixed per-slot offset -- neither can
+     *     express a RELATION between two of them. A function whose behaviour
+     *     turns on one is then value-checked only near the defaults on the
+     *     tier that reaches the shipped binder (#322).
+     *
+     *     Driven off the declared domains, so a new function or a new pair of
+     *     integer parameters is covered the day it lands, with no list here.
+     *     BOTH orderings per pair: which side of a relation is the interesting
+     *     one is a property of the function, which this sweep does not know. */
+    for( k = 0; k < funcInfo->nbOptInput; k++ )
+    {
+        const TA_OptInputParameterInfo *oiK;
+        double loK, hiK;
+        TA_GetOptInputParameterInfo(handle, k, &oiK);
+        if( oiK->type != TA_OptInput_IntegerRange ) continue;
+        if( !d2_lo_hi(oiK, &loK, &hiK) ) continue;
+
+        for( j = k + 1; j < funcInfo->nbOptInput; j++ )
+        {
+            const TA_OptInputParameterInfo *oiJ;
+            double loJ, hiJ;
+            unsigned int m;
+            int ord;
+
+            TA_GetOptInputParameterInfo(handle, j, &oiJ);
+            if( oiJ->type != TA_OptInput_IntegerRange ) continue;
+            if( !d2_lo_hi(oiJ, &loJ, &hiJ) ) continue;
+
+            for( ord = 0; ord < 2; ord++ )
+            {
+                for( m = 0; m < funcInfo->nbOptInput; m++ ) vec[m] = base[m];
+                vec[k] = ord ? hiK : loK;
+                vec[j] = ord ? loJ : hiJ;
+                g_d2Ordering++;
+                e = d2_drive(funcName, handle, funcInfo, paramHolder, input, size,
+                             vec, "ordering", relaxValues, D2_CLASS_ORDERING, NULL);
+                if( e != TA_TEST_PASS ) return e;
+            }
+        }
+    }
 
     /* 2. and 3., one parameter at a time so a failure names the slot. */
     for( k = 0; k < funcInfo->nbOptInput; k++ )
@@ -2059,12 +2126,18 @@ ErrorNumber test_abstract( void )
          return TA_ABSTRACT_CALL_MISMATCH;
       }
 
-      if( g_d2Vectors == 0 || g_d2NonDefault == 0 || g_d2Sentinel == 0 || g_d2Reject == 0 )
+      /* Ordering carries a LITERAL floor, not merely non-zero, for the reason
+       * the non-finite sweep above states: a derived count moves with the
+       * corpus and lets the class go quiet unnoticed. 64 pairs today; it rose
+       * from 62 when KC landed, which is the class doing its job. Raise it when
+       * a function gains an integer parameter -- that is the point. */
+      if( g_d2Vectors == 0 || g_d2NonDefault == 0 || g_d2Sentinel == 0 || g_d2Reject == 0
+          || g_d2Ordering < 64 )
       {
          printf( "  ABSTRACT ERROR: the binder parameter-contract sweep produced no "
-                 "vectors of some class (%lld/%lld/%lld/%lld) — the binders are back "
+                 "vectors of some class (%lld/%lld/%lld/%lld/%lld) — the binders are back "
                  "to being tested only at their declared defaults\n",
-                 g_d2Vectors, g_d2NonDefault, g_d2Sentinel, g_d2Reject );
+                 g_d2Vectors, g_d2NonDefault, g_d2Sentinel, g_d2Reject, g_d2Ordering );
          return TA_ABSTRACT_CALL_MISMATCH;
       }
    }


### PR DESCRIPTION
Takes option 2 of #322 — the parameter-interaction half. It does **not** touch the Java splice (option 1), which is the real fix for the asymmetry and is a separate change.

## What was missing, verified rather than quoted

`d2_param_vectors`'s three classes are each a one-slot move:

    non-default       d2_non_default(oi, k) → def + (k+1) for every integer slot
    default-sentinel  one slot at a time set to TA_INTEGER_DEFAULT
    out-of-range      one slot at a time set to min-1 / max+1

So the only multi-slot vector in the sweep is the non-default one, and it moves every slot by a *fixed* per-slot offset. Neither shape can express a relation between two slots. For the KC case in the issue that is (20,10) and (21,12), both on the same side of `optInATRPeriod > optInTimePeriod - 1`.

## The change

A fourth class: for every pair of `TA_OptInput_IntegerRange` slots, one vector per ordering, every other slot at its default. Derived from the declared domains, so a new function or a new integer pair is covered the day it lands with no list here. Both directions per pair, because which side of a relation matters is a property of the function and this sweep does not know it.

`d2_lo_hi` picks `min+2` / `min+9`, clamped, falling back to the full range when the domain is narrower, and returns 0 when there is no room for two distinct values — a slot that cannot be ordered is skipped rather than failing. Small on purpose: the point is the relation, and a large period only buys runtime. For KC that would be (4, 10) — the exact vector the issue's reproduction uses.

**62 vectors** over the corpus, on top of the 457 already driven:

    Binder parameter contract (#164): 519 vector(s) driven through both binders
      — 84 non-default, 133 default-sentinel, 240 out-of-range, 62 ordering

The count is asserted alongside the other three in the non-vacuity guard, for the reason already written there: a sweep that quietly stopped producing a class reads exactly like a passing one.

## Control

A throwaway divergence in the C server's `handle_abstract_call` (`templates/c/ta_abstract_serve.c`): for `ADOSC` only, when the first integer slot exceeds the second and both are in a plausible band, the server perturbs the second slot before calling. That is an ordering-conditional defect and nothing else.

    with the ordering class     ABSTRACT ERROR [ADOSC]: real output[0][0]
                                C=-0.380571049705841 server=-0.320904805316095
                                ABSTRACT ERROR [ADOSC]: the ordering vector diverged
    without it (this commit
    reverted, sabotage kept)    519 → 457 vectors, 0 ordering, run passes

**Two earlier versions of this control were not discriminating, and finding that out is most of why I trust this one.** My first sabotage fired on `v0 > v` alone: the default-sentinel vector sets a slot to `TA_INTEGER_DEFAULT`, a large negative, so `v0 > v` was true there too and the *old* sweep caught it — via the sentinel class, not the ordering one. Guarding with `v0 > 0 && v > 0` then let the out-of-range probe trigger it (`retCode C=2 server=0`), so the old sweep caught it again, that time via the reject class. Only the third guard — both values inside a plausible band — is inert for every vector the three existing classes produce. A control that goes red for the wrong reason proves nothing about the class it is supposed to be exercising.

## What I did not check

- **No non-C language server ran here.** `--language=java` needs JDK 17 to build (`error: release version 17 not supported` on this box's JDK 11), and the C# SDK is 7.0.200 against a `net10.0` library. So the sweep ran C-against-C, which is identity on the value path — what it proves locally is that the vectors are produced, are accepted by the binder, and that a divergence injected at that ordering is detected. **The cross-language value comparison this class exists for is exercised for the first time by CI on this PR.**
- **The `--codegen` run does not complete on this box**: it stops at `cannot start ta_ref_serve (the reference oracle)`, which is built from the pinned `reference-pre-cutover` worktree I do not have. The abstract sweep runs to completion before that point — 519 vectors, no `ABSTRACT ERROR` — and plain `ta_regtest` passes in full.
- **Runtime cost is unmeasured on a runner.** 62 extra vectors against 457 is a ~14% increase in that sweep's vector count; I did not time it on CI hardware.
- I did not touch option 1 or option 3. Option 3 (asserting the two Java texts are identical at generate time) is cheap and independent of this; happy to send it separately if you want it.
