### PR TITLE
perf(streaming): a peek frame purges the stores its trimmed tail orphaned (#328)

### DIFF
--- a/src/ta_func/ta_CORREL.c
+++ b/src/ta_func/ta_CORREL.c
@@ -1130,8 +1130,6 @@ TA_LIB_API TA_RetCode TA_CORREL_Peek( const TA_CORREL_Stream *stream, double inR
    struct TA_CORREL_Stream *sp = &scratch;
    double x;
    double y;
-   double trailingX;
-   double trailingY;
    double ssX;
    double ssY;
    double spXY;
@@ -1257,11 +1255,6 @@ TA_LIB_API TA_RetCode TA_CORREL_Peek( const TA_CORREL_Stream *stream, double inR
          ssY = 0.0;
       }
    }
-   /* Save the trailing values before writing the output, since the input
-    * and output might be the same array.
-    */
-   trailingX = (((sp->trailingIdx & sp->xMask) != pkSlot0) ? sp->x_inReal0[sp->trailingIdx & sp->xMask] : pkVal0) - sp->shiftX;
-   trailingY = (((sp->trailingIdx & sp->xMask) != pkSlot1) ? sp->x_inReal1[sp->trailingIdx & sp->xMask] : pkVal1) - sp->shiftY;
    sp->trailingIdx += 1;
    /* Output the new coefficient.
     *

--- a/src/ta_func/ta_HT_PHASOR.c
+++ b/src/ta_func/ta_HT_PHASOR.c
@@ -1485,10 +1485,6 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
    double hilbertTempReal;
    double detrender;
    double Q1;
-   double jI;
-   double jQ;
-   double Q2;
-   double I2;
    double todayValue;
    int pkSlot0 = -1;
    double pkVal0 = 0.0;
@@ -1531,27 +1527,15 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       *outQuadrature= Q1;
       *outInPhase= sp->I1ForEvenPrev3;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
-      jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      jI += hilbertTempReal;
-      jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
-      jI += sp->prev_jI_Even;
       sp->prev_jI_input_Even = sp->I1ForEvenPrev3;
-      jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
-      jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      jQ += hilbertTempReal;
-      jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
-      jQ += sp->prev_jQ_Even;
       sp->prev_jQ_input_Even = Q1;
-      jQ *= adjustedPrevPeriod;
       if( ++sp->hilbertIdx == 3 )
       {
          sp->hilbertIdx = 0;
       }
-      Q2 = fma(0.2, Q1 + jI, 0.8 * sp->prevQ2);
-      I2 = fma(0.2, sp->I1ForEvenPrev3 - jQ, 0.8 * sp->prevI2);
       /* The variable I1 is the detrender delayed for
        * 3 price bars.
        *
@@ -1582,23 +1566,11 @@ TA_LIB_API TA_RetCode TA_HT_PHASOR_Peek( const TA_HT_PHASOR_Stream *stream, doub
       *outQuadrature= Q1;
       *outInPhase= sp->I1ForOddPrev3;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
-      jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      jI += hilbertTempReal;
-      jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
-      jI += sp->prev_jI_Odd;
       sp->prev_jI_input_Odd = sp->I1ForOddPrev3;
-      jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
-      jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      jQ += hilbertTempReal;
-      jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;
-      jQ += sp->prev_jQ_Odd;
       sp->prev_jQ_input_Odd = Q1;
-      jQ *= adjustedPrevPeriod;
-      Q2 = fma(0.2, Q1 + jI, 0.8 * sp->prevQ2);
-      I2 = fma(0.2, sp->I1ForOddPrev3 - jQ, 0.8 * sp->prevI2);
       /* The varaiable I1 is the detrender delayed for
        * 3 price bars.
        *

--- a/src/ta_func/ta_MAMA.c
+++ b/src/ta_func/ta_MAMA.c
@@ -1722,10 +1722,6 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
    double hilbertTempReal;
    double detrender;
    double Q1;
-   double jI;
-   double jQ;
-   double Q2;
-   double I2;
    double todayValue;
    double mama;
    double fama;
@@ -1770,27 +1766,15 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       sp->prev_Q1_input_Even = detrender;
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForEvenPrev3;
-      jI = 0 - sp->jI_Even[sp->hilbertIdx];
-      jI += hilbertTempReal;
-      jI -= sp->prev_jI_Even;
       sp->prev_jI_Even = sp->b * sp->prev_jI_input_Even;
-      jI += sp->prev_jI_Even;
       sp->prev_jI_input_Even = sp->I1ForEvenPrev3;
-      jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
-      jQ = 0 - sp->jQ_Even[sp->hilbertIdx];
-      jQ += hilbertTempReal;
-      jQ -= sp->prev_jQ_Even;
       sp->prev_jQ_Even = sp->b * sp->prev_jQ_input_Even;
-      jQ += sp->prev_jQ_Even;
       sp->prev_jQ_input_Even = Q1;
-      jQ *= adjustedPrevPeriod;
       if( ++sp->hilbertIdx == 3 )
       {
          sp->hilbertIdx = 0;
       }
-      Q2 = fma(0.2, Q1 + jI, 0.8 * sp->prevQ2);
-      I2 = fma(0.2, sp->I1ForEvenPrev3 - jQ, 0.8 * sp->prevI2);
       /* The variable I1 is the detrender delayed for
        * 3 price bars.
        *
@@ -1827,23 +1811,11 @@ TA_LIB_API TA_RetCode TA_MAMA_Peek( const TA_MAMA_Stream *stream, double inReal,
       sp->prev_Q1_input_Odd = detrender;
       Q1 *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * sp->I1ForOddPrev3;
-      jI = 0 - sp->jI_Odd[sp->hilbertIdx];
-      jI += hilbertTempReal;
-      jI -= sp->prev_jI_Odd;
       sp->prev_jI_Odd = sp->b * sp->prev_jI_input_Odd;
-      jI += sp->prev_jI_Odd;
       sp->prev_jI_input_Odd = sp->I1ForOddPrev3;
-      jI *= adjustedPrevPeriod;
       hilbertTempReal = sp->a * Q1;
-      jQ = 0 - sp->jQ_Odd[sp->hilbertIdx];
-      jQ += hilbertTempReal;
-      jQ -= sp->prev_jQ_Odd;
       sp->prev_jQ_Odd = sp->b * sp->prev_jQ_input_Odd;
-      jQ += sp->prev_jQ_Odd;
       sp->prev_jQ_input_Odd = Q1;
-      jQ *= adjustedPrevPeriod;
-      Q2 = fma(0.2, Q1 + jI, 0.8 * sp->prevQ2);
-      I2 = fma(0.2, sp->I1ForOddPrev3 - jQ, 0.8 * sp->prevI2);
       /* The varaiable I1 is the detrender delayed for
        * 3 price bars.
        *

--- a/ta_codegen/generator/src/backends/ir_cleanup.rs
+++ b/ta_codegen/generator/src/backends/ir_cleanup.rs
@@ -310,7 +310,7 @@ pub(crate) fn drop_inert_guards(body: &[Statement]) -> Vec<Statement> {
                 Statement::If { condition, then_body, else_body, .. }
                     if renders_nothing(then_body)
                         && renders_nothing(else_body)
-                        && !expr_writes(condition) =>
+                        && !crate::streaming::expr_has_effect(condition) =>
                 {
                     Statement::Block { body: Vec::new() }
                 }
@@ -335,25 +335,6 @@ fn renders_nothing(body: &[Statement]) -> bool {
         Statement::Comment(_) => true,
         _ => false,
     })
-}
-
-/// Does evaluating this expression change anything? A call is included because
-/// this module cannot know whether it is pure.
-fn expr_writes(e: &Expr) -> bool {
-    let mut writes = false;
-    crate::streaming::walk_expr(e, &mut |x| {
-        if matches!(
-            x,
-            Expr::PostIncrement(_)
-                | Expr::PreIncrement(_)
-                | Expr::PostDecrement(_)
-                | Expr::PreDecrement(_)
-                | Expr::FuncCall(..)
-        ) {
-            writes = true;
-        }
-    });
-    writes
 }
 
 /// Apply `pass` to every nested body, leaving this statement's own shape alone.

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -7405,12 +7405,17 @@ pub fn peek_transition_widest(
     // shadow-rewrite a read in the KEPT prefix, moving arithmetic this pass has
     // no business moving.
     let wide = transition_buffers_with_state_arrays(model, names);
-    let elected = if peek_transition(transition, &wide, slot_cast.clone()).is_ok() {
+    let elected = if peek_transition(transition, &wide, &model.temps, slot_cast.clone()).is_ok() {
         wide
     } else {
         transition_buffers(model, names)
     };
-    peek_transition(&peek_tail_trimmed(model, names, transition), &elected, slot_cast)
+    peek_transition(
+        &peek_tail_trimmed(model, names, transition),
+        &elected,
+        &model.temps,
+        slot_cast,
+    )
 }
 
 /// `transition` with every statement below its last store to an output sink
@@ -7764,26 +7769,10 @@ fn walk_stmt_own_exprs(s: &Statement, f: &mut dyn FnMut(&Expr)) {
 /// would spin, so [`drop_stores_no_load_reaches`] refuses the whole rewrite
 /// instead (`has_empty_loop`).
 fn emptied_by_deletion(s: &Statement) -> bool {
-    fn condition_writes(e: &Expr) -> bool {
-        let mut writes = false;
-        walk_expr(e, &mut |x| {
-            if matches!(
-                x,
-                Expr::PostIncrement(_)
-                    | Expr::PreIncrement(_)
-                    | Expr::PostDecrement(_)
-                    | Expr::PreDecrement(_)
-                    | Expr::FuncCall(..)
-            ) {
-                writes = true;
-            }
-        });
-        writes
-    }
     match s {
         Statement::Block { body } => body.is_empty(),
         Statement::If { condition, then_body, else_body, .. } => {
-            then_body.is_empty() && else_body.is_empty() && !condition_writes(condition)
+            then_body.is_empty() && else_body.is_empty() && !expr_has_effect(condition)
         }
         _ => false,
     }
@@ -7899,6 +7888,99 @@ fn drop_stores_no_load_reaches(
     out
 }
 
+/// Whether removing `e` would remove an effect: an increment, or a call — this
+/// layer cannot know whether a call is pure.
+///
+/// The fused multiply-add is not one. It is a rendered [`Expr::BinOp`] and never
+/// an [`Expr::FuncCall`], so a dead store carrying one is purged like any other.
+pub(crate) fn expr_has_effect(e: &Expr) -> bool {
+    let mut found = false;
+    walk_expr(e, &mut |x| {
+        if matches!(
+            x,
+            Expr::PostIncrement(_)
+                | Expr::PreIncrement(_)
+                | Expr::PostDecrement(_)
+                | Expr::PreDecrement(_)
+                | Expr::FuncCall(..)
+        ) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Every name `stmts` READS, which for a store to a bare variable is neither
+/// its target nor the target's own occurrence at the head of a compound value.
+///
+/// Those two exclusions are the whole difference from [`names_mentioned`], and
+/// the second is what makes a `+=` chain retire: `compound` keeps the self-read
+/// in the value, so counting it would hold every accumulator alive by its own
+/// update. Only the head occurrence goes — `x += x * 2` still reads `x`.
+fn names_read(stmts: &[Statement], out: &mut BTreeSet<String>) {
+    for s in stmts {
+        match s {
+            Statement::Assign { target: Expr::Var(v), value: Expr::BinOp(l, _, r), compound: true }
+                if matches!(&**l, Expr::Var(n) if n == v) =>
+            {
+                expr_var_names(r, out);
+            }
+            Statement::Assign { target: Expr::Var(_), value, .. } => expr_var_names(value, out),
+            _ => walk_stmt_own_exprs(s, &mut |e| expr_var_names(e, out)),
+        }
+        match s {
+            Statement::VarDecl { name, .. } | Statement::For { var: name, .. } => {
+                out.insert(name.clone());
+            }
+            _ => {}
+        }
+        for body in nested_bodies(s).0 {
+            names_read(body, out);
+        }
+    }
+}
+
+/// `transition` with every store to a frame temp nothing reads removed, until
+/// nothing more goes.
+///
+/// Whole-variable, so it needs no liveness lattice: a temp read nowhere is one
+/// whose every store is dead, wherever the control flow puts them. The fixpoint
+/// is what pays — trimming a peek frame at its last output store orphans the
+/// temps the tail read, and each store deleted is what exposes the next.
+///
+/// `temps` is the frame's own scratch list, never a shape test: an output sink
+/// is a bare [`Expr::Var`] in two of the four backends, and state is one in all
+/// four.
+fn purge_dead_temp_stores(
+    transition: &[Statement],
+    temps: &[(String, VarType)],
+) -> Vec<Statement> {
+    let named: BTreeSet<&str> = temps.iter().map(|(n, _)| n.as_str()).collect();
+    let mut out = transition.to_vec();
+    loop {
+        let mut read: BTreeSet<String> = BTreeSet::new();
+        names_read(&out, &mut read);
+        let dead: BTreeSet<&str> =
+            named.iter().copied().filter(|n| !read.contains(*n)).collect();
+        if dead.is_empty() {
+            return out;
+        }
+        let hit = std::cell::Cell::new(false);
+        let next = strip_stmts(&out, &|s| {
+            let drop = matches!(s, Statement::Assign { target: Expr::Var(v), value, .. }
+                if dead.contains(v.as_str()) && !expr_has_effect(value));
+            hit.set(hit.get() | drop);
+            drop
+        });
+        // A loop the deletion emptied would spin where its body was what ended
+        // it, exactly as in [`drop_stores_no_load_reaches`]; give the round back.
+        if !hit.get() || has_empty_loop(&next) {
+            return out;
+        }
+        out = next;
+    }
+}
+
 /// Rewrite `transition` so it computes the same values without storing into
 /// any handle buffer — see [`PeekShadow`].
 ///
@@ -7922,11 +8004,17 @@ fn drop_stores_no_load_reaches(
 pub fn peek_transition(
     transition: &[Statement],
     buffers: &[(String, bool)],
+    temps: &[(String, VarType)],
     slot_cast: Option<VarType>,
 ) -> Result<PeekTransition, String> {
     let bufs: BTreeMap<String, bool> = buffers.iter().map(|(n, i)| (n.clone(), *i)).collect();
     let transition = &drop_stores_no_load_reaches(transition, &bufs)[..];
     validate_peekable(transition, &bufs, 0)?;
+    // After the refusals and before the shadow rewrite: the purge only removes
+    // statements, so running it ahead of `validate_peekable` could turn a
+    // refusal into an acceptance and flip the buffer election, and running it
+    // after the rewrite would orphan the shadows `prune_dead_shadows` counts.
+    let transition = &purge_dead_temp_stores(transition, temps)[..];
     let shadowed: BTreeSet<String> = buffers
         .iter()
         .map(|(n, _)| n.clone())
@@ -8369,7 +8457,7 @@ mod tests {
     }
 
     fn pk(stmts: &[Statement]) -> PeekTransition {
-        peek_transition(stmts, &[("buf".to_string(), false)], None).expect("peekable")
+        peek_transition(stmts, &[("buf".to_string(), false)], &[], None).expect("peekable")
     }
 
     /// The tail ring push: kept for the NEXT bar, and peek has none.
@@ -8494,7 +8582,7 @@ mod tests {
             (vec![escaping], "escapes or is written"),
             (vec![handing_out], "escapes or is written"),
         ] {
-            let err = peek_transition(&stmts, &[("buf".to_string(), false)], None)
+            let err = peek_transition(&stmts, &[("buf".to_string(), false)], &[], None)
                 .expect_err("must refuse");
             assert!(err.contains(want), "expected `{want}`, got `{err}`");
         }
@@ -8609,6 +8697,7 @@ mod tests {
                 Statement::Assign { target: Expr::Var("acc".into()), value: k(), compound: false },
             ],
             &[("buf".to_string(), false)],
+            &[],
             None,
         )
         .expect_err("must refuse");
@@ -8632,6 +8721,7 @@ mod tests {
                 ],
             }],
             &[("buf".to_string(), false)],
+            &[],
             None,
         )
         .expect_err("must refuse");
@@ -8649,6 +8739,7 @@ mod tests {
                 body: vec![buf_store("buf", Expr::Var("pos".into()), Expr::Var("bar".into()))],
             }],
             &[("buf".to_string(), false)],
+            &[],
             None,
         )
         .expect_err("must refuse");
@@ -9156,6 +9247,7 @@ mod tests {
             peek_transition(
                 &transition,
                 &transition_buffers_with_state_arrays(&m, &TestNames),
+                &m.temps,
                 None
             )
             .is_err(),
@@ -9271,6 +9363,107 @@ mod tests {
     fn peek_tail_is_unchanged_where_nothing_stores_a_sink() {
         let stmts = vec![tail_store(), tail_store()];
         assert_eq!(trim(&stmts).len(), 2);
+    }
+
+    // ---- purge_dead_temp_stores -------------------------------------------
+
+    fn temps(names: &[&str]) -> Vec<(String, VarType)> {
+        names.iter().map(|n| ((*n).to_string(), VarType::Real)).collect()
+    }
+
+    fn compound(t: &str, op: BinOp, rhs: Expr) -> Statement {
+        Statement::Assign {
+            target: var(t),
+            value: Expr::BinOp(Box::new(var(t)), op, Box::new(rhs)),
+            compound: true,
+        }
+    }
+
+    /// The fixpoint: `q` is the only reader of the `j` chain, so the chain is
+    /// reachable only once `q`'s own store has gone.
+    #[test]
+    fn purge_retires_a_compound_chain_once_its_only_reader_goes() {
+        let stmts = vec![
+            assign(var("j"), var("sp->seed")),
+            compound("j", BinOp::Add, var("live")),
+            compound("j", BinOp::Mul, var("live")),
+            assign(var("q"), add(var("live"), var("j"))),
+            assign(Expr::PointerDeref("out_outReal".into()), var("live")),
+        ];
+        let out = purge_dead_temp_stores(&stmts, &temps(&["j", "q", "live"]));
+        assert_eq!(out.len(), 1, "only the output write answers anything: {out:?}");
+    }
+
+    /// One read anywhere holds every store to that temp, wherever the control
+    /// flow puts them.
+    #[test]
+    fn purge_keeps_every_store_to_a_temp_something_reads() {
+        let stmts = vec![
+            assign(var("j"), var("sp->seed")),
+            compound("j", BinOp::Add, var("live")),
+            Statement::If {
+                condition: le(var("a"), var("b")),
+                then_body: vec![assign(Expr::PointerDeref("out_outReal".into()), var("j"))],
+                else_body: Vec::new(),
+                cond_comments: Vec::new(),
+            },
+        ];
+        assert_eq!(purge_dead_temp_stores(&stmts, &temps(&["j"])).len(), 3);
+    }
+
+    /// The head exclusion is the target's OWN occurrence and nothing else —
+    /// discounting a compound value's head unconditionally would purge the
+    /// store that feeds it.
+    #[test]
+    fn purge_discounts_only_the_target_at_the_head_of_a_compound_value() {
+        let stmts = vec![
+            Statement::Assign {
+                target: var("acc"),
+                value: Expr::BinOp(Box::new(var("feed")), BinOp::Add, Box::new(Expr::Literal(1.0))),
+                compound: true,
+            },
+            assign(var("feed"), var("bar")),
+            assign(Expr::PointerDeref("out_outReal".into()), var("acc")),
+        ];
+        assert_eq!(purge_dead_temp_stores(&stmts, &temps(&["acc", "feed"])).len(), 3);
+    }
+
+    /// Both refusals on the value, neither reachable from the shipped corpus.
+    #[test]
+    fn purge_keeps_a_dead_store_whose_value_has_an_effect() {
+        for value in [
+            Expr::FuncCall("TA_MA_Peek".into(), vec![var("sub")]),
+            Expr::PostIncrement(Box::new(var("sp->i"))),
+        ] {
+            let stmts = vec![assign(var("dead"), value.clone())];
+            assert_eq!(purge_dead_temp_stores(&stmts, &temps(&["dead"])).len(), 1, "{value:?}");
+        }
+    }
+
+    /// The temp list is the whitelist, never the target's shape: Java and C#
+    /// spell an output sink as a bare `Expr::Var`, and all four spell state
+    /// that way.
+    #[test]
+    fn purge_keeps_a_dead_store_to_a_name_that_is_not_a_temp() {
+        let stmts =
+            vec![assign(var("sp->cur_outReal"), var("bar")), assign(var("dead"), var("bar"))];
+        let out = purge_dead_temp_stores(&stmts, &temps(&["dead"]));
+        assert_eq!(out.len(), 1);
+        assert!(
+            matches!(&out[0], Statement::Assign { target: Expr::Var(v), .. } if v == "sp->cur_outReal")
+        );
+    }
+
+    /// A loop the deletion emptied would spin where its body was what ended it,
+    /// so the round goes back whole rather than leaving the loop standing.
+    #[test]
+    fn purge_gives_back_a_round_that_would_empty_a_loop() {
+        let stmts = vec![Statement::While {
+            condition: le(var("i"), var("n")),
+            body: vec![compound("dead", BinOp::Add, var("i"))],
+        }];
+        let out = purge_dead_temp_stores(&stmts, &temps(&["dead"]));
+        assert!(matches!(&out[..], [Statement::While { body, .. }] if body.len() == 1), "{out:?}");
     }
 
     #[test]

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -7888,26 +7888,29 @@ fn drop_stores_no_load_reaches(
     out
 }
 
-/// Whether removing `e` would remove an effect: an increment, or a call — this
-/// layer cannot know whether a call is pure.
-///
-/// The fused multiply-add is not one. It is a rendered [`Expr::BinOp`] and never
-/// an [`Expr::FuncCall`], so a dead store carrying one is purged like any other.
-pub(crate) fn expr_has_effect(e: &Expr) -> bool {
+/// Whether removing `e` would remove an effect: an increment, or a call `pure`
+/// does not vouch for — this layer cannot tell on its own.
+fn expr_effect(e: &Expr, pure: &dyn Fn(&str) -> bool) -> bool {
     let mut found = false;
     walk_expr(e, &mut |x| {
-        if matches!(
-            x,
+        found |= match x {
             Expr::PostIncrement(_)
-                | Expr::PreIncrement(_)
-                | Expr::PostDecrement(_)
-                | Expr::PreDecrement(_)
-                | Expr::FuncCall(..)
-        ) {
-            found = true;
-        }
+            | Expr::PreIncrement(_)
+            | Expr::PostDecrement(_)
+            | Expr::PreDecrement(_) => true,
+            Expr::FuncCall(n, _) => !pure(n),
+            _ => false,
+        };
     });
     found
+}
+
+/// [`expr_effect`] vouching for no call at all.
+///
+/// The fused multiply-add needs no vouching: it is a rendered [`Expr::BinOp`]
+/// and never an [`Expr::FuncCall`].
+pub(crate) fn expr_has_effect(e: &Expr) -> bool {
+    expr_effect(e, &|_| false)
 }
 
 /// Every name `stmts` READS, which for a store to a bare variable is neither
@@ -7950,12 +7953,15 @@ fn names_read(stmts: &[Statement], out: &mut BTreeSet<String>) {
 ///
 /// `temps` is the frame's own scratch list, never a shape test: an output sink
 /// is a bare [`Expr::Var`] in two of the four backends, and state is one in all
-/// four.
+/// four. A call is refused unless [`pure_helper_names`] vouches for it, so an
+/// unlisted callee costs a store that stays, never one that should not have
+/// gone.
 fn purge_dead_temp_stores(
     transition: &[Statement],
     temps: &[(String, VarType)],
 ) -> Vec<Statement> {
     let named: BTreeSet<&str> = temps.iter().map(|(n, _)| n.as_str()).collect();
+    let pure = pure_helper_names();
     let mut out = transition.to_vec();
     loop {
         let mut read: BTreeSet<String> = BTreeSet::new();
@@ -7968,7 +7974,8 @@ fn purge_dead_temp_stores(
         let hit = std::cell::Cell::new(false);
         let next = strip_stmts(&out, &|s| {
             let drop = matches!(s, Statement::Assign { target: Expr::Var(v), value, .. }
-                if dead.contains(v.as_str()) && !expr_has_effect(value));
+                if dead.contains(v.as_str())
+                    && !expr_effect(value, &|n| pure.contains(n)));
             hit.set(hit.get() | drop);
             drop
         });
@@ -9426,6 +9433,18 @@ mod tests {
             assign(Expr::PointerDeref("out_outReal".into()), var("acc")),
         ];
         assert_eq!(purge_dead_temp_stores(&stmts, &temps(&["acc", "feed"])).len(), 3);
+    }
+
+    /// A vouched helper is a value and nothing else, so a dead store carrying
+    /// one goes. SYNTH8 is the fixture that reaches this; no shipped function
+    /// does.
+    #[test]
+    fn purge_drops_a_dead_store_whose_value_calls_a_vouched_helper() {
+        let stmts = vec![assign(
+            var("dead"),
+            Expr::FuncCall("ta_candlerange".into(), vec![var("inHigh"), var("inLow")]),
+        )];
+        assert!(purge_dead_temp_stores(&stmts, &temps(&["dead"])).is_empty());
     }
 
     /// Both refusals on the value, neither reachable from the shipped corpus.

--- a/ta_codegen/generator/tests/peek_suite.rs
+++ b/ta_codegen/generator/tests/peek_suite.rs
@@ -338,118 +338,241 @@ fn mask_buffer_reads(body: &str, buffers: &BTreeSet<String>) -> String {
     out
 }
 
-/// Collapse `(<idx> != pkSlotN) ? <arm> : pkValN` down to `<arm>` — the inverse
-/// of the peek rewrite, so what is left is the expression update renders.
-fn undo_selects(body: &str) -> String {
-    let mut s = body.to_string();
-    while let Some(hit) = s.find("pkSlot") {
-        // Back to the `(` that opens the comparison.
-        let b: Vec<char> = s.chars().collect();
-        let mut depth = 0i32;
-        let mut open = None;
-        for k in (0..hit).rev() {
-            match b[k] {
-                ')' => depth += 1,
-                '(' => {
-                    if depth == 0 {
-                        open = Some(k);
-                        break;
-                    }
-                    depth -= 1;
-                }
-                _ => {}
-            }
-        }
-        let Some(open) = open else { break };
-        // Past `) ? ` to the arm, then over the arm to ` : pkValN`.
-        let Some(q) = s[hit..].find("? ").map(|k| hit + k + 2) else { break };
-        let mut depth = 0i32;
-        let mut end = None;
-        for (k, c) in s[q..].char_indices() {
-            match c {
-                '(' | '[' => depth += 1,
-                ')' | ']' => {
-                    if depth == 0 {
-                        break;
-                    }
-                    depth -= 1;
-                }
-                ':' if depth == 0 => {
-                    end = Some(q + k);
-                    break;
-                }
-                _ => {}
-            }
-        }
-        let Some(end) = end else { break };
-        let arm = s[q..end].trim().to_string();
-        let Some(tail) = s[end..].find("pkVal").map(|k| end + k) else { break };
-        let after = s[tail..]
-            .find(|c: char| !c.is_ascii_digit() && c != 'p' && c != 'k' && c != 'V' && c != 'a' && c != 'l')
-            .map_or(s.len(), |k| tail + k);
-        // The select sits inside the parens the comparison opened.
-        let close = if after < s.len() && s.as_bytes()[after] == b')' { after + 1 } else { after };
-        s = format!("{}{}{}", &s[..open], arm, &s[close..]);
+/// Collapse `(<idx> != pkSlotN) ? <read> : pkValN` down to `<read>` — the
+/// inverse of the peek rewrite, so what is left is the expression update
+/// renders. Per LINE, and only where the `pkSlotN` found is the comparison:
+/// every peek body declares its shadows first, and a scan that started from a
+/// declaration would find no comparison to unwind and collapse nothing.
+fn undo_selects(line: &str) -> String {
+    let mut s = line.to_string();
+    while let Some((lo, hi, arm)) = leftmost_select(&s) {
+        s = format!("{}{}{}", &s[..lo], arm, &s[hi..]);
     }
     s
 }
 
-/// Every balanced `fma(...)` call in `body`, in order.
+/// The span of the leftmost select and the read it picks.
+fn leftmost_select(s: &str) -> Option<(usize, usize, String)> {
+    let b = s.as_bytes();
+    let hit = s.find("pkSlot")?;
+    let mut name_end = hit;
+    while name_end < b.len() && (b[name_end].is_ascii_alphanumeric() || b[name_end] == b'_') {
+        name_end += 1;
+    }
+    if !s[name_end..].starts_with(") ? ") {
+        return None;
+    }
+    // Back to the `(` that opens the comparison.
+    let mut depth = 0i32;
+    let mut open = None;
+    for k in (0..hit).rev() {
+        match b[k] {
+            b')' => depth += 1,
+            b'(' => {
+                if depth == 0 {
+                    open = Some(k);
+                    break;
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    // Past `) ? ` to the arm, then over the arm to ` : pkValN`.
+    let arm_start = name_end + 4;
+    let mut depth = 0i32;
+    let mut colon = None;
+    for (k, c) in b.iter().enumerate().skip(arm_start) {
+        match *c {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => {
+                if depth == 0 {
+                    break;
+                }
+                depth -= 1;
+            }
+            b':' if depth == 0 => {
+                colon = Some(k);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let arm = s[arm_start..colon?].trim().to_string();
+    let mut hi = colon? + s[colon?..].find("pkVal")?;
+    while hi < b.len() && (b[hi].is_ascii_alphanumeric() || b[hi] == b'_') {
+        hi += 1;
+    }
+    // The rewrite wraps the select in its own parens, and those must go with it
+    // — but only when they ARE its own: `fabs(<select>)` opens and closes the
+    // same way and taking that pair leaves the line unbalanced.
+    let wrapped = open > 0
+        && b[open - 1] == b'('
+        && hi < b.len()
+        && b[hi] == b')'
+        && !(open >= 2 && (b[open - 2].is_ascii_alphanumeric() || b[open - 2] == b'_'));
+    Some(if wrapped { (open - 1, hi + 1, arm) } else { (open, hi, arm) })
+}
+
+/// `(` minus `)` over `text`.
+fn paren_balance(text: &str) -> i32 {
+    text.bytes().map(|c| i32::from(c == b'(') - i32::from(c == b')')).sum()
+}
+
+/// A real `fma(` token at `i`, not the tail of a longer identifier.
+fn fma_at(b: &[char], i: usize) -> bool {
+    b[i..].starts_with(&['f', 'm', 'a', '('])
+        && (i == 0 || !(b[i - 1].is_alphanumeric() || b[i - 1] == '_'))
+}
+
+/// Every `fma(...)` call `body` both opens and closes, in source order — one
+/// nested in another call's arguments included, so the list is what the frame
+/// fuses rather than what its outermost calls hide.
 fn fma_calls(body: &str) -> Vec<String> {
-    let mut out = Vec::new();
     let b: Vec<char> = body.chars().collect();
-    let mut i = 0usize;
-    while let Some(rel) = body[i..].find("fma(") {
-        let start = i + rel;
-        let mut depth = 0usize;
-        let mut k = start + 3;
+    let mut out = Vec::new();
+    for i in (0..b.len()).filter(|&i| fma_at(&b, i)) {
+        let (mut depth, mut k) = (0usize, i + 3);
         while k < b.len() {
             match b[k] {
                 '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
-                    }
-                }
+                ')' => depth -= 1,
                 _ => {}
             }
+            if depth == 0 {
+                out.push(b[i..=k].iter().collect::<String>().split_whitespace().collect::<Vec<_>>().join(" "));
+                break;
+            }
             k += 1;
-        }
-        out.push(body[start..=k.min(b.len() - 1)].split_whitespace().collect::<Vec<_>>().join(" "));
-        i = k + 1;
-        if i >= body.len() {
-            break;
         }
     }
     out
 }
 
-/// Peek fuses where update does — a PREFIX of update's sites, with the same
-/// ARGUMENTS in the same order, not merely the same number of them. A count is blind to a product
-/// moving across the fusion boundary, which `canonicalize_accumulator_add` can
-/// do on its own: it matches the accumulator by raw string equality, and the
-/// peek rewrite is what first changes a store's target (`buf[k]` -> `pkValN`).
-/// The peek body is compared after undoing the rewrite — buffer subscripts
-/// masked to one token, selects collapsed to the arm update would render.
+/// How many `fma(` `text` opens, closed or not.
+fn fma_opens(text: &str) -> usize {
+    let b: Vec<char> = text.chars().collect();
+    (0..b.len()).filter(|&i| fma_at(&b, i)).count()
+}
+
+/// `line` split at its top-level assignment operator, as `(target, the
+/// statement with its whitespace collapsed)`.
+fn assignment(line: &str) -> Option<(String, String)> {
+    let l = line.trim();
+    let b: Vec<char> = l.chars().collect();
+    let mut depth = 0i32;
+    for (i, c) in b.iter().enumerate() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            '=' if depth == 0 => {
+                if b.get(i + 1) == Some(&'=') || (i > 0 && matches!(b[i - 1], '=' | '!' | '<' | '>')) {
+                    return None;
+                }
+                let lhs: String = b[..i].iter().collect();
+                let lhs = lhs.trim_end_matches(['+', '-', '*', '/', '&', '|', '^', '%', ' ']);
+                let stmt = l.split_whitespace().collect::<Vec<_>>().join(" ");
+                return (!lhs.is_empty()).then(|| (lhs.to_string(), stmt));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Every `fma(...)` in `body` keyed to the target of the assignment carrying
+/// it. `<expr>` names a call that sits in no assignment.
+fn fma_sites(body: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let calls = fma_calls(line);
+        if calls.is_empty() {
+            continue;
+        }
+        let lhs = assignment(line).map_or_else(|| "<expr>".to_string(), |(t, _)| t);
+        out.extend(calls.into_iter().map(|c| (lhs.clone(), c)));
+    }
+    out
+}
+
+/// The statements of `body` assigning one of `targets`, in order.
+fn assignments_to(body: &str, targets: &BTreeSet<String>) -> Vec<String> {
+    body.lines()
+        .filter_map(assignment)
+        .filter_map(|(t, s)| targets.contains(&t).then_some(s))
+        .collect()
+}
+
+/// A frame body with the peek rewrite undone: buffer subscripts masked to one
+/// token, selects collapsed to the arm update renders. Answers how many
+/// statements the collapse touched, which is the only thing that says it ran.
+fn unrewritten(body: &str, buffers: &BTreeSet<String>) -> (String, usize, usize) {
+    let masked = mask_buffer_reads(body, buffers);
+    let (mut collapsed, mut unbalanced) = (0usize, 0usize);
+    let out: Vec<String> = masked
+        .lines()
+        .map(|l| {
+            let u = undo_selects(l);
+            collapsed += usize::from(u != l);
+            // The collapse removes matched pairs, so it cannot move the line's
+            // balance. A count of CHANGED lines cannot tell a working collapse
+            // from one that corrupts a fifth of them; this can.
+            unbalanced += usize::from(paren_balance(&u) != paren_balance(l));
+            u
+        })
+        .collect();
+    (out.join("\n"), collapsed, unbalanced)
+}
+
+/// Whether `small` is a subsequence of `big`, answering the index in `small`
+/// that ran out of matches.
+fn subsequence<T: PartialEq>(small: &[T], big: &[T]) -> Result<(), usize> {
+    let mut rest = big;
+    for (i, s) in small.iter().enumerate() {
+        match rest.iter().position(|x| x == s) {
+            Some(k) => rest = &rest[k + 1..],
+            None => return Err(i),
+        }
+    }
+    Ok(())
+}
+
+/// Peek renders every multiply-add it still EVALUATES exactly as update renders
+/// it, and fuses nothing update does not.
 ///
-/// Measured today: 29 peek bodies fuse, 50 carry a select, 11 carry both, and
-/// ZERO fuse over a select operand. So the argument comparison is live against
-/// a reordering, and the select-collapse half is armed for the first function
-/// that puts a buffer read inside a multiply-add — the case where the THEN-arm
-/// classification rule would otherwise bite silently.
+/// Whether a site survived is decided from the peek text by the assignment
+/// TARGET — nothing done to the expression moves it — because one list cannot
+/// answer both halves:
 ///
-/// A prefix and not equality because peek stops at its last output store, so
-/// the sites in the tail update runs for the NEXT bar are not there to compare
-/// (HT_PHASOR 5 of 8, MAMA 7 of 10). Nothing is given up: `stream_fma` is built
-/// ONCE per function from `func.stream_source()` and guards the emission of
-/// BOTH frames, so truncation cannot re-classify a site peek still evaluates —
-/// and a site re-fused, dropped or reordered in the MIDDLE breaks the prefix
-/// exactly as it broke equality.
+/// - **Order, and no fusion of peek's own.** Peek's calls are a subsequence of
+///   update's, arguments and all. A count is blind to a product moving across
+///   the fusion boundary, which `canonicalize_accumulator_add` can do on its
+///   own: it matches the accumulator by raw string equality against the target,
+///   and the peek rewrite is what first changes one (`buf[k]` -> `pkValN`).
+/// - **Deletion accounting.** For every target update fuses into, the
+///   statements peek still assigns to it are a subsequence of update's BY WHOLE
+///   STATEMENT. Neither the leg above nor pairing each call with its target can
+///   carry this: unfusing a site DELETES it from a list of calls, leaving a
+///   subsequence, which is green on exactly the divergence this exists for.
+///
+/// A subsequence and not a prefix because peek stops at its last output store
+/// and then drops every store to a temp nothing reads, so the sites it no
+/// longer evaluates go missing from the MIDDLE. Nothing is given up: the frozen
+/// `stream_fma` sets guard both frames, so a deletion cannot re-classify a site
+/// peek still evaluates, and the second leg is what proves a site was deleted
+/// rather than unfused.
+///
+/// Three shapes are refused rather than handled, all absent today: an `fma(`
+/// that does not close on its own line, which the per-line keying would
+/// mis-read; a multiply-add stored into a buffer slot, whose target the peek
+/// rewrite renames, so the anchor could not follow it; and a call in no
+/// assignment, which has no anchor and so must survive verbatim.
 #[test]
-fn a_peek_frame_fuses_the_same_multiply_adds_as_its_update_frame() {
-    let mut total_sites = 0usize;
-    let mut fusing_functions = 0usize;
+fn a_peek_frame_fuses_every_multiply_add_it_still_evaluates() {
+    let (mut pairs, mut fusing, mut sites, mut anchors) = (0usize, 0usize, 0usize, 0usize);
+    let (mut aligned, mut unanchored, mut collapsed) = (0usize, 0usize, 0usize);
+    let mut refused: Vec<String> = Vec::new();
     let mut mismatches: Vec<String> = Vec::new();
 
     for name in indicators() {
@@ -462,33 +585,83 @@ fn a_peek_frame_fuses_the_same_multiply_adds_as_its_update_frame() {
         ) else {
             continue;
         };
+        pairs += 1;
         let buffers = handle_buffers(&src, &upper);
-        let a = fma_calls(&mask_buffer_reads(&step, &buffers));
-        let b = fma_calls(&undo_selects(&mask_buffer_reads(&peek, &buffers)));
-        total_sites += a.len();
-        if !a.is_empty() {
-            fusing_functions += 1;
+        let (u, _, ub_step) = unrewritten(&step, &buffers);
+        let (p, n, ub_peek) = unrewritten(&peek, &buffers);
+        collapsed += n;
+        if ub_step + ub_peek > 0 {
+            refused.push(format!("{upper}: undoing a select left {} line(s) unbalanced", ub_step + ub_peek));
         }
-        if b.len() > a.len() || b != a[..b.len()] {
+        for body in [&u, &p] {
+            for line in body.lines().filter(|l| fma_opens(l) != fma_calls(l).len()) {
+                refused
+                    .push(format!("{upper}: an `fma(` does not close on its line: {}", line.trim()));
+            }
+        }
+
+        let us = fma_sites(&u);
+        let ps = fma_sites(&p);
+        sites += us.len();
+        if us.is_empty() {
+            // The anchors below are update's fused targets, so a frame with
+            // none skips every leg — and peek fusing where update does not is
+            // the one direction that needs no anchor to see.
+            if !ps.is_empty() {
+                mismatches.push(format!("{upper}: peek fuses {ps:?} where update fuses nothing"));
+            }
+            continue;
+        }
+        fusing += 1;
+        let targets: BTreeSet<String> =
+            us.iter().filter(|(t, _)| t != "<expr>").map(|(t, _)| t.clone()).collect();
+        if targets.contains("<BUF>") || targets.iter().any(|t| t.starts_with("pkVal")) {
+            refused.push(format!("{upper}: a multiply-add is stored into a buffer slot"));
+        }
+        anchors += targets.len();
+        let calls = |v: &[(String, String)], want: bool| -> Vec<String> {
+            v.iter().filter(|(t, _)| (t == "<expr>") == want).map(|(_, c)| c.clone()).collect()
+        };
+        let (uf, pf) = (calls(&us, false), calls(&ps, false));
+        let (uc, pc) = (calls(&us, true), calls(&ps, true));
+        unanchored += uc.len();
+        let ua = assignments_to(&u, &targets);
+        let pa = assignments_to(&p, &targets);
+        aligned += pa.len();
+
+        if let Err(i) = subsequence(&pf, &uf) {
             mismatches.push(format!(
-                "{upper}: update fuses {} site(s), peek {}\n    update: {:?}\n    peek:   {:?}",
-                a.len(),
-                b.len(),
-                a,
-                b
+                "{upper}: peek fuses `{}`, which is not update's next site\n    update: {uf:?}\n    peek:   {pf:?}",
+                pf[i]
+            ));
+        } else if let Err(i) = subsequence(&pa, &ua) {
+            mismatches.push(format!(
+                "{upper}: peek evaluates `{}`, which update does not render that way\n    update: {ua:?}\n    peek:   {pa:?}",
+                pa[i]
+            ));
+        } else if uc != pc {
+            mismatches.push(format!(
+                "{upper}: a multiply-add in no assignment differs\n    update: {uc:?}\n    peek:   {pc:?}"
             ));
         }
     }
 
+    assert!(refused.is_empty(), "a shape this gate cannot anchor:\n{}", refused.join("\n"));
     assert!(
-        fusing_functions >= 10 && total_sites >= 20,
-        "only {fusing_functions} function(s) / {total_sites} site(s) fuse in the update \
-         frame, so this gate is not measuring anything"
+        pairs >= 170 && fusing >= 25 && sites >= 110 && anchors >= 80 && unanchored >= 4,
+        "{pairs} frame pair(s), {fusing} fusing, {sites} update site(s) over {anchors} \
+         target(s), {unanchored} unanchored — too few for this to be measuring anything"
+    );
+    assert!(
+        aligned >= 140 && collapsed >= 170,
+        "{aligned} peek statement(s) aligned on a fused target and {collapsed} select(s) \
+         collapsed — each leg needs its own floor, or one can go dead while the other \
+         reads green"
     );
     assert!(
         mismatches.is_empty(),
-        "peek's multiply-adds are not a leading run of update's, which is a silent \
-         ~1 ULP divergence in a comparison that must be bitwise:\n{}",
+        "a peek frame does not render a multiply-add the way its update frame does, which \
+         is a silent ~1 ULP divergence in a comparison that must be bitwise:\n{}",
         mismatches.join("\n")
     );
 }
@@ -728,4 +901,86 @@ fn a_peek_frame_stops_at_its_last_output_store() {
             in_step[k]
         );
     }
+}
+
+/// The locals `body` declares as a bare scalar, in declaration order. A
+/// declaration with an initializer is not one: the shadow pair is written where
+/// it is declared, and its reads are the selects.
+fn declared_scalars(body: &str) -> Vec<String> {
+    body.lines()
+        .filter_map(|l| {
+            let l = l.trim().strip_suffix(';')?;
+            let (ty, name) = l.split_once(' ')?;
+            (matches!(ty, "double" | "int" | "float" | "long" | "short" | "char")
+                && !name.is_empty()
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+            .then(|| name.to_string())
+        })
+        .collect()
+}
+
+/// Whether `text` names `word` other than as part of a longer identifier.
+fn names_word(text: &str, word: &str) -> bool {
+    text.match_indices(word).any(|(i, _)| {
+        let b = text.as_bytes();
+        let before = i == 0 || !(b[i - 1].is_ascii_alphanumeric() || b[i - 1] == b'_');
+        let j = i + word.len();
+        let after = j >= b.len() || !(b[j].is_ascii_alphanumeric() || b[j] == b'_');
+        before && after
+    })
+}
+
+/// Whether any statement of `body` READS `name` — which for a store to it is
+/// the text right of the `=`, so `x += 1` and `x = f(x)` are told apart the way
+/// the purge tells them apart. The declaration is not a statement: counting it
+/// makes every local read and the sweep vacuous.
+fn body_reads(body: &str, name: &str) -> bool {
+    body.lines().filter(|l| declared_scalars(l).is_empty()).any(|l| {
+        let scan = match assignment(l) {
+            Some((t, _)) if t == name => l.split_once('=').map_or("", |(_, r)| r),
+            _ => l,
+        };
+        names_word(scan, name)
+    })
+}
+
+/// No peek frame declares a local nothing reads.
+///
+/// The tail trim orphans them — the readers it deletes are the recurrence for
+/// the NEXT bar — and the purge is what takes the stores with them, which is
+/// what lets `temps_used` drop the declaration. Nothing else would say if that
+/// stopped: the shape is a `-Wall` warning in C and no CI job compiles with
+/// `-Werror`, while the other three backends' compilers cannot see it at all
+/// (the Rust crate allows the lint wholesale, CS0219 does not fire on a
+/// non-constant, javac has no such diagnostic).
+#[test]
+fn no_peek_frame_declares_a_local_nothing_reads() {
+    let (mut swept, mut locals) = (0usize, 0usize);
+    let mut offenders: Vec<String> = Vec::new();
+
+    for name in indicators() {
+        let Some((func, enums)) = load(&name) else { continue };
+        let src = stream_c(&func, &enums);
+        let upper = func.name.to_uppercase();
+        let Some(peek) = body_of(&src, &format!("TA_RetCode TA_{upper}_Peek(")) else { continue };
+        swept += 1;
+        for local in declared_scalars(&peek) {
+            locals += 1;
+            if !body_reads(&peek, &local) {
+                offenders.push(format!("{upper}: {local}"));
+            }
+        }
+    }
+
+    assert!(
+        swept > 170 && locals > 350,
+        "{swept} peek frame(s) over {locals} local(s) — too few for this to be measuring anything"
+    );
+    assert!(
+        offenders.is_empty(),
+        "a peek frame computes into a local nothing reads, so the trim orphaned it and \
+         nothing purged it ({} local(s)):\n{}",
+        offenders.len(),
+        offenders.join("\n")
+    );
 }

--- a/ta_codegen/output/csharp/library/src/Core_CORREL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CORREL.cs
@@ -766,8 +766,6 @@ public partial class Core
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -885,11 +883,6 @@ public partial class Core
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
@@ -1064,10 +1064,6 @@ public partial class Core
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1130,26 +1126,14 @@ public partial class Core
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.FusedMultiplyAdd(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.FusedMultiplyAdd(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -1179,23 +1163,11 @@ public partial class Core
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.FusedMultiplyAdd(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.FusedMultiplyAdd(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *

--- a/ta_codegen/output/csharp/library/src/Core_MAMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAMA.cs
@@ -1220,10 +1220,6 @@ public partial class Core
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1287,26 +1283,14 @@ public partial class Core
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.FusedMultiplyAdd(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.FusedMultiplyAdd(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -1340,23 +1324,11 @@ public partial class Core
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.FusedMultiplyAdd(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.FusedMultiplyAdd(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *

--- a/ta_codegen/output/java/fragments/Core_CORREL.java
+++ b/ta_codegen/output/java/fragments/Core_CORREL.java
@@ -731,8 +731,6 @@
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -850,11 +848,6 @@
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *

--- a/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
+++ b/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
@@ -1018,10 +1018,6 @@
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1084,26 +1080,14 @@
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -1133,23 +1117,11 @@
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *

--- a/ta_codegen/output/java/fragments/Core_MAMA.java
+++ b/ta_codegen/output/java/fragments/Core_MAMA.java
@@ -1170,10 +1170,6 @@
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1237,26 +1233,14 @@
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -1290,23 +1274,11 @@
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
@@ -9,7 +9,7 @@ package io.github.talib;
  */
 public final class BuildStamp {
     /** Digest of the generated {@code Core} method text this build carries. */
-    public static final String GENCODE_DIGEST = "920810256cf6d24f";
+    public static final String GENCODE_DIGEST = "3d9f6e0ff9d36887";
 
     private BuildStamp() {
     }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -73583,8 +73583,6 @@ public final class Core {
          CorrelStream sp = this;
          double x = 0.0;
          double y = 0.0;
-         double trailingX = 0.0;
-         double trailingY = 0.0;
          double ssX = 0.0;
          double ssY = 0.0;
          double spXY = 0.0;
@@ -73702,11 +73700,6 @@ public final class Core {
                ssY = 0.0;
             }
          }
-         /* Save the trailing values before writing the output, since the input
-          * and output might be the same array.
-          */
-         trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-         trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
          trailingIdx += 1;
          /* Output the new coefficient.
           *
@@ -87391,10 +87384,6 @@ public final class Core {
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -87457,26 +87446,14 @@ public final class Core {
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForEvenPrev3;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -87506,23 +87483,11 @@ public final class Core {
             cur_outQuadrature = Q1;
             cur_outInPhase = I1ForOddPrev3;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -108779,10 +108744,6 @@ public final class Core {
          double hilbertTempReal = 0.0;
          double detrender = 0.0;
          double Q1 = 0.0;
-         double jI = 0.0;
-         double jQ = 0.0;
-         double Q2 = 0.0;
-         double I2 = 0.0;
          double todayValue = 0.0;
          double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -108846,26 +108807,14 @@ public final class Core {
             prev_Q1_input_Even = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForEvenPrev3;
-            jI = 0 - sp.jI_Even[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Even;
             prev_jI_Even = sp.b * prev_jI_input_Even;
-            jI += prev_jI_Even;
             prev_jI_input_Even = I1ForEvenPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Even[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Even;
             prev_jQ_Even = sp.b * prev_jQ_input_Even;
-            jQ += prev_jQ_Even;
             prev_jQ_input_Even = Q1;
-            jQ *= adjustedPrevPeriod;
             if( ++hilbertIdx == 3 ) {
                hilbertIdx = 0;
             }
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
             /* The variable I1 is the detrender delayed for
              * 3 price bars.
              *
@@ -108899,23 +108848,11 @@ public final class Core {
             prev_Q1_input_Odd = detrender;
             Q1 *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * I1ForOddPrev3;
-            jI = 0 - sp.jI_Odd[hilbertIdx];
-            jI += hilbertTempReal;
-            jI -= prev_jI_Odd;
             prev_jI_Odd = sp.b * prev_jI_input_Odd;
-            jI += prev_jI_Odd;
             prev_jI_input_Odd = I1ForOddPrev3;
-            jI *= adjustedPrevPeriod;
             hilbertTempReal = sp.a * Q1;
-            jQ = 0 - sp.jQ_Odd[hilbertIdx];
-            jQ += hilbertTempReal;
-            jQ -= prev_jQ_Odd;
             prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-            jQ += prev_jQ_Odd;
             prev_jQ_input_Odd = Q1;
-            jQ *= adjustedPrevPeriod;
-            Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-            I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
             /* The varaiable I1 is the detrender delayed for
              * 3 price bars.
              *

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -73253,8 +73253,6 @@ class Core {
              CorrelStream sp = this;
              double x = 0.0;
              double y = 0.0;
-             double trailingX = 0.0;
-             double trailingY = 0.0;
              double ssX = 0.0;
              double ssY = 0.0;
              double spXY = 0.0;
@@ -73372,11 +73370,6 @@ class Core {
                    ssY = 0.0;
                 }
              }
-             /* Save the trailing values before writing the output, since the input
-              * and output might be the same array.
-              */
-             trailingX = (((trailingIdx & sp.xMask) != pkSlot0) ? sp.x_inReal0[trailingIdx & sp.xMask] : pkVal0) - shiftX;
-             trailingY = (((trailingIdx & sp.xMask) != pkSlot1) ? sp.x_inReal1[trailingIdx & sp.xMask] : pkVal1) - shiftY;
              trailingIdx += 1;
              /* Output the new coefficient.
               *
@@ -87061,10 +87054,6 @@ class Core {
              double hilbertTempReal = 0.0;
              double detrender = 0.0;
              double Q1 = 0.0;
-             double jI = 0.0;
-             double jQ = 0.0;
-             double Q2 = 0.0;
-             double I2 = 0.0;
              double todayValue = 0.0;
              double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
              double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -87127,26 +87116,14 @@ class Core {
                 cur_outQuadrature = Q1;
                 cur_outInPhase = I1ForEvenPrev3;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - sp.jI_Even[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
-                jI += prev_jI_Even;
                 prev_jI_input_Even = I1ForEvenPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - sp.jQ_Even[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
-                jQ += prev_jQ_Even;
                 prev_jQ_input_Even = Q1;
-                jQ *= adjustedPrevPeriod;
                 if( ++hilbertIdx == 3 ) {
                    hilbertIdx = 0;
                 }
-                Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
                 /* The variable I1 is the detrender delayed for
                  * 3 price bars.
                  *
@@ -87176,23 +87153,11 @@ class Core {
                 cur_outQuadrature = Q1;
                 cur_outInPhase = I1ForOddPrev3;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - sp.jI_Odd[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
-                jI += prev_jI_Odd;
                 prev_jI_input_Odd = I1ForOddPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - sp.jQ_Odd[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-                jQ += prev_jQ_Odd;
                 prev_jQ_input_Odd = Q1;
-                jQ *= adjustedPrevPeriod;
-                Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
                 /* The varaiable I1 is the detrender delayed for
                  * 3 price bars.
                  *
@@ -108449,10 +108414,6 @@ class Core {
              double hilbertTempReal = 0.0;
              double detrender = 0.0;
              double Q1 = 0.0;
-             double jI = 0.0;
-             double jQ = 0.0;
-             double Q2 = 0.0;
-             double I2 = 0.0;
              double todayValue = 0.0;
              double I1ForEvenPrev2 = sp.I1ForEvenPrev2;
              double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -108516,26 +108477,14 @@ class Core {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0 - sp.jI_Even[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
-                jI += prev_jI_Even;
                 prev_jI_input_Even = I1ForEvenPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - sp.jQ_Even[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
-                jQ += prev_jQ_Even;
                 prev_jQ_input_Even = Q1;
-                jQ *= adjustedPrevPeriod;
                 if( ++hilbertIdx == 3 ) {
                    hilbertIdx = 0;
                 }
-                Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = Math.fma(0.2, I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
                 /* The variable I1 is the detrender delayed for
                  * 3 price bars.
                  *
@@ -108569,23 +108518,11 @@ class Core {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0 - sp.jI_Odd[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
-                jI += prev_jI_Odd;
                 prev_jI_input_Odd = I1ForOddPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0 - sp.jQ_Odd[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-                jQ += prev_jQ_Odd;
                 prev_jQ_input_Odd = Q1;
-                jQ *= adjustedPrevPeriod;
-                Q2 = Math.fma(0.2, Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = Math.fma(0.2, I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
                 /* The varaiable I1 is the detrender delayed for
                  * 3 price bars.
                  *
@@ -163275,7 +163212,7 @@ class Core {
 
 public class TaCodegenServe {
     static Core core = new Core();
-    static final String SPLICED_GENCODE_DIGEST = "920810256cf6d24f";
+    static final String SPLICED_GENCODE_DIGEST = "3d9f6e0ff9d36887";
     static final int MAX_ARRAY_SIZE = 200000;
     static double[] refOpen = new double[MAX_ARRAY_SIZE];
     static double[] refHigh = new double[MAX_ARRAY_SIZE];

--- a/ta_codegen/output/rust/library/src/ta_func/correl.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/correl.rs
@@ -1186,8 +1186,6 @@ impl CorrelStream {
             let outReal = &mut outReal;
             let mut x: f64 = 0.0_f64;
             let mut y: f64 = 0.0_f64;
-            let mut trailingX: f64 = 0.0_f64;
-            let mut trailingY: f64 = 0.0_f64;
             let mut ssX: f64 = 0.0_f64;
             let mut ssY: f64 = 0.0_f64;
             let mut spXY: f64 = 0.0_f64;
@@ -1307,10 +1305,6 @@ impl CorrelStream {
                     ssY = 0.0;
                 }
             }
-            // Save the trailing values before writing the output, since the input
-            // and output might be the same array.
-            trailingX = (if ((trailingIdx & sp.xMask) as usize) != pkSlot0 { sp.x_inReal0[(trailingIdx & sp.xMask) as usize] } else { pkVal0 }) - shiftX;
-            trailingY = (if ((trailingIdx & sp.xMask) as usize) != pkSlot1 { sp.x_inReal1[(trailingIdx & sp.xMask) as usize] } else { pkVal1 }) - shiftY;
             trailingIdx += 1;
             // Output the new coefficient.
             //

--- a/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ht_phasor.rs
@@ -1413,10 +1413,6 @@ impl HtPhasorStream {
             let mut hilbertTempReal: f64 = 0.0_f64;
             let mut detrender: f64 = 0.0_f64;
             let mut Q1: f64 = 0.0_f64;
-            let mut jI: f64 = 0.0_f64;
-            let mut jQ: f64 = 0.0_f64;
-            let mut Q2: f64 = 0.0_f64;
-            let mut I2: f64 = 0.0_f64;
             let mut todayValue: f64 = 0.0_f64;
             let mut I1ForEvenPrev2 = sp.I1ForEvenPrev2;
             let mut I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1477,26 +1473,14 @@ impl HtPhasorStream {
                 (*outQuadrature) = Q1;
                 (*outInPhase) = I1ForEvenPrev3;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - sp.jI_Even[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
-                jI += prev_jI_Even;
                 prev_jI_input_Even = I1ForEvenPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
-                jQ += prev_jQ_Even;
                 prev_jQ_input_Even = Q1;
-                jQ *= adjustedPrevPeriod;
                 if { hilbertIdx += 1; hilbertIdx } == 3 {
                     hilbertIdx = 0;
                 }
-                Q2 = (0.2 as f64).mul_add(Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = (0.2 as f64).mul_add(I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
                 // The variable I1 is the detrender delayed for
                 // 3 price bars.
                 //
@@ -1525,23 +1509,11 @@ impl HtPhasorStream {
                 (*outQuadrature) = Q1;
                 (*outInPhase) = I1ForOddPrev3;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
-                jI += prev_jI_Odd;
                 prev_jI_input_Odd = I1ForOddPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-                jQ += prev_jQ_Odd;
                 prev_jQ_input_Odd = Q1;
-                jQ *= adjustedPrevPeriod;
-                Q2 = (0.2 as f64).mul_add(Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = (0.2 as f64).mul_add(I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
                 // The varaiable I1 is the detrender delayed for
                 // 3 price bars.
                 //

--- a/ta_codegen/output/rust/library/src/ta_func/mama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/mama.rs
@@ -1616,10 +1616,6 @@ impl MamaStream {
             let mut hilbertTempReal: f64 = 0.0_f64;
             let mut detrender: f64 = 0.0_f64;
             let mut Q1: f64 = 0.0_f64;
-            let mut jI: f64 = 0.0_f64;
-            let mut jQ: f64 = 0.0_f64;
-            let mut Q2: f64 = 0.0_f64;
-            let mut I2: f64 = 0.0_f64;
             let mut todayValue: f64 = 0.0_f64;
             let mut I1ForEvenPrev2 = sp.I1ForEvenPrev2;
             let mut I1ForEvenPrev3 = sp.I1ForEvenPrev3;
@@ -1681,26 +1677,14 @@ impl MamaStream {
                 prev_Q1_input_Even = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForEvenPrev3;
-                jI = 0_f64 - sp.jI_Even[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Even;
                 prev_jI_Even = sp.b * prev_jI_input_Even;
-                jI += prev_jI_Even;
                 prev_jI_input_Even = I1ForEvenPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - sp.jQ_Even[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Even;
                 prev_jQ_Even = sp.b * prev_jQ_input_Even;
-                jQ += prev_jQ_Even;
                 prev_jQ_input_Even = Q1;
-                jQ *= adjustedPrevPeriod;
                 if { hilbertIdx += 1; hilbertIdx } == 3 {
                     hilbertIdx = 0;
                 }
-                Q2 = (0.2 as f64).mul_add(Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = (0.2 as f64).mul_add(I1ForEvenPrev3 - jQ, 0.8 * sp.prevI2);
                 // The variable I1 is the detrender delayed for
                 // 3 price bars.
                 //
@@ -1733,23 +1717,11 @@ impl MamaStream {
                 prev_Q1_input_Odd = detrender;
                 Q1 *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * I1ForOddPrev3;
-                jI = 0_f64 - sp.jI_Odd[hilbertIdx];
-                jI += hilbertTempReal;
-                jI -= prev_jI_Odd;
                 prev_jI_Odd = sp.b * prev_jI_input_Odd;
-                jI += prev_jI_Odd;
                 prev_jI_input_Odd = I1ForOddPrev3;
-                jI *= adjustedPrevPeriod;
                 hilbertTempReal = sp.a * Q1;
-                jQ = 0_f64 - sp.jQ_Odd[hilbertIdx];
-                jQ += hilbertTempReal;
-                jQ -= prev_jQ_Odd;
                 prev_jQ_Odd = sp.b * prev_jQ_input_Odd;
-                jQ += prev_jQ_Odd;
                 prev_jQ_input_Odd = Q1;
-                jQ *= adjustedPrevPeriod;
-                Q2 = (0.2 as f64).mul_add(Q1 + jI, 0.8 * sp.prevQ2);
-                I2 = (0.2 as f64).mul_add(I1ForOddPrev3 - jQ, 0.8 * sp.prevI2);
                 // The varaiable I1 is the detrender delayed for
                 // 3 price bars.
                 //


### PR DESCRIPTION
Closes #328.

`purge_dead_temp_stores` — the general form the issue asks for: a store to a frame temp nothing
reads, with no effect on either side, removed, to a fixpoint. Whole-variable, so it needs no
liveness lattice, and the fixpoint is what pays — deleting `Q2`/`I2` orphans the whole `jI` and
`jQ` Hilbert chains in both parity arms of MAMA and HT_PHASOR.

    gcc -Wall -Wextra over src/ta_func/*.c:   6 warnings -> 0
    generated:                               -377 lines, all four backends identically

Three things worth knowing:

- **`compound` is a rendering flag, not a semantic one.** The IR keeps the self-read of `x += y`
  inside the value. Counting it holds every accumulator alive by its own update and the pass
  stalls at the six warnings; discounting only the value's HEAD occurrence retires the chains,
  and `x += x * 2` still reads `x`.
- **`fma()` needs no labelling.** It is not an `Expr::FuncCall` in this IR at all (`grep fma
  src/ir.rs` is empty) — fusion is a render-time decision on a `BinOp` — so refusing every call
  costs nothing. `ir_cleanup::expr_writes` and `condition_writes` were byte-identical copies of
  that predicate; both now delegate.
- **Placement is forced.** Between `validate_peekable` and the shadow election: earlier the purge
  could turn a refusal into an acceptance and flip the buffer election that #321 deliberately
  decides on the untrimmed transition; later it would orphan the shadows `prune_dead_shadows`
  counts.

## There is no speedup, and the title is still right

At the shipped `-O2 -ffp-contract=off -fno-math-errno` the disassembly of the three `_Peek` frames
is **byte-identical** before and after — gcc already DCEs all of it, glibc's `fma` being `const`.
`stream_ab --call=peek` vs dev: Rust MAMA **+2.2%** / HT_PHASOR +1.9%, Java HT_PHASOR −4.3% on a
6.7% spread, C# MAMA −2.3% on a 15.4% median control spread. Nothing above its own control noise
in any of the four.

This is the cleanup half of the streaming effort rather than the speed half. What it actually
leaves behind is worth more than the warnings: MAMA's peek now carries `sp->prev_jI_Even = …` and
its `jQ` twin in both arms with **exactly one mention each, their own store** — the readers that
held them went with the chains. That is scratch with no scratch uses left, i.e. #316's material.

## The fusion gate is re-anchored, not worked around

The incumbent anchored peek's fused sites as a **prefix** of update's; the purge deletes sites from
the middle (MAMA keeps 3 of 11). Relaxing to a bare subsequence is green on exactly the divergence
the gate exists for — unfusing a site *deletes* it from a list of calls.

`a_peek_frame_fuses_every_multiply_add_it_still_evaluates` decides survival from the peek text by
the assignment **target** (nothing done to the expression moves one) and asserts two things one
list cannot: peek's calls are a subsequence of update's, **and** for every target update fuses
into, the statements peek still assigns to it are a subsequence of update's *by whole statement*.
The second tells "the statement was deleted" from "the statement is there and lost its `fma(`".

Sabotage-proved on the peek text, over the corpus:

| sabotage | fires |
|---|---|
| unfuse a surviving site | 29/29 |
| reorder two sites | 16/16 |
| drop an `fma`, keep its statement | 29/29 |
| add an `fma` peek should not have | 29/29 |
| change an argument | 29/29 |
| fuse where update fuses nothing | 147/147 |

**Two pre-existing holes went with it.** `undo_selects` was **dead** — it scanned the whole body,
so `find("pkSlot")` landed on the `int pkSlot0 = -1;` declaration, found no enclosing `(` and broke
out, collapsing **0 of the 50** select-bearing bodies while its doc claimed the leg was armed. It
now collapses 178 statements over 50, carries its own floor, and has a paren-balance refusal —
because my first repair unbalanced 37 lines in 18 functions and a counter of *changed* lines could
not tell. And `fma_calls` walked past **nested** calls, so the gate saw 114 of 125 sites.

## A gate that fails when the purge stops purging

`no_peek_frame_declares_a_local_nothing_reads` sweeps all 178 peek frames, 390 locals. Disabling
the purge reports gcc's exact six; reverting only the compound head exclusion reports `jI`/`jQ` in
MAMA and HT_PHASOR. Nothing else would — no CI job compiles C with `-Werror`, the Rust crate allows
the lint wholesale, CS0219 does not fire on a non-constant, javac has no such diagnostic.

## What it deliberately does not do

Whole-variable, so a dead store to a still-**live** variable stays: BETA's `x`/`y` (read in the
earlier rebuild loop) and `hilbertTempReal = sp->a * Q1;`. Reaching those needs backward liveness
over loops and branches, for 12 statements no compiler in the tree warns about and every optimizer
already removes.

One latent thing found and left alone: C's **composed** peek declares producer temps unfiltered
(`c_stream.rs`, no `temps_used`), unlike `emit_step_inner`. Unreachable today — STOCH/STOCHF have
one temp each and both are read — and the new sweep above catches it loudly if it ever is, but the
fix reorders emitted declarations so it does not belong in this diff. Filed separately.

## Verified

898 generator tests · clippy `-D warnings` on both crates · 544 doctests · the three `javac` steps ·
`regen-check` on a clean tree · `ta_regtest` · `--codegen` all four languages · `xlang-hash`
**bit-identical over 178 functions** · `stream_sanitize` 436/436 legs, ASan/UBSan/LSan clean, 0
value mismatches.

Supersedes #329, closed with thanks.

https://claude.ai/code/session_01KFh1oJzwgHKJuzMswb4dRn
