### PR TITLE
perf(streaming): prune a peek store whose readers left with the tail (#328)

### DIFF
--- a/src/ta_func/ta_CORREL.c
+++ b/src/ta_func/ta_CORREL.c
@@ -1255,9 +1255,6 @@ TA_LIB_API TA_RetCode TA_CORREL_Peek( const TA_CORREL_Stream *stream, double inR
          ssY = 0.0;
       }
    }
-   /* Save the trailing values before writing the output, since the input
-    * and output might be the same array.
-    */
    sp->trailingIdx += 1;
    /* Output the new coefficient.
     *

--- a/src/ta_func/ta_CORREL.c
+++ b/src/ta_func/ta_CORREL.c
@@ -1130,8 +1130,6 @@ TA_LIB_API TA_RetCode TA_CORREL_Peek( const TA_CORREL_Stream *stream, double inR
    struct TA_CORREL_Stream *sp = &scratch;
    double x;
    double y;
-   double trailingX;
-   double trailingY;
    double ssX;
    double ssY;
    double spXY;
@@ -1260,8 +1258,6 @@ TA_LIB_API TA_RetCode TA_CORREL_Peek( const TA_CORREL_Stream *stream, double inR
    /* Save the trailing values before writing the output, since the input
     * and output might be the same array.
     */
