### PR TITLE
build(java): fail the server splice when the shipped Core has gone stale (#322)

### DIFF
--- a/ta_codegen/generator/src/backends/mod.rs
+++ b/ta_codegen/generator/src/backends/mod.rs
@@ -352,6 +352,18 @@ impl LanguageBackend for JavaBackend {
         std::fs::create_dir_all(&tools_dir).unwrap();
         let template = server_gen::generate_java_server(funcs, enums);
         let output = server_gen::inline_java_core_methods(&template, &frag_dir, funcs);
+        // The server and the shipped library are the same text only for as long
+        // as both are regenerated together. `generate --func=<NAME>` rewrites a
+        // fragment and deliberately skips Core.java, and `build.py servers`
+        // re-splices the server from the fragments — so in that window the
+        // cross-language sweep measures new code while the shipped library is
+        // old, and `--codegen --language=java` reads green (#322).
+        //
+        // Checked here rather than in a test: this is the moment the server is
+        // built from the fragments, so it is the moment the two can part. The
+        // fragment is the same text `java_shipped` splices into Core.java's
+        // GENCODE section, so containment is exact rather than approximate.
+        server_gen::assert_java_core_matches_fragments(&frag_dir, out_base, funcs);
         let path = tools_dir.join("TaCodegenServe.java");
         crate::emit::write_if_changed(&path, &output).unwrap();
         println!("  Java server -> {}", path.display());

--- a/ta_codegen/generator/src/server_gen.rs
+++ b/ta_codegen/generator/src/server_gen.rs
@@ -188,6 +188,75 @@ fn func_unst_id(name: &str, enums: &HashMap<String, EnumDef>) -> Option<i32> {
 /// merely hide that behind a server whose bytes differ from the library's. All
 /// 168 fragments contain zero such pairs, so this costs nothing today and stops
 /// a future emitter from quietly breaking the identity.
+/// Fail if the shipped `Core.java`'s generated section is no longer the fragments.
+///
+/// Both texts come from `backends::java::generate`, but by different routes: the
+/// shipped one is spliced in memory by `java_shipped::generate_core`, the
+/// server's is read off disk from `fragments/Core_<NAME>.java`. `build.py
+/// servers` re-splices the server from the fragments and does NOT rewrite
+/// Core.java, so in that window the cross-language sweep measures new code while
+/// the shipped library is old and `--codegen --language=java` reads green
+/// (#322). `regen-check` does not backstop it locally: it runs on a clean
+/// checkout and excludes the files being worked on.
+///
+/// EQUALITY of the whole GENCODE section, not per-line containment. Containment
+/// cannot see an ADDITION -- a line the shipped file gained is still "carried"
+/// by every fragment line it contains -- which is most of the drift worth
+/// catching. Normalized on both sides the way `inline_java_core_methods`
+/// normalizes: the `/* Generated */` prefix dropped, blank lines dropped, each
+/// line trimmed, since the two differ in indentation by construction.
+pub fn assert_java_core_matches_fragments(frag_dir: &Path, out_base: &Path, funcs: &[FuncDef]) {
+    const CORE_START: &str = "/**** START GENCODE SECTION 1 - DO NOT DELETE THIS LINE ****/";
+    const CORE_END: &str = "/**** END GENCODE SECTION 1 - DO NOT DELETE THIS LINE ****/";
+
+    let core_path = out_base.join("java/library/src/main/java/io/github/talib/Core.java");
+    let Ok(core) = std::fs::read_to_string(&core_path) else {
+        return; // No shipped Core yet on a fresh tree; generate writes it.
+    };
+    let (Some(s0), Some(e0)) = (core.find(CORE_START), core.find(CORE_END)) else {
+        return; // Markers absent: java_shipped::generate_core reports that itself.
+    };
+    let norm = |text: &str| -> Vec<String> {
+        text.lines()
+            .map(|l| l.strip_prefix("/* Generated */").unwrap_or(l).trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect()
+    };
+
+    let shipped = norm(&core[s0 + CORE_START.len()..e0]);
+    let mut wanted: Vec<String> = Vec::new();
+    for func in funcs {
+        let frag_path = frag_dir.join(format!("Core_{}.java", func.name));
+        let Ok(frag) = std::fs::read_to_string(&frag_path) else {
+            continue;
+        };
+        wanted.extend(norm(&frag));
+    }
+
+    if shipped != wanted {
+        let at = shipped
+            .iter()
+            .zip(wanted.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or_else(|| shipped.len().min(wanted.len()));
+        let got = shipped.get(at).map_or("<end of section>", String::as_str);
+        let exp = wanted.get(at).map_or("<end of fragments>", String::as_str);
+        panic!(
+            "{}: its generated section is not what the fragments say, so the Java \
+             server would be spliced from text the shipped library no longer matches \
+             and `--codegen --language=java` would measure the wrong thing (#322).\n\
+             \x20 first difference at generated line {}:\n    shipped:  {got}\n    \
+             fragments: {exp}\n  ({} shipped lines vs {} from fragments)\n  Re-run a \
+             full `scripts/build.py generate` — a `--func=` run deliberately skips \
+             Core.java.",
+            core_path.display(),
+            at + 1,
+            shipped.len(),
+            wanted.len()
+        );
+    }
+}
+
 pub fn inline_java_core_methods(template: &str, java_dir: &Path, funcs: &[FuncDef]) -> String {
     let mut result = template.to_string();
     for func in funcs {


### PR DESCRIPTION
Takes option 3 of #322 — the staleness half. Independent of #323 (option 2, parameter coverage) and of option 1, which stays the real fix.

## Where the check goes, and why there

`build.py servers` re-splices the Java server from `fragments/Core_<NAME>.java` and does **not** rewrite `Core.java`. That is the window the issue names, and it is the moment the two texts can part — so the assert runs there, in `generate_server` for the Java backend, right after `inline_java_core_methods`.

Not in a test: on a clean checkout there is nothing to catch, which is exactly why `regen-check` does not backstop this (it also excludes the files being worked on, as the issue notes).

## The check is equality, not containment — and that mattered

My first version compared per line: every fragment line must appear somewhere in `Core.java`. It passed its own control, and it was wrong. I sabotaged `Core.java` by appending ` // STALE` to a line, ran it, and it stayed green — because `"foo // STALE"` still *contains* `"foo"`. **Containment cannot see an addition**, which is a large share of the drift worth catching.

The shipped version compares the whole GENCODE section against the concatenated fragments for equality, normalized on both sides the way `inline_java_core_methods` already normalizes (drop the `/* Generated */` prefix, drop blank lines, trim), since the two differ in indentation by construction. It reports the first differing generated line with both sides and the two lengths.

## Control

Three shapes of drift, each applied to `Core.java` alone and then reverted, with `build.py servers --language=java`:

    clean tree   0 false positives
    append       fires, first difference at generated line 3602
    modify       fires, first difference at generated line 3601
    delete       fires, first difference at generated line 3601

The append row is the one the first version missed.

## Verification

- Full `scripts/build.py generate` then `git status`: no drift outside the two generator files this commit touches.
- `cargo test --no-fail-fast` in `ta_codegen/generator`: 884 pass, 0 fail.
- `cargo clippy --all-targets -- -D warnings`: exit 0.

## What I did not check

- **The Java library does not compile here** — this box's JDK is 11 and the pom asks for release 17 (`error: release version 17 not supported`), so `build.py servers --language=java` fails at maven *after* the generation step. The assert runs before that and its output is what the control above reads; nothing downstream of maven was exercised.
- The `--func=` path is unaffected on purpose: it prints `skipping shipped Core.java` and does not generate the server, so it never reaches this. This makes the stale state loudly visible the next time a server is built, rather than blocking the partial-regenerate workflow the message documents. If you would rather `--func=` itself warn, that is a different and slightly noisier change.
- Only the Java backend. C# compiles the shipped sources directly and has no splice to check; C and Rust likewise.
