### PR TITLE
perf(java): a multi-output stream writes a caller-owned Out (#310)

### DIFF
--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -105,6 +105,14 @@ pub fn stream_class_name(func: &FuncDef) -> String {
     format!("{}Stream", common::pascal_words(&func.name))
 }
 
+/// The caller-owned output object a multi-output stream writes through.
+/// A sibling of the stream class at `Core` level, where C# already puts its
+/// equivalent -- it is the type the CALLER allocates, so it should not need the
+/// stream class to name it (#310).
+pub fn out_class_name(func: &FuncDef) -> String {
+    format!("{}Out", common::pascal_words(&func.name))
+}
+
 fn out_is_int(func: &FuncDef, name: &str) -> bool {
     func.outputs
         .iter()
@@ -247,7 +255,7 @@ fn field_type_and_default(ty: &VarType) -> (String, String) {
     }
 }
 
-/// The params + `cur_<out>` (+ cachedValue) fields every tier's handle carries
+/// The params + `cur_<out>` fields every tier's handle carries
 /// (dispatch/period-bank/loopless-composed build on exactly this base).
 fn base_fields(func: &FuncDef) -> Vec<Field> {
     let mut fields: Vec<Field> = Vec::new();
@@ -259,9 +267,6 @@ fn base_fields(func: &FuncDef) -> Vec<Field> {
     }
     for out in &func.outputs {
         fields.push((format!("cur_{}", out.name), out_java_type(func, &out.name).to_string(), "0".into()));
-    }
-    if has_value_class(func) {
-        fields.push(("cachedValue".into(), "Value".into(), "null".into()));
     }
     fields
 }
@@ -385,9 +390,6 @@ fn state_fields_from(
     for out in &func.outputs {
         let t = out_java_type(func, &out.name);
         fields.push((format!("cur_{}", out.name), t.to_string(), "0".to_string()));
-    }
-    if has_value_class(func) {
-        fields.push(("cachedValue".into(), "Value".into(), "null".into()));
     }
     fields
 }
@@ -730,10 +732,13 @@ fn emit_handle_class_with_members(
     let _ = writeln!(o, "         this.outRangeCount = other.outRangeCount;");
     let _ = writeln!(o, "      }}");
 
-    emit_value_class(o, func);
     emit_update_peek_value_copy(o, func, frame);
 
     let _ = writeln!(o, "   }}");
+
+    // At Core level, a sibling of the stream class: it is the type the CALLER
+    // allocates, so it should not need the stream class to name it (#310).
+    emit_out_class(o, func);
 }
 
 /// The immutable multi-output value record (batch output order, components
@@ -751,37 +756,62 @@ fn emit_handle_class_with_members(
 /// protect (any tuple of outputs is a legitimate reading), and in exchange the
 /// type destructures in record patterns and binds in JSON mappers with no
 /// configuration.
-fn emit_value_class(o: &mut String, func: &FuncDef) {
+fn emit_out_class(o: &mut String, func: &FuncDef) {
     if !has_value_class(func) {
         return;
     }
-    let components: Vec<String> = func
-        .outputs
-        .iter()
-        .map(|out| format!("{} {}", out_java_type(func, &out.name), value_field_name(&out.name)))
-        .collect();
-    let _ = writeln!(o, "\n      /**");
-    let _ = writeln!(o, "       * One output set, in batch output order. Immutable.");
-    let _ = writeln!(o, "       *");
+    let cls = out_class_name(func);
+    let _ = writeln!(o, "\n   /**");
     let _ = writeln!(
         o,
-        "       * <p>{{@code equals}} compares every component bitwise, so {{@code NaN}}\n\
-         \x20      * equals {{@code NaN}} and {{@code 0.0}} does not equal {{@code -0.0}}.\n\
-         \x20      * {{@code hashCode}} is consistent with it but its exact value is\n\
-         \x20      * unspecified — do not persist it or compare it across JVM versions.\n\
-         \x20      *"
+        "    * The outputs of one {} bar, written by the stream into an object the\n\
+         \x20   * CALLER owns. Allocate one and reuse it: {{@code update}}, {{@code peek}}\n\
+         \x20   * and {{@code value}} overwrite its fields and allocate nothing.\n\
+         \x20   *\n\
+         \x20   * <p><b>Its contents are only valid until the next call that writes it.</b>\n\
+         \x20   * It is a mutable buffer, not a reading: a reference kept past that call,\n\
+         \x20   * or one put in a collection, sees the value change underneath it. Copy the\n\
+         \x20   * fields out if the reading has to outlive the call.\n\
+         \x20   *\n\
+         \x20   * <p>Deliberately no {{@code equals}} or {{@code hashCode}}: a mutable type\n\
+         \x20   * with value equality breaks the {{@code HashMap}}/{{@code HashSet}}\n\
+         \x20   * invariant the moment a reused instance becomes a key. Compare the fields.\n\
+         \x20   */",
+        func.name
     );
+    let _ = writeln!(o, "   public static final class {cls} {{");
     for out in &func.outputs {
-        // Same prose the batch method's `@param out…` carries, so an output
-        // reads identically in both tiers.
         let desc = func
             .doc
             .as_ref()
             .map_or_else(|| "Output values.".to_string(), |d| super::java_doc::output_desc(out, d));
-        let _ = writeln!(o, "       * @param {} {desc}", value_field_name(&out.name));
+        let _ = writeln!(o, "      /** {desc} */");
+        let _ = writeln!(
+            o,
+            "      public {} {};",
+            out_java_type(func, &out.name),
+            value_field_name(&out.name)
+        );
     }
-    let _ = writeln!(o, "       */");
-    let _ = writeln!(o, "      public record Value({}) {{ }}", components.join(", "));
+    let _ = writeln!(o, "   }}");
+}
+
+
+
+/// Statements writing the current outputs into a caller-owned sink. `src` names
+/// where the values are read from -- `this` for a committed handle, `""` for a
+/// peek frame whose outputs are locals.
+fn write_out_stmts(func: &FuncDef, sink: &str, src: &str, indent: &str) -> String {
+    let mut o = String::new();
+    for out in &func.outputs {
+        let rhs = if src.is_empty() {
+            format!("cur_{}", out.name)
+        } else {
+            format!("{src}.cur_{}", out.name)
+        };
+        let _ = writeln!(o, "{indent}{sink}.{} = {rhs};", value_field_name(&out.name));
+    }
+    o
 }
 
 /// The value expression reading the current outputs off a handle variable.
@@ -869,10 +899,16 @@ fn emit_update_peek_value_copy(o: &mut String, func: &FuncDef, frame: Option<&st
 
 // --- update --------------------------------------------------------------------
 fn emit_update_method(o: &mut String, func: &FuncDef) {
-    let vt = if has_value_class(func) {
-        "Value".to_string()
+    let multi = has_value_class(func);
+    let vt = if multi {
+        "void".to_string()
     } else {
         out_java_type(func, &func.outputs[0].name).to_string()
+    };
+    let sink = if multi {
+        format!(", {} out", out_class_name(func))
+    } else {
+        String::new()
     };
     let base = method_base(func);
     let (sig_bars, fwd_bars) = bar_params(func);
@@ -896,16 +932,15 @@ fn emit_update_method(o: &mut String, func: &FuncDef) {
          \x20      * later value it produces.\n\
          \x20      */"
     );
-    let _ = writeln!(o, "      public {vt} update( {sig_bars} ) {{");
+    let _ = writeln!(o, "      public {vt} update( {sig_bars}{sink} ) {{");
     o.push_str(&finite_bar_check(func, "         ", "update", true));
     let _ = writeln!(o, "         core.{base}StepImpl(this, {fwd_bars});");
     // After the step, so a bar the step throws out of is not counted. The
     // finite-bar reject above counts its own bar and is the only rejection that
     // does; `peek` runs a frame that commits nothing and reaches neither.
     let _ = writeln!(o, "         {}", advance_out_range());
-    if has_value_class(func) {
-        let _ = writeln!(o, "         this.cachedValue = {};", fresh_value_expr(func, "this"));
-        let _ = writeln!(o, "         return this.cachedValue;");
+    if multi {
+        o.push_str(&write_out_stmts(func, "out", "this", "         "));
     } else {
         let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
     }
@@ -1034,12 +1069,11 @@ fn emit_update_and_fill_method(o: &mut String, func: &FuncDef) {
     // Java's cache stale would make the two backends disagree on an observable
     // the streaming design says they agree on. Single-output handles read
     // `cur_<out>` directly and have no cache at all.
-    let cached = has_value_class(func);
-    if cached {
-        let _ = writeln!(o, "         int done = 0;");
-        let _ = writeln!(o, "         try {{");
-    }
-    let pad = if cached { "            " } else { "         " };
+    // No cache to refresh: `updateAndFill` writes each bar straight into the
+    // caller's arrays, and a multi-output `value` now writes a caller-owned
+    // sink rather than replaying a stored instance (#310). So no `done`, no
+    // `try`/`finally`, and the loop body needs no extra indent.
+    let pad = "         ";
     let _ = writeln!(o, "{pad}for( int i = 0; i < barCount; i++ ) {{");
     let idx_bars: Vec<String> = inputs.iter().map(|a| format!("{a}[i]")).collect();
     if !inputs.is_empty() {
@@ -1048,9 +1082,7 @@ fn emit_update_and_fill_method(o: &mut String, func: &FuncDef) {
             .map(|b| format!("!Double.isFinite({b}[i])"))
             .collect();
         // Rule U3 per bar: the rejected bar is counted, so `outRange()` ends on
-        // the offending bar. Output slot `i` is deliberately left unwritten, and
-        // `done` is not moved — the `finally` below must publish bar `i-1`, the
-        // last one the step actually committed.
+        // the offending bar. Output slot `i` is deliberately left unwritten.
         let _ = writeln!(o, "{pad}   if( {} ) {{", conds.join(" || "));
         let _ = writeln!(o, "{pad}      {}", advance_out_range());
         let _ = writeln!(o, "{pad}      {reject}");
@@ -1063,29 +1095,23 @@ fn emit_update_and_fill_method(o: &mut String, func: &FuncDef) {
         let _ = writeln!(o, "{pad}   {guard}{name}[i] = this.cur_{name};");
     }
     let _ = writeln!(o, "{pad}   {}", advance_out_range());
-    if cached {
-        let _ = writeln!(o, "{pad}   done = i + 1;");
-    }
     let _ = writeln!(o, "{pad}}}");
-    if cached {
-        let _ = writeln!(o, "         }} finally {{");
-        let _ = writeln!(
-            o,
-            "            if( done > 0 ) this.cachedValue = {};",
-            fresh_value_expr(func, "this")
-        );
-        let _ = writeln!(o, "         }}");
-    }
     let _ = writeln!(o, "      }}");
 }
 
 // --- peek ------------------------------------------------------------------------
 fn emit_peek_method(o: &mut String, func: &FuncDef, frame: Option<&str>) {
     let class = stream_class_name(func);
-    let vt = if has_value_class(func) {
-        "Value".to_string()
+    let multi = has_value_class(func);
+    let vt = if multi {
+        "void".to_string()
     } else {
         out_java_type(func, &func.outputs[0].name).to_string()
+    };
+    let sink = if multi {
+        format!(", {} out", out_class_name(func))
+    } else {
+        String::new()
     };
     let (sig_bars, _) = bar_params(func);
 
@@ -1115,24 +1141,30 @@ fn emit_peek_method(o: &mut String, func: &FuncDef, frame: Option<&str>) {
          \x20      * run concurrently with each other. {cost}\n\
          \x20      */"
     );
-    let _ = writeln!(o, "      public {vt} peek( {sig_bars} ) {{");
+    let _ = writeln!(o, "      public {vt} peek( {sig_bars}{sink} ) {{");
     // Ahead of the frame, not left to the transition: a rejected bar must not
     // run any of it.
     o.push_str(&finite_bar_check(func, "         ", "peek", false));
     let body = frame.expect("every tier emits a peek frame");
     let _ = writeln!(o, "         {class} sp = this;");
     o.push_str(body);
-    let _ = writeln!(o, "         return {};", fresh_value_expr_local(func));
+    if multi {
+        o.push_str(&write_out_stmts(func, "out", "", "         "));
+    } else {
+        let _ = writeln!(o, "         return {};", fresh_value_expr_local(func));
+    }
     let _ = writeln!(o, "      }}");
 }
 
 // --- value -----------------------------------------------------------------------
 fn emit_value_method(o: &mut String, func: &FuncDef) {
-    let vt = if has_value_class(func) {
-        "Value".to_string()
+    let multi = has_value_class(func);
+    let vt = if multi {
+        "void".to_string()
     } else {
         out_java_type(func, &func.outputs[0].name).to_string()
     };
+    let sink = if multi { format!(" {} out ", out_class_name(func)) } else { String::new() };
 
     let _ = writeln!(
         o,
@@ -1143,9 +1175,9 @@ fn emit_value_method(o: &mut String, func: &FuncDef) {
          \x20      * A pure field read; {{@code peek}} does not change it.\n\
          \x20      */"
     );
-    let _ = writeln!(o, "      public {vt} value() {{");
-    if has_value_class(func) {
-        let _ = writeln!(o, "         return this.cachedValue;");
+    let _ = writeln!(o, "      public {vt} value({sink}) {{");
+    if multi {
+        o.push_str(&write_out_stmts(func, "out", "this", "         "));
     } else {
         let _ = writeln!(o, "         return {};", fresh_value_expr(func, "this"));
     }
@@ -1363,6 +1395,7 @@ fn build_dispatch_peek_frame(
     for arm in dp.arms.iter().filter(|a| a.supported) {
         let label = super::java::render_java_switch_label(&arm.label, enums);
         let cls = callee_stream_class(registry, &arm.callee);
+        let ocls = callee_out_class(registry, &arm.callee);
         let _ = writeln!(f, "         case {label}: {{");
         if arm.out_map.len() == 1 {
             let streaming::OutSlot::Forward(k) = arm.out_map[0] else {
@@ -1376,13 +1409,14 @@ fn build_dispatch_peek_frame(
         } else {
             let _ = writeln!(
                 f,
-                "            {cls}.Value subValue = (({cls}) sp.sub).peek({bar_args});"
+                "            {ocls} subValue = new {ocls}();\n\
+                 \x20           (({cls}) sp.sub).peek({bar_args}, subValue);"
             );
             for (i, slot) in arm.out_map.iter().enumerate() {
                 if let streaming::OutSlot::Forward(k) = slot {
                     let _ = writeln!(
                         f,
-                        "            cur_{} = subValue.{}();",
+                        "            cur_{} = subValue.{};",
                         outputs[*k],
                         callee_value_field(registry, &arm.callee, i)
                     );
@@ -2078,7 +2112,7 @@ fn emit_identity_fast_path(
     // Identity state: params captured, everything else deterministic defaults
     // (1-slot buffers keep the transition's cap-0 guard well-defined).
     for (name, _, default) in fields {
-        if name == "cachedValue" || name.starts_with("cur_") {
+        if name.starts_with("cur_") {
             continue;
         }
         if model.parity.as_ref().is_some_and(|p| &p.field == name) {
@@ -2107,24 +2141,10 @@ fn emit_identity_fast_path(
     for (out, _inp) in &idp.pairs {
         let _ = writeln!(o, "         sp.cur_{out} = {out}[(outNBElement.value - 1) * outStride];");
     }
-    if has_value_class(func) {
-        let _ = writeln!(o, "         sp.cachedValue = {};", capture_value_expr(func));
-    }
     let _ = writeln!(o, "         return RetCode.Success;");
     let _ = writeln!(o, "      }}");
 }
 
-/// `new Value(sp.cur_a, ...)` for the capture sites (Value resolves inside the
-/// nested handle class; from Core scope it needs the class qualifier).
-fn capture_value_expr(func: &FuncDef) -> String {
-    let class = stream_class_name(func);
-    let args: Vec<String> = func
-        .outputs
-        .iter()
-        .map(|out| format!("sp.cur_{}", out.name))
-        .collect();
-    format!("new {class}.Value({})", args.join(", "))
-}
 
 // ---------------------------------------------------------------------------
 // State capture
@@ -2365,7 +2385,7 @@ enum CurSource {
     Scratch,
 }
 
-/// Seed `sp.cur_*` (+ the cached Value) at the end of an open body.
+/// Seed `sp.cur_*` at the end of an open body.
 fn emit_cur_capture(o: &mut String, func: &FuncDef, outputs: &[String], source: CurSource) {
     let nullable = super::common::nullable_output_names(func);
     assert!(
@@ -2384,9 +2404,6 @@ fn emit_cur_capture(o: &mut String, func: &FuncDef, outputs: &[String], source: 
             }
         };
         let _ = writeln!(o, "      sp.cur_{out} = {expr};");
-    }
-    if has_value_class(func) {
-        let _ = writeln!(o, "      sp.cachedValue = {};", capture_value_expr(func));
     }
 }
 
@@ -2968,6 +2985,10 @@ fn callee_stream_class(registry: &Registry, callee: &str) -> String {
     format!("{}Stream", common::pascal_words(&registry.name_of(callee)))
 }
 
+fn callee_out_class(registry: &Registry, callee: &str) -> String {
+    format!("{}Out", common::pascal_words(&registry.name_of(callee)))
+}
+
 /// `sp.cur_<out>` / `Value` member routing for one forwarded callee slot.
 fn callee_value_field(registry: &Registry, callee: &str, slot: usize) -> String {
     value_field_name(&registry.callee_outputs(callee)[slot])
@@ -3090,17 +3111,17 @@ fn emit_dispatch(
                 outputs[k]
             );
         } else {
-            let _ = writeln!(
-                o,
-                "         {cls}.Value subValue = (({cls}) sp.sub).update({bar_args});"
-            );
+            // `update` commits, so the sub-handle's own `cur_*` fields hold the
+            // bar it just wrote -- no sink and no allocation here at all. Only
+            // `peek` needs one, because it commits nothing (#310).
+            let _ = writeln!(o, "         (({cls}) sp.sub).update({bar_args});");
             for (i, slot) in arm.out_map.iter().enumerate() {
                 if let streaming::OutSlot::Forward(k) = slot {
                     let _ = writeln!(
                         o,
-                        "         sp.cur_{} = subValue.{}();",
+                        "         sp.cur_{} = (({cls}) sp.sub).cur_{};",
                         outputs[*k],
-                        callee_value_field(registry, &arm.callee, i)
+                        registry.callee_outputs(&arm.callee)[i]
                     );
                 }
             }
@@ -3181,9 +3202,6 @@ fn emit_dispatch(
                         let _ = writeln!(o, "         sp.cur_{out} = {out}[outNBElement.value - 1];");
                     }
                 }
-            }
-            if has_value_class(func) {
-                let _ = writeln!(o, "         sp.cachedValue = {};", capture_value_expr(func));
             }
             let _ = writeln!(o, "         return RetCode.Success;");
             let _ = writeln!(o, "      }}");
@@ -3279,9 +3297,6 @@ fn emit_dispatch(
         let _ = writeln!(o, "      }}");
         for p in &func.optional_inputs {
             let _ = writeln!(o, "      sp.{0} = {0};", p.name);
-        }
-        if has_value_class(func) {
-            let _ = writeln!(o, "      sp.cachedValue = {};", capture_value_expr(func));
         }
         let _ = writeln!(o, "      return RetCode.Success;");
         let _ = writeln!(o, "   }}");
@@ -3808,13 +3823,22 @@ fn emit_composed_step(
                     let d = &sub.dsts[0];
                     let _ = writeln!(o, "{pad}cur_{d} = sp.sub{sub_idx}.{verb}({arg_str});");
                 } else {
-                    let cls = callee_stream_class(registry, &callee_key);
+                    // A multi-output sub-handle writes a caller-owned sink. `update`
+                    // commits, so its outputs could be read off the sub's own
+                    // `cur_*` fields -- but `peek` does not commit, and both verbs
+                    // share this emitter, so one shape serves both. The local is
+                    // the per-call allocation #310 settled on and #325 records:
+                    // this callee is far over the inline budget, so escape
+                    // analysis never fired here even when the sink was the
+                    // returned Value.
+                    let ocls = callee_out_class(registry, &callee_key);
                     let _ = writeln!(o, "{pad}{{");
-                    let _ = writeln!(o, "{pad}   {cls}.Value subOut{sub_idx} = sp.sub{sub_idx}.{verb}({arg_str});");
+                    let _ = writeln!(o, "{pad}   {ocls} subOut{sub_idx} = new {ocls}();");
+                    let _ = writeln!(o, "{pad}   sp.sub{sub_idx}.{verb}({arg_str}, subOut{sub_idx});");
                     for (k, d) in sub.dsts.iter().enumerate() {
                         let _ = writeln!(
                             o,
-                            "{pad}   cur_{d} = subOut{sub_idx}.{}();",
+                            "{pad}   cur_{d} = subOut{sub_idx}.{};",
                             callee_value_field(registry, &callee_key, k)
                         );
                     }

--- a/ta_codegen/generator/tests/java_stream_suite.rs
+++ b/ta_codegen/generator/tests/java_stream_suite.rs
@@ -171,22 +171,46 @@ fn test_java_ema_derived_state_and_compat() {
 #[test]
 fn test_java_mama_value_class_protocol() {
     let s = java_stream_section("mama");
-    // Multi-output => nested immutable Value record, components named after the
-    // outputs and in batch output order.
-    assert!(s.contains("public record Value(double mama, double fama) { }"));
+    // Multi-output => a caller-owned OUT class at Core level, fields named after
+    // the outputs and in batch output order, mutable and with no value equality
+    // (#310). Deliberately not a record: a reused instance as a map key would
+    // break the hash invariant the moment its fields moved.
+    assert!(s.contains("public static final class MamaOut {"));
+    assert!(s.contains("public double mama;"));
+    assert!(s.contains("public double fama;"));
+    assert!(!s.contains("public record Value("), "the record is gone, not renamed");
+    assert!(
+        !s.contains("equals(") && !s.contains("hashCode("),
+        "an Out carries no value equality"
+    );
     // The object protocol is the record's, so what used to be three generated
     // methods is now the absence of them — assert they are gone rather than
     // leaving the check vacuous.
     assert!(!s.contains("@Override public String toString() {"));
     assert!(!s.contains("Double.doubleToLongBits(this.mama)"));
     assert!(!s.contains("@Override public int hashCode() {"));
-    // Components carry the batch method's own prose (java_doc::output_desc), so
-    // one output reads the same in both tiers.
-    assert!(s.contains("@param mama "));
-    assert!(s.contains("@param fama "));
-    // update caches the instance so value() is a pure field read.
-    assert!(s.contains("this.cachedValue ="));
-    assert!(s.contains("return this.cachedValue;"));
+    // Fields carry the batch method's own prose (java_doc::output_desc), so one
+    // output reads the same in both tiers. A record documented its components
+    // with @param; a class documents each field where the field is.
+    for field in ["mama", "fama"] {
+        let decl = s
+            .find(&format!("public double {field};"))
+            .unwrap_or_else(|| panic!("{field} is not a field of the Out class"));
+        // The line immediately above carries the batch method's own prose, so a
+        // silently undocumented field fails rather than passing on a doc comment
+        // that happens to exist elsewhere in the section.
+        let above = s[..decl].rfind('\n').and_then(|e| s[..e].rfind('\n').map(|b| &s[b + 1..e]));
+        let above = above.unwrap_or("").trim();
+        assert!(
+            above.starts_with("/** ") && above.len() > 12,
+            "{field} has no prose on the line above it, found: {above:?}"
+        );
+    }
+    // No cache: update/peek/value write the caller's sink and store nothing.
+    assert!(!s.contains("cachedValue"), "the cached instance is gone (#310)");
+    assert!(s.contains("public void value( MamaOut out ) {"));
+    assert!(s.contains("public void update( double inReal, MamaOut out ) {"));
+    assert!(s.contains("public void peek( double inReal, MamaOut out ) {"));
 }
 
 #[test]
@@ -260,10 +284,16 @@ fn test_java_ma_dispatch() {
             "arm {label} must appear in both the copy constructor and dispatch switches"
         );
     }
-    // MAMA arm routes OutSlot Forward(0) through the Value field and discards
-    // FAMA; the fill tail materializes a throwaway buffer for the Discard.
-    assert!(s.contains("MamaStream.Value subValue = ((MamaStream) sp.sub).update(inReal);"));
-    assert!(s.contains("sp.cur_outReal = subValue.mama();"));
+    // MAMA arm routes OutSlot Forward(0) and discards FAMA. `update` commits, so
+    // the forwarded value is read off the sub-handle's own committed field — no
+    // sink and no allocation on this path at all (#310); only a composed PEEK
+    // needs one, because it commits nothing.
+    assert!(s.contains("((MamaStream) sp.sub).update(inReal);"));
+    assert!(s.contains("sp.cur_outReal = ((MamaStream) sp.sub).cur_outMAMA;"));
+    assert!(
+        !s.contains("MamaStream.Value"),
+        "the dispatch update path allocates nothing"
+    );
     // …and the Discard slot DECLINES the callee's nullable output rather than
     // materializing a throwaway buffer for it (rule B6a at the opener).
     assert!(s.contains("mamaOpenAndFill(inReal, 0.5, 0.05, outReal, null)"));
@@ -313,8 +343,10 @@ fn test_java_stoch_composed() {
         !s.contains("System.arraycopy(sc_outSlowK, 0, outSlowK, 0, outNBElement.value);"),
         "the stride-1 copy-back is elided: the scratch already IS outSlowK"
     );
-    // Multi-output Value with the stripped component names.
-    assert!(s.contains("public record Value(double slowK, double slowD) { }"));
+    // Multi-output OUT class with the stripped field names (#310).
+    assert!(s.contains("public static final class StochOut {"));
+    assert!(s.contains("public double slowK;"));
+    assert!(s.contains("public double slowD;"));
 }
 
 /// The sub-open range materialization (issue #203). Java has no slice type, so
@@ -792,6 +824,7 @@ fn no_java_peek_copies_the_handle() {
     let mut swept = 0usize;
     let mut frames = 0usize;
     let mut writes = 0usize;
+    let mut sink_sites: BTreeSet<String> = BTreeSet::new();
     let mut fully_shadowed: BTreeSet<String> = BTreeSet::new();
     let mut offenders: Vec<String> = Vec::new();
     for name in streaming_indicators() {
@@ -831,12 +864,21 @@ fn no_java_peek_copies_the_handle() {
                 }
             }
             // Comments carry the word too, and `throw new
-            // TaLibArgumentException` is the bar rejection while `new Value(`
-            // packs the answer — none of the three copies a handle.
+            // TaLibArgumentException` is the bar rejection — neither copies a
+            // handle. `new <N>Out()` is the sink a COMPOSED frame allocates for
+            // a multi-output sub-handle (#310); it is counted separately and
+            // pinned to an exact set below rather than blanket-exempted, so a
+            // third site fails and so does losing one of the two.
+            let composed_sink = !code
+                && l.contains(" = new ")
+                && l.contains("Out();");
+            if composed_sink {
+                sink_sites.insert(name.clone());
+            }
             let allocates_handle = !code
                 && l.contains("new ")
                 && !l.starts_with("throw new")
-                && !l.contains("new Value(");
+                && !composed_sink;
             // `.clone()` is the OTHER way to allocate here, and matching only
             // `new ` missed it: a frame clones a written array field because a
             // Java array is a reference. No frame may.
@@ -867,6 +909,19 @@ fn no_java_peek_copies_the_handle() {
         fully_shadowed.len()
     );
     assert!(offenders.is_empty(), "a peek copies:\n{}", offenders.join("\n"));
+
+    // EXACTLY these two, not "at most". Both are composed peeks whose callee is
+    // far over C2's inline budget, so the sink is allocated whatever shape it
+    // takes — it allocated as a returned `Value` before #310 too. #325 records
+    // the analysis and the only fix (inlining the sub-frame). A third site
+    // means a new composed multi-output peek nobody costed; losing one means
+    // #325 landed and this bound should tighten with it.
+    let expected: BTreeSet<String> =
+        ["ma", "stochrsi"].iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        sink_sites, expected,
+        "the set of composed peeks allocating a sub-handle sink moved"
+    );
 }
 
 #[test]

--- a/ta_codegen/generator/tests/update_and_fill_suite.rs
+++ b/ta_codegen/generator/tests/update_and_fill_suite.rs
@@ -286,39 +286,44 @@ fn the_check_is_inside_the_loop_and_not_a_pre_scan() {
 /// `value()` names a bar before the ones the call committed, and disagrees with
 /// `outRange()` by exactly the committed bars.
 ///
-/// It is refreshed in a `finally`, which covers every exit including the two
-/// throwing ones (a non-finite bar, and a sub-stream rejecting a computed
-/// intermediate mid-step). That is sound only because a step writes its `cur_*`
-/// fields last — pinned separately by
-/// `no_throwing_sub_call_follows_the_cur_capture_in_a_java_step`.
-///
-/// C# has no cache (a record struct built fresh from the fields), so it must NOT
-/// grow one here — and is already correct at every exit for the same reason.
+/// The cache is gone (#310): a multi-output `update`/`peek`/`value` writes a
+/// caller-owned `<N>Out`, so there is no stored instance to keep fresh and
+/// nothing for the `finally` to publish. This replaces the refresh test rather
+/// than deleting it — the property worth pinning is now the ABSENCE, swept over
+/// both managed backends so neither grows one back.
 #[test]
-fn the_java_value_cache_is_refreshed_on_every_exit() {
-    let multi = body_of(&section("bbands", "java"), "public void updateAndFill(");
-    assert!(
-        multi.contains("} finally {"),
-        "a multi-output updateAndFill refreshes the cache in a finally:\n{multi}"
-    );
-    assert_eq!(
-        multi.matches("if( done > 0 ) this.cachedValue =").count(),
-        1,
-        "one refresh, in the finally — not repeated per exit:\n{multi}"
-    );
-    let fin = multi.find("} finally {").expect("the finally");
-    let refresh = multi.find("if( done > 0 ) this.cachedValue =").expect("the refresh");
-    assert!(refresh > fin, "the refresh belongs inside the finally:\n{multi}");
-    let single = body_of(&section("sma", "java"), "public void updateAndFill(");
-    assert!(
-        !single.contains("cachedValue") && !single.contains("finally"),
-        "a single-output handle has no cache to refresh:\n{single}"
-    );
-    let cs = body_of(&section("bbands", "csharp"), "public void UpdateAndFill(");
-    assert!(
-        !cs.contains("cachedValue") && !cs.contains("finally"),
-        "C#'s Value is a fresh record struct and needs no refresh:\n{cs}"
-    );
+fn no_managed_handle_caches_the_multi_output_value() {
+    let mut swept = 0;
+    for (func, lang, verb) in [
+        ("bbands", "java", "public void updateAndFill("),
+        ("macd", "java", "public void updateAndFill("),
+        ("stoch", "java", "public void updateAndFill("),
+        ("bbands", "csharp", "public void UpdateAndFill("),
+    ] {
+        let sect = section(func, lang);
+        let fill = body_of(&sect, verb);
+        assert!(
+            !fill.contains("cachedValue") && !fill.contains("finally"),
+            "{func}/{lang} updateAndFill still keeps a cache fresh:\n{fill}"
+        );
+        // The whole handle, not just the filler: a cache re-grown anywhere else
+        // would leave this passing while the allocation is back.
+        assert!(
+            !sect.contains("cachedValue"),
+            "{func}/{lang} still declares or writes a cached value"
+        );
+        swept += 1;
+    }
+    assert_eq!(swept, 4, "the sweep did not reach every case it names");
+
+    // Non-vacuity: these are multi-output handles, so they DO have an out type
+    // to have cached. A single-output handle proves nothing here.
+    for (func, lang, ty) in [("bbands", "java", "BbandsOut"), ("bbands", "csharp", "BbandsValue")] {
+        assert!(
+            section(func, lang).contains(ty),
+            "{func}/{lang} has no {ty}, so its lack of a cache is not evidence"
+        );
+    }
 }
 
 /// C is the only backend with a bar count and the only one that has to reject

--- a/ta_codegen/output/java/fragments/Core_ACCBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_ACCBANDS.java
@@ -465,7 +465,6 @@
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -498,24 +497,9 @@
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand SMA of the range-scaled high band.
-       * @param realMiddleBand SMA of the close.
-       * @param realLowerBand SMA of the range-scaled low band.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -533,15 +517,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, AccbandsOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("ACCBANDS update: BadParam", RetCode.BadParam);
          }
          core.accbandsStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -567,22 +552,16 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -596,7 +575,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, AccbandsOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("ACCBANDS peek: BadParam", RetCode.BadParam);
          AccbandsStream sp = this;
@@ -659,7 +638,9 @@
          if( ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
             ringPos_trailingIdx = 0;
          }
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -668,8 +649,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( AccbandsOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -687,6 +670,29 @@
       public AccbandsStream clone() {
          return new AccbandsStream(this);
       }
+   }
+
+   /**
+    * The outputs of one ACCBANDS bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class AccbandsOut {
+      /** SMA of the range-scaled high band. */
+      public double realUpperBand;
+      /** SMA of the close. */
+      public double realMiddleBand;
+      /** SMA of the range-scaled low band. */
+      public double realLowerBand;
    }
    void accbandsStepImpl( AccbandsStream sp, double inHigh, double inLow, double inClose )
    {
@@ -895,7 +901,6 @@
       sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_AROON.java
+++ b/ta_codegen/output/java/fragments/Core_AROON.java
@@ -420,7 +420,6 @@
       double[] x_inLow;
       double cur_outAroonDown;
       double cur_outAroonUp;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -455,23 +454,9 @@
          this.x_inLow = other.x_inLow.clone();
          this.cur_outAroonDown = other.cur_outAroonDown;
          this.cur_outAroonUp = other.cur_outAroonUp;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param aroonDown Recency of the lowest low (100 = it is the current bar, decaying as it ages)
-       * @param aroonUp Recency of the highest high (100 = it is the current bar, decaying as it ages)
-       */
-      public record Value(double aroonDown, double aroonUp) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -489,15 +474,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow ) {
+      public void update( double inHigh, double inLow, AroonOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("AROON update: BadParam", RetCode.BadParam);
          }
          core.aroonStepImpl(this, inHigh, inLow);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-         return this.cachedValue;
+         out.aroonDown = this.cur_outAroonDown;
+         out.aroonUp = this.cur_outAroonUp;
       }
 
       /**
@@ -521,21 +506,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
             throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.aroonStepImpl(this, inHigh[i], inLow[i]);
-               outAroonDown[i] = this.cur_outAroonDown;
-               outAroonUp[i] = this.cur_outAroonUp;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+            core.aroonStepImpl(this, inHigh[i], inLow[i]);
+            outAroonDown[i] = this.cur_outAroonDown;
+            outAroonUp[i] = this.cur_outAroonUp;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -549,7 +528,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow ) {
+      public void peek( double inHigh, double inLow, AroonOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
             throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
          AroonStream sp = this;
@@ -620,7 +599,8 @@
          cur_outAroonDown = sp.factor * (sp.optInTimePeriod - (today - lowestIdx));
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outAroonDown, cur_outAroonUp);
+         out.aroonDown = cur_outAroonDown;
+         out.aroonUp = cur_outAroonUp;
       }
 
       /**
@@ -629,8 +609,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( AroonOut out ) {
+         out.aroonDown = this.cur_outAroonDown;
+         out.aroonUp = this.cur_outAroonUp;
       }
 
       /**
@@ -648,6 +629,27 @@
       public AroonStream clone() {
          return new AroonStream(this);
       }
+   }
+
+   /**
+    * The outputs of one AROON bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class AroonOut {
+      /** Recency of the lowest low (100 = it is the current bar, decaying as it ages) */
+      public double aroonDown;
+      /** Recency of the highest high (100 = it is the current bar, decaying as it ages) */
+      public double aroonUp;
    }
    void aroonStepImpl( AroonStream sp, double inHigh, double inLow )
    {
@@ -845,7 +847,6 @@
       sp.x_inLow = capX_inLow;
       sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
       sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
       return RetCode.Success;
    }
    /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_BBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_BBANDS.java
@@ -811,7 +811,6 @@
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       MaStream sub0;
       StddevStream sub1;
       int outRangeBegIdx;
@@ -841,26 +840,11 @@
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new StddevStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand Middle band plus nbDevUp standard deviations.
-       * @param realMiddleBand The moving average.
-       * @param realLowerBand Middle band minus nbDevDn standard deviations.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -878,15 +862,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, BbandsOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("BBANDS update: BadParam", RetCode.BadParam);
          }
          core.bbandsStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -910,22 +895,16 @@
          final int barCount = inReal.length;
          if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.bbandsStepImpl(this, inReal[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.bbandsStepImpl(this, inReal[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -939,7 +918,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, BbandsOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("BBANDS peek: BadParam", RetCode.BadParam);
          BbandsStream sp = this;
@@ -965,7 +944,9 @@
             cur_outRealLowerBand = tempReal2 - cur_tempBuffer2 * sp.optInNbDevDn;
          }
          cur_outRealMiddleBand = cur_tempBuffer1;
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -974,8 +955,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( BbandsOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -993,6 +976,29 @@
       public BbandsStream clone() {
          return new BbandsStream(this);
       }
+   }
+
+   /**
+    * The outputs of one BBANDS bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class BbandsOut {
+      /** Middle band plus nbDevUp standard deviations. */
+      public double realUpperBand;
+      /** The moving average. */
+      public double realMiddleBand;
+      /** Middle band minus nbDevDn standard deviations. */
+      public double realLowerBand;
    }
    void bbandsStepImpl( BbandsStream sp, double inReal )
    {
@@ -1153,7 +1159,6 @@
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
+++ b/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
@@ -869,7 +869,6 @@
       double[] ring_trailingWMAIdx_inReal;
       double cur_outInPhase;
       double cur_outQuadrature;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -936,23 +935,9 @@
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outInPhase = other.cur_outInPhase;
          this.cur_outQuadrature = other.cur_outQuadrature;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param inPhase In-phase component (detrender delayed 3 bars)
-       * @param quadrature Quadrature component (Q1 of the Hilbert Transform)
-       */
-      public record Value(double inPhase, double quadrature) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -970,15 +955,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, HtPhasorOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("HT_PHASOR update: BadParam", RetCode.BadParam);
          }
          core.htPhasorStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-         return this.cachedValue;
+         out.inPhase = this.cur_outInPhase;
+         out.quadrature = this.cur_outQuadrature;
       }
 
       /**
@@ -1001,21 +986,15 @@
          final int barCount = inReal.length;
          if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
             throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htPhasorStepImpl(this, inReal[i]);
-               outInPhase[i] = this.cur_outInPhase;
-               outQuadrature[i] = this.cur_outQuadrature;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+            core.htPhasorStepImpl(this, inReal[i]);
+            outInPhase[i] = this.cur_outInPhase;
+            outQuadrature[i] = this.cur_outQuadrature;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1029,7 +1008,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, HtPhasorOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("HT_PHASOR peek: BadParam", RetCode.BadParam);
          HtPhasorStream sp = this;
@@ -1217,7 +1196,8 @@
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outInPhase, cur_outQuadrature);
+         out.inPhase = cur_outInPhase;
+         out.quadrature = cur_outQuadrature;
       }
 
       /**
@@ -1226,8 +1206,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( HtPhasorOut out ) {
+         out.inPhase = this.cur_outInPhase;
+         out.quadrature = this.cur_outQuadrature;
       }
 
       /**
@@ -1245,6 +1226,27 @@
       public HtPhasorStream clone() {
          return new HtPhasorStream(this);
       }
+   }
+
+   /**
+    * The outputs of one HT_PHASOR bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class HtPhasorOut {
+      /** In-phase component (detrender delayed 3 bars) */
+      public double inPhase;
+      /** Quadrature component (Q1 of the Hilbert Transform) */
+      public double quadrature;
    }
    void htPhasorStepImpl( HtPhasorStream sp, double inReal )
    {
@@ -1803,7 +1805,6 @@
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
       sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
       return RetCode.Success;
    }
    /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_HT_SINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_SINE.java
@@ -995,7 +995,6 @@
       double[] cb_smoothPrice;
       double cur_outSine;
       double cur_outLeadSine;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -1070,23 +1069,9 @@
          this.cb_smoothPrice = other.cb_smoothPrice.clone();
          this.cur_outSine = other.cur_outSine;
          this.cur_outLeadSine = other.cur_outLeadSine;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param sine Sine of the dominant-cycle phase.
-       * @param leadSine Sine of the phase advanced 45 degrees (lead)
-       */
-      public record Value(double sine, double leadSine) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -1104,15 +1089,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, HtSineOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("HT_SINE update: BadParam", RetCode.BadParam);
          }
          core.htSineStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-         return this.cachedValue;
+         out.sine = this.cur_outSine;
+         out.leadSine = this.cur_outLeadSine;
       }
 
       /**
@@ -1135,21 +1120,15 @@
          final int barCount = inReal.length;
          if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
             throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htSineStepImpl(this, inReal[i]);
-               outSine[i] = this.cur_outSine;
-               outLeadSine[i] = this.cur_outLeadSine;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+            core.htSineStepImpl(this, inReal[i]);
+            outSine[i] = this.cur_outSine;
+            outLeadSine[i] = this.cur_outLeadSine;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1163,7 +1142,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, HtSineOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("HT_SINE peek: BadParam", RetCode.BadParam);
          HtSineStream sp = this;
@@ -1409,7 +1388,8 @@
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outSine, cur_outLeadSine);
+         out.sine = cur_outSine;
+         out.leadSine = cur_outLeadSine;
       }
 
       /**
@@ -1418,8 +1398,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( HtSineOut out ) {
+         out.sine = this.cur_outSine;
+         out.leadSine = this.cur_outLeadSine;
       }
 
       /**
@@ -1437,6 +1418,27 @@
       public HtSineStream clone() {
          return new HtSineStream(this);
       }
+   }
+
+   /**
+    * The outputs of one HT_SINE bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class HtSineOut {
+      /** Sine of the dominant-cycle phase. */
+      public double sine;
+      /** Sine of the phase advanced 45 degrees (lead) */
+      public double leadSine;
    }
    void htSineStepImpl( HtSineStream sp, double inReal )
    {
@@ -2127,7 +2129,6 @@
       sp.cb_smoothPrice = smoothPrice;
       sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
       sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
       return RetCode.Success;
    }
    /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_KC.java
+++ b/ta_codegen/output/java/fragments/Core_KC.java
@@ -466,7 +466,6 @@
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       TyppriceStream sub0;
       AtrStream sub1;
       EmaStream sub2;
@@ -496,27 +495,12 @@
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new TyppriceStream(other.sub0);
          this.sub1 = new AtrStream(other.sub1);
          this.sub2 = new EmaStream(other.sub2);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand Centre line plus the scaled Average True Range.
-       * @param realMiddleBand Exponential moving average of the typical price.
-       * @param realLowerBand Centre line minus the scaled Average True Range.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -534,15 +518,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, KcOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("KC update: BadParam", RetCode.BadParam);
          }
          core.kcStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -568,22 +553,16 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -597,7 +576,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, KcOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("KC peek: BadParam", RetCode.BadParam);
          KcStream sp = this;
@@ -617,7 +596,9 @@
          tempReal = cur_tempATR * sp.optInNbDev;
          cur_outRealUpperBand = middle + tempReal;
          cur_outRealLowerBand = middle - tempReal;
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -626,8 +607,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( KcOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -645,6 +628,29 @@
       public KcStream clone() {
          return new KcStream(this);
       }
+   }
+
+   /**
+    * The outputs of one KC bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class KcOut {
+      /** Centre line plus the scaled Average True Range. */
+      public double realUpperBand;
+      /** Exponential moving average of the typical price. */
+      public double realMiddleBand;
+      /** Centre line minus the scaled Average True Range. */
+      public double realLowerBand;
    }
    void kcStepImpl( KcStream sp, double inHigh, double inLow, double inClose )
    {
@@ -783,7 +789,6 @@
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new KcStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* kcOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MA.java
+++ b/ta_codegen/output/java/fragments/Core_MA.java
@@ -690,8 +690,9 @@
             break;
          }
          case MAMA: {
-            MamaStream.Value subValue = ((MamaStream) sp.sub).peek(inReal);
-            cur_outReal = subValue.mama();
+            MamaOut subValue = new MamaOut();
+            ((MamaStream) sp.sub).peek(inReal, subValue);
+            cur_outReal = subValue.mama;
             break;
          }
          case T3: {
@@ -771,8 +772,8 @@
          break;
       }
       case MAMA: {
-         MamaStream.Value subValue = ((MamaStream) sp.sub).update(inReal);
-         sp.cur_outReal = subValue.mama();
+         ((MamaStream) sp.sub).update(inReal);
+         sp.cur_outReal = ((MamaStream) sp.sub).cur_outMAMA;
          break;
       }
       case T3: {

--- a/ta_codegen/output/java/fragments/Core_MACD.java
+++ b/ta_codegen/output/java/fragments/Core_MACD.java
@@ -612,7 +612,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -645,24 +644,9 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd Fast EMA minus slow EMA.
-       * @param macdSignal EMA of the MACD line.
-       * @param macdHist MACD minus signal line.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -680,15 +664,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACD update: BadParam", RetCode.BadParam);
          }
          core.macdStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -712,22 +697,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -741,7 +720,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACD peek: BadParam", RetCode.BadParam);
          MacdStream sp = this;
@@ -765,7 +744,9 @@
          cur_outMACD = macdValue;
          cur_outMACDSignal = prevSignal;
          cur_outMACDHist = macdValue - prevSignal;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -774,8 +755,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -793,6 +776,29 @@
       public MacdStream clone() {
          return new MacdStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACD bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdOut {
+      /** Fast EMA minus slow EMA. */
+      public double macd;
+      /** EMA of the MACD line. */
+      public double macdSignal;
+      /** MACD minus signal line. */
+      public double macdHist;
    }
    void macdStepImpl( MacdStream sp, double inReal )
    {
@@ -1022,7 +1028,6 @@
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MACDEXT.java
+++ b/ta_codegen/output/java/fragments/Core_MACDEXT.java
@@ -597,7 +597,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       MaStream sub2;
@@ -630,27 +629,12 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.sub2 = new MaStream(other.sub2);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd MACD line: fast MA minus slow MA.
-       * @param macdSignal Signal line: MA of the MACD line.
-       * @param macdHist Histogram: MACD minus signal.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -668,15 +652,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdextOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACDEXT update: BadParam", RetCode.BadParam);
          }
          core.macdextStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -700,22 +685,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdextStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdextStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -729,7 +708,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdextOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACDEXT peek: BadParam", RetCode.BadParam);
          MacdextStream sp = this;
@@ -747,7 +726,9 @@
          /* Combine map (batch tail, per bar). */
          cur_outMACDHist = cur_fastMABuffer - cur_outMACDSignal;
          cur_outMACD = cur_fastMABuffer;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -756,8 +737,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdextOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -775,6 +758,29 @@
       public MacdextStream clone() {
          return new MacdextStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACDEXT bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdextOut {
+      /** MACD line: fast MA minus slow MA. */
+      public double macd;
+      /** Signal line: MA of the MACD line. */
+      public double macdSignal;
+      /** Histogram: MACD minus signal. */
+      public double macdHist;
    }
    void macdextStepImpl( MacdextStream sp, double inReal )
    {
@@ -950,7 +956,6 @@
       sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
       sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
       sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-      sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MACDFIX.java
+++ b/ta_codegen/output/java/fragments/Core_MACDFIX.java
@@ -522,7 +522,6 @@
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -553,24 +552,9 @@
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd Fixed EMA12 minus EMA26.
-       * @param macdSignal EMA of the MACD line.
-       * @param macdHist MACD minus signal.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -588,15 +572,16 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdfixOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACDFIX update: BadParam", RetCode.BadParam);
          }
          core.macdfixStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -620,22 +605,16 @@
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdfixStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdfixStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -649,7 +628,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdfixOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACDFIX peek: BadParam", RetCode.BadParam);
          MacdfixStream sp = this;
@@ -673,7 +652,9 @@
          cur_outMACD = macdValue;
          cur_outMACDSignal = prevSignal;
          cur_outMACDHist = macdValue - prevSignal;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -682,8 +663,10 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdfixOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -701,6 +684,29 @@
       public MacdfixStream clone() {
          return new MacdfixStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACDFIX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdfixOut {
+      /** Fixed EMA12 minus EMA26. */
+      public double macd;
+      /** EMA of the MACD line. */
+      public double macdSignal;
+      /** MACD minus signal. */
+      public double macdHist;
    }
    void macdfixStepImpl( MacdfixStream sp, double inReal )
    {
@@ -905,7 +911,6 @@
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MAMA.java
+++ b/ta_codegen/output/java/fragments/Core_MAMA.java
@@ -1012,7 +1012,6 @@
       double[] ring_trailingWMAIdx_inReal;
       double cur_outMAMA;
       double cur_outFAMA;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -1084,23 +1083,9 @@
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outMAMA = other.cur_outMAMA;
          this.cur_outFAMA = other.cur_outFAMA;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param mama Adaptive moving average (fast line)
-       * @param fama Following adaptive moving average, using half the alpha (slow line)
-       */
-      public record Value(double mama, double fama) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -1118,15 +1103,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MamaOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MAMA update: BadParam", RetCode.BadParam);
          }
          core.mamaStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-         return this.cachedValue;
+         out.mama = this.cur_outMAMA;
+         out.fama = this.cur_outFAMA;
       }
 
       /**
@@ -1151,21 +1136,15 @@
          final int barCount = inReal.length;
          if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
             throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.mamaStepImpl(this, inReal[i]);
-               outMAMA[i] = this.cur_outMAMA;
-               if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+            core.mamaStepImpl(this, inReal[i]);
+            outMAMA[i] = this.cur_outMAMA;
+            if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -1179,7 +1158,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MamaOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MAMA peek: BadParam", RetCode.BadParam);
          MamaStream sp = this;
@@ -1402,7 +1381,8 @@
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outMAMA, cur_outFAMA);
+         out.mama = cur_outMAMA;
+         out.fama = cur_outFAMA;
       }
 
       /**
@@ -1411,8 +1391,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MamaOut out ) {
+         out.mama = this.cur_outMAMA;
+         out.fama = this.cur_outFAMA;
       }
 
       /**
@@ -1430,6 +1411,27 @@
       public MamaStream clone() {
          return new MamaStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MAMA bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MamaOut {
+      /** Adaptive moving average (fast line) */
+      public double mama;
+      /** Following adaptive moving average, using half the alpha (slow line) */
+      public double fama;
    }
    void mamaStepImpl( MamaStream sp, double inReal )
    {
@@ -2074,7 +2076,6 @@
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
       sp.cur_outFAMA = lastCur_outFAMA;
-      sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
       return RetCode.Success;
    }
    /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MINMAX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAX.java
@@ -536,7 +536,6 @@
       double[] x_inReal;
       double cur_outMin;
       double cur_outMax;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -569,23 +568,9 @@
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMin = other.cur_outMin;
          this.cur_outMax = other.cur_outMax;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param min Lowest value in each rolling window.
-       * @param max Highest value in each rolling window.
-       */
-      public record Value(double min, double max) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -603,15 +588,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MinmaxOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MINMAX update: BadParam", RetCode.BadParam);
          }
          core.minmaxStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-         return this.cachedValue;
+         out.min = this.cur_outMin;
+         out.max = this.cur_outMax;
       }
 
       /**
@@ -634,21 +619,15 @@
          final int barCount = inReal.length;
          if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
             throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxStepImpl(this, inReal[i]);
-               outMin[i] = this.cur_outMin;
-               outMax[i] = this.cur_outMax;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+            core.minmaxStepImpl(this, inReal[i]);
+            outMin[i] = this.cur_outMin;
+            outMax[i] = this.cur_outMax;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -662,7 +641,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MinmaxOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MINMAX peek: BadParam", RetCode.BadParam);
          MinmaxStream sp = this;
@@ -725,7 +704,8 @@
          cur_outMin = lowest;
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outMin, cur_outMax);
+         out.min = cur_outMin;
+         out.max = cur_outMax;
       }
 
       /**
@@ -734,8 +714,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MinmaxOut out ) {
+         out.min = this.cur_outMin;
+         out.max = this.cur_outMax;
       }
 
       /**
@@ -753,6 +734,27 @@
       public MinmaxStream clone() {
          return new MinmaxStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MINMAX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MinmaxOut {
+      /** Lowest value in each rolling window. */
+      public double min;
+      /** Highest value in each rolling window. */
+      public double max;
    }
    void minmaxStepImpl( MinmaxStream sp, double inReal )
    {
@@ -949,7 +951,6 @@
       sp.x_inReal = capX_inReal;
       sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
       sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
       return RetCode.Success;
    }
    /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
@@ -404,7 +404,6 @@
       double[] x_inReal;
       int cur_outMinIdx;
       int cur_outMaxIdx;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -437,23 +436,9 @@
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMinIdx = other.cur_outMinIdx;
          this.cur_outMaxIdx = other.cur_outMaxIdx;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param minIdx Absolute index (into inReal) of the window minimum.
-       * @param maxIdx Absolute index (into inReal) of the window maximum.
-       */
-      public record Value(int minIdx, int maxIdx) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -471,15 +456,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MinmaxindexOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MINMAXINDEX update: BadParam", RetCode.BadParam);
          }
          core.minmaxindexStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-         return this.cachedValue;
+         out.minIdx = this.cur_outMinIdx;
+         out.maxIdx = this.cur_outMaxIdx;
       }
 
       /**
@@ -502,21 +487,15 @@
          final int barCount = inReal.length;
          if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
             throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxindexStepImpl(this, inReal[i]);
-               outMinIdx[i] = this.cur_outMinIdx;
-               outMaxIdx[i] = this.cur_outMaxIdx;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+            core.minmaxindexStepImpl(this, inReal[i]);
+            outMinIdx[i] = this.cur_outMinIdx;
+            outMaxIdx[i] = this.cur_outMaxIdx;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -530,7 +509,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MinmaxindexOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MINMAXINDEX peek: BadParam", RetCode.BadParam);
          MinmaxindexStream sp = this;
@@ -593,7 +572,8 @@
          cur_outMinIdx = lowestIdx;
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outMinIdx, cur_outMaxIdx);
+         out.minIdx = cur_outMinIdx;
+         out.maxIdx = cur_outMaxIdx;
       }
 
       /**
@@ -602,8 +582,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MinmaxindexOut out ) {
+         out.minIdx = this.cur_outMinIdx;
+         out.maxIdx = this.cur_outMaxIdx;
       }
 
       /**
@@ -621,6 +602,27 @@
       public MinmaxindexStream clone() {
          return new MinmaxindexStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MINMAXINDEX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MinmaxindexOut {
+      /** Absolute index (into inReal) of the window minimum. */
+      public int minIdx;
+      /** Absolute index (into inReal) of the window maximum. */
+      public int maxIdx;
    }
    void minmaxindexStepImpl( MinmaxindexStream sp, double inReal )
    {
@@ -800,7 +802,6 @@
       sp.x_inReal = capX_inReal;
       sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
       sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
       return RetCode.Success;
    }
    /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_SMI.java
+++ b/ta_codegen/output/java/fragments/Core_SMI.java
@@ -853,7 +853,6 @@
       double[] x_inClose;
       double cur_outSMI;
       double cur_outSMISignal;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -899,23 +898,9 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSMI = other.cur_outSMI;
          this.cur_outSMISignal = other.cur_outSMISignal;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param smi Stochastic Momentum Index, -100 to +100.
-       * @param smiSignal Exponential average of the SMI line.
-       */
-      public record Value(double smi, double smiSignal) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -933,15 +918,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, SmiOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("SMI update: BadParam", RetCode.BadParam);
          }
          core.smiStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-         return this.cachedValue;
+         out.smi = this.cur_outSMI;
+         out.smiSignal = this.cur_outSMISignal;
       }
 
       /**
@@ -966,21 +951,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
             throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSMI[i] = this.cur_outSMI;
-               outSMISignal[i] = this.cur_outSMISignal;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+            core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSMI[i] = this.cur_outSMI;
+            outSMISignal[i] = this.cur_outSMISignal;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -994,7 +973,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, SmiOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("SMI peek: BadParam", RetCode.BadParam);
          SmiStream sp = this;
@@ -1099,7 +1078,8 @@
          cur_outSMISignal = prevSignal;
          trailingIdx = trailingIdx + 1;
          today = today + 1;
-         return new Value(cur_outSMI, cur_outSMISignal);
+         out.smi = cur_outSMI;
+         out.smiSignal = cur_outSMISignal;
       }
 
       /**
@@ -1108,8 +1088,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( SmiOut out ) {
+         out.smi = this.cur_outSMI;
+         out.smiSignal = this.cur_outSMISignal;
       }
 
       /**
@@ -1127,6 +1108,27 @@
       public SmiStream clone() {
          return new SmiStream(this);
       }
+   }
+
+   /**
+    * The outputs of one SMI bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class SmiOut {
+      /** Stochastic Momentum Index, -100 to +100. */
+      public double smi;
+      /** Exponential average of the SMI line. */
+      public double smiSignal;
    }
    void smiStepImpl( SmiStream sp, double inHigh, double inLow, double inClose )
    {
@@ -1545,7 +1547,6 @@
       sp.x_inClose = capX_inClose;
       sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
       sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
       return RetCode.Success;
    }
    /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_STOCH.java
+++ b/ta_codegen/output/java/fragments/Core_STOCH.java
@@ -711,7 +711,6 @@
       double[] x_inClose;
       double cur_outSlowK;
       double cur_outSlowD;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       int outRangeBegIdx;
@@ -753,25 +752,11 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSlowK = other.cur_outSlowK;
          this.cur_outSlowD = other.cur_outSlowD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param slowK Raw FastK smoothed by SlowK_Period MA.
-       * @param slowD Signal line: SlowK smoothed by SlowD_Period MA.
-       */
-      public record Value(double slowK, double slowD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -789,15 +774,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, StochOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCH update: BadParam", RetCode.BadParam);
          }
          core.stochStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-         return this.cachedValue;
+         out.slowK = this.cur_outSlowK;
+         out.slowD = this.cur_outSlowD;
       }
 
       /**
@@ -822,21 +807,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
             throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSlowK[i] = this.cur_outSlowK;
-               outSlowD[i] = this.cur_outSlowD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+            core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSlowK[i] = this.cur_outSlowK;
+            outSlowD[i] = this.cur_outSlowD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -850,7 +829,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, StochOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("STOCH peek: BadParam", RetCode.BadParam);
          StochStream sp = this;
@@ -943,7 +922,8 @@
          cur_tempBuffer = sp.sub0.peek(cur_tempBuffer);
          cur_outSlowD = sp.sub1.peek(cur_tempBuffer);
          cur_outSlowK = cur_tempBuffer;
-         return new Value(cur_outSlowK, cur_outSlowD);
+         out.slowK = cur_outSlowK;
+         out.slowD = cur_outSlowD;
       }
 
       /**
@@ -952,8 +932,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochOut out ) {
+         out.slowK = this.cur_outSlowK;
+         out.slowD = this.cur_outSlowD;
       }
 
       /**
@@ -971,6 +952,27 @@
       public StochStream clone() {
          return new StochStream(this);
       }
+   }
+
+   /**
+    * The outputs of one STOCH bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochOut {
+      /** Raw FastK smoothed by SlowK_Period MA. */
+      public double slowK;
+      /** Signal line: SlowK smoothed by SlowD_Period MA. */
+      public double slowD;
    }
    void stochStepImpl( StochStream sp, double inHigh, double inLow, double inClose )
    {
@@ -1333,7 +1335,6 @@
       sp.sub1 = sub1;
       sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
       sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-      sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
       return RetCode.Success;
    }
    /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_STOCHF.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHF.java
@@ -632,7 +632,6 @@
       double[] x_inClose;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       MaStream sub0;
       int outRangeBegIdx;
       int outRangeCount;
@@ -671,24 +670,10 @@
          this.x_inClose = other.x_inClose.clone();
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param fastK Raw %K stochastic line.
-       * @param fastD MA-smoothed %K (signal line)
-       */
-      public record Value(double fastK, double fastD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -706,15 +691,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, StochfOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCHF update: BadParam", RetCode.BadParam);
          }
          core.stochfStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -739,21 +724,15 @@
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -767,7 +746,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, StochfOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("STOCHF peek: BadParam", RetCode.BadParam);
          StochfStream sp = this;
@@ -859,7 +838,8 @@
          /* Pipeline the new bar through the sub-streams (batch tail order). */
          cur_outFastD = sp.sub0.peek(cur_tempBuffer);
          cur_outFastK = cur_tempBuffer;
-         return new Value(cur_outFastK, cur_outFastD);
+         out.fastK = cur_outFastK;
+         out.fastD = cur_outFastD;
       }
 
       /**
@@ -868,8 +848,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochfOut out ) {
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -887,6 +868,27 @@
       public StochfStream clone() {
          return new StochfStream(this);
       }
+   }
+
+   /**
+    * The outputs of one STOCHF bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochfOut {
+      /** Raw %K stochastic line. */
+      public double fastK;
+      /** MA-smoothed %K (signal line) */
+      public double fastD;
    }
    void stochfStepImpl( StochfStream sp, double inHigh, double inLow, double inClose )
    {
@@ -1223,7 +1225,6 @@
       sp.sub0 = sub0;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/fragments/Core_STOCHRSI.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHRSI.java
@@ -448,7 +448,6 @@
       MAType optInFastD_MAType;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       RsiStream sub0;
       StochfStream sub1;
       int outRangeBegIdx;
@@ -477,25 +476,11 @@
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new RsiStream(other.sub0);
          this.sub1 = new StochfStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param fastK Unsmoothed stochastic of the RSI (raw %K)
-       * @param fastD %K smoothed over FastD_Period (signal line)
-       */
-      public record Value(double fastK, double fastD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -513,15 +498,15 @@
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, StochrsiOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCHRSI update: BadParam", RetCode.BadParam);
          }
          core.stochrsiStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -544,21 +529,15 @@
          final int barCount = inReal.length;
          if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochrsiStepImpl(this, inReal[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochrsiStepImpl(this, inReal[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -572,7 +551,7 @@
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, StochrsiOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("STOCHRSI peek: BadParam", RetCode.BadParam);
          StochrsiStream sp = this;
@@ -582,11 +561,13 @@
          /* Pipeline the new bar through the sub-streams (batch tail order). */
          cur_tempRSIBuffer = sp.sub0.peek(inReal);
          {
-            StochfStream.Value subOut1 = sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-            cur_outFastK = subOut1.fastK();
-            cur_outFastD = subOut1.fastD();
+            StochfOut subOut1 = new StochfOut();
+            sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+            cur_outFastK = subOut1.fastK;
+            cur_outFastD = subOut1.fastD;
          }
-         return new Value(cur_outFastK, cur_outFastD);
+         out.fastK = cur_outFastK;
+         out.fastD = cur_outFastD;
       }
 
       /**
@@ -595,8 +576,9 @@
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochrsiOut out ) {
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -615,6 +597,27 @@
          return new StochrsiStream(this);
       }
    }
+
+   /**
+    * The outputs of one STOCHRSI bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochrsiOut {
+      /** Unsmoothed stochastic of the RSI (raw %K) */
+      public double fastK;
+      /** %K smoothed over FastD_Period (signal line) */
+      public double fastD;
+   }
    void stochrsiStepImpl( StochrsiStream sp, double inReal )
    {
       double cur_tempRSIBuffer = 0.0;
@@ -623,9 +626,10 @@
       /* Pipeline the new bar through the sub-streams (batch tail order). */
       cur_tempRSIBuffer = sp.sub0.update(inReal);
       {
-         StochfStream.Value subOut1 = sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-         cur_outFastK = subOut1.fastK();
-         cur_outFastD = subOut1.fastD();
+         StochfOut subOut1 = new StochfOut();
+         sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+         cur_outFastK = subOut1.fastK;
+         cur_outFastD = subOut1.fastD;
       }
       sp.cur_outFastK = cur_outFastK;
       sp.cur_outFastD = cur_outFastD;
@@ -747,7 +751,6 @@
       sp.sub1 = sub1;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -2100,7 +2100,6 @@ public final class Core {
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -2133,24 +2132,9 @@ public final class Core {
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand SMA of the range-scaled high band.
-       * @param realMiddleBand SMA of the close.
-       * @param realLowerBand SMA of the range-scaled low band.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -2168,15 +2152,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, AccbandsOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("ACCBANDS update: BadParam", RetCode.BadParam);
          }
          core.accbandsStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -2202,22 +2187,16 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -2231,7 +2210,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, AccbandsOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("ACCBANDS peek: BadParam", RetCode.BadParam);
          AccbandsStream sp = this;
@@ -2294,7 +2273,9 @@ public final class Core {
          if( ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
             ringPos_trailingIdx = 0;
          }
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -2303,8 +2284,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( AccbandsOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -2322,6 +2305,29 @@ public final class Core {
       public AccbandsStream clone() {
          return new AccbandsStream(this);
       }
+   }
+
+   /**
+    * The outputs of one ACCBANDS bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class AccbandsOut {
+      /** SMA of the range-scaled high band. */
+      public double realUpperBand;
+      /** SMA of the close. */
+      public double realMiddleBand;
+      /** SMA of the range-scaled low band. */
+      public double realLowerBand;
    }
    void accbandsStepImpl( AccbandsStream sp, double inHigh, double inLow, double inClose )
    {
@@ -2530,7 +2536,6 @@ public final class Core {
       sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
       sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -9282,7 +9287,6 @@ public final class Core {
       double[] x_inLow;
       double cur_outAroonDown;
       double cur_outAroonUp;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -9317,23 +9321,9 @@ public final class Core {
          this.x_inLow = other.x_inLow.clone();
          this.cur_outAroonDown = other.cur_outAroonDown;
          this.cur_outAroonUp = other.cur_outAroonUp;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param aroonDown Recency of the lowest low (100 = it is the current bar, decaying as it ages)
-       * @param aroonUp Recency of the highest high (100 = it is the current bar, decaying as it ages)
-       */
-      public record Value(double aroonDown, double aroonUp) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -9351,15 +9341,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow ) {
+      public void update( double inHigh, double inLow, AroonOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("AROON update: BadParam", RetCode.BadParam);
          }
          core.aroonStepImpl(this, inHigh, inLow);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-         return this.cachedValue;
+         out.aroonDown = this.cur_outAroonDown;
+         out.aroonUp = this.cur_outAroonUp;
       }
 
       /**
@@ -9383,21 +9373,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
             throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.aroonStepImpl(this, inHigh[i], inLow[i]);
-               outAroonDown[i] = this.cur_outAroonDown;
-               outAroonUp[i] = this.cur_outAroonUp;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+            core.aroonStepImpl(this, inHigh[i], inLow[i]);
+            outAroonDown[i] = this.cur_outAroonDown;
+            outAroonUp[i] = this.cur_outAroonUp;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -9411,7 +9395,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow ) {
+      public void peek( double inHigh, double inLow, AroonOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
             throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
          AroonStream sp = this;
@@ -9482,7 +9466,8 @@ public final class Core {
          cur_outAroonDown = sp.factor * (sp.optInTimePeriod - (today - lowestIdx));
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outAroonDown, cur_outAroonUp);
+         out.aroonDown = cur_outAroonDown;
+         out.aroonUp = cur_outAroonUp;
       }
 
       /**
@@ -9491,8 +9476,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( AroonOut out ) {
+         out.aroonDown = this.cur_outAroonDown;
+         out.aroonUp = this.cur_outAroonUp;
       }
 
       /**
@@ -9510,6 +9496,27 @@ public final class Core {
       public AroonStream clone() {
          return new AroonStream(this);
       }
+   }
+
+   /**
+    * The outputs of one AROON bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class AroonOut {
+      /** Recency of the lowest low (100 = it is the current bar, decaying as it ages) */
+      public double aroonDown;
+      /** Recency of the highest high (100 = it is the current bar, decaying as it ages) */
+      public double aroonUp;
    }
    void aroonStepImpl( AroonStream sp, double inHigh, double inLow )
    {
@@ -9707,7 +9714,6 @@ public final class Core {
       sp.x_inLow = capX_inLow;
       sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
       sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
       return RetCode.Success;
    }
    /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -14471,7 +14477,6 @@ public final class Core {
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       MaStream sub0;
       StddevStream sub1;
       int outRangeBegIdx;
@@ -14501,26 +14506,11 @@ public final class Core {
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new StddevStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand Middle band plus nbDevUp standard deviations.
-       * @param realMiddleBand The moving average.
-       * @param realLowerBand Middle band minus nbDevDn standard deviations.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -14538,15 +14528,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, BbandsOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("BBANDS update: BadParam", RetCode.BadParam);
          }
          core.bbandsStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -14570,22 +14561,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.bbandsStepImpl(this, inReal[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.bbandsStepImpl(this, inReal[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -14599,7 +14584,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, BbandsOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("BBANDS peek: BadParam", RetCode.BadParam);
          BbandsStream sp = this;
@@ -14625,7 +14610,9 @@ public final class Core {
             cur_outRealLowerBand = tempReal2 - cur_tempBuffer2 * sp.optInNbDevDn;
          }
          cur_outRealMiddleBand = cur_tempBuffer1;
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -14634,8 +14621,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( BbandsOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -14653,6 +14642,29 @@ public final class Core {
       public BbandsStream clone() {
          return new BbandsStream(this);
       }
+   }
+
+   /**
+    * The outputs of one BBANDS bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class BbandsOut {
+      /** Middle band plus nbDevUp standard deviations. */
+      public double realUpperBand;
+      /** The moving average. */
+      public double realMiddleBand;
+      /** Middle band minus nbDevDn standard deviations. */
+      public double realLowerBand;
    }
    void bbandsStepImpl( BbandsStream sp, double inReal )
    {
@@ -14813,7 +14825,6 @@ public final class Core {
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -89456,7 +89467,6 @@ public final class Core {
       double[] ring_trailingWMAIdx_inReal;
       double cur_outInPhase;
       double cur_outQuadrature;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -89523,23 +89533,9 @@ public final class Core {
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outInPhase = other.cur_outInPhase;
          this.cur_outQuadrature = other.cur_outQuadrature;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param inPhase In-phase component (detrender delayed 3 bars)
-       * @param quadrature Quadrature component (Q1 of the Hilbert Transform)
-       */
-      public record Value(double inPhase, double quadrature) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -89557,15 +89553,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, HtPhasorOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("HT_PHASOR update: BadParam", RetCode.BadParam);
          }
          core.htPhasorStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-         return this.cachedValue;
+         out.inPhase = this.cur_outInPhase;
+         out.quadrature = this.cur_outQuadrature;
       }
 
       /**
@@ -89588,21 +89584,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
             throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htPhasorStepImpl(this, inReal[i]);
-               outInPhase[i] = this.cur_outInPhase;
-               outQuadrature[i] = this.cur_outQuadrature;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+            core.htPhasorStepImpl(this, inReal[i]);
+            outInPhase[i] = this.cur_outInPhase;
+            outQuadrature[i] = this.cur_outQuadrature;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -89616,7 +89606,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, HtPhasorOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("HT_PHASOR peek: BadParam", RetCode.BadParam);
          HtPhasorStream sp = this;
@@ -89804,7 +89794,8 @@ public final class Core {
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outInPhase, cur_outQuadrature);
+         out.inPhase = cur_outInPhase;
+         out.quadrature = cur_outQuadrature;
       }
 
       /**
@@ -89813,8 +89804,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( HtPhasorOut out ) {
+         out.inPhase = this.cur_outInPhase;
+         out.quadrature = this.cur_outQuadrature;
       }
 
       /**
@@ -89832,6 +89824,27 @@ public final class Core {
       public HtPhasorStream clone() {
          return new HtPhasorStream(this);
       }
+   }
+
+   /**
+    * The outputs of one HT_PHASOR bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class HtPhasorOut {
+      /** In-phase component (detrender delayed 3 bars) */
+      public double inPhase;
+      /** Quadrature component (Q1 of the Hilbert Transform) */
+      public double quadrature;
    }
    void htPhasorStepImpl( HtPhasorStream sp, double inReal )
    {
@@ -90390,7 +90403,6 @@ public final class Core {
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
       sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
       return RetCode.Success;
    }
    /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -91474,7 +91486,6 @@ public final class Core {
       double[] cb_smoothPrice;
       double cur_outSine;
       double cur_outLeadSine;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -91549,23 +91560,9 @@ public final class Core {
          this.cb_smoothPrice = other.cb_smoothPrice.clone();
          this.cur_outSine = other.cur_outSine;
          this.cur_outLeadSine = other.cur_outLeadSine;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param sine Sine of the dominant-cycle phase.
-       * @param leadSine Sine of the phase advanced 45 degrees (lead)
-       */
-      public record Value(double sine, double leadSine) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -91583,15 +91580,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, HtSineOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("HT_SINE update: BadParam", RetCode.BadParam);
          }
          core.htSineStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-         return this.cachedValue;
+         out.sine = this.cur_outSine;
+         out.leadSine = this.cur_outLeadSine;
       }
 
       /**
@@ -91614,21 +91611,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
             throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.htSineStepImpl(this, inReal[i]);
-               outSine[i] = this.cur_outSine;
-               outLeadSine[i] = this.cur_outLeadSine;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+            core.htSineStepImpl(this, inReal[i]);
+            outSine[i] = this.cur_outSine;
+            outLeadSine[i] = this.cur_outLeadSine;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -91642,7 +91633,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, HtSineOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("HT_SINE peek: BadParam", RetCode.BadParam);
          HtSineStream sp = this;
@@ -91888,7 +91879,8 @@ public final class Core {
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outSine, cur_outLeadSine);
+         out.sine = cur_outSine;
+         out.leadSine = cur_outLeadSine;
       }
 
       /**
@@ -91897,8 +91889,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( HtSineOut out ) {
+         out.sine = this.cur_outSine;
+         out.leadSine = this.cur_outLeadSine;
       }
 
       /**
@@ -91916,6 +91909,27 @@ public final class Core {
       public HtSineStream clone() {
          return new HtSineStream(this);
       }
+   }
+
+   /**
+    * The outputs of one HT_SINE bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class HtSineOut {
+      /** Sine of the dominant-cycle phase. */
+      public double sine;
+      /** Sine of the phase advanced 45 degrees (lead) */
+      public double leadSine;
    }
    void htSineStepImpl( HtSineStream sp, double inReal )
    {
@@ -92606,7 +92620,6 @@ public final class Core {
       sp.cb_smoothPrice = smoothPrice;
       sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
       sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
       return RetCode.Success;
    }
    /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -99636,7 +99649,6 @@ public final class Core {
       double cur_outRealUpperBand;
       double cur_outRealMiddleBand;
       double cur_outRealLowerBand;
-      Value cachedValue;
       TyppriceStream sub0;
       AtrStream sub1;
       EmaStream sub2;
@@ -99666,27 +99678,12 @@ public final class Core {
          this.cur_outRealUpperBand = other.cur_outRealUpperBand;
          this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
          this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new TyppriceStream(other.sub0);
          this.sub1 = new AtrStream(other.sub1);
          this.sub2 = new EmaStream(other.sub2);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param realUpperBand Centre line plus the scaled Average True Range.
-       * @param realMiddleBand Exponential moving average of the typical price.
-       * @param realLowerBand Centre line minus the scaled Average True Range.
-       */
-      public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -99704,15 +99701,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, KcOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("KC update: BadParam", RetCode.BadParam);
          }
          core.kcStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-         return this.cachedValue;
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -99738,22 +99736,16 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
             throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outRealUpperBand[i] = this.cur_outRealUpperBand;
-               outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-               outRealLowerBand[i] = this.cur_outRealLowerBand;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+            core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outRealUpperBand[i] = this.cur_outRealUpperBand;
+            outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+            outRealLowerBand[i] = this.cur_outRealLowerBand;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -99767,7 +99759,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, KcOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("KC peek: BadParam", RetCode.BadParam);
          KcStream sp = this;
@@ -99787,7 +99779,9 @@ public final class Core {
          tempReal = cur_tempATR * sp.optInNbDev;
          cur_outRealUpperBand = middle + tempReal;
          cur_outRealLowerBand = middle - tempReal;
-         return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+         out.realUpperBand = cur_outRealUpperBand;
+         out.realMiddleBand = cur_outRealMiddleBand;
+         out.realLowerBand = cur_outRealLowerBand;
       }
 
       /**
@@ -99796,8 +99790,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( KcOut out ) {
+         out.realUpperBand = this.cur_outRealUpperBand;
+         out.realMiddleBand = this.cur_outRealMiddleBand;
+         out.realLowerBand = this.cur_outRealLowerBand;
       }
 
       /**
@@ -99815,6 +99811,29 @@ public final class Core {
       public KcStream clone() {
          return new KcStream(this);
       }
+   }
+
+   /**
+    * The outputs of one KC bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class KcOut {
+      /** Centre line plus the scaled Average True Range. */
+      public double realUpperBand;
+      /** Exponential moving average of the typical price. */
+      public double realMiddleBand;
+      /** Centre line minus the scaled Average True Range. */
+      public double realLowerBand;
    }
    void kcStepImpl( KcStream sp, double inHigh, double inLow, double inClose )
    {
@@ -99953,7 +99972,6 @@ public final class Core {
       sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
       sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
       sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-      sp.cachedValue = new KcStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
       return RetCode.Success;
    }
    /* kcOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -106171,8 +106189,9 @@ public final class Core {
             break;
          }
          case MAMA: {
-            MamaStream.Value subValue = ((MamaStream) sp.sub).peek(inReal);
-            cur_outReal = subValue.mama();
+            MamaOut subValue = new MamaOut();
+            ((MamaStream) sp.sub).peek(inReal, subValue);
+            cur_outReal = subValue.mama;
             break;
          }
          case T3: {
@@ -106252,8 +106271,8 @@ public final class Core {
          break;
       }
       case MAMA: {
-         MamaStream.Value subValue = ((MamaStream) sp.sub).update(inReal);
-         sp.cur_outReal = subValue.mama();
+         ((MamaStream) sp.sub).update(inReal);
+         sp.cur_outReal = ((MamaStream) sp.sub).cur_outMAMA;
          break;
       }
       case T3: {
@@ -107334,7 +107353,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -107367,24 +107385,9 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd Fast EMA minus slow EMA.
-       * @param macdSignal EMA of the MACD line.
-       * @param macdHist MACD minus signal line.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -107402,15 +107405,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACD update: BadParam", RetCode.BadParam);
          }
          core.macdStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -107434,22 +107438,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -107463,7 +107461,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACD peek: BadParam", RetCode.BadParam);
          MacdStream sp = this;
@@ -107487,7 +107485,9 @@ public final class Core {
          cur_outMACD = macdValue;
          cur_outMACDSignal = prevSignal;
          cur_outMACDHist = macdValue - prevSignal;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -107496,8 +107496,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -107515,6 +107517,29 @@ public final class Core {
       public MacdStream clone() {
          return new MacdStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACD bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdOut {
+      /** Fast EMA minus slow EMA. */
+      public double macd;
+      /** EMA of the MACD line. */
+      public double macdSignal;
+      /** MACD minus signal line. */
+      public double macdHist;
    }
    void macdStepImpl( MacdStream sp, double inReal )
    {
@@ -107744,7 +107769,6 @@ public final class Core {
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -108432,7 +108456,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       MaStream sub2;
@@ -108465,27 +108488,12 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.sub2 = new MaStream(other.sub2);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd MACD line: fast MA minus slow MA.
-       * @param macdSignal Signal line: MA of the MACD line.
-       * @param macdHist Histogram: MACD minus signal.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -108503,15 +108511,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdextOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACDEXT update: BadParam", RetCode.BadParam);
          }
          core.macdextStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -108535,22 +108544,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdextStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdextStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -108564,7 +108567,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdextOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACDEXT peek: BadParam", RetCode.BadParam);
          MacdextStream sp = this;
@@ -108582,7 +108585,9 @@ public final class Core {
          /* Combine map (batch tail, per bar). */
          cur_outMACDHist = cur_fastMABuffer - cur_outMACDSignal;
          cur_outMACD = cur_fastMABuffer;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -108591,8 +108596,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdextOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -108610,6 +108617,29 @@ public final class Core {
       public MacdextStream clone() {
          return new MacdextStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACDEXT bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdextOut {
+      /** MACD line: fast MA minus slow MA. */
+      public double macd;
+      /** Signal line: MA of the MACD line. */
+      public double macdSignal;
+      /** Histogram: MACD minus signal. */
+      public double macdHist;
    }
    void macdextStepImpl( MacdextStream sp, double inReal )
    {
@@ -108785,7 +108815,6 @@ public final class Core {
       sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
       sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
       sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-      sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -109404,7 +109433,6 @@ public final class Core {
       double cur_outMACD;
       double cur_outMACDSignal;
       double cur_outMACDHist;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -109435,24 +109463,9 @@ public final class Core {
          this.cur_outMACD = other.cur_outMACD;
          this.cur_outMACDSignal = other.cur_outMACDSignal;
          this.cur_outMACDHist = other.cur_outMACDHist;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param macd Fixed EMA12 minus EMA26.
-       * @param macdSignal EMA of the MACD line.
-       * @param macdHist MACD minus signal.
-       */
-      public record Value(double macd, double macdSignal, double macdHist) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -109470,15 +109483,16 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MacdfixOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MACDFIX update: BadParam", RetCode.BadParam);
          }
          core.macdfixStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-         return this.cachedValue;
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -109502,22 +109516,16 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
             throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.macdfixStepImpl(this, inReal[i]);
-               outMACD[i] = this.cur_outMACD;
-               outMACDSignal[i] = this.cur_outMACDSignal;
-               outMACDHist[i] = this.cur_outMACDHist;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+            core.macdfixStepImpl(this, inReal[i]);
+            outMACD[i] = this.cur_outMACD;
+            outMACDSignal[i] = this.cur_outMACDSignal;
+            outMACDHist[i] = this.cur_outMACDHist;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -109531,7 +109539,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MacdfixOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MACDFIX peek: BadParam", RetCode.BadParam);
          MacdfixStream sp = this;
@@ -109555,7 +109563,9 @@ public final class Core {
          cur_outMACD = macdValue;
          cur_outMACDSignal = prevSignal;
          cur_outMACDHist = macdValue - prevSignal;
-         return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+         out.macd = cur_outMACD;
+         out.macdSignal = cur_outMACDSignal;
+         out.macdHist = cur_outMACDHist;
       }
 
       /**
@@ -109564,8 +109574,10 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MacdfixOut out ) {
+         out.macd = this.cur_outMACD;
+         out.macdSignal = this.cur_outMACDSignal;
+         out.macdHist = this.cur_outMACDHist;
       }
 
       /**
@@ -109583,6 +109595,29 @@ public final class Core {
       public MacdfixStream clone() {
          return new MacdfixStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MACDFIX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MacdfixOut {
+      /** Fixed EMA12 minus EMA26. */
+      public double macd;
+      /** EMA of the MACD line. */
+      public double macdSignal;
+      /** MACD minus signal. */
+      public double macdHist;
    }
    void macdfixStepImpl( MacdfixStream sp, double inReal )
    {
@@ -109787,7 +109822,6 @@ public final class Core {
       sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
       sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
       return RetCode.Success;
    }
    /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -110890,7 +110924,6 @@ public final class Core {
       double[] ring_trailingWMAIdx_inReal;
       double cur_outMAMA;
       double cur_outFAMA;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -110962,23 +110995,9 @@ public final class Core {
          this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
          this.cur_outMAMA = other.cur_outMAMA;
          this.cur_outFAMA = other.cur_outFAMA;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param mama Adaptive moving average (fast line)
-       * @param fama Following adaptive moving average, using half the alpha (slow line)
-       */
-      public record Value(double mama, double fama) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -110996,15 +111015,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MamaOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MAMA update: BadParam", RetCode.BadParam);
          }
          core.mamaStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-         return this.cachedValue;
+         out.mama = this.cur_outMAMA;
+         out.fama = this.cur_outFAMA;
       }
 
       /**
@@ -111029,21 +111048,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
             throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.mamaStepImpl(this, inReal[i]);
-               outMAMA[i] = this.cur_outMAMA;
-               if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+            core.mamaStepImpl(this, inReal[i]);
+            outMAMA[i] = this.cur_outMAMA;
+            if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -111057,7 +111070,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MamaOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MAMA peek: BadParam", RetCode.BadParam);
          MamaStream sp = this;
@@ -111280,7 +111293,8 @@ public final class Core {
             ringPos_trailingWMAIdx = 0;
          }
          streamParity = 1 - streamParity;
-         return new Value(cur_outMAMA, cur_outFAMA);
+         out.mama = cur_outMAMA;
+         out.fama = cur_outFAMA;
       }
 
       /**
@@ -111289,8 +111303,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MamaOut out ) {
+         out.mama = this.cur_outMAMA;
+         out.fama = this.cur_outFAMA;
       }
 
       /**
@@ -111308,6 +111323,27 @@ public final class Core {
       public MamaStream clone() {
          return new MamaStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MAMA bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MamaOut {
+      /** Adaptive moving average (fast line) */
+      public double mama;
+      /** Following adaptive moving average, using half the alpha (slow line) */
+      public double fama;
    }
    void mamaStepImpl( MamaStream sp, double inReal )
    {
@@ -111952,7 +111988,6 @@ public final class Core {
       sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
       sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
       sp.cur_outFAMA = lastCur_outFAMA;
-      sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
       return RetCode.Success;
    }
    /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -120892,7 +120927,6 @@ public final class Core {
       double[] x_inReal;
       double cur_outMin;
       double cur_outMax;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -120925,23 +120959,9 @@ public final class Core {
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMin = other.cur_outMin;
          this.cur_outMax = other.cur_outMax;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param min Lowest value in each rolling window.
-       * @param max Highest value in each rolling window.
-       */
-      public record Value(double min, double max) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -120959,15 +120979,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MinmaxOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MINMAX update: BadParam", RetCode.BadParam);
          }
          core.minmaxStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-         return this.cachedValue;
+         out.min = this.cur_outMin;
+         out.max = this.cur_outMax;
       }
 
       /**
@@ -120990,21 +121010,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
             throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxStepImpl(this, inReal[i]);
-               outMin[i] = this.cur_outMin;
-               outMax[i] = this.cur_outMax;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+            core.minmaxStepImpl(this, inReal[i]);
+            outMin[i] = this.cur_outMin;
+            outMax[i] = this.cur_outMax;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -121018,7 +121032,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MinmaxOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MINMAX peek: BadParam", RetCode.BadParam);
          MinmaxStream sp = this;
@@ -121081,7 +121095,8 @@ public final class Core {
          cur_outMin = lowest;
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outMin, cur_outMax);
+         out.min = cur_outMin;
+         out.max = cur_outMax;
       }
 
       /**
@@ -121090,8 +121105,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MinmaxOut out ) {
+         out.min = this.cur_outMin;
+         out.max = this.cur_outMax;
       }
 
       /**
@@ -121109,6 +121125,27 @@ public final class Core {
       public MinmaxStream clone() {
          return new MinmaxStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MINMAX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MinmaxOut {
+      /** Lowest value in each rolling window. */
+      public double min;
+      /** Highest value in each rolling window. */
+      public double max;
    }
    void minmaxStepImpl( MinmaxStream sp, double inReal )
    {
@@ -121305,7 +121342,6 @@ public final class Core {
       sp.x_inReal = capX_inReal;
       sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
       sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
       return RetCode.Success;
    }
    /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -121798,7 +121834,6 @@ public final class Core {
       double[] x_inReal;
       int cur_outMinIdx;
       int cur_outMaxIdx;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -121831,23 +121866,9 @@ public final class Core {
          this.x_inReal = other.x_inReal.clone();
          this.cur_outMinIdx = other.cur_outMinIdx;
          this.cur_outMaxIdx = other.cur_outMaxIdx;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param minIdx Absolute index (into inReal) of the window minimum.
-       * @param maxIdx Absolute index (into inReal) of the window maximum.
-       */
-      public record Value(int minIdx, int maxIdx) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -121865,15 +121886,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, MinmaxindexOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("MINMAXINDEX update: BadParam", RetCode.BadParam);
          }
          core.minmaxindexStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-         return this.cachedValue;
+         out.minIdx = this.cur_outMinIdx;
+         out.maxIdx = this.cur_outMaxIdx;
       }
 
       /**
@@ -121896,21 +121917,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
             throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.minmaxindexStepImpl(this, inReal[i]);
-               outMinIdx[i] = this.cur_outMinIdx;
-               outMaxIdx[i] = this.cur_outMaxIdx;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+            core.minmaxindexStepImpl(this, inReal[i]);
+            outMinIdx[i] = this.cur_outMinIdx;
+            outMaxIdx[i] = this.cur_outMaxIdx;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -121924,7 +121939,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, MinmaxindexOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MINMAXINDEX peek: BadParam", RetCode.BadParam);
          MinmaxindexStream sp = this;
@@ -121987,7 +122002,8 @@ public final class Core {
          cur_outMinIdx = lowestIdx;
          trailingIdx += 1;
          today += 1;
-         return new Value(cur_outMinIdx, cur_outMaxIdx);
+         out.minIdx = cur_outMinIdx;
+         out.maxIdx = cur_outMaxIdx;
       }
 
       /**
@@ -121996,8 +122012,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( MinmaxindexOut out ) {
+         out.minIdx = this.cur_outMinIdx;
+         out.maxIdx = this.cur_outMaxIdx;
       }
 
       /**
@@ -122015,6 +122032,27 @@ public final class Core {
       public MinmaxindexStream clone() {
          return new MinmaxindexStream(this);
       }
+   }
+
+   /**
+    * The outputs of one MINMAXINDEX bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class MinmaxindexOut {
+      /** Absolute index (into inReal) of the window minimum. */
+      public int minIdx;
+      /** Absolute index (into inReal) of the window maximum. */
+      public int maxIdx;
    }
    void minmaxindexStepImpl( MinmaxindexStream sp, double inReal )
    {
@@ -122194,7 +122232,6 @@ public final class Core {
       sp.x_inReal = capX_inReal;
       sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
       sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
       return RetCode.Success;
    }
    /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -143038,7 +143075,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outSMI;
       double cur_outSMISignal;
-      Value cachedValue;
       int outRangeBegIdx;
       int outRangeCount;
 
@@ -143084,23 +143120,9 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSMI = other.cur_outSMI;
          this.cur_outSMISignal = other.cur_outSMISignal;
-         this.cachedValue = other.cachedValue;
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param smi Stochastic Momentum Index, -100 to +100.
-       * @param smiSignal Exponential average of the SMI line.
-       */
-      public record Value(double smi, double smiSignal) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -143118,15 +143140,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, SmiOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("SMI update: BadParam", RetCode.BadParam);
          }
          core.smiStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-         return this.cachedValue;
+         out.smi = this.cur_outSMI;
+         out.smiSignal = this.cur_outSMISignal;
       }
 
       /**
@@ -143151,21 +143173,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
             throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSMI[i] = this.cur_outSMI;
-               outSMISignal[i] = this.cur_outSMISignal;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+            core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSMI[i] = this.cur_outSMI;
+            outSMISignal[i] = this.cur_outSMISignal;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -143179,7 +143195,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, SmiOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("SMI peek: BadParam", RetCode.BadParam);
          SmiStream sp = this;
@@ -143284,7 +143300,8 @@ public final class Core {
          cur_outSMISignal = prevSignal;
          trailingIdx = trailingIdx + 1;
          today = today + 1;
-         return new Value(cur_outSMI, cur_outSMISignal);
+         out.smi = cur_outSMI;
+         out.smiSignal = cur_outSMISignal;
       }
 
       /**
@@ -143293,8 +143310,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( SmiOut out ) {
+         out.smi = this.cur_outSMI;
+         out.smiSignal = this.cur_outSMISignal;
       }
 
       /**
@@ -143312,6 +143330,27 @@ public final class Core {
       public SmiStream clone() {
          return new SmiStream(this);
       }
+   }
+
+   /**
+    * The outputs of one SMI bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class SmiOut {
+      /** Stochastic Momentum Index, -100 to +100. */
+      public double smi;
+      /** Exponential average of the SMI line. */
+      public double smiSignal;
    }
    void smiStepImpl( SmiStream sp, double inHigh, double inLow, double inClose )
    {
@@ -143730,7 +143769,6 @@ public final class Core {
       sp.x_inClose = capX_inClose;
       sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
       sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-      sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
       return RetCode.Success;
    }
    /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -145611,7 +145649,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outSlowK;
       double cur_outSlowD;
-      Value cachedValue;
       MaStream sub0;
       MaStream sub1;
       int outRangeBegIdx;
@@ -145653,25 +145690,11 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outSlowK = other.cur_outSlowK;
          this.cur_outSlowD = other.cur_outSlowD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.sub1 = new MaStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param slowK Raw FastK smoothed by SlowK_Period MA.
-       * @param slowD Signal line: SlowK smoothed by SlowD_Period MA.
-       */
-      public record Value(double slowK, double slowD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -145689,15 +145712,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, StochOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCH update: BadParam", RetCode.BadParam);
          }
          core.stochStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-         return this.cachedValue;
+         out.slowK = this.cur_outSlowK;
+         out.slowD = this.cur_outSlowD;
       }
 
       /**
@@ -145722,21 +145745,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
             throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outSlowK[i] = this.cur_outSlowK;
-               outSlowD[i] = this.cur_outSlowD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+            core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outSlowK[i] = this.cur_outSlowK;
+            outSlowD[i] = this.cur_outSlowD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -145750,7 +145767,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, StochOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("STOCH peek: BadParam", RetCode.BadParam);
          StochStream sp = this;
@@ -145843,7 +145860,8 @@ public final class Core {
          cur_tempBuffer = sp.sub0.peek(cur_tempBuffer);
          cur_outSlowD = sp.sub1.peek(cur_tempBuffer);
          cur_outSlowK = cur_tempBuffer;
-         return new Value(cur_outSlowK, cur_outSlowD);
+         out.slowK = cur_outSlowK;
+         out.slowD = cur_outSlowD;
       }
 
       /**
@@ -145852,8 +145870,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochOut out ) {
+         out.slowK = this.cur_outSlowK;
+         out.slowD = this.cur_outSlowD;
       }
 
       /**
@@ -145871,6 +145890,27 @@ public final class Core {
       public StochStream clone() {
          return new StochStream(this);
       }
+   }
+
+   /**
+    * The outputs of one STOCH bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochOut {
+      /** Raw FastK smoothed by SlowK_Period MA. */
+      public double slowK;
+      /** Signal line: SlowK smoothed by SlowD_Period MA. */
+      public double slowD;
    }
    void stochStepImpl( StochStream sp, double inHigh, double inLow, double inClose )
    {
@@ -146233,7 +146273,6 @@ public final class Core {
       sp.sub1 = sub1;
       sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
       sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-      sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
       return RetCode.Success;
    }
    /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -146966,7 +147005,6 @@ public final class Core {
       double[] x_inClose;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       MaStream sub0;
       int outRangeBegIdx;
       int outRangeCount;
@@ -147005,24 +147043,10 @@ public final class Core {
          this.x_inClose = other.x_inClose.clone();
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new MaStream(other.sub0);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param fastK Raw %K stochastic line.
-       * @param fastD MA-smoothed %K (signal line)
-       */
-      public record Value(double fastK, double fastD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -147040,15 +147064,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inHigh, double inLow, double inClose ) {
+      public void update( double inHigh, double inLow, double inClose, StochfOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCHF update: BadParam", RetCode.BadParam);
          }
          core.stochfStepImpl(this, inHigh, inLow, inClose);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -147073,21 +147097,15 @@ public final class Core {
          final int barCount = inHigh.length;
          if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -147101,7 +147119,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inHigh, double inLow, double inClose ) {
+      public void peek( double inHigh, double inLow, double inClose, StochfOut out ) {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("STOCHF peek: BadParam", RetCode.BadParam);
          StochfStream sp = this;
@@ -147193,7 +147211,8 @@ public final class Core {
          /* Pipeline the new bar through the sub-streams (batch tail order). */
          cur_outFastD = sp.sub0.peek(cur_tempBuffer);
          cur_outFastK = cur_tempBuffer;
-         return new Value(cur_outFastK, cur_outFastD);
+         out.fastK = cur_outFastK;
+         out.fastD = cur_outFastD;
       }
 
       /**
@@ -147202,8 +147221,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochfOut out ) {
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -147221,6 +147241,27 @@ public final class Core {
       public StochfStream clone() {
          return new StochfStream(this);
       }
+   }
+
+   /**
+    * The outputs of one STOCHF bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochfOut {
+      /** Raw %K stochastic line. */
+      public double fastK;
+      /** MA-smoothed %K (signal line) */
+      public double fastD;
    }
    void stochfStepImpl( StochfStream sp, double inHigh, double inLow, double inClose )
    {
@@ -147557,7 +147598,6 @@ public final class Core {
       sp.sub0 = sub0;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -148104,7 +148144,6 @@ public final class Core {
       MAType optInFastD_MAType;
       double cur_outFastK;
       double cur_outFastD;
-      Value cachedValue;
       RsiStream sub0;
       StochfStream sub1;
       int outRangeBegIdx;
@@ -148133,25 +148172,11 @@ public final class Core {
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.cur_outFastK = other.cur_outFastK;
          this.cur_outFastD = other.cur_outFastD;
-         this.cachedValue = other.cachedValue;
          this.sub0 = new RsiStream(other.sub0);
          this.sub1 = new StochfStream(other.sub1);
          this.outRangeBegIdx = other.outRangeBegIdx;
          this.outRangeCount = other.outRangeCount;
       }
-
-      /**
-       * One output set, in batch output order. Immutable.
-       *
-       * <p>{@code equals} compares every component bitwise, so {@code NaN}
-       * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-       * {@code hashCode} is consistent with it but its exact value is
-       * unspecified — do not persist it or compare it across JVM versions.
-       *
-       * @param fastK Unsmoothed stochastic of the RSI (raw %K)
-       * @param fastD %K smoothed over FastD_Period (signal line)
-       */
-      public record Value(double fastK, double fastD) { }
 
       /**
        * Commit one closed bar, returning the new current value.
@@ -148169,15 +148194,15 @@ public final class Core {
        * retains its state, so a single non-finite bar would poison every
        * later value it produces.
        */
-      public Value update( double inReal ) {
+      public void update( double inReal, StochrsiOut out ) {
          if( !Double.isFinite(inReal) ) {
             if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
             throw new TaLibArgumentException("STOCHRSI update: BadParam", RetCode.BadParam);
          }
          core.stochrsiStepImpl(this, inReal);
          if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-         this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-         return this.cachedValue;
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -148200,21 +148225,15 @@ public final class Core {
          final int barCount = inReal.length;
          if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
             throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-         int done = 0;
-         try {
-            for( int i = 0; i < barCount; i++ ) {
-               if( !Double.isFinite(inReal[i]) ) {
-                  if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                  throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-               }
-               core.stochrsiStepImpl(this, inReal[i]);
-               outFastK[i] = this.cur_outFastK;
-               outFastD[i] = this.cur_outFastD;
+         for( int i = 0; i < barCount; i++ ) {
+            if( !Double.isFinite(inReal[i]) ) {
                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-               done = i + 1;
+               throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
             }
-         } finally {
-            if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+            core.stochrsiStepImpl(this, inReal[i]);
+            outFastK[i] = this.cur_outFastK;
+            outFastD[i] = this.cur_outFastD;
+            if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
          }
       }
 
@@ -148228,7 +148247,7 @@ public final class Core {
        * does not grow with the period. It does allocate a small bounded amount
        * per call — a size fixed by the indicator, never by the period.
        */
-      public Value peek( double inReal ) {
+      public void peek( double inReal, StochrsiOut out ) {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("STOCHRSI peek: BadParam", RetCode.BadParam);
          StochrsiStream sp = this;
@@ -148238,11 +148257,13 @@ public final class Core {
          /* Pipeline the new bar through the sub-streams (batch tail order). */
          cur_tempRSIBuffer = sp.sub0.peek(inReal);
          {
-            StochfStream.Value subOut1 = sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-            cur_outFastK = subOut1.fastK();
-            cur_outFastD = subOut1.fastD();
+            StochfOut subOut1 = new StochfOut();
+            sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+            cur_outFastK = subOut1.fastK;
+            cur_outFastD = subOut1.fastD;
          }
-         return new Value(cur_outFastK, cur_outFastD);
+         out.fastK = cur_outFastK;
+         out.fastD = cur_outFastD;
       }
 
       /**
@@ -148251,8 +148272,9 @@ public final class Core {
        * then whatever the latest accepted {@code update} returned.
        * A pure field read; {@code peek} does not change it.
        */
-      public Value value() {
-         return this.cachedValue;
+      public void value( StochrsiOut out ) {
+         out.fastK = this.cur_outFastK;
+         out.fastD = this.cur_outFastD;
       }
 
       /**
@@ -148271,6 +148293,27 @@ public final class Core {
          return new StochrsiStream(this);
       }
    }
+
+   /**
+    * The outputs of one STOCHRSI bar, written by the stream into an object the
+    * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+    * and {@code value} overwrite its fields and allocate nothing.
+    *
+    * <p><b>Its contents are only valid until the next call that writes it.</b>
+    * It is a mutable buffer, not a reading: a reference kept past that call,
+    * or one put in a collection, sees the value change underneath it. Copy the
+    * fields out if the reading has to outlive the call.
+    *
+    * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+    * with value equality breaks the {@code HashMap}/{@code HashSet}
+    * invariant the moment a reused instance becomes a key. Compare the fields.
+    */
+   public static final class StochrsiOut {
+      /** Unsmoothed stochastic of the RSI (raw %K) */
+      public double fastK;
+      /** %K smoothed over FastD_Period (signal line) */
+      public double fastD;
+   }
    void stochrsiStepImpl( StochrsiStream sp, double inReal )
    {
       double cur_tempRSIBuffer = 0.0;
@@ -148279,9 +148322,10 @@ public final class Core {
       /* Pipeline the new bar through the sub-streams (batch tail order). */
       cur_tempRSIBuffer = sp.sub0.update(inReal);
       {
-         StochfStream.Value subOut1 = sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-         cur_outFastK = subOut1.fastK();
-         cur_outFastD = subOut1.fastD();
+         StochfOut subOut1 = new StochfOut();
+         sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+         cur_outFastK = subOut1.fastK;
+         cur_outFastD = subOut1.fastD;
       }
       sp.cur_outFastK = cur_outFastK;
       sp.cur_outFastD = cur_outFastD;
@@ -148403,7 +148447,6 @@ public final class Core {
       sp.sub1 = sub1;
       sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
       sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-      sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
       return RetCode.Success;
    }
    /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -1770,7 +1770,6 @@ class Core {
           double cur_outRealUpperBand;
           double cur_outRealMiddleBand;
           double cur_outRealLowerBand;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -1803,24 +1802,9 @@ class Core {
              this.cur_outRealUpperBand = other.cur_outRealUpperBand;
              this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
              this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param realUpperBand SMA of the range-scaled high band.
-           * @param realMiddleBand SMA of the close.
-           * @param realLowerBand SMA of the range-scaled low band.
-           */
-          public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -1838,15 +1822,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow, double inClose ) {
+          public void update( double inHigh, double inLow, double inClose, AccbandsOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("ACCBANDS update: BadParam", RetCode.BadParam);
              }
              core.accbandsStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-             return this.cachedValue;
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -1872,22 +1857,16 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
                 throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outRealUpperBand[i] = this.cur_outRealUpperBand;
-                   outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-                   outRealLowerBand[i] = this.cur_outRealLowerBand;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("ACCBANDS updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+                core.accbandsStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outRealUpperBand[i] = this.cur_outRealUpperBand;
+                outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+                outRealLowerBand[i] = this.cur_outRealLowerBand;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -1901,7 +1880,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow, double inClose ) {
+          public void peek( double inHigh, double inLow, double inClose, AccbandsOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("ACCBANDS peek: BadParam", RetCode.BadParam);
              AccbandsStream sp = this;
@@ -1964,7 +1943,9 @@ class Core {
              if( ringPos_trailingIdx >= sp.ringCap_trailingIdx ) {
                 ringPos_trailingIdx = 0;
              }
-             return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+             out.realUpperBand = cur_outRealUpperBand;
+             out.realMiddleBand = cur_outRealMiddleBand;
+             out.realLowerBand = cur_outRealLowerBand;
           }
 
           /**
@@ -1973,8 +1954,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( AccbandsOut out ) {
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -1992,6 +1975,29 @@ class Core {
           public AccbandsStream clone() {
              return new AccbandsStream(this);
           }
+       }
+
+       /**
+        * The outputs of one ACCBANDS bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class AccbandsOut {
+          /** SMA of the range-scaled high band. */
+          public double realUpperBand;
+          /** SMA of the close. */
+          public double realMiddleBand;
+          /** SMA of the range-scaled low band. */
+          public double realLowerBand;
        }
        void accbandsStepImpl( AccbandsStream sp, double inHigh, double inLow, double inClose )
        {
@@ -2200,7 +2206,6 @@ class Core {
           sp.cur_outRealUpperBand = outRealUpperBand[(outNBElement.value - 1) * outStride];
           sp.cur_outRealMiddleBand = outRealMiddleBand[(outNBElement.value - 1) * outStride];
           sp.cur_outRealLowerBand = outRealLowerBand[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new AccbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
           return RetCode.Success;
        }
        /* accbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -8952,7 +8957,6 @@ class Core {
           double[] x_inLow;
           double cur_outAroonDown;
           double cur_outAroonUp;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -8987,23 +8991,9 @@ class Core {
              this.x_inLow = other.x_inLow.clone();
              this.cur_outAroonDown = other.cur_outAroonDown;
              this.cur_outAroonUp = other.cur_outAroonUp;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param aroonDown Recency of the lowest low (100 = it is the current bar, decaying as it ages)
-           * @param aroonUp Recency of the highest high (100 = it is the current bar, decaying as it ages)
-           */
-          public record Value(double aroonDown, double aroonUp) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -9021,15 +9011,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow ) {
+          public void update( double inHigh, double inLow, AroonOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("AROON update: BadParam", RetCode.BadParam);
              }
              core.aroonStepImpl(this, inHigh, inLow);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
-             return this.cachedValue;
+             out.aroonDown = this.cur_outAroonDown;
+             out.aroonUp = this.cur_outAroonUp;
           }
 
           /**
@@ -9053,21 +9043,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || outAroonDown.length < barCount || outAroonUp.length < barCount || (Object)outAroonDown == (Object)inHigh || (Object)outAroonDown == (Object)inLow || (Object)outAroonUp == (Object)inHigh || (Object)outAroonUp == (Object)inLow || (Object)outAroonDown == (Object)outAroonUp )
                 throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.aroonStepImpl(this, inHigh[i], inLow[i]);
-                   outAroonDown[i] = this.cur_outAroonDown;
-                   outAroonUp[i] = this.cur_outAroonUp;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("AROON updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outAroonDown, this.cur_outAroonUp);
+                core.aroonStepImpl(this, inHigh[i], inLow[i]);
+                outAroonDown[i] = this.cur_outAroonDown;
+                outAroonUp[i] = this.cur_outAroonUp;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -9081,7 +9065,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow ) {
+          public void peek( double inHigh, double inLow, AroonOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
                 throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
              AroonStream sp = this;
@@ -9152,7 +9136,8 @@ class Core {
              cur_outAroonDown = sp.factor * (sp.optInTimePeriod - (today - lowestIdx));
              trailingIdx += 1;
              today += 1;
-             return new Value(cur_outAroonDown, cur_outAroonUp);
+             out.aroonDown = cur_outAroonDown;
+             out.aroonUp = cur_outAroonUp;
           }
 
           /**
@@ -9161,8 +9146,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( AroonOut out ) {
+             out.aroonDown = this.cur_outAroonDown;
+             out.aroonUp = this.cur_outAroonUp;
           }
 
           /**
@@ -9180,6 +9166,27 @@ class Core {
           public AroonStream clone() {
              return new AroonStream(this);
           }
+       }
+
+       /**
+        * The outputs of one AROON bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class AroonOut {
+          /** Recency of the lowest low (100 = it is the current bar, decaying as it ages) */
+          public double aroonDown;
+          /** Recency of the highest high (100 = it is the current bar, decaying as it ages) */
+          public double aroonUp;
        }
        void aroonStepImpl( AroonStream sp, double inHigh, double inLow )
        {
@@ -9377,7 +9384,6 @@ class Core {
           sp.x_inLow = capX_inLow;
           sp.cur_outAroonDown = outAroonDown[(outNBElement.value - 1) * outStride];
           sp.cur_outAroonUp = outAroonUp[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new AroonStream.Value(sp.cur_outAroonDown, sp.cur_outAroonUp);
           return RetCode.Success;
        }
        /* aroonOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -14141,7 +14147,6 @@ class Core {
           double cur_outRealUpperBand;
           double cur_outRealMiddleBand;
           double cur_outRealLowerBand;
-          Value cachedValue;
           MaStream sub0;
           StddevStream sub1;
           int outRangeBegIdx;
@@ -14171,26 +14176,11 @@ class Core {
              this.cur_outRealUpperBand = other.cur_outRealUpperBand;
              this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
              this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new StddevStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param realUpperBand Middle band plus nbDevUp standard deviations.
-           * @param realMiddleBand The moving average.
-           * @param realLowerBand Middle band minus nbDevDn standard deviations.
-           */
-          public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -14208,15 +14198,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, BbandsOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("BBANDS update: BadParam", RetCode.BadParam);
              }
              core.bbandsStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-             return this.cachedValue;
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -14240,22 +14231,16 @@ class Core {
              final int barCount = inReal.length;
              if( outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inReal || (Object)outRealMiddleBand == (Object)inReal || (Object)outRealLowerBand == (Object)inReal || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
                 throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.bbandsStepImpl(this, inReal[i]);
-                   outRealUpperBand[i] = this.cur_outRealUpperBand;
-                   outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-                   outRealLowerBand[i] = this.cur_outRealLowerBand;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("BBANDS updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+                core.bbandsStepImpl(this, inReal[i]);
+                outRealUpperBand[i] = this.cur_outRealUpperBand;
+                outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+                outRealLowerBand[i] = this.cur_outRealLowerBand;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -14269,7 +14254,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, BbandsOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("BBANDS peek: BadParam", RetCode.BadParam);
              BbandsStream sp = this;
@@ -14295,7 +14280,9 @@ class Core {
                 cur_outRealLowerBand = tempReal2 - cur_tempBuffer2 * sp.optInNbDevDn;
              }
              cur_outRealMiddleBand = cur_tempBuffer1;
-             return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+             out.realUpperBand = cur_outRealUpperBand;
+             out.realMiddleBand = cur_outRealMiddleBand;
+             out.realLowerBand = cur_outRealLowerBand;
           }
 
           /**
@@ -14304,8 +14291,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( BbandsOut out ) {
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -14323,6 +14312,29 @@ class Core {
           public BbandsStream clone() {
              return new BbandsStream(this);
           }
+       }
+
+       /**
+        * The outputs of one BBANDS bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class BbandsOut {
+          /** Middle band plus nbDevUp standard deviations. */
+          public double realUpperBand;
+          /** The moving average. */
+          public double realMiddleBand;
+          /** Middle band minus nbDevDn standard deviations. */
+          public double realLowerBand;
        }
        void bbandsStepImpl( BbandsStream sp, double inReal )
        {
@@ -14483,7 +14495,6 @@ class Core {
           sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
           sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
           sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-          sp.cachedValue = new BbandsStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
           return RetCode.Success;
        }
        /* bbandsOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -89126,7 +89137,6 @@ class Core {
           double[] ring_trailingWMAIdx_inReal;
           double cur_outInPhase;
           double cur_outQuadrature;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -89193,23 +89203,9 @@ class Core {
              this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
              this.cur_outInPhase = other.cur_outInPhase;
              this.cur_outQuadrature = other.cur_outQuadrature;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param inPhase In-phase component (detrender delayed 3 bars)
-           * @param quadrature Quadrature component (Q1 of the Hilbert Transform)
-           */
-          public record Value(double inPhase, double quadrature) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -89227,15 +89223,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, HtPhasorOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("HT_PHASOR update: BadParam", RetCode.BadParam);
              }
              core.htPhasorStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
-             return this.cachedValue;
+             out.inPhase = this.cur_outInPhase;
+             out.quadrature = this.cur_outQuadrature;
           }
 
           /**
@@ -89258,21 +89254,15 @@ class Core {
              final int barCount = inReal.length;
              if( outInPhase.length < barCount || outQuadrature.length < barCount || (Object)outInPhase == (Object)inReal || (Object)outQuadrature == (Object)inReal || (Object)outInPhase == (Object)outQuadrature )
                 throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.htPhasorStepImpl(this, inReal[i]);
-                   outInPhase[i] = this.cur_outInPhase;
-                   outQuadrature[i] = this.cur_outQuadrature;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("HT_PHASOR updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outInPhase, this.cur_outQuadrature);
+                core.htPhasorStepImpl(this, inReal[i]);
+                outInPhase[i] = this.cur_outInPhase;
+                outQuadrature[i] = this.cur_outQuadrature;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -89286,7 +89276,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, HtPhasorOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("HT_PHASOR peek: BadParam", RetCode.BadParam);
              HtPhasorStream sp = this;
@@ -89474,7 +89464,8 @@ class Core {
                 ringPos_trailingWMAIdx = 0;
              }
              streamParity = 1 - streamParity;
-             return new Value(cur_outInPhase, cur_outQuadrature);
+             out.inPhase = cur_outInPhase;
+             out.quadrature = cur_outQuadrature;
           }
 
           /**
@@ -89483,8 +89474,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( HtPhasorOut out ) {
+             out.inPhase = this.cur_outInPhase;
+             out.quadrature = this.cur_outQuadrature;
           }
 
           /**
@@ -89502,6 +89494,27 @@ class Core {
           public HtPhasorStream clone() {
              return new HtPhasorStream(this);
           }
+       }
+
+       /**
+        * The outputs of one HT_PHASOR bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class HtPhasorOut {
+          /** In-phase component (detrender delayed 3 bars) */
+          public double inPhase;
+          /** Quadrature component (Q1 of the Hilbert Transform) */
+          public double quadrature;
        }
        void htPhasorStepImpl( HtPhasorStream sp, double inReal )
        {
@@ -90060,7 +90073,6 @@ class Core {
           sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
           sp.cur_outInPhase = outInPhase[(outNBElement.value - 1) * outStride];
           sp.cur_outQuadrature = outQuadrature[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new HtPhasorStream.Value(sp.cur_outInPhase, sp.cur_outQuadrature);
           return RetCode.Success;
        }
        /* htPhasorOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -91144,7 +91156,6 @@ class Core {
           double[] cb_smoothPrice;
           double cur_outSine;
           double cur_outLeadSine;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -91219,23 +91230,9 @@ class Core {
              this.cb_smoothPrice = other.cb_smoothPrice.clone();
              this.cur_outSine = other.cur_outSine;
              this.cur_outLeadSine = other.cur_outLeadSine;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param sine Sine of the dominant-cycle phase.
-           * @param leadSine Sine of the phase advanced 45 degrees (lead)
-           */
-          public record Value(double sine, double leadSine) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -91253,15 +91250,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, HtSineOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("HT_SINE update: BadParam", RetCode.BadParam);
              }
              core.htSineStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
-             return this.cachedValue;
+             out.sine = this.cur_outSine;
+             out.leadSine = this.cur_outLeadSine;
           }
 
           /**
@@ -91284,21 +91281,15 @@ class Core {
              final int barCount = inReal.length;
              if( outSine.length < barCount || outLeadSine.length < barCount || (Object)outSine == (Object)inReal || (Object)outLeadSine == (Object)inReal || (Object)outSine == (Object)outLeadSine )
                 throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.htSineStepImpl(this, inReal[i]);
-                   outSine[i] = this.cur_outSine;
-                   outLeadSine[i] = this.cur_outLeadSine;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("HT_SINE updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSine, this.cur_outLeadSine);
+                core.htSineStepImpl(this, inReal[i]);
+                outSine[i] = this.cur_outSine;
+                outLeadSine[i] = this.cur_outLeadSine;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -91312,7 +91303,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, HtSineOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("HT_SINE peek: BadParam", RetCode.BadParam);
              HtSineStream sp = this;
@@ -91558,7 +91549,8 @@ class Core {
                 ringPos_trailingWMAIdx = 0;
              }
              streamParity = 1 - streamParity;
-             return new Value(cur_outSine, cur_outLeadSine);
+             out.sine = cur_outSine;
+             out.leadSine = cur_outLeadSine;
           }
 
           /**
@@ -91567,8 +91559,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( HtSineOut out ) {
+             out.sine = this.cur_outSine;
+             out.leadSine = this.cur_outLeadSine;
           }
 
           /**
@@ -91586,6 +91579,27 @@ class Core {
           public HtSineStream clone() {
              return new HtSineStream(this);
           }
+       }
+
+       /**
+        * The outputs of one HT_SINE bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class HtSineOut {
+          /** Sine of the dominant-cycle phase. */
+          public double sine;
+          /** Sine of the phase advanced 45 degrees (lead) */
+          public double leadSine;
        }
        void htSineStepImpl( HtSineStream sp, double inReal )
        {
@@ -92276,7 +92290,6 @@ class Core {
           sp.cb_smoothPrice = smoothPrice;
           sp.cur_outSine = outSine[(outNBElement.value - 1) * outStride];
           sp.cur_outLeadSine = outLeadSine[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new HtSineStream.Value(sp.cur_outSine, sp.cur_outLeadSine);
           return RetCode.Success;
        }
        /* htSineOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -99306,7 +99319,6 @@ class Core {
           double cur_outRealUpperBand;
           double cur_outRealMiddleBand;
           double cur_outRealLowerBand;
-          Value cachedValue;
           TyppriceStream sub0;
           AtrStream sub1;
           EmaStream sub2;
@@ -99336,27 +99348,12 @@ class Core {
              this.cur_outRealUpperBand = other.cur_outRealUpperBand;
              this.cur_outRealMiddleBand = other.cur_outRealMiddleBand;
              this.cur_outRealLowerBand = other.cur_outRealLowerBand;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new TyppriceStream(other.sub0);
              this.sub1 = new AtrStream(other.sub1);
              this.sub2 = new EmaStream(other.sub2);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param realUpperBand Centre line plus the scaled Average True Range.
-           * @param realMiddleBand Exponential moving average of the typical price.
-           * @param realLowerBand Centre line minus the scaled Average True Range.
-           */
-          public record Value(double realUpperBand, double realMiddleBand, double realLowerBand) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -99374,15 +99371,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow, double inClose ) {
+          public void update( double inHigh, double inLow, double inClose, KcOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("KC update: BadParam", RetCode.BadParam);
              }
              core.kcStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
-             return this.cachedValue;
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -99408,22 +99406,16 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outRealUpperBand.length < barCount || outRealMiddleBand.length < barCount || outRealLowerBand.length < barCount || (Object)outRealUpperBand == (Object)inHigh || (Object)outRealUpperBand == (Object)inLow || (Object)outRealUpperBand == (Object)inClose || (Object)outRealMiddleBand == (Object)inHigh || (Object)outRealMiddleBand == (Object)inLow || (Object)outRealMiddleBand == (Object)inClose || (Object)outRealLowerBand == (Object)inHigh || (Object)outRealLowerBand == (Object)inLow || (Object)outRealLowerBand == (Object)inClose || (Object)outRealUpperBand == (Object)outRealMiddleBand || (Object)outRealUpperBand == (Object)outRealLowerBand || (Object)outRealMiddleBand == (Object)outRealLowerBand )
                 throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outRealUpperBand[i] = this.cur_outRealUpperBand;
-                   outRealMiddleBand[i] = this.cur_outRealMiddleBand;
-                   outRealLowerBand[i] = this.cur_outRealLowerBand;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("KC updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outRealUpperBand, this.cur_outRealMiddleBand, this.cur_outRealLowerBand);
+                core.kcStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outRealUpperBand[i] = this.cur_outRealUpperBand;
+                outRealMiddleBand[i] = this.cur_outRealMiddleBand;
+                outRealLowerBand[i] = this.cur_outRealLowerBand;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -99437,7 +99429,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow, double inClose ) {
+          public void peek( double inHigh, double inLow, double inClose, KcOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("KC peek: BadParam", RetCode.BadParam);
              KcStream sp = this;
@@ -99457,7 +99449,9 @@ class Core {
              tempReal = cur_tempATR * sp.optInNbDev;
              cur_outRealUpperBand = middle + tempReal;
              cur_outRealLowerBand = middle - tempReal;
-             return new Value(cur_outRealUpperBand, cur_outRealMiddleBand, cur_outRealLowerBand);
+             out.realUpperBand = cur_outRealUpperBand;
+             out.realMiddleBand = cur_outRealMiddleBand;
+             out.realLowerBand = cur_outRealLowerBand;
           }
 
           /**
@@ -99466,8 +99460,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( KcOut out ) {
+             out.realUpperBand = this.cur_outRealUpperBand;
+             out.realMiddleBand = this.cur_outRealMiddleBand;
+             out.realLowerBand = this.cur_outRealLowerBand;
           }
 
           /**
@@ -99485,6 +99481,29 @@ class Core {
           public KcStream clone() {
              return new KcStream(this);
           }
+       }
+
+       /**
+        * The outputs of one KC bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class KcOut {
+          /** Centre line plus the scaled Average True Range. */
+          public double realUpperBand;
+          /** Exponential moving average of the typical price. */
+          public double realMiddleBand;
+          /** Centre line minus the scaled Average True Range. */
+          public double realLowerBand;
        }
        void kcStepImpl( KcStream sp, double inHigh, double inLow, double inClose )
        {
@@ -99623,7 +99642,6 @@ class Core {
           sp.cur_outRealUpperBand = sc_outRealUpperBand[outNBElement.value - 1];
           sp.cur_outRealMiddleBand = sc_outRealMiddleBand[outNBElement.value - 1];
           sp.cur_outRealLowerBand = sc_outRealLowerBand[outNBElement.value - 1];
-          sp.cachedValue = new KcStream.Value(sp.cur_outRealUpperBand, sp.cur_outRealMiddleBand, sp.cur_outRealLowerBand);
           return RetCode.Success;
        }
        /* kcOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -105841,8 +105859,9 @@ class Core {
                 break;
              }
              case MAMA: {
-                MamaStream.Value subValue = ((MamaStream) sp.sub).peek(inReal);
-                cur_outReal = subValue.mama();
+                MamaOut subValue = new MamaOut();
+                ((MamaStream) sp.sub).peek(inReal, subValue);
+                cur_outReal = subValue.mama;
                 break;
              }
              case T3: {
@@ -105922,8 +105941,8 @@ class Core {
              break;
           }
           case MAMA: {
-             MamaStream.Value subValue = ((MamaStream) sp.sub).update(inReal);
-             sp.cur_outReal = subValue.mama();
+             ((MamaStream) sp.sub).update(inReal);
+             sp.cur_outReal = ((MamaStream) sp.sub).cur_outMAMA;
              break;
           }
           case T3: {
@@ -107004,7 +107023,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -107037,24 +107055,9 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param macd Fast EMA minus slow EMA.
-           * @param macdSignal EMA of the MACD line.
-           * @param macdHist MACD minus signal line.
-           */
-          public record Value(double macd, double macdSignal, double macdHist) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -107072,15 +107075,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MacdOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MACD update: BadParam", RetCode.BadParam);
              }
              core.macdStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -107104,22 +107108,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACD updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -107133,7 +107131,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MacdOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MACD peek: BadParam", RetCode.BadParam);
              MacdStream sp = this;
@@ -107157,7 +107155,9 @@ class Core {
              cur_outMACD = macdValue;
              cur_outMACDSignal = prevSignal;
              cur_outMACDHist = macdValue - prevSignal;
-             return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+             out.macd = cur_outMACD;
+             out.macdSignal = cur_outMACDSignal;
+             out.macdHist = cur_outMACDHist;
           }
 
           /**
@@ -107166,8 +107166,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MacdOut out ) {
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -107185,6 +107187,29 @@ class Core {
           public MacdStream clone() {
              return new MacdStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MACD bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MacdOut {
+          /** Fast EMA minus slow EMA. */
+          public double macd;
+          /** EMA of the MACD line. */
+          public double macdSignal;
+          /** MACD minus signal line. */
+          public double macdHist;
        }
        void macdStepImpl( MacdStream sp, double inReal )
        {
@@ -107414,7 +107439,6 @@ class Core {
           sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MacdStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -108102,7 +108126,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           MaStream sub0;
           MaStream sub1;
           MaStream sub2;
@@ -108135,27 +108158,12 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new MaStream(other.sub1);
              this.sub2 = new MaStream(other.sub2);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param macd MACD line: fast MA minus slow MA.
-           * @param macdSignal Signal line: MA of the MACD line.
-           * @param macdHist Histogram: MACD minus signal.
-           */
-          public record Value(double macd, double macdSignal, double macdHist) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -108173,15 +108181,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MacdextOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MACDEXT update: BadParam", RetCode.BadParam);
              }
              core.macdextStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -108205,22 +108214,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdextStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACDEXT updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdextStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -108234,7 +108237,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MacdextOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MACDEXT peek: BadParam", RetCode.BadParam);
              MacdextStream sp = this;
@@ -108252,7 +108255,9 @@ class Core {
              /* Combine map (batch tail, per bar). */
              cur_outMACDHist = cur_fastMABuffer - cur_outMACDSignal;
              cur_outMACD = cur_fastMABuffer;
-             return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+             out.macd = cur_outMACD;
+             out.macdSignal = cur_outMACDSignal;
+             out.macdHist = cur_outMACDHist;
           }
 
           /**
@@ -108261,8 +108266,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MacdextOut out ) {
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -108280,6 +108287,29 @@ class Core {
           public MacdextStream clone() {
              return new MacdextStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MACDEXT bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MacdextOut {
+          /** MACD line: fast MA minus slow MA. */
+          public double macd;
+          /** Signal line: MA of the MACD line. */
+          public double macdSignal;
+          /** Histogram: MACD minus signal. */
+          public double macdHist;
        }
        void macdextStepImpl( MacdextStream sp, double inReal )
        {
@@ -108455,7 +108485,6 @@ class Core {
           sp.cur_outMACD = sc_outMACD[outNBElement.value - 1];
           sp.cur_outMACDSignal = sc_outMACDSignal[outNBElement.value - 1];
           sp.cur_outMACDHist = sc_outMACDHist[outNBElement.value - 1];
-          sp.cachedValue = new MacdextStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdextOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -109074,7 +109103,6 @@ class Core {
           double cur_outMACD;
           double cur_outMACDSignal;
           double cur_outMACDHist;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -109105,24 +109133,9 @@ class Core {
              this.cur_outMACD = other.cur_outMACD;
              this.cur_outMACDSignal = other.cur_outMACDSignal;
              this.cur_outMACDHist = other.cur_outMACDHist;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param macd Fixed EMA12 minus EMA26.
-           * @param macdSignal EMA of the MACD line.
-           * @param macdHist MACD minus signal.
-           */
-          public record Value(double macd, double macdSignal, double macdHist) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -109140,15 +109153,16 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MacdfixOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MACDFIX update: BadParam", RetCode.BadParam);
              }
              core.macdfixStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
-             return this.cachedValue;
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -109172,22 +109186,16 @@ class Core {
              final int barCount = inReal.length;
              if( outMACD.length < barCount || outMACDSignal.length < barCount || outMACDHist.length < barCount || (Object)outMACD == (Object)inReal || (Object)outMACDSignal == (Object)inReal || (Object)outMACDHist == (Object)inReal || (Object)outMACD == (Object)outMACDSignal || (Object)outMACD == (Object)outMACDHist || (Object)outMACDSignal == (Object)outMACDHist )
                 throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.macdfixStepImpl(this, inReal[i]);
-                   outMACD[i] = this.cur_outMACD;
-                   outMACDSignal[i] = this.cur_outMACDSignal;
-                   outMACDHist[i] = this.cur_outMACDHist;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MACDFIX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMACD, this.cur_outMACDSignal, this.cur_outMACDHist);
+                core.macdfixStepImpl(this, inReal[i]);
+                outMACD[i] = this.cur_outMACD;
+                outMACDSignal[i] = this.cur_outMACDSignal;
+                outMACDHist[i] = this.cur_outMACDHist;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -109201,7 +109209,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MacdfixOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MACDFIX peek: BadParam", RetCode.BadParam);
              MacdfixStream sp = this;
@@ -109225,7 +109233,9 @@ class Core {
              cur_outMACD = macdValue;
              cur_outMACDSignal = prevSignal;
              cur_outMACDHist = macdValue - prevSignal;
-             return new Value(cur_outMACD, cur_outMACDSignal, cur_outMACDHist);
+             out.macd = cur_outMACD;
+             out.macdSignal = cur_outMACDSignal;
+             out.macdHist = cur_outMACDHist;
           }
 
           /**
@@ -109234,8 +109244,10 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MacdfixOut out ) {
+             out.macd = this.cur_outMACD;
+             out.macdSignal = this.cur_outMACDSignal;
+             out.macdHist = this.cur_outMACDHist;
           }
 
           /**
@@ -109253,6 +109265,29 @@ class Core {
           public MacdfixStream clone() {
              return new MacdfixStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MACDFIX bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MacdfixOut {
+          /** Fixed EMA12 minus EMA26. */
+          public double macd;
+          /** EMA of the MACD line. */
+          public double macdSignal;
+          /** MACD minus signal. */
+          public double macdHist;
        }
        void macdfixStepImpl( MacdfixStream sp, double inReal )
        {
@@ -109457,7 +109492,6 @@ class Core {
           sp.cur_outMACD = outMACD[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDSignal = outMACDSignal[(outNBElement.value - 1) * outStride];
           sp.cur_outMACDHist = outMACDHist[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MacdfixStream.Value(sp.cur_outMACD, sp.cur_outMACDSignal, sp.cur_outMACDHist);
           return RetCode.Success;
        }
        /* macdfixOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -110560,7 +110594,6 @@ class Core {
           double[] ring_trailingWMAIdx_inReal;
           double cur_outMAMA;
           double cur_outFAMA;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -110632,23 +110665,9 @@ class Core {
              this.ring_trailingWMAIdx_inReal = other.ring_trailingWMAIdx_inReal.clone();
              this.cur_outMAMA = other.cur_outMAMA;
              this.cur_outFAMA = other.cur_outFAMA;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param mama Adaptive moving average (fast line)
-           * @param fama Following adaptive moving average, using half the alpha (slow line)
-           */
-          public record Value(double mama, double fama) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -110666,15 +110685,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MamaOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MAMA update: BadParam", RetCode.BadParam);
              }
              core.mamaStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
-             return this.cachedValue;
+             out.mama = this.cur_outMAMA;
+             out.fama = this.cur_outFAMA;
           }
 
           /**
@@ -110699,21 +110718,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMAMA.length < barCount || (outFAMA != null && outFAMA.length < barCount) || (Object)outMAMA == (Object)inReal || (outFAMA != null && (Object)outFAMA == (Object)inReal) || (outFAMA != null && (Object)outMAMA == (Object)outFAMA) )
                 throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.mamaStepImpl(this, inReal[i]);
-                   outMAMA[i] = this.cur_outMAMA;
-                   if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MAMA updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMAMA, this.cur_outFAMA);
+                core.mamaStepImpl(this, inReal[i]);
+                outMAMA[i] = this.cur_outMAMA;
+                if( outFAMA != null ) outFAMA[i] = this.cur_outFAMA;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -110727,7 +110740,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MamaOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MAMA peek: BadParam", RetCode.BadParam);
              MamaStream sp = this;
@@ -110950,7 +110963,8 @@ class Core {
                 ringPos_trailingWMAIdx = 0;
              }
              streamParity = 1 - streamParity;
-             return new Value(cur_outMAMA, cur_outFAMA);
+             out.mama = cur_outMAMA;
+             out.fama = cur_outFAMA;
           }
 
           /**
@@ -110959,8 +110973,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MamaOut out ) {
+             out.mama = this.cur_outMAMA;
+             out.fama = this.cur_outFAMA;
           }
 
           /**
@@ -110978,6 +110993,27 @@ class Core {
           public MamaStream clone() {
              return new MamaStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MAMA bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MamaOut {
+          /** Adaptive moving average (fast line) */
+          public double mama;
+          /** Following adaptive moving average, using half the alpha (slow line) */
+          public double fama;
        }
        void mamaStepImpl( MamaStream sp, double inReal )
        {
@@ -111622,7 +111658,6 @@ class Core {
           sp.ring_trailingWMAIdx_inReal = capRing_trailingWMAIdx_inReal;
           sp.cur_outMAMA = outMAMA[(outNBElement.value - 1) * outStride];
           sp.cur_outFAMA = lastCur_outFAMA;
-          sp.cachedValue = new MamaStream.Value(sp.cur_outMAMA, sp.cur_outFAMA);
           return RetCode.Success;
        }
        /* mamaOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -120562,7 +120597,6 @@ class Core {
           double[] x_inReal;
           double cur_outMin;
           double cur_outMax;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -120595,23 +120629,9 @@ class Core {
              this.x_inReal = other.x_inReal.clone();
              this.cur_outMin = other.cur_outMin;
              this.cur_outMax = other.cur_outMax;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param min Lowest value in each rolling window.
-           * @param max Highest value in each rolling window.
-           */
-          public record Value(double min, double max) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -120629,15 +120649,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MinmaxOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MINMAX update: BadParam", RetCode.BadParam);
              }
              core.minmaxStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
-             return this.cachedValue;
+             out.min = this.cur_outMin;
+             out.max = this.cur_outMax;
           }
 
           /**
@@ -120660,21 +120680,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMin.length < barCount || outMax.length < barCount || (Object)outMin == (Object)inReal || (Object)outMax == (Object)inReal || (Object)outMin == (Object)outMax )
                 throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.minmaxStepImpl(this, inReal[i]);
-                   outMin[i] = this.cur_outMin;
-                   outMax[i] = this.cur_outMax;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MINMAX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMin, this.cur_outMax);
+                core.minmaxStepImpl(this, inReal[i]);
+                outMin[i] = this.cur_outMin;
+                outMax[i] = this.cur_outMax;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -120688,7 +120702,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MinmaxOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MINMAX peek: BadParam", RetCode.BadParam);
              MinmaxStream sp = this;
@@ -120751,7 +120765,8 @@ class Core {
              cur_outMin = lowest;
              trailingIdx += 1;
              today += 1;
-             return new Value(cur_outMin, cur_outMax);
+             out.min = cur_outMin;
+             out.max = cur_outMax;
           }
 
           /**
@@ -120760,8 +120775,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MinmaxOut out ) {
+             out.min = this.cur_outMin;
+             out.max = this.cur_outMax;
           }
 
           /**
@@ -120779,6 +120795,27 @@ class Core {
           public MinmaxStream clone() {
              return new MinmaxStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MINMAX bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MinmaxOut {
+          /** Lowest value in each rolling window. */
+          public double min;
+          /** Highest value in each rolling window. */
+          public double max;
        }
        void minmaxStepImpl( MinmaxStream sp, double inReal )
        {
@@ -120975,7 +121012,6 @@ class Core {
           sp.x_inReal = capX_inReal;
           sp.cur_outMin = outMin[(outNBElement.value - 1) * outStride];
           sp.cur_outMax = outMax[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MinmaxStream.Value(sp.cur_outMin, sp.cur_outMax);
           return RetCode.Success;
        }
        /* minmaxOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -121468,7 +121504,6 @@ class Core {
           double[] x_inReal;
           int cur_outMinIdx;
           int cur_outMaxIdx;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -121501,23 +121536,9 @@ class Core {
              this.x_inReal = other.x_inReal.clone();
              this.cur_outMinIdx = other.cur_outMinIdx;
              this.cur_outMaxIdx = other.cur_outMaxIdx;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param minIdx Absolute index (into inReal) of the window minimum.
-           * @param maxIdx Absolute index (into inReal) of the window maximum.
-           */
-          public record Value(int minIdx, int maxIdx) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -121535,15 +121556,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, MinmaxindexOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("MINMAXINDEX update: BadParam", RetCode.BadParam);
              }
              core.minmaxindexStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
-             return this.cachedValue;
+             out.minIdx = this.cur_outMinIdx;
+             out.maxIdx = this.cur_outMaxIdx;
           }
 
           /**
@@ -121566,21 +121587,15 @@ class Core {
              final int barCount = inReal.length;
              if( outMinIdx.length < barCount || outMaxIdx.length < barCount || (Object)outMinIdx == (Object)inReal || (Object)outMaxIdx == (Object)inReal || (Object)outMinIdx == (Object)outMaxIdx )
                 throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.minmaxindexStepImpl(this, inReal[i]);
-                   outMinIdx[i] = this.cur_outMinIdx;
-                   outMaxIdx[i] = this.cur_outMaxIdx;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("MINMAXINDEX updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outMinIdx, this.cur_outMaxIdx);
+                core.minmaxindexStepImpl(this, inReal[i]);
+                outMinIdx[i] = this.cur_outMinIdx;
+                outMaxIdx[i] = this.cur_outMaxIdx;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -121594,7 +121609,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, MinmaxindexOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MINMAXINDEX peek: BadParam", RetCode.BadParam);
              MinmaxindexStream sp = this;
@@ -121657,7 +121672,8 @@ class Core {
              cur_outMinIdx = lowestIdx;
              trailingIdx += 1;
              today += 1;
-             return new Value(cur_outMinIdx, cur_outMaxIdx);
+             out.minIdx = cur_outMinIdx;
+             out.maxIdx = cur_outMaxIdx;
           }
 
           /**
@@ -121666,8 +121682,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( MinmaxindexOut out ) {
+             out.minIdx = this.cur_outMinIdx;
+             out.maxIdx = this.cur_outMaxIdx;
           }
 
           /**
@@ -121685,6 +121702,27 @@ class Core {
           public MinmaxindexStream clone() {
              return new MinmaxindexStream(this);
           }
+       }
+
+       /**
+        * The outputs of one MINMAXINDEX bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class MinmaxindexOut {
+          /** Absolute index (into inReal) of the window minimum. */
+          public int minIdx;
+          /** Absolute index (into inReal) of the window maximum. */
+          public int maxIdx;
        }
        void minmaxindexStepImpl( MinmaxindexStream sp, double inReal )
        {
@@ -121864,7 +121902,6 @@ class Core {
           sp.x_inReal = capX_inReal;
           sp.cur_outMinIdx = outMinIdx[(outNBElement.value - 1) * outStride];
           sp.cur_outMaxIdx = outMaxIdx[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new MinmaxindexStream.Value(sp.cur_outMinIdx, sp.cur_outMaxIdx);
           return RetCode.Success;
        }
        /* minmaxindexOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -142708,7 +142745,6 @@ class Core {
           double[] x_inClose;
           double cur_outSMI;
           double cur_outSMISignal;
-          Value cachedValue;
           int outRangeBegIdx;
           int outRangeCount;
 
@@ -142754,23 +142790,9 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outSMI = other.cur_outSMI;
              this.cur_outSMISignal = other.cur_outSMISignal;
-             this.cachedValue = other.cachedValue;
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param smi Stochastic Momentum Index, -100 to +100.
-           * @param smiSignal Exponential average of the SMI line.
-           */
-          public record Value(double smi, double smiSignal) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -142788,15 +142810,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow, double inClose ) {
+          public void update( double inHigh, double inLow, double inClose, SmiOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("SMI update: BadParam", RetCode.BadParam);
              }
              core.smiStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
-             return this.cachedValue;
+             out.smi = this.cur_outSMI;
+             out.smiSignal = this.cur_outSMISignal;
           }
 
           /**
@@ -142821,21 +142843,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outSMI.length < barCount || outSMISignal.length < barCount || (Object)outSMI == (Object)inHigh || (Object)outSMI == (Object)inLow || (Object)outSMI == (Object)inClose || (Object)outSMISignal == (Object)inHigh || (Object)outSMISignal == (Object)inLow || (Object)outSMISignal == (Object)inClose || (Object)outSMI == (Object)outSMISignal )
                 throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outSMI[i] = this.cur_outSMI;
-                   outSMISignal[i] = this.cur_outSMISignal;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("SMI updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSMI, this.cur_outSMISignal);
+                core.smiStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outSMI[i] = this.cur_outSMI;
+                outSMISignal[i] = this.cur_outSMISignal;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -142849,7 +142865,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow, double inClose ) {
+          public void peek( double inHigh, double inLow, double inClose, SmiOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("SMI peek: BadParam", RetCode.BadParam);
              SmiStream sp = this;
@@ -142954,7 +142970,8 @@ class Core {
              cur_outSMISignal = prevSignal;
              trailingIdx = trailingIdx + 1;
              today = today + 1;
-             return new Value(cur_outSMI, cur_outSMISignal);
+             out.smi = cur_outSMI;
+             out.smiSignal = cur_outSMISignal;
           }
 
           /**
@@ -142963,8 +142980,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( SmiOut out ) {
+             out.smi = this.cur_outSMI;
+             out.smiSignal = this.cur_outSMISignal;
           }
 
           /**
@@ -142982,6 +143000,27 @@ class Core {
           public SmiStream clone() {
              return new SmiStream(this);
           }
+       }
+
+       /**
+        * The outputs of one SMI bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class SmiOut {
+          /** Stochastic Momentum Index, -100 to +100. */
+          public double smi;
+          /** Exponential average of the SMI line. */
+          public double smiSignal;
        }
        void smiStepImpl( SmiStream sp, double inHigh, double inLow, double inClose )
        {
@@ -143400,7 +143439,6 @@ class Core {
           sp.x_inClose = capX_inClose;
           sp.cur_outSMI = outSMI[(outNBElement.value - 1) * outStride];
           sp.cur_outSMISignal = outSMISignal[(outNBElement.value - 1) * outStride];
-          sp.cachedValue = new SmiStream.Value(sp.cur_outSMI, sp.cur_outSMISignal);
           return RetCode.Success;
        }
        /* smiOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -145281,7 +145319,6 @@ class Core {
           double[] x_inClose;
           double cur_outSlowK;
           double cur_outSlowD;
-          Value cachedValue;
           MaStream sub0;
           MaStream sub1;
           int outRangeBegIdx;
@@ -145323,25 +145360,11 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outSlowK = other.cur_outSlowK;
              this.cur_outSlowD = other.cur_outSlowD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.sub1 = new MaStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param slowK Raw FastK smoothed by SlowK_Period MA.
-           * @param slowD Signal line: SlowK smoothed by SlowD_Period MA.
-           */
-          public record Value(double slowK, double slowD) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -145359,15 +145382,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow, double inClose ) {
+          public void update( double inHigh, double inLow, double inClose, StochOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("STOCH update: BadParam", RetCode.BadParam);
              }
              core.stochStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
-             return this.cachedValue;
+             out.slowK = this.cur_outSlowK;
+             out.slowD = this.cur_outSlowD;
           }
 
           /**
@@ -145392,21 +145415,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outSlowK.length < barCount || outSlowD.length < barCount || (Object)outSlowK == (Object)inHigh || (Object)outSlowK == (Object)inLow || (Object)outSlowK == (Object)inClose || (Object)outSlowD == (Object)inHigh || (Object)outSlowD == (Object)inLow || (Object)outSlowD == (Object)inClose || (Object)outSlowK == (Object)outSlowD )
                 throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outSlowK[i] = this.cur_outSlowK;
-                   outSlowD[i] = this.cur_outSlowD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCH updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outSlowK, this.cur_outSlowD);
+                core.stochStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outSlowK[i] = this.cur_outSlowK;
+                outSlowD[i] = this.cur_outSlowD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -145420,7 +145437,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow, double inClose ) {
+          public void peek( double inHigh, double inLow, double inClose, StochOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("STOCH peek: BadParam", RetCode.BadParam);
              StochStream sp = this;
@@ -145513,7 +145530,8 @@ class Core {
              cur_tempBuffer = sp.sub0.peek(cur_tempBuffer);
              cur_outSlowD = sp.sub1.peek(cur_tempBuffer);
              cur_outSlowK = cur_tempBuffer;
-             return new Value(cur_outSlowK, cur_outSlowD);
+             out.slowK = cur_outSlowK;
+             out.slowD = cur_outSlowD;
           }
 
           /**
@@ -145522,8 +145540,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( StochOut out ) {
+             out.slowK = this.cur_outSlowK;
+             out.slowD = this.cur_outSlowD;
           }
 
           /**
@@ -145541,6 +145560,27 @@ class Core {
           public StochStream clone() {
              return new StochStream(this);
           }
+       }
+
+       /**
+        * The outputs of one STOCH bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class StochOut {
+          /** Raw FastK smoothed by SlowK_Period MA. */
+          public double slowK;
+          /** Signal line: SlowK smoothed by SlowD_Period MA. */
+          public double slowD;
        }
        void stochStepImpl( StochStream sp, double inHigh, double inLow, double inClose )
        {
@@ -145903,7 +145943,6 @@ class Core {
           sp.sub1 = sub1;
           sp.cur_outSlowK = sc_outSlowK[outNBElement.value - 1];
           sp.cur_outSlowD = sc_outSlowD[outNBElement.value - 1];
-          sp.cachedValue = new StochStream.Value(sp.cur_outSlowK, sp.cur_outSlowD);
           return RetCode.Success;
        }
        /* stochOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -146636,7 +146675,6 @@ class Core {
           double[] x_inClose;
           double cur_outFastK;
           double cur_outFastD;
-          Value cachedValue;
           MaStream sub0;
           int outRangeBegIdx;
           int outRangeCount;
@@ -146675,24 +146713,10 @@ class Core {
              this.x_inClose = other.x_inClose.clone();
              this.cur_outFastK = other.cur_outFastK;
              this.cur_outFastD = other.cur_outFastD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new MaStream(other.sub0);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param fastK Raw %K stochastic line.
-           * @param fastD MA-smoothed %K (signal line)
-           */
-          public record Value(double fastK, double fastD) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -146710,15 +146734,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inHigh, double inLow, double inClose ) {
+          public void update( double inHigh, double inLow, double inClose, StochfOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("STOCHF update: BadParam", RetCode.BadParam);
              }
              core.stochfStepImpl(this, inHigh, inLow, inClose);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-             return this.cachedValue;
+             out.fastK = this.cur_outFastK;
+             out.fastD = this.cur_outFastD;
           }
 
           /**
@@ -146743,21 +146767,15 @@ class Core {
              final int barCount = inHigh.length;
              if( inLow.length != barCount || inClose.length != barCount || outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inHigh || (Object)outFastK == (Object)inLow || (Object)outFastK == (Object)inClose || (Object)outFastD == (Object)inHigh || (Object)outFastD == (Object)inLow || (Object)outFastD == (Object)inClose || (Object)outFastK == (Object)outFastD )
                 throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
-                   outFastK[i] = this.cur_outFastK;
-                   outFastD[i] = this.cur_outFastD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inHigh[i]) || !Double.isFinite(inLow[i]) || !Double.isFinite(inClose[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCHF updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+                core.stochfStepImpl(this, inHigh[i], inLow[i], inClose[i]);
+                outFastK[i] = this.cur_outFastK;
+                outFastD[i] = this.cur_outFastD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -146771,7 +146789,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inHigh, double inLow, double inClose ) {
+          public void peek( double inHigh, double inLow, double inClose, StochfOut out ) {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("STOCHF peek: BadParam", RetCode.BadParam);
              StochfStream sp = this;
@@ -146863,7 +146881,8 @@ class Core {
              /* Pipeline the new bar through the sub-streams (batch tail order). */
              cur_outFastD = sp.sub0.peek(cur_tempBuffer);
              cur_outFastK = cur_tempBuffer;
-             return new Value(cur_outFastK, cur_outFastD);
+             out.fastK = cur_outFastK;
+             out.fastD = cur_outFastD;
           }
 
           /**
@@ -146872,8 +146891,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( StochfOut out ) {
+             out.fastK = this.cur_outFastK;
+             out.fastD = this.cur_outFastD;
           }
 
           /**
@@ -146891,6 +146911,27 @@ class Core {
           public StochfStream clone() {
              return new StochfStream(this);
           }
+       }
+
+       /**
+        * The outputs of one STOCHF bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class StochfOut {
+          /** Raw %K stochastic line. */
+          public double fastK;
+          /** MA-smoothed %K (signal line) */
+          public double fastD;
        }
        void stochfStepImpl( StochfStream sp, double inHigh, double inLow, double inClose )
        {
@@ -147227,7 +147268,6 @@ class Core {
           sp.sub0 = sub0;
           sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
           sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-          sp.cachedValue = new StochfStream.Value(sp.cur_outFastK, sp.cur_outFastD);
           return RetCode.Success;
        }
        /* stochfOpenAndFill anchored at startIdx — the composed-open fusion seam. */
@@ -147774,7 +147814,6 @@ class Core {
           MAType optInFastD_MAType;
           double cur_outFastK;
           double cur_outFastD;
-          Value cachedValue;
           RsiStream sub0;
           StochfStream sub1;
           int outRangeBegIdx;
@@ -147803,25 +147842,11 @@ class Core {
              this.optInFastD_MAType = other.optInFastD_MAType;
              this.cur_outFastK = other.cur_outFastK;
              this.cur_outFastD = other.cur_outFastD;
-             this.cachedValue = other.cachedValue;
              this.sub0 = new RsiStream(other.sub0);
              this.sub1 = new StochfStream(other.sub1);
              this.outRangeBegIdx = other.outRangeBegIdx;
              this.outRangeCount = other.outRangeCount;
           }
-
-          /**
-           * One output set, in batch output order. Immutable.
-           *
-           * <p>{@code equals} compares every component bitwise, so {@code NaN}
-           * equals {@code NaN} and {@code 0.0} does not equal {@code -0.0}.
-           * {@code hashCode} is consistent with it but its exact value is
-           * unspecified — do not persist it or compare it across JVM versions.
-           *
-           * @param fastK Unsmoothed stochastic of the RSI (raw %K)
-           * @param fastD %K smoothed over FastD_Period (signal line)
-           */
-          public record Value(double fastK, double fastD) { }
 
           /**
            * Commit one closed bar, returning the new current value.
@@ -147839,15 +147864,15 @@ class Core {
            * retains its state, so a single non-finite bar would poison every
            * later value it produces.
            */
-          public Value update( double inReal ) {
+          public void update( double inReal, StochrsiOut out ) {
              if( !Double.isFinite(inReal) ) {
                 if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
                 throw new TaLibArgumentException("STOCHRSI update: BadParam", RetCode.BadParam);
              }
              core.stochrsiStepImpl(this, inReal);
              if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-             this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
-             return this.cachedValue;
+             out.fastK = this.cur_outFastK;
+             out.fastD = this.cur_outFastD;
           }
 
           /**
@@ -147870,21 +147895,15 @@ class Core {
              final int barCount = inReal.length;
              if( outFastK.length < barCount || outFastD.length < barCount || (Object)outFastK == (Object)inReal || (Object)outFastD == (Object)inReal || (Object)outFastK == (Object)outFastD )
                 throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-             int done = 0;
-             try {
-                for( int i = 0; i < barCount; i++ ) {
-                   if( !Double.isFinite(inReal[i]) ) {
-                      if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                      throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
-                   }
-                   core.stochrsiStepImpl(this, inReal[i]);
-                   outFastK[i] = this.cur_outFastK;
-                   outFastD[i] = this.cur_outFastD;
+             for( int i = 0; i < barCount; i++ ) {
+                if( !Double.isFinite(inReal[i]) ) {
                    if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
-                   done = i + 1;
+                   throw new TaLibArgumentException("STOCHRSI updateAndFill: BadParam", RetCode.BadParam);
                 }
-             } finally {
-                if( done > 0 ) this.cachedValue = new Value(this.cur_outFastK, this.cur_outFastD);
+                core.stochrsiStepImpl(this, inReal[i]);
+                outFastK[i] = this.cur_outFastK;
+                outFastD[i] = this.cur_outFastD;
+                if( this.outRangeCount < MAX_INDEX ) this.outRangeCount++;
              }
           }
 
@@ -147898,7 +147917,7 @@ class Core {
            * does not grow with the period. It does allocate a small bounded amount
            * per call — a size fixed by the indicator, never by the period.
            */
-          public Value peek( double inReal ) {
+          public void peek( double inReal, StochrsiOut out ) {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("STOCHRSI peek: BadParam", RetCode.BadParam);
              StochrsiStream sp = this;
@@ -147908,11 +147927,13 @@ class Core {
              /* Pipeline the new bar through the sub-streams (batch tail order). */
              cur_tempRSIBuffer = sp.sub0.peek(inReal);
              {
-                StochfStream.Value subOut1 = sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-                cur_outFastK = subOut1.fastK();
-                cur_outFastD = subOut1.fastD();
+                StochfOut subOut1 = new StochfOut();
+                sp.sub1.peek(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+                cur_outFastK = subOut1.fastK;
+                cur_outFastD = subOut1.fastD;
              }
-             return new Value(cur_outFastK, cur_outFastD);
+             out.fastK = cur_outFastK;
+             out.fastD = cur_outFastD;
           }
 
           /**
@@ -147921,8 +147942,9 @@ class Core {
            * then whatever the latest accepted {@code update} returned.
            * A pure field read; {@code peek} does not change it.
            */
-          public Value value() {
-             return this.cachedValue;
+          public void value( StochrsiOut out ) {
+             out.fastK = this.cur_outFastK;
+             out.fastD = this.cur_outFastD;
           }
 
           /**
@@ -147941,6 +147963,27 @@ class Core {
              return new StochrsiStream(this);
           }
        }
+
+       /**
+        * The outputs of one STOCHRSI bar, written by the stream into an object the
+        * CALLER owns. Allocate one and reuse it: {@code update}, {@code peek}
+        * and {@code value} overwrite its fields and allocate nothing.
+        *
+        * <p><b>Its contents are only valid until the next call that writes it.</b>
+        * It is a mutable buffer, not a reading: a reference kept past that call,
+        * or one put in a collection, sees the value change underneath it. Copy the
+        * fields out if the reading has to outlive the call.
+        *
+        * <p>Deliberately no {@code equals} or {@code hashCode}: a mutable type
+        * with value equality breaks the {@code HashMap}/{@code HashSet}
+        * invariant the moment a reused instance becomes a key. Compare the fields.
+        */
+       public static final class StochrsiOut {
+          /** Unsmoothed stochastic of the RSI (raw %K) */
+          public double fastK;
+          /** %K smoothed over FastD_Period (signal line) */
+          public double fastD;
+       }
        void stochrsiStepImpl( StochrsiStream sp, double inReal )
        {
           double cur_tempRSIBuffer = 0.0;
@@ -147949,9 +147992,10 @@ class Core {
           /* Pipeline the new bar through the sub-streams (batch tail order). */
           cur_tempRSIBuffer = sp.sub0.update(inReal);
           {
-             StochfStream.Value subOut1 = sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer);
-             cur_outFastK = subOut1.fastK();
-             cur_outFastD = subOut1.fastD();
+             StochfOut subOut1 = new StochfOut();
+             sp.sub1.update(cur_tempRSIBuffer, cur_tempRSIBuffer, cur_tempRSIBuffer, subOut1);
+             cur_outFastK = subOut1.fastK;
+             cur_outFastD = subOut1.fastD;
           }
           sp.cur_outFastK = cur_outFastK;
           sp.cur_outFastD = cur_outFastD;
@@ -148073,7 +148117,6 @@ class Core {
           sp.sub1 = sub1;
           sp.cur_outFastK = sc_outFastK[outNBElement.value - 1];
           sp.cur_outFastD = sc_outFastD[outNBElement.value - 1];
-          sp.cachedValue = new StochrsiStream.Value(sp.cur_outFastK, sp.cur_outFastD);
           return RetCode.Success;
        }
        /* stochrsiOpenAndFill anchored at startIdx — the composed-open fusion seam. */


### PR DESCRIPTION
Closes #310, implementing the shape you settled on. Splits out #325 for the composed-peek residue, as asked.

## The API

    void update( double inReal, MacdOut out );   // commits, writes out
    void peek(   double inReal, MacdOut out );   // commits nothing, writes out
    void value(  MacdOut out );                  // writes the last counted bar

`MacdOut` is a mutable public-field class at `Core` level, a sibling of `MacdStream` — where C# already puts `MacdValue`. Single-output handles are byte-identical, and so are C, Rust and C#.

Both decisions you called are in:

- **No `equals`/`hashCode`.** The javadoc says why, and says the other half too: *"Its contents are only valid until the next call that writes it… a reference kept past that call, or one put in a collection, sees the value change underneath it."*
- **Composed peek: one `Out` per call.** Two sites, `ma` and `stochrsi`.

**Composed `update` allocates nothing at all** — it commits, so the forwarded value comes off the sub-handle's own `cur_*` field and there is no sink on that path. That is better than the local I had proposed for symmetry, and it follows from your own observation on the issue.

`updateAndFill` loses the `done` / `try` / `finally` that existed only to keep the cache fresh on a partial fill.

## The gates, and one made stricter rather than looser

`no_java_peek_copies_the_handle` went red on the two composed sinks. **I did not exempt the allocation.** The sweep now pins the set of composed peeks that allocate to *exactly* `{ma, stochrsi}`:

- a third site fails — a new composed multi-output peek nobody costed;
- **losing one also fails** — that is #325 landing, and the bound should tighten with it rather than silently over-permitting.

`the_java_value_cache_is_refreshed_on_every_exit` asserted a mechanism that no longer exists. Replaced, not deleted, by `no_managed_handle_caches_the_multi_output_value`: a sweep over Java and C#, over `updateAndFill` and the whole handle, for any cache or `finally` — with a non-vacuity check that the handles it sweeps really are multi-output, since a single-output handle's lack of a cache proves nothing.

The three remaining expectation updates are contract changes: the record → the Out class, and the dispatch `update` path now reading `cur_outMAMA` with an explicit assertion that `MamaStream.Value` appears nowhere.

## Verification

- `cargo test --no-fail-fast`: **884 pass, 0 fail**.
- `cargo clippy --all-targets -- -D warnings`: exit 0.
- Full `generate` twice: idempotent, no drift.
- Diff touches `ta_codegen/output/java/` and three generator files. **Zero files under `output/c`, `output/rust`, `output/csharp`.**
- `cachedValue` and `record Value(` appear nowhere in the generated Java.
- Rebased onto `c5dd353a` (KC). KC is multi-output and picked up `KcOut` with no work — the emitter is driven off the corpus, so a new indicator is covered the day it lands.

## What I did not check

- **Nothing Java was compiled or executed.** This box's JDK is 11 and the pom asks for release 17 (`error: release version 17 not supported`), so `build.py servers --language=java` fails at maven, and the four-language regtest cannot run its Java leg here. Everything above is generator-side: text assertions, the sweeps, and clippy. **The first compile and the first bit-exactness run of this change are the CI on this PR.** That is a real gap on a change of this size and I would rather name it than let the green ticks above imply more.
- **The allocation claim is not re-measured.** The 0 B/bar for the 15 multi-output `update`s follows from there being no allocation site left in the generated text, which is checkable by reading it — but I have not run `ThreadMXBean` against a built jar, for the same reason.
- **`StreamSmokeTest` is not updated here.** It lives in the Java library sources, which I cannot compile to check I have not broken it; its identity assertions on the returned `Value` will need to become field comparisons. Say the word if you want that in this PR anyway and I will write it blind and mark it as untested.