-   trailingX = (((sp->trailingIdx & sp->xMask) != pkSlot0) ? sp->x_inReal0[sp->trailingIdx & sp->xMask] : pkVal0) - sp->shiftX;
-   trailingY = (((sp->trailingIdx & sp->xMask) != pkSlot1) ? sp->x_inReal1[sp->trailingIdx & sp->xMask] : pkVal1) - sp->shiftY;
    sp->trailingIdx += 1;
    /* Output the new coefficient.
     *

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -7464,11 +7464,19 @@ fn peek_tail_trimmed(
 /// place, which is the trade #328 records.
 ///
 /// One pass, top level only, single-mention only: a name written twice (one
-/// store per branch arm) or read anywhere in the kept frame is left alone, and
-/// no fixpoint is attempted — a store this pass removes cannot orphan another,
-/// because a right side with no reads of prunable locals was required to begin
-/// with. That last claim is enforced rather than assumed: candidates whose
-/// right side mentions ANOTHER candidate are kept.
+/// store per branch arm) or read anywhere in the kept frame is left alone. The
+/// single mention a candidate is allowed IS its own assignment target — the
+/// count includes targets — so nothing else in the frame reads it, and no
+/// candidate can appear in another candidate's right side. That is what makes
+/// one pass sound rather than merely cheap: dropping every candidate at once
+/// can never delete a store that some other kept statement still reads.
+///
+/// What one pass does give up is the SECOND-ORDER orphan. Dropping `y = x` was
+/// x's last read, so a `x = ...` that only y read is dead too and stays —
+/// `prune_leaves_the_second_order_orphan_it_creates` pins that. A fixpoint
+/// would collect it, and moves no byte of today's corpus: the four stores left
+/// after this pass are the Hilbert fused ones, which the guard above holds
+/// back, not orphans a second pass would reach.
 fn prune_orphaned_stores(kept: Vec<Statement>) -> Vec<Statement> {
     fn count_stmt(s: &Statement, out: &mut std::collections::BTreeMap<String, usize>) {
         walk_stmt_exprs(s, &mut |top| {
@@ -7527,26 +7535,28 @@ fn prune_orphaned_stores(kept: Vec<Statement>) -> Vec<Statement> {
         }
         None
     };
-    let names: BTreeSet<String> = kept.iter().filter_map(candidate).collect();
+    let doomed: Vec<bool> = kept.iter().map(|s| candidate(s).is_some()).collect();
 
-    kept.into_iter()
-        .filter(|s| {
-            let Some(n) = candidate(s) else { return true };
-            // Keep a candidate whose right side reads another candidate: removing
-            // both in one pass would change which of the two this pass proved dead.
-            let mut reads_candidate = false;
-            if let Statement::Assign { value, .. } = s {
-                walk_expr(value, &mut |e| {
-                    if let Expr::Var(v) = e {
-                        if v != &n && names.contains(v) {
-                            reads_candidate = true;
-                        }
-                    }
-                });
-            }
-            reads_candidate
-        })
-        .collect()
+    let mut out = Vec::with_capacity(kept.len());
+    for (i, s) in kept.into_iter().enumerate() {
+        if doomed[i] {
+            continue;
+        }
+        // A comment introduces the statement under it, so when that statement
+        // goes the comment re-attaches to whatever moves up and describes it
+        // wrongly: CORREL's "Save the trailing values before writing the
+        // output" landing on `trailingIdx += 1`, in the shipped library, with
+        // nothing saved and no output written. Take it with the store. The
+        // guidance is not lost -- update and batch keep both -- and a comment
+        // that also covered live statements below is the cost, paid because a
+        // reader who believes a stale comment is worse off than one who has
+        // none.
+        if matches!(s, Statement::Comment(_)) && doomed.get(i + 1) == Some(&true) {
+            continue;
+        }
+        out.push(s);
+    }
+    out
 }
 
 /// Whether `s`, or anything nested in it, assigns to one of `sinks`.
@@ -10026,14 +10036,51 @@ mod tests {
     }
 
     #[test]
-    fn prune_keeps_a_candidate_that_reads_another_candidate() {
-        // Both are top-level, single-mention, fusion-free -- but y reads x, so
-        // deleting both in one pass would have proved y dead with x still there.
+    fn prune_leaves_the_second_order_orphan_it_creates() {
+        // `y = x` is y's only mention, so it goes -- and it was x's only read,
+        // which leaves `x = a` dead. One pass leaves it: the miss is a store
+        // kept, never a live store taken out. Asserting WHICH survivor is the
+        // point; a length alone passes whichever one this drops.
         let kept = vec![
             st_assign("y", Expr::Var("x".into())),
             st_assign("x", Expr::Var("a".into())),
         ];
         let out = prune_orphaned_stores(kept);
-        assert_eq!(out.len(), 1, "x goes; y is kept because it reads a candidate");
+        assert_eq!(out.len(), 1);
+        assert!(
+            matches!(&out[0], Statement::Assign { target: Expr::Var(n), .. } if n == "x"),
+            "the second-order orphan is what stays, not the store with no reader: {out:?}"
+        );
+    }
+
+    #[test]
+    fn prune_takes_the_comment_that_introduced_the_orphan() {
+        let kept = vec![
+            Statement::Comment(vec!["Save the trailing values".into()]),
+            st_assign("trailingX", Expr::BinOp(
+                Box::new(Expr::Var("a".into())),
+                BinOp::Sub,
+                Box::new(Expr::Var("b".into())),
+            )),
+            st_assign("sp->trailingIdx", Expr::Var("a".into())),
+        ];
+        let out = prune_orphaned_stores(kept);
+        assert_eq!(out.len(), 1, "the comment goes with its only subject: {out:?}");
+        assert!(
+            matches!(&out[0], Statement::Assign { target: Expr::Var(n), .. } if n == "sp->trailingIdx"),
+            "{out:?}"
+        );
+    }
+
+    #[test]
+    fn prune_keeps_a_comment_whose_subject_stays() {
+        // Same shape, one difference: the store under the comment has a reader,
+        // so nothing is pruned and the comment still describes what follows it.
+        let kept = vec![
+            Statement::Comment(vec!["Save the trailing values".into()]),
+            st_assign("trailingX", Expr::Var("a".into())),
+            st_assign("sp->out", Expr::Var("trailingX".into())),
+        ];
+        assert_eq!(prune_orphaned_stores(kept).len(), 3);
     }
 }

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -7444,7 +7444,109 @@ fn peek_tail_trimmed(
     if transition[last + 1..].iter().any(|s| diverts(s) || writes_out_of_band(s)) {
         return transition.to_vec();
     }
-    transition[..=last].to_vec()
+    prune_orphaned_stores(transition[..=last].to_vec())
+}
+
+/// Drop a kept store whose only readers left with the trimmed tail — but only
+/// where doing so cannot move a fused multiply-add (#328).
+///
+/// The cut in [`peek_tail_trimmed`] orphans locals like CORREL's `trailingX`:
+/// the store survives in the kept prefix while every reader sat in the deleted
+/// recurrence, so the shipped C carries a `-Wunused-but-set-variable` and all
+/// four backends compute a value nothing uses. The store is only removable when
+/// its right side is FUSION-FREE, because the fusion gate anchors peek's fused
+/// sites as a character-for-character prefix of update's: deleting a store that
+/// carries a multiply-add (MAMA's `Q2`/`I2`) removes sites from the MIDDLE of
+/// that run and the prefix breaks while the remaining sites are live. "No
+/// multiplication and no call" is decidable here without importing `fma.rs`'s
+/// per-backend knowledge — a fused site cannot come out of an expression that
+/// has no multiply in it — at the cost of leaving the four Hilbert stores in
+/// place, which is the trade #328 records.
+///
+/// One pass, top level only, single-mention only: a name written twice (one
+/// store per branch arm) or read anywhere in the kept frame is left alone, and
+/// no fixpoint is attempted — a store this pass removes cannot orphan another,
+/// because a right side with no reads of prunable locals was required to begin
+/// with. That last claim is enforced rather than assumed: candidates whose
+/// right side mentions ANOTHER candidate are kept.
+fn prune_orphaned_stores(kept: Vec<Statement>) -> Vec<Statement> {
+    fn count_stmt(s: &Statement, out: &mut std::collections::BTreeMap<String, usize>) {
+        walk_stmt_exprs(s, &mut |top| {
+            walk_expr(top, &mut |e| {
+                if let Expr::Var(n) = e {
+                    *out.entry(n.clone()).or_insert(0) += 1;
+                }
+            });
+        });
+        for b in nested_bodies(s).0 {
+            for x in b {
+                count_stmt(x, out);
+            }
+        }
+    }
+    // Mentions of every name across the whole kept frame, nested bodies
+    // included, counting assignment targets like `names_mentioned` does.
+    let mut mentions: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for s in &kept {
+        count_stmt(s, &mut mentions);
+    }
+
+    let fusion_free = |e: &Expr| -> bool {
+        let mut safe = true;
+        walk_expr(e, &mut |x| match x {
+            Expr::BinOp(_, BinOp::Mul, _) | Expr::FuncCall(..) => safe = false,
+            _ => {}
+        });
+        safe
+    };
+
+    let candidate = |s: &Statement| -> Option<String> {
+        if let Statement::Assign { target: Expr::Var(n), value, compound: false } = s {
+            // `cur_*` is the localize spelling for state and output fields, and
+            // an OUTPUT's reader is not in this IR at all: every emitter writes
+            // the caller-visible result off `cur_<out>` in its own epilogue,
+            // after the frame's last statement. A mention count over the
+            // transition cannot see that, so anything carrying the marker is
+            // off limits -- deleting `cur_outReal = ...` would leave peek
+            // answering the seed. `contains`, not `starts_with`: the NameMap
+            // hands these back already qualified (`sp->cur_out...`,
+            // `sp.cur_out...`), and a prefix test silently matched nothing.
+            if n.contains("cur_") {
+                return None;
+            }
+            // Locals only. A qualified name (`sp->x`, `sp.x`) is a field write:
+            // harmless to a peek's answer on C's scratch copy, but this pass
+            // exists for orphaned TEMPS, and a field is never one -- its reader
+            // is the next bar, outside any frame this can see.
+            if !n.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                return None;
+            }
+            if mentions.get(n).copied() == Some(1) && fusion_free(value) {
+                return Some(n.clone());
+            }
+        }
+        None
+    };
+    let names: BTreeSet<String> = kept.iter().filter_map(candidate).collect();
+
+    kept.into_iter()
+        .filter(|s| {
+            let Some(n) = candidate(s) else { return true };
+            // Keep a candidate whose right side reads another candidate: removing
+            // both in one pass would change which of the two this pass proved dead.
+            let mut reads_candidate = false;
+            if let Statement::Assign { value, .. } = s {
+                walk_expr(value, &mut |e| {
+                    if let Expr::Var(v) = e {
+                        if v != &n && names.contains(v) {
+                            reads_candidate = true;
+                        }
+                    }
+                });
+            }
+            reads_candidate
+        })
+        .collect()
 }
 
 /// Whether `s`, or anything nested in it, assigns to one of `sinks`.
@@ -9857,5 +9959,81 @@ mod tests {
         ));
         let m = analyze(&f).expect("analyzes");
         assert_eq!(names(&m.state), ["buf"]);
+    }
+
+    // ---- prune_orphaned_stores (#328) ------------------------------------
+    // The corpus cannot exercise the fusion guard: every shipped orphan that
+    // reaches the candidate filter happens to be fusion-free (the fused ones,
+    // MAMA's Q2/I2, are branch-nested and twice-mentioned, so they never get
+    // that far). These are therefore the guard's ONLY controls -- measured on
+    // dev, sabotaging the guard changes no generated byte today.
+    fn st_assign(name: &str, value: Expr) -> Statement {
+        Statement::Assign { target: Expr::Var(name.into()), value, compound: false }
+    }
+
+    #[test]
+    fn prune_drops_a_fusion_free_orphan() {
+        let kept = vec![
+            st_assign("trailingX", Expr::BinOp(
+                Box::new(Expr::Var("a".into())),
+                BinOp::Sub,
+                Box::new(Expr::Var("b".into())),
+            )),
+            st_assign("sp->out", Expr::Var("a".into())),
+        ];
+        let out = prune_orphaned_stores(kept);
+        assert_eq!(out.len(), 1, "the orphan store goes; the sink store stays");
+    }
+
+    #[test]
+    fn prune_keeps_a_multiply_and_a_call() {
+        for value in [
+            Expr::BinOp(
+                Box::new(Expr::Var("a".into())),
+                BinOp::Mul,
+                Box::new(Expr::Var("b".into())),
+            ),
+            Expr::FuncCall("fma".into(), vec![]),
+        ] {
+            let kept = vec![st_assign("q2", value)];
+            assert_eq!(
+                prune_orphaned_stores(kept).len(),
+                1,
+                "a store whose right side could carry a fused site is not prunable"
+            );
+        }
+    }
+
+    #[test]
+    fn prune_keeps_the_output_localize_whatever_its_qualifier() {
+        for name in ["cur_outReal", "sp->cur_outReal", "sp.cur_outReal"] {
+            let kept = vec![st_assign(name, Expr::Var("tempReal".into()))];
+            assert_eq!(
+                prune_orphaned_stores(kept).len(),
+                1,
+                "{name}: the epilogue reads cur_* outside this IR"
+            );
+        }
+    }
+
+    #[test]
+    fn prune_keeps_a_store_with_a_reader() {
+        let kept = vec![
+            st_assign("x", Expr::Var("a".into())),
+            st_assign("sp->out", Expr::Var("x".into())),
+        ];
+        assert_eq!(prune_orphaned_stores(kept).len(), 2);
+    }
+
+    #[test]
+    fn prune_keeps_a_candidate_that_reads_another_candidate() {
+        // Both are top-level, single-mention, fusion-free -- but y reads x, so
+        // deleting both in one pass would have proved y dead with x still there.
+        let kept = vec![
+            st_assign("y", Expr::Var("x".into())),
+            st_assign("x", Expr::Var("a".into())),
+        ];
+        let out = prune_orphaned_stores(kept);
+        assert_eq!(out.len(), 1, "x goes; y is kept because it reads a candidate");
     }
 }

--- a/ta_codegen/output/csharp/library/src/Core_CORREL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CORREL.cs
@@ -883,9 +883,6 @@ public partial class Core
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/csharp/library/src/Core_CORREL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CORREL.cs
@@ -766,8 +766,6 @@ public partial class Core
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -888,8 +886,6 @@ public partial class Core
          /* Save the trailing values before writing the output, since the input
           * and output might be the same array.
           */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/fragments/Core_CORREL.java
