### PR TITLE
fix(codegen): the composed peek frame filters its producer temps (#334)

### DIFF
--- a/src/ta_func/ta_STOCH.c
+++ b/src/ta_func/ta_STOCH.c
@@ -635,9 +635,9 @@ static void TA_STOCH_ReleaseImpl( struct TA_STOCH_Stream *sp )
 /* Private function, not in public API. */
 static TA_RetCode TA_STOCH_StepImpl( struct TA_STOCH_Stream *sp, double inHigh, double inLow, double inClose, double *outSlowK, double *outSlowD )
 {
-   double tmp;
    double cur_tempBuffer = 0.0;
    double cur_outSlowD = 0.0;
+   double tmp;
 
    if( sp->today >= 1073741824 )
    {
@@ -1179,9 +1179,9 @@ TA_LIB_API TA_RetCode TA_STOCH_Peek( const TA_STOCH_Stream *stream, double inHig
 {
    struct TA_STOCH_Stream scratch;
    struct TA_STOCH_Stream *sp = &scratch;
-   double tmp;
    double cur_tempBuffer = 0.0;
    double cur_outSlowD = 0.0;
+   double tmp;
    int pkSlot0 = -1;
    double pkVal0 = 0.0;
    int pkSlot1 = -1;

--- a/src/ta_func/ta_STOCHF.c
+++ b/src/ta_func/ta_STOCHF.c
@@ -572,9 +572,9 @@ static void TA_STOCHF_ReleaseImpl( struct TA_STOCHF_Stream *sp )
 /* Private function, not in public API. */
 static TA_RetCode TA_STOCHF_StepImpl( struct TA_STOCHF_Stream *sp, double inHigh, double inLow, double inClose, double *outFastK, double *outFastD )
 {
-   double tmp;
    double cur_tempBuffer = 0.0;
    double cur_outFastD = 0.0;
+   double tmp;
 
    if( sp->today >= 1073741824 )
    {
@@ -1065,9 +1065,9 @@ TA_LIB_API TA_RetCode TA_STOCHF_Peek( const TA_STOCHF_Stream *stream, double inH
 {
    struct TA_STOCHF_Stream scratch;
    struct TA_STOCHF_Stream *sp = &scratch;
-   double tmp;
    double cur_tempBuffer = 0.0;
    double cur_outFastD = 0.0;
+   double tmp;
    int pkSlot0 = -1;
    double pkVal0 = 0.0;
    int pkSlot1 = -1;

--- a/ta_codegen/generator/src/backends/c_stream.rs
+++ b/ta_codegen/generator/src/backends/c_stream.rs
@@ -1460,11 +1460,6 @@ fn emit_composed_frame_body(
     counter: &Cell<usize>,
     frame: StepFrame,
 ) {
-    if let Some(model) = &cp.producer {
-        for (name, ty) in &model.temps {
-            let _ = writeln!(decls, "   {};", c_decl(ty, name));
-        }
-    }
     for (name, ty) in &cp.map_temps {
         let _ = writeln!(decls, "   {};", c_decl(ty, name));
     }
@@ -1503,19 +1498,23 @@ fn emit_composed_frame_body(
         };
         let transition = streaming::build_transition(model, &names)
             .unwrap_or_else(|e| panic!("streaming transition: {e}"));
-        // The shadow locals join the declarations above, ahead of the rebase:
-        // the extrema rebase is a STATEMENT, and a declaration after it would
-        // be C99, which this tier's producers (STOCH, STOCHF) would be the only
-        // place in the emitted library to need.
-        let transition = match frame {
-            StepFrame::Commit => transition,
+        let (transition, temps, shadow_decls) = match frame {
+            StepFrame::Commit => (transition, model.temps.clone(), String::new()),
             StepFrame::Peek => {
                 let pt = streaming::peek_transition_widest(model, &names, &transition, None)
                     .unwrap_or_else(|e| panic!("{}: {e}", func.name));
-                decls.push_str(&peek_shadow_decls(&pt.shadows, &pt.slot_temps, 3));
-                answer_bare_returns(&pt.body)
+                let body = answer_bare_returns(&pt.body);
+                let temps = streaming::temps_used(&model.temps, &body);
+                (body, temps, peek_shadow_decls(&pt.shadows, &pt.slot_temps, 3))
             }
         };
+        // Into `decls`, both of them: the extrema rebase below is a STATEMENT,
+        // and a declaration after it would be C99, which this tier's producers
+        // would be the only place in the emitted library to need.
+        for (name, ty) in &temps {
+            let _ = writeln!(decls, "   {};", c_decl(ty, name));
+        }
+        decls.push_str(&shadow_decls);
         emit_extrema_rebase(o, model);
         let mut body_c = String::new();
         for s in &transition {


### PR DESCRIPTION
Closes #334.

`emit_step_inner` filters the peek frame's temp declarations through `temps_used`, because that
frame **deletes statements** — the #321 tail trim and the #328 purge — and a declaration nothing
then reads is a `-Wall` warning. `emit_composed_frame_body` declared `model.temps` unfiltered for
both frames. Java, C# and Rust all suppress their unfiltered block on the peek frame
(`java_stream.rs`'s `if let (Some(model), false) = (&cp.producer, frame)` and its two twins); C was
the odd one out.

The declaration loop moves down into the block where the transition is known, so it can be filtered
there. **Whole regeneration delta: 4 hunks, 2 files, C only** — `double tmp;` moves after the
`cur_*` scalars in STOCH and STOCHF, both frames. No declaration is added or removed anywhere in
the shipped tree.

## Not unreachable — unreached, and two statements away

I said in the issue that this was unreachable. That was wrong, and the sharper framing is what makes
the change worth having. Adding to `ta_codegen/input/stoch/stoch.c` after the last `tempBuffer`
store:

```c
tmp2 = highest - lowest;
diff  = tmp2 / 100.0;
```

| | `TA_STOCH_Peek` | gcc | `no_peek_frame_declares_a_local_nothing_reads` |
|---|---|---|---|
| HEAD | `double tmp2;` emitted | `warning: unused variable 'tmp2'` | **fails**, `STOCH: tmp2` |
| this PR | absent (`StepImpl` keeps it) | clean | passes |

Rust, Java and C# emit no `tmp2` in their peek frames on the same input — C really was the only one.

## Why no synthetic fixture

The gate that already exists is the standing detector: `no_peek_frame_declares_a_local_nothing_reads`
sweeps the composed peeks, and `double tmp;` from this very loop is inside `TA_STOCH_Peek`.

A composed-producer fixture (SYNTH15) was prototyped and dropped. The shape does satisfy
`analyze_composed` — a top-level `endIdx` loop writing exactly one intermediate series, a tail
sub-call to `sma()`, a temp written after the series store — but the draft writes **13 values where
its range allows 12** (`1 + sma_lookback` against a `today` start of `startIdx - sma_lookback - 1`).
Fixing that, hand-deriving a `GOLDEN` row, and getting four-language bitwise agreement for a
path-dependent composed function is not what an unreached declaration is worth. Notes for anyone who
wants it later are in the issue.

## Also

`cp.map_temps` stays unfiltered, in all four backends — the trim only touches the producer
transition, never the combine maps. And the pre-existing C89 comment ("a declaration after the
rebase would be C99") was stranded by the move; it now sits on the two `decls` pushes it actually
governs.

## Verified

`regen-check` on a clean tree · 899 generator tests · clippy `-D warnings` · `ta_regtest` · gcc
`-Wall -Wextra` over `src/ta_func/*.c` unchanged at 0 · C89 checked with
`-Wdeclaration-after-statement` on both changed files.

https://claude.ai/code/session_01KFh1oJzwgHKJuzMswb4dRn