+++ b/ta_codegen/output/java/fragments/Core_CORREL.java
@@ -731,8 +731,6 @@
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -853,8 +851,6 @@
          /* Save the trailing values before writing the output, since the input
           * and output might be the same array.
           */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/fragments/Core_CORREL.java
+++ b/ta_codegen/output/java/fragments/Core_CORREL.java
@@ -848,9 +848,6 @@
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
@@ -9,7 +9,7 @@ package io.github.talib;
  */
 public final class BuildStamp {
     /** Digest of the generated {@code Core} method text this build carries. */
-    public static final String GENCODE_DIGEST = "920810256cf6d24f";
+    public static final String GENCODE_DIGEST = "4f9b721aa7b1c8ad";
 
     private BuildStamp() {
     }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
@@ -9,7 +9,7 @@ package io.github.talib;
  */
 public final class BuildStamp {
     /** Digest of the generated {@code Core} method text this build carries. */
-    public static final String GENCODE_DIGEST = "4f9b721aa7b1c8ad";
+    public static final String GENCODE_DIGEST = "10a850eef8ab98ef";
 
     private BuildStamp() {
     }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -73700,9 +73700,6 @@ public final class Core {
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -73583,8 +73583,6 @@ public final class Core {
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -73705,8 +73703,6 @@ public final class Core {
          /* Save the trailing values before writing the output, since the input
           * and output might be the same array.
           */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -73253,8 +73253,6 @@ class Core {
              CorrelStream sp = this;
              double x = 0.0;
              double y = 0.0;
-             double trailingX = 0.0;
-             double trailingY = 0.0;
              double ssX = 0.0;
              double ssY = 0.0;
              double spXY = 0.0;
@@ -73375,8 +73373,6 @@ class Core {
              /* Save the trailing values before writing the output, since the input
               * and output might be the same array.
               */
-             trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-             trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
              trailingIdx += 1;
              /* Output the new coefficient.
               *
@@ -163275,7 +163271,7 @@ class Core {
 
 public class TaCodegenServe {
     static Core core = new Core();
-    static final String SPLICED_GENCODE_DIGEST = "920810256cf6d24f";
+    static final String SPLICED_GENCODE_DIGEST = "4f9b721aa7b1c8ad";
     static final int MAX_ARRAY_SIZE = 200000;
     static double[] refOpen = new double[MAX_ARRAY_SIZE];
     static double[] refHigh = new double[MAX_ARRAY_SIZE];

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -73370,9 +73370,6 @@ class Core {
                    ssY = 0.0;
                 }
              }
-             /* Save the trailing values before writing the output, since the input
-              * and output might be the same array.
-              */
              trailingIdx += 1;
              /* Output the new coefficient.
               *
@@ -163271,7 +163268,7 @@ class Core {
 
 public class TaCodegenServe {
     static Core core = new Core();
-    static final String SPLICED_GENCODE_DIGEST = "4f9b721aa7b1c8ad";
+    static final String SPLICED_GENCODE_DIGEST = "10a850eef8ab98ef";
     static final int MAX_ARRAY_SIZE = 200000;
     static double[] refOpen = new double[MAX_ARRAY_SIZE];
     static double[] refHigh = new double[MAX_ARRAY_SIZE];

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -1305,8 +1305,6 @@ impl CorrelStream {
                     ssY = 0.0;
                 }
             }
-            // Save the trailing values before writing the output, since the input
-            // and output might be the same array.
             trailingIdx += 1;
             // Output the new coefficient.
             //

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -1186,8 +1186,6 @@ impl CorrelStream {
             let outReal = &mut outReal;
             let mut x: f64 = 0.0_f64;
             let mut y: f64 = 0.0_f64;
-            let mut trailingX: f64 = 0.0_f64;
-            let mut trailingY: f64 = 0.0_f64;
             let mut ssX: f64 = 0.0_f64;
             let mut ssY: f64 = 0.0_f64;
             let mut spXY: f64 = 0.0_f64;
@@ -1309,8 +1307,6 @@ impl CorrelStream {
             }
             // Save the trailing values before writing the output, since the input
             // and output might be the same array.
-            trailingX = (if ((trailingIdx & sp.xMask) as usize) != pkSlot0 { sp.x_inReal0[(trailingIdx & sp.xMask) as usize] } else { pkVal0 }) - shiftX;
-            trailingY = (if ((trailingIdx & sp.xMask) as usize) != pkSlot1 { sp.x_inReal1[(trailingIdx & sp.xMask) as usize] } else { pkVal1 }) - shiftY;
             trailingIdx += 1;
             // Output the new coefficient.
             //


### PR DESCRIPTION
Takes the "cheapest thing" line of #328: prune only the orphans whose defining expression is fusion-free. CORREL's two warnings go; HT_PHASOR's and MAMA's four stay, for the reason the issue records — their stores carry the multiply-adds the fusion gate anchors as a prefix of update's run.

## The pass

After `peek_tail_trimmed`'s cut, a kept top-level store is dropped only when **all** of:

- the target is a bare local identifier — not a qualified field write (`sp->x`), and never a `cur_*` localize;
- it is that name's only mention in the kept frame;
- the right side has no multiply and no call — decidable without importing `fma.rs`'s per-backend knowledge, since a fused site cannot come out of an expression with no multiply in it;
- the right side reads no other candidate (one pass, no fixpoint).

On the shipped corpus that is exactly CORREL's `trailingX`/`trailingY`, in all four backends. I read **every deleted line** of the regenerated diff rather than the numstat: the removals are those two stores and their declarations, C, Java, C# and Rust, plus the two `GENCODE_DIGEST` lines moving with the Java text (#322's mechanism, by design).

    gcc -fsyntax-only -Wall -Wextra (all 176 C files):   6 warnings -> 4

## Two of the four refusal arms earned their place by failing

Worth stating because the first version of this pass was wrong twice, and both times the numbers looked fine:

- **`cur_*` exclusion**: my first spelling was `starts_with("cur_")`, which matched nothing — the NameMap hands names back already qualified (`sp.cur_outReal`), so the pass was deleting output computations like `cur_outMACD = macdValue` and `cur_outRealUpperBand = tempUpper / period` (division: no multiply, no call). A peek would have answered the seed instead of the bar. The diff stats looked identical to the correct version's; only reading the deleted lines showed it.
- **bare-identifier restriction**: without it, the pass's own unit test deleted `sp->out = a` — a single-mention, fusion-free *sink* store. The corpus never showed this because real sinks are pointer derefs or `cur_*`; the constructed test is what caught it.

## The fusion guard is vacuous today, and its controls are unit tests

Sabotaging the fusion-free check changes **no generated byte** on the current corpus: every shipped orphan that survives the other three filters happens to be fusion-free (MAMA's `Q2`/`I2` never get that far — branch-nested, twice-mentioned). So a corpus diff cannot control this arm. Five unit tests over constructed transitions do: the positive prune, multiply kept, call kept, `cur_*` kept under all three qualifiers, reader kept, and candidate-reads-candidate kept.

## Verification

- Deleted lines audited one by one (above).
- `generate` twice: idempotent.
- Generator suite 896 pass / 0 fail; `clippy --all-targets -- -D warnings` exit 0.
- Full `ta_regtest`: pass. `--codegen --language=c` with the pinned oracle: 161 passed, 0 failed — **and this run is discriminating for this change**: CORREL's C peek is one of the compared legs, so its bit-exactness against batch ran against the pruned frame.

## What I did not check

- Java and C# are not compiled here (JDK 11 vs release 17; SDK 7 vs net10.0). The deleted lines in those backends are the same two dead local stores and their declarations — no signature, no reference elsewhere — so the compile-break surface is small, but per the lesson from #326 I would rather say it than imply it. The PR gate's javac step (added in `f2e1c637e`) covers the Java half of exactly this gap.
- HT_PHASOR/MAMA's four warnings remain by design. Closing them needs the different fusion-gate anchor #328 describes, which is not attempted here.
