### PR TITLE
refactor(streaming): managed peek frames stop seeding output locals they overwrite (#343)

### DIFF
--- a/ta_codegen/generator/src/backends/csharp_stream.rs
+++ b/ta_codegen/generator/src/backends/csharp_stream.rs
@@ -1634,6 +1634,17 @@ fn peek_frame_arm_named(
         let (cty, default) = field_type_and_default(ty);
         let _ = writeln!(out, "{pad}{cty} {name} = {default};");
     }
+    // An output local whose every mentioning path writes it before any read
+    // does not need the handle's value: a peek commits nothing, so the previous
+    // bar's output is never an input to the transition (issue #343). Seeding it
+    // anyway is a dead field load on every call. Anything the analysis cannot
+    // prove keeps the seed.
+    let dead_seeds: BTreeSet<String> = func
+        .outputs
+        .iter()
+        .map(|o| format!("cur_{}", o.name))
+        .filter(|n| locals.contains(n) && streaming::peek_seed_is_dead(&body_ir, n))
+        .collect();
     for name in &locals {
         if predeclared.contains(name) {
             continue;
@@ -1645,6 +1656,9 @@ fn peek_frame_arm_named(
         if let Some(elem) = cty.strip_suffix("[]") {
             let _ = writeln!(out, "{pad}{cty} {name} = new {elem}[sp.{name}.Length];");
             let _ = writeln!(out, "{pad}Array.Copy( sp.{name}, {name}, sp.{name}.Length );");
+        } else if dead_seeds.contains(name) {
+            let zero = if cty == "int" { "0" } else { "0.0" };
+            let _ = writeln!(out, "{pad}{cty} {name} = {zero};");
         } else {
             let _ = writeln!(out, "{pad}{cty} {name} = sp.{name};");
         }

--- a/ta_codegen/generator/src/backends/java_stream.rs
+++ b/ta_codegen/generator/src/backends/java_stream.rs
@@ -1507,6 +1507,17 @@ fn peek_frame_arm_named(
         let (jty, default) = field_type_and_default(ty);
         let _ = writeln!(out, "{pad}{jty} {name} = {default};");
     }
+    // An output local whose every mentioning path writes it before any read
+    // does not need the handle's value: a peek commits nothing, so the previous
+    // bar's output is never an input to the transition (issue #343). Seeding it
+    // anyway is a dead field load on every call. Anything the analysis cannot
+    // prove keeps the seed.
+    let dead_seeds: BTreeSet<String> = func
+        .outputs
+        .iter()
+        .map(|o| format!("cur_{}", o.name))
+        .filter(|n| locals.contains(n) && streaming::peek_seed_is_dead(&body_ir, n))
+        .collect();
     for name in &locals {
         if predeclared.contains(name) {
             continue;
@@ -1514,7 +1525,9 @@ fn peek_frame_arm_named(
         let jty = types.get(name.as_str()).copied()?;
         // A Java array field is a reference: taking it plain would write the
         // handle through it.
-        let init = if jty.ends_with("[]") {
+        let init = if dead_seeds.contains(name) {
+            if jty == "int" { "0".to_string() } else { "0.0".to_string() }
+        } else if jty.ends_with("[]") {
             format!("sp.{name}.clone()")
         } else {
             format!("sp.{name}")

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -865,6 +865,89 @@ impl StreamModel<'_> {
 // IR walking helpers
 // ---------------------------------------------------------------------------
 
+/// What a linear scan of a statement list concluded about one scalar local.
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum FirstUse {
+    NotMentioned,
+    WriteFirst,
+    ReadOrUnknown,
+}
+
+/// Whether seeding `var` from the handle at the top of a peek frame is dead:
+/// every path that mentions it WRITES it before any read (issue #343). The
+/// analysis is deliberately conservative — a mention inside a loop or switch,
+/// a compound assignment, or an `if` whose arms disagree all answer `false`,
+/// which keeps the seed. `false` never mis-renders; it only leaves the one
+/// field load this exists to drop.
+pub fn peek_seed_is_dead(body: &[Statement], var: &str) -> bool {
+    fn reads(e: &Expr, var: &str) -> bool {
+        let mut hit = false;
+        walk_expr(e, &mut |x| match x {
+            Expr::Var(v) if v == var => hit = true,
+            Expr::ArrayAccess(n, _) if n == var => hit = true,
+            _ => {}
+        });
+        hit
+    }
+    fn mentions_stmts(list: &[Statement], var: &str) -> bool {
+        let mut hit = false;
+        for st in list {
+            walk_stmt_exprs(st, &mut |e| {
+                if reads(e, var) {
+                    hit = true;
+                }
+            });
+        }
+        hit
+    }
+    fn scan(list: &[Statement], var: &str) -> FirstUse {
+        for st in list {
+            match st {
+                Statement::Assign { target: Expr::Var(t), value, compound } if t == var => {
+                    if *compound || reads(value, var) {
+                        return FirstUse::ReadOrUnknown;
+                    }
+                    return FirstUse::WriteFirst;
+                }
+                Statement::If { condition, then_body, else_body, .. } => {
+                    if reads(condition, var) {
+                        return FirstUse::ReadOrUnknown;
+                    }
+                    let t = scan(then_body, var);
+                    let e = scan(else_body, var);
+                    // An arm that ends in `return` never rejoins the code
+                    // below the `if`; writing there settles that path for
+                    // good. This is the period-1 identity branch's exact
+                    // shape: `if( p == 1 ) { cur_x = in; return cur_x; }`.
+                    let t_exits = matches!(then_body.last(), Some(Statement::Return { .. }));
+                    let e_exits = matches!(else_body.last(), Some(Statement::Return { .. }));
+                    match (t, e) {
+                        (FirstUse::NotMentioned, FirstUse::NotMentioned) => {}
+                        (FirstUse::WriteFirst, FirstUse::WriteFirst) => {
+                            return FirstUse::WriteFirst;
+                        }
+                        (FirstUse::WriteFirst, FirstUse::NotMentioned) if t_exits => {}
+                        (FirstUse::NotMentioned, FirstUse::WriteFirst) if e_exits => {}
+                        // One arm writes without exiting and the other does not
+                        // touch it: the untouched path leaves the seed live
+                        // downstream.
+                        _ => return FirstUse::ReadOrUnknown,
+                    }
+                }
+                // A loop may run zero times and a switch arm is data-picked;
+                // any mention inside is treated as a read.
+                other => {
+                    if mentions_stmts(std::slice::from_ref(other), var) {
+                        return FirstUse::ReadOrUnknown;
+                    }
+                }
+            }
+        }
+        FirstUse::NotMentioned
+    }
+    scan(body, var) == FirstUse::WriteFirst
+}
+
 /// Visit every expression held by a statement tree (conditions, initializers,
 /// targets, values), recursing into nested statements.
 pub fn walk_stmt_exprs(s: &Statement, f: &mut dyn FnMut(&Expr)) {

--- a/ta_codegen/generator/tests/update_and_fill_suite.rs
+++ b/ta_codegen/generator/tests/update_and_fill_suite.rs
@@ -19,7 +19,7 @@
 //! Both are cross-backend, so they live together here rather than one copy per
 //! per-language suite.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use ta_codegen_lib::helper_registry::HelperRegistry;
 use ta_codegen_lib::registry::Registry;
@@ -319,6 +319,55 @@ fn no_managed_handle_caches_the_multi_output_value() {
         assert!(
             section(func, lang).contains(ty),
             "{func}/{lang} has no {ty}, so its lack of a cache is not evidence"
+        );
+    }
+}
+
+/// A peek frame does not seed an output local from the handle when its own
+/// body provably overwrites it before any read (issue #343): a peek commits
+/// nothing, so the previous bar's output is never an input to the transition,
+/// and the seed was one dead field load per output per call. Swept over both
+/// managed backends — C writes through an out-param and Rust rebinds its
+/// locals, so only these two ever carried the shape. Exact-set in both
+/// directions: a frame that grows a seed back fails, and so does a change
+/// that silently drops the one seed the analysis deliberately keeps — IMI,
+/// whose sole store sits inside the period loop, and the IR cannot prove a
+/// loop body runs.
+#[test]
+fn no_managed_peek_seeds_a_dead_output_local() {
+    for (lang, needle) in [("java", " peek("), ("csharp", " Peek(")] {
+        let mut swept = 0usize;
+        let mut seedless = 0usize;
+        let mut seeded: BTreeSet<String> = BTreeSet::new();
+        for name in streaming_funcs() {
+            let (func, _) = load(&name);
+            let sect = section(&name, lang);
+            if !sect.contains(needle) {
+                continue;
+            }
+            let body = body_of(&sect, needle);
+            swept += 1;
+            let mut any = false;
+            for out in &func.outputs {
+                let seed = format!("cur_{} = sp.cur_{};", out.name, out.name);
+                if body.contains(&seed) {
+                    any = true;
+                    seeded.insert(name.clone());
+                }
+            }
+            if !any {
+                seedless += 1;
+            }
+        }
+        // Non-vacuity floors: the sweep must have found the corpus AND the
+        // subject. A needle that stops matching peeks would zero `swept`; an
+        // emitter that re-grew every seed would zero `seedless`.
+        assert!(swept > 150, "{lang}: swept only {swept} peek frames");
+        assert!(seedless > 150, "{lang}: only {seedless} seed-free frames");
+        let expected: BTreeSet<String> = ["imi".to_string()].into_iter().collect();
+        assert_eq!(
+            seeded, expected,
+            "{lang}: peek frames seeding an output local from the handle"
         );
     }
 }

--- a/ta_codegen/output/csharp/library/src/Core_AC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AC.cs
@@ -711,7 +711,7 @@ public partial class Core
          double medianPrice = 0.0;
          double osc = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int oscBuffer_Idx = sp.oscBuffer_Idx;
          double sumFast = sp.sumFast;
          double sumSignal = sp.sumSignal;

--- a/ta_codegen/output/csharp/library/src/Core_ACCBANDS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ACCBANDS.cs
@@ -629,9 +629,9 @@ public partial class Core
          double tempMiddle = 0.0;
          double tempLower = 0.0;
          double tempReal = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double periodTotalLower = sp.periodTotalLower;
          double periodTotalMiddle = sp.periodTotalMiddle;
          double periodTotalUpper = sp.periodTotalUpper;

--- a/ta_codegen/output/csharp/library/src/Core_ACOS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ACOS.cs
@@ -333,7 +333,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ACOS", "peek", RetCode.BadParam);
          AcosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Acos(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_AD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AD.cs
@@ -427,7 +427,7 @@ public partial class Core
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          high = inHigh;
          low = inLow;
          tmp = high - low;

--- a/ta_codegen/output/csharp/library/src/Core_ADD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ADD.cs
@@ -337,7 +337,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal0) || !double.IsFinite(inReal1) ) throw Core.StreamFailure("ADD", "peek", RetCode.BadParam);
          AddStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 + inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_ADOSC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ADOSC.cs
@@ -625,7 +625,7 @@ public partial class Core
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double fastEMA = sp.fastEMA;
          double slowEMA = sp.slowEMA;
          high = inHigh;

--- a/ta_codegen/output/csharp/library/src/Core_ADX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ADX.cs
@@ -950,7 +950,7 @@ public partial class Core
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevADX = sp.prevADX;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;

--- a/ta_codegen/output/csharp/library/src/Core_AO.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AO.cs
@@ -584,7 +584,7 @@ public partial class Core
          AoStream sp = this;
          double medianPrice = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumFast = sp.sumFast;
          double sumSlow = sp.sumSlow;
          int pkSlot0 = -1;

--- a/ta_codegen/output/csharp/library/src/Core_AROON.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AROON.cs
@@ -575,8 +575,8 @@ public partial class Core
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) ) throw Core.StreamFailure("AROON", "peek", RetCode.BadParam);
          AroonStream sp = this;
          double tmp = 0.0;
-         double cur_outAroonDown = sp.cur_outAroonDown;
-         double cur_outAroonUp = sp.cur_outAroonUp;
+         double cur_outAroonDown = 0.0;
+         double cur_outAroonUp = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_AROONOSC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AROONOSC.cs
@@ -566,7 +566,7 @@ public partial class Core
          AroonoscStream sp = this;
          double tmp = 0.0;
          double aroon = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_ASIN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ASIN.cs
@@ -333,7 +333,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ASIN", "peek", RetCode.BadParam);
          AsinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Asin(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_ATAN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ATAN.cs
@@ -328,7 +328,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ATAN", "peek", RetCode.BadParam);
          AtanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Atan(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_ATR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ATR.cs
@@ -627,7 +627,7 @@ public partial class Core
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;

--- a/ta_codegen/output/csharp/library/src/Core_AVGDEV.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AVGDEV.cs
@@ -422,7 +422,7 @@ public partial class Core
          double todaySum = 0.0;
          double todayDev = 0.0;
          int i = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          pkSlot0 = sp.winPos_i;

--- a/ta_codegen/output/csharp/library/src/Core_AVGPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_AVGPRICE.cs
@@ -368,7 +368,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("AVGPRICE", "peek", RetCode.BadParam);
          AvgpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose + inOpen) / 4;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_BETA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_BETA.cs
@@ -954,7 +954,7 @@ public partial class Core
          double S_y = sp.S_y;
          double S_yy = sp.S_yy;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double last_price_x = sp.last_price_x;

--- a/ta_codegen/output/csharp/library/src/Core_BOP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_BOP.cs
@@ -389,7 +389,7 @@ public partial class Core
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("BOP", "peek", RetCode.BadParam);
          BopStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* BOP is a fraction of the bar's own range, so it is scale-free and the
           * divisor only has to be positive. An exact test, not the fixed
           * TA_IS_ZERO_OR_NEG band it used to be: the range carries the quote unit,

--- a/ta_codegen/output/csharp/library/src/Core_CCI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CCI.cs
@@ -559,7 +559,7 @@ public partial class Core
          double theAverage = 0.0;
          double lastValue = 0.0;
          int j = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          lastValue = (inHigh + inLow + inClose) / 3;

--- a/ta_codegen/output/csharp/library/src/Core_CDL2CROWS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL2CROWS.cs
@@ -492,7 +492,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL2CROWS", "peek", RetCode.BadParam);
          Cdl2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDL3BLACKCROWS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3BLACKCROWS.cs
@@ -517,7 +517,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3BLACKCROWS", "peek", RetCode.BadParam);
          Cdl3blackcrowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDL3INSIDE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3INSIDE.cs
@@ -537,7 +537,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3INSIDE", "peek", RetCode.BadParam);
          Cdl3insideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDL3LINESTRIKE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3LINESTRIKE.cs
@@ -519,7 +519,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3LINESTRIKE", "peek", RetCode.BadParam);
          Cdl3linestrikeStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDL3OUTSIDE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3OUTSIDE.cs
@@ -428,7 +428,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3OUTSIDE", "peek", RetCode.BadParam);
          Cdl3outsideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 0 - 1 && sp.lag1_inClose > sp.lag2_inOpen && sp.lag1_inOpen < sp.lag2_inClose && inClose > sp.lag1_inClose || ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 1 && sp.lag1_inOpen > sp.lag2_inClose && sp.lag1_inClose < sp.lag2_inOpen && inClose < sp.lag1_inClose ) {
             /* white engulfs black */
             /* third candle higher */

--- a/ta_codegen/output/csharp/library/src/Core_CDL3STARSINSOUTH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3STARSINSOUTH.cs
@@ -657,7 +657,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3STARSINSOUTH", "peek", RetCode.BadParam);
          Cdl3starsinsouthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDL3WHITESOLDIERS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDL3WHITESOLDIERS.cs
@@ -678,7 +678,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDL3WHITESOLDIERS", "peek", RetCode.BadParam);
          Cdl3whitesoldiersStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLABANDONEDBABY.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLABANDONEDBABY.cs
@@ -609,7 +609,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLABANDONEDBABY", "peek", RetCode.BadParam);
          CdlabandonedbabyStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLADVANCEBLOCK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLADVANCEBLOCK.cs
@@ -733,7 +733,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLADVANCEBLOCK", "peek", RetCode.BadParam);
          CdladvanceblockStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLBELTHOLD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLBELTHOLD.cs
@@ -519,7 +519,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLBELTHOLD", "peek", RetCode.BadParam);
          CdlbeltholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLBREAKAWAY.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLBREAKAWAY.cs
@@ -509,7 +509,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLBREAKAWAY", "peek", RetCode.BadParam);
          CdlbreakawayStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLCLOSINGMARUBOZU.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLCLOSINGMARUBOZU.cs
@@ -514,7 +514,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLCLOSINGMARUBOZU", "peek", RetCode.BadParam);
          CdlclosingmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLCONCEALBABYSWALL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLCONCEALBABYSWALL.cs
@@ -518,7 +518,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLCONCEALBABYSWALL", "peek", RetCode.BadParam);
          CdlconcealbabyswallStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLCOUNTERATTACK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLCOUNTERATTACK.cs
@@ -539,7 +539,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLCOUNTERATTACK", "peek", RetCode.BadParam);
          CdlcounterattackStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLDARKCLOUDCOVER.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLDARKCLOUDCOVER.cs
@@ -510,7 +510,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLDARKCLOUDCOVER", "peek", RetCode.BadParam);
          CdldarkcloudcoverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLDOJI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLDOJI.cs
@@ -458,7 +458,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLDOJI", "peek", RetCode.BadParam);
          CdldojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLDOJISTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLDOJISTAR.cs
@@ -536,7 +536,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLDOJISTAR", "peek", RetCode.BadParam);
          CdldojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLDRAGONFLYDOJI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLDRAGONFLYDOJI.cs
@@ -523,7 +523,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLDRAGONFLYDOJI", "peek", RetCode.BadParam);
          CdldragonflydojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLENGULFING.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLENGULFING.cs
@@ -438,7 +438,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLENGULFING", "peek", RetCode.BadParam);
          CdlengulfingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((inClose >= inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && (inClose >= sp.lag1_inOpen && inOpen < sp.lag1_inClose || inClose > sp.lag1_inOpen && inOpen <= sp.lag1_inClose) || ((inClose >= inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && (inOpen >= sp.lag1_inClose && inClose < sp.lag1_inOpen || inOpen > sp.lag1_inClose && inClose <= sp.lag1_inOpen) ) {
             /* white engulfs black */
             /* black engulfs white */

--- a/ta_codegen/output/csharp/library/src/Core_CDLEVENINGDOJISTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLEVENINGDOJISTAR.cs
@@ -611,7 +611,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLEVENINGDOJISTAR", "peek", RetCode.BadParam);
          CdleveningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLEVENINGSTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLEVENINGSTAR.cs
@@ -579,7 +579,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLEVENINGSTAR", "peek", RetCode.BadParam);
          CdleveningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLGAPSIDESIDEWHITE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLGAPSIDESIDEWHITE.cs
@@ -542,7 +542,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLGAPSIDESIDEWHITE", "peek", RetCode.BadParam);
          CdlgapsidesidewhiteStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLGRAVESTONEDOJI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLGRAVESTONEDOJI.cs
@@ -523,7 +523,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLGRAVESTONEDOJI", "peek", RetCode.BadParam);
          CdlgravestonedojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHAMMER.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHAMMER.cs
@@ -612,7 +612,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHAMMER", "peek", RetCode.BadParam);
          CdlhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHANGINGMAN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHANGINGMAN.cs
@@ -615,7 +615,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHANGINGMAN", "peek", RetCode.BadParam);
          CdlhangingmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHARAMI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHARAMI.cs
@@ -551,7 +551,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHARAMI", "peek", RetCode.BadParam);
          CdlharamiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHARAMICROSS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHARAMICROSS.cs
@@ -551,7 +551,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHARAMICROSS", "peek", RetCode.BadParam);
          CdlharamicrossStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHIGHWAVE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHIGHWAVE.cs
@@ -516,7 +516,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHIGHWAVE", "peek", RetCode.BadParam);
          CdlhighwaveStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHIKKAKE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHIKKAKE.cs
@@ -521,7 +521,7 @@ public partial class Core
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHIKKAKE", "peek", RetCode.BadParam);
          CdlhikkakeStream sp = this;
          int cd = sp.cd;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternResult = sp.patternResult;
          double savedHigh = sp.savedHigh;
          double savedLow = sp.savedLow;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHIKKAKEMOD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHIKKAKEMOD.cs
@@ -595,7 +595,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHIKKAKEMOD", "peek", RetCode.BadParam);
          CdlhikkakemodStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternCount = sp.patternCount;
          double patternHigh = sp.patternHigh;
          double patternLow = sp.patternLow;

--- a/ta_codegen/output/csharp/library/src/Core_CDLHOMINGPIGEON.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLHOMINGPIGEON.cs
@@ -532,7 +532,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLHOMINGPIGEON", "peek", RetCode.BadParam);
          CdlhomingpigeonStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLIDENTICAL3CROWS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLIDENTICAL3CROWS.cs
@@ -570,7 +570,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLIDENTICAL3CROWS", "peek", RetCode.BadParam);
          Cdlidentical3crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLINNECK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLINNECK.cs
@@ -537,7 +537,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLINNECK", "peek", RetCode.BadParam);
          CdlinneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLINVERTEDHAMMER.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLINVERTEDHAMMER.cs
@@ -564,7 +564,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLINVERTEDHAMMER", "peek", RetCode.BadParam);
          CdlinvertedhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLKICKING.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLKICKING.cs
@@ -542,7 +542,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLKICKING", "peek", RetCode.BadParam);
          CdlkickingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLKICKINGBYLENGTH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLKICKINGBYLENGTH.cs
@@ -540,7 +540,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLKICKINGBYLENGTH", "peek", RetCode.BadParam);
          CdlkickingbylengthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLLADDERBOTTOM.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLLADDERBOTTOM.cs
@@ -504,7 +504,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLLADDERBOTTOM", "peek", RetCode.BadParam);
          CdlladderbottomStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLLONGLEGGEDDOJI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLLONGLEGGEDDOJI.cs
@@ -515,7 +515,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLLONGLEGGEDDOJI", "peek", RetCode.BadParam);
          CdllongleggeddojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLLONGLINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLLONGLINE.cs
@@ -497,7 +497,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLLONGLINE", "peek", RetCode.BadParam);
          CdllonglineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLMARUBOZU.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLMARUBOZU.cs
@@ -511,7 +511,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLMARUBOZU", "peek", RetCode.BadParam);
          CdlmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLMATCHINGLOW.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLMATCHINGLOW.cs
@@ -486,7 +486,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLMATCHINGLOW", "peek", RetCode.BadParam);
          CdlmatchinglowStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLMATHOLD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLMATHOLD.cs
@@ -611,7 +611,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLMATHOLD", "peek", RetCode.BadParam);
          CdlmatholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLMORNINGDOJISTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLMORNINGDOJISTAR.cs
@@ -615,7 +615,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLMORNINGDOJISTAR", "peek", RetCode.BadParam);
          CdlmorningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLMORNINGSTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLMORNINGSTAR.cs
@@ -585,7 +585,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLMORNINGSTAR", "peek", RetCode.BadParam);
          CdlmorningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLONNECK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLONNECK.cs
@@ -537,7 +537,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLONNECK", "peek", RetCode.BadParam);
          CdlonneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLPIERCING.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLPIERCING.cs
@@ -490,7 +490,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLPIERCING", "peek", RetCode.BadParam);
          CdlpiercingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLRICKSHAWMAN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLRICKSHAWMAN.cs
@@ -558,7 +558,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLRICKSHAWMAN", "peek", RetCode.BadParam);
          CdlrickshawmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLRISEFALL3METHODS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLRISEFALL3METHODS.cs
@@ -592,7 +592,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLRISEFALL3METHODS", "peek", RetCode.BadParam);
          Cdlrisefall3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSEPARATINGLINES.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSEPARATINGLINES.cs
@@ -579,7 +579,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSEPARATINGLINES", "peek", RetCode.BadParam);
          CdlseparatinglinesStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSHOOTINGSTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSHOOTINGSTAR.cs
@@ -566,7 +566,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSHOOTINGSTAR", "peek", RetCode.BadParam);
          CdlshootingstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSHORTLINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSHORTLINE.cs
@@ -514,7 +514,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSHORTLINE", "peek", RetCode.BadParam);
          CdlshortlineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSPINNINGTOP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSPINNINGTOP.cs
@@ -461,7 +461,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSPINNINGTOP", "peek", RetCode.BadParam);
          CdlspinningtopStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSTALLEDPATTERN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSTALLEDPATTERN.cs
@@ -660,7 +660,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSTALLEDPATTERN", "peek", RetCode.BadParam);
          CdlstalledpatternStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLSTICKSANDWICH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLSTICKSANDWICH.cs
@@ -489,7 +489,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLSTICKSANDWICH", "peek", RetCode.BadParam);
          CdlsticksandwichStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLTAKURI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLTAKURI.cs
@@ -556,7 +556,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLTAKURI", "peek", RetCode.BadParam);
          CdltakuriStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLTASUKIGAP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLTASUKIGAP.cs
@@ -498,7 +498,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLTASUKIGAP", "peek", RetCode.BadParam);
          CdltasukigapStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLTHRUSTING.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLTHRUSTING.cs
@@ -533,7 +533,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLTHRUSTING", "peek", RetCode.BadParam);
          CdlthrustingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLTRISTAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLTRISTAR.cs
@@ -500,7 +500,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLTRISTAR", "peek", RetCode.BadParam);
          CdltristarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLUNIQUE3RIVER.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLUNIQUE3RIVER.cs
@@ -536,7 +536,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLUNIQUE3RIVER", "peek", RetCode.BadParam);
          Cdlunique3riverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLUPSIDEGAP2CROWS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLUPSIDEGAP2CROWS.cs
@@ -540,7 +540,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLUPSIDEGAP2CROWS", "peek", RetCode.BadParam);
          Cdlupsidegap2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/csharp/library/src/Core_CDLXSIDEGAP3METHODS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CDLXSIDEGAP3METHODS.cs
@@ -438,7 +438,7 @@ public partial class Core
       {
          if( !double.IsFinite(inOpen) || !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("CDLXSIDEGAP3METHODS", "peek", RetCode.BadParam);
          Cdlxsidegap3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) && /* 1st and 2nd of same color */
              ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - ((inClose >= inOpen) ? 1 : 0 - 1) && /* 3rd opposite color */
              inOpen < Math.Max(sp.lag1_inClose, sp.lag1_inOpen) &&  /* 3rd opens within 2nd rb */

--- a/ta_codegen/output/csharp/library/src/Core_CEIL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CEIL.cs
@@ -329,7 +329,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("CEIL", "peek", RetCode.BadParam);
          CeilStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Ceiling(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_CMF.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CMF.cs
@@ -636,7 +636,7 @@ public partial class Core
          double close = 0.0;
          double tmp = 0.0;
          double mfv = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumMFV = sp.sumMFV;
          double sumVol = sp.sumVol;
          sumMFV -= sp.cb_mfv_flow[sp.mfv_Idx];

--- a/ta_codegen/output/csharp/library/src/Core_CMO.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CMO.cs
@@ -621,7 +621,7 @@ public partial class Core
          CmoStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/csharp/library/src/Core_CMOU.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CMOU.cs
@@ -614,7 +614,7 @@ public partial class Core
          double sum = 0.0;
          double diff = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double downSum = sp.downSum;
          int nullRun = sp.nullRun;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/csharp/library/src/Core_CORREL.cs
+++ b/ta_codegen/output/csharp/library/src/Core_CORREL.cs
@@ -772,7 +772,7 @@ public partial class Core
          double tempReal = 0.0;
          int windowStart = 0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double shiftX = sp.shiftX;
          double shiftY = sp.shiftY;

--- a/ta_codegen/output/csharp/library/src/Core_COS.cs
+++ b/ta_codegen/output/csharp/library/src/Core_COS.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("COS", "peek", RetCode.BadParam);
          CosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Cos(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_COSH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_COSH.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("COSH", "peek", RetCode.BadParam);
          CoshStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Cosh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_DEMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_DEMA.cs
@@ -555,7 +555,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("DEMA", "peek", RetCode.BadParam);
          DemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          if( sp.optInTimePeriod == 1 ) {

--- a/ta_codegen/output/csharp/library/src/Core_DIV.cs
+++ b/ta_codegen/output/csharp/library/src/Core_DIV.cs
@@ -343,7 +343,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal0) || !double.IsFinite(inReal1) ) throw Core.StreamFailure("DIV", "peek", RetCode.BadParam);
          DivStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 / inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_DONCHIAN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_DONCHIAN.cs
@@ -621,9 +621,9 @@ public partial class Core
          DonchianStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_DX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_DX.cs
@@ -857,7 +857,7 @@ public partial class Core
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;
          double prevLow = sp.prevLow;

--- a/ta_codegen/output/csharp/library/src/Core_EMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_EMA.cs
@@ -490,7 +490,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("EMA", "peek", RetCode.BadParam);
          EmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          if( sp.optInTimePeriod == 1 ) {
             cur_outReal = inReal;

--- a/ta_codegen/output/csharp/library/src/Core_EXP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_EXP.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("EXP", "peek", RetCode.BadParam);
          ExpStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Exp(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_FLOOR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_FLOOR.cs
@@ -329,7 +329,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("FLOOR", "peek", RetCode.BadParam);
          FloorStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Floor(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_HT_DCPERIOD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_DCPERIOD.cs
@@ -1031,7 +1031,7 @@ public partial class Core
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/csharp/library/src/Core_HT_DCPHASE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_DCPHASE.cs
@@ -1182,7 +1182,7 @@ public partial class Core
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_PHASOR.cs
@@ -1069,8 +1069,8 @@ public partial class Core
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outInPhase = sp.cur_outInPhase;
-         double cur_outQuadrature = sp.cur_outQuadrature;
+         double cur_outInPhase = 0.0;
+         double cur_outQuadrature = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;

--- a/ta_codegen/output/csharp/library/src/Core_HT_SINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_SINE.cs
@@ -1221,8 +1221,8 @@ public partial class Core
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outLeadSine = sp.cur_outLeadSine;
-         double cur_outSine = sp.cur_outSine;
+         double cur_outLeadSine = 0.0;
+         double cur_outSine = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/csharp/library/src/Core_HT_TRENDLINE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_TRENDLINE.cs
@@ -1129,7 +1129,7 @@ public partial class Core
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;

--- a/ta_codegen/output/csharp/library/src/Core_HT_TRENDMODE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_HT_TRENDMODE.cs
@@ -1354,7 +1354,7 @@ public partial class Core
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int daysInTrend = sp.daysInTrend;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;

--- a/ta_codegen/output/csharp/library/src/Core_KAMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_KAMA.cs
@@ -745,7 +745,7 @@ public partial class Core
          double tempReal = 0.0;
          double tempReal2 = 0.0;
          double periodROC = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          double prevKAMA = sp.prevKAMA;
          double sumROC1 = sp.sumROC1;

--- a/ta_codegen/output/csharp/library/src/Core_LINEARREG.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LINEARREG.cs
@@ -633,7 +633,7 @@ public partial class Core
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/csharp/library/src/Core_LINEARREG_ANGLE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LINEARREG_ANGLE.cs
@@ -640,7 +640,7 @@ public partial class Core
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/csharp/library/src/Core_LINEARREG_INTERCEPT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LINEARREG_INTERCEPT.cs
@@ -639,7 +639,7 @@ public partial class Core
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/csharp/library/src/Core_LINEARREG_SLOPE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LINEARREG_SLOPE.cs
@@ -634,7 +634,7 @@ public partial class Core
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/csharp/library/src/Core_LN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LN.cs
@@ -333,7 +333,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("LN", "peek", RetCode.BadParam);
          LnStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Log(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_LOG10.cs
+++ b/ta_codegen/output/csharp/library/src/Core_LOG10.cs
@@ -333,7 +333,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("LOG10", "peek", RetCode.BadParam);
          Log10Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Log10(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_MACD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MACD.cs
@@ -763,9 +763,9 @@ public partial class Core
          MacdStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;

--- a/ta_codegen/output/csharp/library/src/Core_MACDFIX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MACDFIX.cs
@@ -669,9 +669,9 @@ public partial class Core
          MacdfixStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;

--- a/ta_codegen/output/csharp/library/src/Core_MAMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAMA.cs
@@ -1225,8 +1225,8 @@ public partial class Core
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outFAMA = sp.cur_outFAMA;
-         double cur_outMAMA = sp.cur_outMAMA;
+         double cur_outFAMA = 0.0;
+         double cur_outMAMA = 0.0;
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
          double mama = sp.mama;

--- a/ta_codegen/output/csharp/library/src/Core_MARKETFI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MARKETFI.cs
@@ -406,7 +406,7 @@ public partial class Core
       {
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inVolume) ) throw Core.StreamFailure("MARKETFI", "peek", RetCode.BadParam);
          MarketfiStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* A zero-volume bar would divide by zero. Neither reference guards
           * it -- they emit +/-Inf, or NaN when the range is zero too -- but
           * issue #112 settled that a successful call never emits NaN or Inf,

--- a/ta_codegen/output/csharp/library/src/Core_MAX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAX.cs
@@ -578,7 +578,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("MAX", "peek", RetCode.BadParam);
          MaxStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MAXINDEX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MAXINDEX.cs
@@ -473,7 +473,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("MAXINDEX", "peek", RetCode.BadParam);
          MaxindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MEDPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MEDPRICE.cs
@@ -351,7 +351,7 @@ public partial class Core
       {
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) ) throw Core.StreamFailure("MEDPRICE", "peek", RetCode.BadParam);
          MedpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow) / 2.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_MFI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MFI.cs
@@ -686,7 +686,7 @@ public partial class Core
          double posFlow = 0.0;
          double negFlow = 0.0;
          double posClamped = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double negSumMF = sp.negSumMF;
          int nullRun = sp.nullRun;
          double posSumMF = sp.posSumMF;

--- a/ta_codegen/output/csharp/library/src/Core_MIDPOINT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIDPOINT.cs
@@ -658,7 +658,7 @@ public partial class Core
          MidpointStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MIDPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIDPRICE.cs
@@ -680,7 +680,7 @@ public partial class Core
          MidpriceStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MIN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MIN.cs
@@ -575,7 +575,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("MIN", "peek", RetCode.BadParam);
          MinStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;

--- a/ta_codegen/output/csharp/library/src/Core_MININDEX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MININDEX.cs
@@ -473,7 +473,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("MININDEX", "peek", RetCode.BadParam);
          MinindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;

--- a/ta_codegen/output/csharp/library/src/Core_MINMAX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MINMAX.cs
@@ -687,8 +687,8 @@ public partial class Core
          MinmaxStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         double cur_outMax = sp.cur_outMax;
-         double cur_outMin = sp.cur_outMin;
+         double cur_outMax = 0.0;
+         double cur_outMin = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MINMAXINDEX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MINMAXINDEX.cs
@@ -555,8 +555,8 @@ public partial class Core
          MinmaxindexStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         int cur_outMaxIdx = sp.cur_outMaxIdx;
-         int cur_outMinIdx = sp.cur_outMinIdx;
+         int cur_outMaxIdx = 0;
+         int cur_outMinIdx = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/csharp/library/src/Core_MOM.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MOM.cs
@@ -431,7 +431,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("MOM", "peek", RetCode.BadParam);
          MomStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/csharp/library/src/Core_MULT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_MULT.cs
@@ -345,7 +345,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal0) || !double.IsFinite(inReal1) ) throw Core.StreamFailure("MULT", "peek", RetCode.BadParam);
          MultStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 * inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_NATR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_NATR.cs
@@ -696,7 +696,7 @@ public partial class Core
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;

--- a/ta_codegen/output/csharp/library/src/Core_NVI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_NVI.cs
@@ -435,7 +435,7 @@ public partial class Core
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempNVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevNVI = sp.prevNVI;
          tempClose = inClose;
          tempVolume = inVolume;

--- a/ta_codegen/output/csharp/library/src/Core_OBV.cs
+++ b/ta_codegen/output/csharp/library/src/Core_OBV.cs
@@ -377,7 +377,7 @@ public partial class Core
          if( !double.IsFinite(inReal) || !double.IsFinite(inVolume) ) throw Core.StreamFailure("OBV", "peek", RetCode.BadParam);
          ObvStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevOBV = sp.prevOBV;
          tempReal = inReal;
          if( tempReal > sp.prevReal ) {

--- a/ta_codegen/output/csharp/library/src/Core_PVI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_PVI.cs
@@ -435,7 +435,7 @@ public partial class Core
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempPVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevPVI = sp.prevPVI;
          tempClose = inClose;
          tempVolume = inVolume;

--- a/ta_codegen/output/csharp/library/src/Core_QSTICK.cs
+++ b/ta_codegen/output/csharp/library/src/Core_QSTICK.cs
@@ -480,7 +480,7 @@ public partial class Core
          if( !double.IsFinite(inOpen) || !double.IsFinite(inClose) ) throw Core.StreamFailure("QSTICK", "peek", RetCode.BadParam);
          QstickStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/csharp/library/src/Core_RMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_RMA.cs
@@ -507,7 +507,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("RMA", "peek", RetCode.BadParam);
          RmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevRMA = sp.prevRMA;
          prevRMA = Math.FusedMultiplyAdd(sp.wBeta, prevRMA, sp.wAlpha * inReal);
          cur_outReal = prevRMA;

--- a/ta_codegen/output/csharp/library/src/Core_ROC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ROC.cs
@@ -445,7 +445,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ROC", "peek", RetCode.BadParam);
          RocStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/csharp/library/src/Core_ROCP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ROCP.cs
@@ -443,7 +443,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ROCP", "peek", RetCode.BadParam);
          RocpStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/csharp/library/src/Core_ROCR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ROCR.cs
@@ -443,7 +443,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ROCR", "peek", RetCode.BadParam);
          RocrStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/csharp/library/src/Core_ROCR100.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ROCR100.cs
@@ -445,7 +445,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ROCR100", "peek", RetCode.BadParam);
          Rocr100Stream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/csharp/library/src/Core_RSI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_RSI.cs
@@ -654,7 +654,7 @@ public partial class Core
          RsiStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/csharp/library/src/Core_SAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SAR.cs
@@ -765,7 +765,7 @@ public partial class Core
          double prevHigh = 0.0;
          double prevLow = 0.0;
          double af = sp.af;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;

--- a/ta_codegen/output/csharp/library/src/Core_SAREXT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SAREXT.cs
@@ -1021,7 +1021,7 @@ public partial class Core
          double prevLow = 0.0;
          double afLong = sp.afLong;
          double afShort = sp.afShort;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;

--- a/ta_codegen/output/csharp/library/src/Core_SIN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SIN.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("SIN", "peek", RetCode.BadParam);
          SinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Sin(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_SINH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SINH.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("SINH", "peek", RetCode.BadParam);
          SinhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Sinh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_SMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SMA.cs
@@ -446,7 +446,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("SMA", "peek", RetCode.BadParam);
          SmaStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/csharp/library/src/Core_SMI.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SMI.cs
@@ -1020,8 +1020,8 @@ public partial class Core
          double den = 0.0;
          double halfDen = 0.0;
          double smiValue = 0.0;
-         double cur_outSMI = sp.cur_outSMI;
-         double cur_outSMISignal = sp.cur_outSMISignal;
+         double cur_outSMI = 0.0;
+         double cur_outSMISignal = 0.0;
          double emaFastDen = sp.emaFastDen;
          double emaFastNum = sp.emaFastNum;
          double emaSlowDen = sp.emaSlowDen;

--- a/ta_codegen/output/csharp/library/src/Core_SQRT.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SQRT.cs
@@ -333,7 +333,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("SQRT", "peek", RetCode.BadParam);
          SqrtStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Sqrt(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_SUB.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SUB.cs
@@ -338,7 +338,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal0) || !double.IsFinite(inReal1) ) throw Core.StreamFailure("SUB", "peek", RetCode.BadParam);
          SubStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 - inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_SUM.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SUM.cs
@@ -431,7 +431,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("SUM", "peek", RetCode.BadParam);
          SumStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/csharp/library/src/Core_SUPERTREND.cs
+++ b/ta_codegen/output/csharp/library/src/Core_SUPERTREND.cs
@@ -777,8 +777,8 @@ public partial class Core
          double basicUpper = 0.0;
          double basicLower = 0.0;
          double closeToday = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
-         double cur_outReal = sp.cur_outReal;
+         int cur_outInteger = 0;
+         double cur_outReal = 0.0;
          double finalLower = sp.finalLower;
          double finalUpper = sp.finalUpper;
          int isUptrend = sp.isUptrend;

--- a/ta_codegen/output/csharp/library/src/Core_T3.cs
+++ b/ta_codegen/output/csharp/library/src/Core_T3.cs
@@ -678,7 +678,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("T3", "peek", RetCode.BadParam);
          T3Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double e1 = sp.e1;
          double e2 = sp.e2;
          double e3 = sp.e3;

--- a/ta_codegen/output/csharp/library/src/Core_TAN.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TAN.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("TAN", "peek", RetCode.BadParam);
          TanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Tan(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_TANH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TANH.cs
@@ -327,7 +327,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("TANH", "peek", RetCode.BadParam);
          TanhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.Tanh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_TEMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TEMA.cs
@@ -597,7 +597,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("TEMA", "peek", RetCode.BadParam);
          TemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;

--- a/ta_codegen/output/csharp/library/src/Core_TRANGE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TRANGE.cs
@@ -446,7 +446,7 @@ public partial class Core
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;
          tempHT = inHigh;

--- a/ta_codegen/output/csharp/library/src/Core_TRIX.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TRIX.cs
@@ -548,7 +548,7 @@ public partial class Core
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("TRIX", "peek", RetCode.BadParam);
          TrixStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;

--- a/ta_codegen/output/csharp/library/src/Core_TSF.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TSF.cs
@@ -641,7 +641,7 @@ public partial class Core
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/csharp/library/src/Core_TYPPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_TYPPRICE.cs
@@ -356,7 +356,7 @@ public partial class Core
       {
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("TYPPRICE", "peek", RetCode.BadParam);
          TyppriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose) / 3.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_ULTOSC.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ULTOSC.cs
@@ -937,7 +937,7 @@ public partial class Core
          double b1Total = sp.b1Total;
          double b2Total = sp.b2Total;
          double b3Total = sp.b3Total;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          int term_Idx = sp.term_Idx;
          int trailingPos1 = sp.trailingPos1;

--- a/ta_codegen/output/csharp/library/src/Core_VAR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_VAR.cs
@@ -658,7 +658,7 @@ public partial class Core
          double meanValue1 = 0.0;
          double variance = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double periodTotal1 = sp.periodTotal1;

--- a/ta_codegen/output/csharp/library/src/Core_VWAP.cs
+++ b/ta_codegen/output/csharp/library/src/Core_VWAP.cs
@@ -529,7 +529,7 @@ public partial class Core
          double typPrice = 0.0;
          double volume = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          double vwap = sp.vwap;

--- a/ta_codegen/output/csharp/library/src/Core_VWMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_VWMA.cs
@@ -541,7 +541,7 @@ public partial class Core
          double tempPV = 0.0;
          double tempV = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          int pkSlot0 = -1;

--- a/ta_codegen/output/csharp/library/src/Core_WAD.cs
+++ b/ta_codegen/output/csharp/library/src/Core_WAD.cs
@@ -485,7 +485,7 @@ public partial class Core
          WadStream sp = this;
          double close = 0.0;
          double trueExtreme = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sum = sp.sum;
          close = inClose;
          if( close > sp.prevClose ) {

--- a/ta_codegen/output/csharp/library/src/Core_WCLPRICE.cs
+++ b/ta_codegen/output/csharp/library/src/Core_WCLPRICE.cs
@@ -356,7 +356,7 @@ public partial class Core
       {
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("WCLPRICE", "peek", RetCode.BadParam);
          WclpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (Math.FusedMultiplyAdd(inClose, 2.0, inHigh + inLow)) / 4.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/csharp/library/src/Core_WILLR.cs
+++ b/ta_codegen/output/csharp/library/src/Core_WILLR.cs
@@ -712,7 +712,7 @@ public partial class Core
          if( !double.IsFinite(inHigh) || !double.IsFinite(inLow) || !double.IsFinite(inClose) ) throw Core.StreamFailure("WILLR", "peek", RetCode.BadParam);
          WillrStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;

--- a/ta_codegen/output/csharp/library/src/Core_WMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_WMA.cs
@@ -633,7 +633,7 @@ public partial class Core
          int rw = 0;
          double tempReal = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodSub = sp.periodSub;
          double periodSum = sp.periodSum;
          double trailingValue = sp.trailingValue;

--- a/ta_codegen/output/csharp/library/src/Core_ZLEMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ZLEMA.cs
@@ -537,7 +537,7 @@ public partial class Core
       {
          if( !double.IsFinite(inReal) ) throw Core.StreamFailure("ZLEMA", "peek", RetCode.BadParam);
          ZlemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/fragments/Core_AC.java
+++ b/ta_codegen/output/java/fragments/Core_AC.java
@@ -686,7 +686,7 @@
          double medianPrice = 0.0;
          double osc = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int oscBuffer_Idx = sp.oscBuffer_Idx;
          double sumFast = sp.sumFast;
          double sumSignal = sp.sumSignal;

--- a/ta_codegen/output/java/fragments/Core_ACCBANDS.java
+++ b/ta_codegen/output/java/fragments/Core_ACCBANDS.java
@@ -584,9 +584,9 @@
          double tempMiddle = 0.0;
          double tempLower = 0.0;
          double tempReal = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double periodTotalLower = sp.periodTotalLower;
          double periodTotalMiddle = sp.periodTotalMiddle;
          double periodTotalUpper = sp.periodTotalUpper;

--- a/ta_codegen/output/java/fragments/Core_ACOS.java
+++ b/ta_codegen/output/java/fragments/Core_ACOS.java
@@ -301,7 +301,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ACOS peek: BadParam", RetCode.BadParam);
          AcosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.acos(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_AD.java
+++ b/ta_codegen/output/java/fragments/Core_AD.java
@@ -388,7 +388,7 @@
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          high = inHigh;
          low = inLow;
          tmp = high - low;

--- a/ta_codegen/output/java/fragments/Core_ADD.java
+++ b/ta_codegen/output/java/fragments/Core_ADD.java
@@ -302,7 +302,7 @@
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("ADD peek: BadParam", RetCode.BadParam);
          AddStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 + inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_ADOSC.java
+++ b/ta_codegen/output/java/fragments/Core_ADOSC.java
@@ -586,7 +586,7 @@
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double fastEMA = sp.fastEMA;
          double slowEMA = sp.slowEMA;
          high = inHigh;

--- a/ta_codegen/output/java/fragments/Core_ADX.java
+++ b/ta_codegen/output/java/fragments/Core_ADX.java
@@ -926,7 +926,7 @@
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevADX = sp.prevADX;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;

--- a/ta_codegen/output/java/fragments/Core_AO.java
+++ b/ta_codegen/output/java/fragments/Core_AO.java
@@ -551,7 +551,7 @@
          AoStream sp = this;
          double medianPrice = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumFast = sp.sumFast;
          double sumSlow = sp.sumSlow;
          int pkSlot0 = -1;

--- a/ta_codegen/output/java/fragments/Core_AROON.java
+++ b/ta_codegen/output/java/fragments/Core_AROON.java
@@ -534,8 +534,8 @@
             throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
          AroonStream sp = this;
          double tmp = 0.0;
-         double cur_outAroonDown = sp.cur_outAroonDown;
-         double cur_outAroonUp = sp.cur_outAroonUp;
+         double cur_outAroonDown = 0.0;
+         double cur_outAroonUp = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_AROONOSC.java
+++ b/ta_codegen/output/java/fragments/Core_AROONOSC.java
@@ -530,7 +530,7 @@
          AroonoscStream sp = this;
          double tmp = 0.0;
          double aroon = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_ASIN.java
+++ b/ta_codegen/output/java/fragments/Core_ASIN.java
@@ -303,7 +303,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ASIN peek: BadParam", RetCode.BadParam);
          AsinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.asin(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_ATAN.java
+++ b/ta_codegen/output/java/fragments/Core_ATAN.java
@@ -294,7 +294,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ATAN peek: BadParam", RetCode.BadParam);
          AtanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.atan(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_ATR.java
+++ b/ta_codegen/output/java/fragments/Core_ATR.java
@@ -592,7 +592,7 @@
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;

--- a/ta_codegen/output/java/fragments/Core_AVGDEV.java
+++ b/ta_codegen/output/java/fragments/Core_AVGDEV.java
@@ -387,7 +387,7 @@
          double todaySum = 0.0;
          double todayDev = 0.0;
          int i = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          pkSlot0 = sp.winPos_i;

--- a/ta_codegen/output/java/fragments/Core_AVGPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_AVGPRICE.java
@@ -331,7 +331,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("AVGPRICE peek: BadParam", RetCode.BadParam);
          AvgpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose + inOpen) / 4;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_BETA.java
+++ b/ta_codegen/output/java/fragments/Core_BETA.java
@@ -922,7 +922,7 @@
          double S_y = sp.S_y;
          double S_yy = sp.S_yy;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double last_price_x = sp.last_price_x;

--- a/ta_codegen/output/java/fragments/Core_BOP.java
+++ b/ta_codegen/output/java/fragments/Core_BOP.java
@@ -344,7 +344,7 @@
             throw new TaLibArgumentException("BOP peek: BadParam", RetCode.BadParam);
          BopStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* BOP is a fraction of the bar's own range, so it is scale-free and the
           * divisor only has to be positive. An exact test, not the fixed
           * TA_IS_ZERO_OR_NEG band it used to be: the range carries the quote unit,

--- a/ta_codegen/output/java/fragments/Core_CCI.java
+++ b/ta_codegen/output/java/fragments/Core_CCI.java
@@ -525,7 +525,7 @@
          double theAverage = 0.0;
          double lastValue = 0.0;
          int j = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          lastValue = (inHigh + inLow + inClose) / 3;

--- a/ta_codegen/output/java/fragments/Core_CDL2CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL2CROWS.java
@@ -459,7 +459,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL2CROWS peek: BadParam", RetCode.BadParam);
          Cdl2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3BLACKCROWS.java
@@ -482,7 +482,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3BLACKCROWS peek: BadParam", RetCode.BadParam);
          Cdl3blackcrowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDL3INSIDE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3INSIDE.java
@@ -503,7 +503,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3INSIDE peek: BadParam", RetCode.BadParam);
          Cdl3insideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3LINESTRIKE.java
@@ -482,7 +482,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3LINESTRIKE peek: BadParam", RetCode.BadParam);
          Cdl3linestrikeStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;

--- a/ta_codegen/output/java/fragments/Core_CDL3OUTSIDE.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3OUTSIDE.java
@@ -398,7 +398,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3OUTSIDE peek: BadParam", RetCode.BadParam);
          Cdl3outsideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 0 - 1 && sp.lag1_inClose > sp.lag2_inOpen && sp.lag1_inOpen < sp.lag2_inClose && inClose > sp.lag1_inClose || ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 1 && sp.lag1_inOpen > sp.lag2_inClose && sp.lag1_inClose < sp.lag2_inOpen && inClose < sp.lag1_inClose ) {
             /* white engulfs black */
             /* third candle higher */

--- a/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3STARSINSOUTH.java
@@ -621,7 +621,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3STARSINSOUTH peek: BadParam", RetCode.BadParam);
          Cdl3starsinsouthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
+++ b/ta_codegen/output/java/fragments/Core_CDL3WHITESOLDIERS.java
@@ -638,7 +638,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3WHITESOLDIERS peek: BadParam", RetCode.BadParam);
          Cdl3whitesoldiersStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLABANDONEDBABY.java
+++ b/ta_codegen/output/java/fragments/Core_CDLABANDONEDBABY.java
@@ -580,7 +580,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLABANDONEDBABY peek: BadParam", RetCode.BadParam);
          CdlabandonedbabyStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLADVANCEBLOCK.java
@@ -691,7 +691,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLADVANCEBLOCK peek: BadParam", RetCode.BadParam);
          CdladvanceblockStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLBELTHOLD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLBELTHOLD.java
@@ -485,7 +485,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLBELTHOLD peek: BadParam", RetCode.BadParam);
          CdlbeltholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLBREAKAWAY.java
+++ b/ta_codegen/output/java/fragments/Core_CDLBREAKAWAY.java
@@ -476,7 +476,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLBREAKAWAY peek: BadParam", RetCode.BadParam);
          CdlbreakawayStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLCLOSINGMARUBOZU.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCLOSINGMARUBOZU.java
@@ -481,7 +481,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCLOSINGMARUBOZU peek: BadParam", RetCode.BadParam);
          CdlclosingmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCONCEALBABYSWALL.java
@@ -483,7 +483,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCONCEALBABYSWALL peek: BadParam", RetCode.BadParam);
          CdlconcealbabyswallStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLCOUNTERATTACK.java
@@ -503,7 +503,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCOUNTERATTACK peek: BadParam", RetCode.BadParam);
          CdlcounterattackStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLDARKCLOUDCOVER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDARKCLOUDCOVER.java
@@ -478,7 +478,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDARKCLOUDCOVER peek: BadParam", RetCode.BadParam);
          CdldarkcloudcoverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDOJI.java
@@ -425,7 +425,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDOJI peek: BadParam", RetCode.BadParam);
          CdldojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDOJISTAR.java
@@ -506,7 +506,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDOJISTAR peek: BadParam", RetCode.BadParam);
          CdldojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLDRAGONFLYDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLDRAGONFLYDOJI.java
@@ -490,7 +490,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDRAGONFLYDOJI peek: BadParam", RetCode.BadParam);
          CdldragonflydojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLENGULFING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLENGULFING.java
@@ -406,7 +406,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLENGULFING peek: BadParam", RetCode.BadParam);
          CdlengulfingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((inClose >= inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && (inClose >= sp.lag1_inOpen && inOpen < sp.lag1_inClose || inClose > sp.lag1_inOpen && inOpen <= sp.lag1_inClose) || ((inClose >= inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && (inOpen >= sp.lag1_inClose && inClose < sp.lag1_inOpen || inOpen > sp.lag1_inClose && inClose <= sp.lag1_inOpen) ) {
             /* white engulfs black */
             /* black engulfs white */

--- a/ta_codegen/output/java/fragments/Core_CDLEVENINGDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLEVENINGDOJISTAR.java
@@ -579,7 +579,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLEVENINGDOJISTAR peek: BadParam", RetCode.BadParam);
          CdleveningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLEVENINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLEVENINGSTAR.java
@@ -544,7 +544,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLEVENINGSTAR peek: BadParam", RetCode.BadParam);
          CdleveningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLGAPSIDESIDEWHITE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLGAPSIDESIDEWHITE.java
@@ -505,7 +505,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLGAPSIDESIDEWHITE peek: BadParam", RetCode.BadParam);
          CdlgapsidesidewhiteStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLGRAVESTONEDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLGRAVESTONEDOJI.java
@@ -490,7 +490,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLGRAVESTONEDOJI peek: BadParam", RetCode.BadParam);
          CdlgravestonedojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHAMMER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHAMMER.java
@@ -578,7 +578,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHAMMER peek: BadParam", RetCode.BadParam);
          CdlhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHANGINGMAN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHANGINGMAN.java
@@ -580,7 +580,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHANGINGMAN peek: BadParam", RetCode.BadParam);
          CdlhangingmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHARAMI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHARAMI.java
@@ -515,7 +515,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHARAMI peek: BadParam", RetCode.BadParam);
          CdlharamiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHARAMICROSS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHARAMICROSS.java
@@ -514,7 +514,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHARAMICROSS peek: BadParam", RetCode.BadParam);
          CdlharamicrossStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHIGHWAVE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIGHWAVE.java
@@ -486,7 +486,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHIGHWAVE peek: BadParam", RetCode.BadParam);
          CdlhighwaveStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLHIKKAKE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIKKAKE.java
@@ -487,7 +487,7 @@
             throw new TaLibArgumentException("CDLHIKKAKE peek: BadParam", RetCode.BadParam);
          CdlhikkakeStream sp = this;
          int cd = sp.cd;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternResult = sp.patternResult;
          double savedHigh = sp.savedHigh;
          double savedLow = sp.savedLow;

--- a/ta_codegen/output/java/fragments/Core_CDLHIKKAKEMOD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHIKKAKEMOD.java
@@ -557,7 +557,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHIKKAKEMOD peek: BadParam", RetCode.BadParam);
          CdlhikkakemodStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternCount = sp.patternCount;
          double patternHigh = sp.patternHigh;
          double patternLow = sp.patternLow;

--- a/ta_codegen/output/java/fragments/Core_CDLHOMINGPIGEON.java
+++ b/ta_codegen/output/java/fragments/Core_CDLHOMINGPIGEON.java
@@ -497,7 +497,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHOMINGPIGEON peek: BadParam", RetCode.BadParam);
          CdlhomingpigeonStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLIDENTICAL3CROWS.java
@@ -533,7 +533,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLIDENTICAL3CROWS peek: BadParam", RetCode.BadParam);
          Cdlidentical3crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLINNECK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLINNECK.java
@@ -503,7 +503,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLINNECK peek: BadParam", RetCode.BadParam);
          CdlinneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLINVERTEDHAMMER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLINVERTEDHAMMER.java
@@ -528,7 +528,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLINVERTEDHAMMER peek: BadParam", RetCode.BadParam);
          CdlinvertedhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLKICKING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKING.java
@@ -506,7 +506,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLKICKING peek: BadParam", RetCode.BadParam);
          CdlkickingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
+++ b/ta_codegen/output/java/fragments/Core_CDLKICKINGBYLENGTH.java
@@ -501,7 +501,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLKICKINGBYLENGTH peek: BadParam", RetCode.BadParam);
          CdlkickingbylengthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLLADDERBOTTOM.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLADDERBOTTOM.java
@@ -470,7 +470,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLADDERBOTTOM peek: BadParam", RetCode.BadParam);
          CdlladderbottomStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLLONGLEGGEDDOJI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLONGLEGGEDDOJI.java
@@ -482,7 +482,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLONGLEGGEDDOJI peek: BadParam", RetCode.BadParam);
          CdllongleggeddojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLLONGLINE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLLONGLINE.java
@@ -465,7 +465,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLONGLINE peek: BadParam", RetCode.BadParam);
          CdllonglineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLMARUBOZU.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMARUBOZU.java
@@ -477,7 +477,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMARUBOZU peek: BadParam", RetCode.BadParam);
          CdlmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLMATCHINGLOW.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMATCHINGLOW.java
@@ -448,7 +448,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMATCHINGLOW peek: BadParam", RetCode.BadParam);
          CdlmatchinglowStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMATHOLD.java
@@ -577,7 +577,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMATHOLD peek: BadParam", RetCode.BadParam);
          CdlmatholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLMORNINGDOJISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMORNINGDOJISTAR.java
@@ -586,7 +586,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMORNINGDOJISTAR peek: BadParam", RetCode.BadParam);
          CdlmorningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLMORNINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLMORNINGSTAR.java
@@ -552,7 +552,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMORNINGSTAR peek: BadParam", RetCode.BadParam);
          CdlmorningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLONNECK.java
+++ b/ta_codegen/output/java/fragments/Core_CDLONNECK.java
@@ -501,7 +501,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLONNECK peek: BadParam", RetCode.BadParam);
          CdlonneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLPIERCING.java
@@ -458,7 +458,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLPIERCING peek: BadParam", RetCode.BadParam);
          CdlpiercingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLRICKSHAWMAN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLRICKSHAWMAN.java
@@ -522,7 +522,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLRICKSHAWMAN peek: BadParam", RetCode.BadParam);
          CdlrickshawmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLRISEFALL3METHODS.java
@@ -556,7 +556,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLRISEFALL3METHODS peek: BadParam", RetCode.BadParam);
          Cdlrisefall3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSEPARATINGLINES.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSEPARATINGLINES.java
@@ -539,7 +539,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSEPARATINGLINES peek: BadParam", RetCode.BadParam);
          CdlseparatinglinesStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSHOOTINGSTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSHOOTINGSTAR.java
@@ -532,7 +532,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSHOOTINGSTAR peek: BadParam", RetCode.BadParam);
          CdlshootingstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSHORTLINE.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSHORTLINE.java
@@ -480,7 +480,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSHORTLINE peek: BadParam", RetCode.BadParam);
          CdlshortlineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSPINNINGTOP.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSPINNINGTOP.java
@@ -425,7 +425,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSPINNINGTOP peek: BadParam", RetCode.BadParam);
          CdlspinningtopStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSTALLEDPATTERN.java
@@ -623,7 +623,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSTALLEDPATTERN peek: BadParam", RetCode.BadParam);
          CdlstalledpatternStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLSTICKSANDWICH.java
+++ b/ta_codegen/output/java/fragments/Core_CDLSTICKSANDWICH.java
@@ -455,7 +455,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSTICKSANDWICH peek: BadParam", RetCode.BadParam);
          CdlsticksandwichStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLTAKURI.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTAKURI.java
@@ -523,7 +523,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTAKURI peek: BadParam", RetCode.BadParam);
          CdltakuriStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLTASUKIGAP.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTASUKIGAP.java
@@ -463,7 +463,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTASUKIGAP peek: BadParam", RetCode.BadParam);
          CdltasukigapStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLTHRUSTING.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTHRUSTING.java
@@ -501,7 +501,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTHRUSTING peek: BadParam", RetCode.BadParam);
          CdlthrustingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLTRISTAR.java
+++ b/ta_codegen/output/java/fragments/Core_CDLTRISTAR.java
@@ -469,7 +469,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTRISTAR peek: BadParam", RetCode.BadParam);
          CdltristarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLUNIQUE3RIVER.java
+++ b/ta_codegen/output/java/fragments/Core_CDLUNIQUE3RIVER.java
@@ -503,7 +503,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLUNIQUE3RIVER peek: BadParam", RetCode.BadParam);
          Cdlunique3riverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLUPSIDEGAP2CROWS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLUPSIDEGAP2CROWS.java
@@ -505,7 +505,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLUPSIDEGAP2CROWS peek: BadParam", RetCode.BadParam);
          Cdlupsidegap2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;

--- a/ta_codegen/output/java/fragments/Core_CDLXSIDEGAP3METHODS.java
+++ b/ta_codegen/output/java/fragments/Core_CDLXSIDEGAP3METHODS.java
@@ -405,7 +405,7 @@
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLXSIDEGAP3METHODS peek: BadParam", RetCode.BadParam);
          Cdlxsidegap3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) && /* 1st and 2nd of same color */
              ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - ((inClose >= inOpen) ? 1 : 0 - 1) && /* 3rd opposite color */
              inOpen < Math.max(sp.lag1_inClose, sp.lag1_inOpen) &&  /* 3rd opens within 2nd rb */

--- a/ta_codegen/output/java/fragments/Core_CEIL.java
+++ b/ta_codegen/output/java/fragments/Core_CEIL.java
@@ -291,7 +291,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("CEIL peek: BadParam", RetCode.BadParam);
          CeilStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.ceil(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_CMF.java
+++ b/ta_codegen/output/java/fragments/Core_CMF.java
@@ -601,7 +601,7 @@
          double close = 0.0;
          double tmp = 0.0;
          double mfv = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumMFV = sp.sumMFV;
          double sumVol = sp.sumVol;
          sumMFV -= sp.cb_mfv_flow[sp.mfv_Idx];

--- a/ta_codegen/output/java/fragments/Core_CMO.java
+++ b/ta_codegen/output/java/fragments/Core_CMO.java
@@ -584,7 +584,7 @@
          CmoStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/java/fragments/Core_CMOU.java
+++ b/ta_codegen/output/java/fragments/Core_CMOU.java
@@ -577,7 +577,7 @@
          double sum = 0.0;
          double diff = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double downSum = sp.downSum;
          int nullRun = sp.nullRun;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/java/fragments/Core_CORREL.java
+++ b/ta_codegen/output/java/fragments/Core_CORREL.java
@@ -737,7 +737,7 @@
          double tempReal = 0.0;
          int windowStart = 0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double shiftX = sp.shiftX;
          double shiftY = sp.shiftY;

--- a/ta_codegen/output/java/fragments/Core_COS.java
+++ b/ta_codegen/output/java/fragments/Core_COS.java
@@ -295,7 +295,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("COS peek: BadParam", RetCode.BadParam);
          CosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.cos(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_COSH.java
+++ b/ta_codegen/output/java/fragments/Core_COSH.java
@@ -293,7 +293,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("COSH peek: BadParam", RetCode.BadParam);
          CoshStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.cosh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_DEMA.java
+++ b/ta_codegen/output/java/fragments/Core_DEMA.java
@@ -525,7 +525,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("DEMA peek: BadParam", RetCode.BadParam);
          DemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          if( sp.optInTimePeriod == 1 ) {

--- a/ta_codegen/output/java/fragments/Core_DIV.java
+++ b/ta_codegen/output/java/fragments/Core_DIV.java
@@ -310,7 +310,7 @@
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("DIV peek: BadParam", RetCode.BadParam);
          DivStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 / inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_DONCHIAN.java
+++ b/ta_codegen/output/java/fragments/Core_DONCHIAN.java
@@ -572,9 +572,9 @@
          DonchianStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_DX.java
+++ b/ta_codegen/output/java/fragments/Core_DX.java
@@ -830,7 +830,7 @@
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;
          double prevLow = sp.prevLow;

--- a/ta_codegen/output/java/fragments/Core_EMA.java
+++ b/ta_codegen/output/java/fragments/Core_EMA.java
@@ -466,7 +466,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("EMA peek: BadParam", RetCode.BadParam);
          EmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          if( sp.optInTimePeriod == 1 ) {
             cur_outReal = inReal;

--- a/ta_codegen/output/java/fragments/Core_EXP.java
+++ b/ta_codegen/output/java/fragments/Core_EXP.java
@@ -291,7 +291,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("EXP peek: BadParam", RetCode.BadParam);
          ExpStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.exp(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_FLOOR.java
+++ b/ta_codegen/output/java/fragments/Core_FLOOR.java
@@ -291,7 +291,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("FLOOR peek: BadParam", RetCode.BadParam);
          FloorStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.floor(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPERIOD.java
@@ -993,7 +993,7 @@
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_DCPHASE.java
@@ -1145,7 +1145,7 @@
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
+++ b/ta_codegen/output/java/fragments/Core_HT_PHASOR.java
@@ -1023,8 +1023,8 @@
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outInPhase = sp.cur_outInPhase;
-         double cur_outQuadrature = sp.cur_outQuadrature;
+         double cur_outInPhase = 0.0;
+         double cur_outQuadrature = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;

--- a/ta_codegen/output/java/fragments/Core_HT_SINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_SINE.java
@@ -1172,8 +1172,8 @@
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outLeadSine = sp.cur_outLeadSine;
-         double cur_outSine = sp.cur_outSine;
+         double cur_outLeadSine = 0.0;
+         double cur_outSine = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDLINE.java
@@ -1086,7 +1086,7 @@
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;

--- a/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
+++ b/ta_codegen/output/java/fragments/Core_HT_TRENDMODE.java
@@ -1315,7 +1315,7 @@
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int daysInTrend = sp.daysInTrend;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;

--- a/ta_codegen/output/java/fragments/Core_KAMA.java
+++ b/ta_codegen/output/java/fragments/Core_KAMA.java
@@ -711,7 +711,7 @@
          double tempReal = 0.0;
          double tempReal2 = 0.0;
          double periodROC = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          double prevKAMA = sp.prevKAMA;
          double sumROC1 = sp.sumROC1;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG.java
@@ -600,7 +600,7 @@
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_ANGLE.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_ANGLE.java
@@ -606,7 +606,7 @@
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_INTERCEPT.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_INTERCEPT.java
@@ -605,7 +605,7 @@
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/java/fragments/Core_LINEARREG_SLOPE.java
+++ b/ta_codegen/output/java/fragments/Core_LINEARREG_SLOPE.java
@@ -600,7 +600,7 @@
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/java/fragments/Core_LN.java
+++ b/ta_codegen/output/java/fragments/Core_LN.java
@@ -301,7 +301,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("LN peek: BadParam", RetCode.BadParam);
          LnStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.log(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_LOG10.java
+++ b/ta_codegen/output/java/fragments/Core_LOG10.java
@@ -299,7 +299,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("LOG10 peek: BadParam", RetCode.BadParam);
          Log10Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.log10(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_MACD.java
+++ b/ta_codegen/output/java/fragments/Core_MACD.java
@@ -727,9 +727,9 @@
          MacdStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;

--- a/ta_codegen/output/java/fragments/Core_MACDFIX.java
+++ b/ta_codegen/output/java/fragments/Core_MACDFIX.java
@@ -635,9 +635,9 @@
          MacdfixStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;

--- a/ta_codegen/output/java/fragments/Core_MAMA.java
+++ b/ta_codegen/output/java/fragments/Core_MAMA.java
@@ -1175,8 +1175,8 @@
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outFAMA = sp.cur_outFAMA;
-         double cur_outMAMA = sp.cur_outMAMA;
+         double cur_outFAMA = 0.0;
+         double cur_outMAMA = 0.0;
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
          double mama = sp.mama;

--- a/ta_codegen/output/java/fragments/Core_MARKETFI.java
+++ b/ta_codegen/output/java/fragments/Core_MARKETFI.java
@@ -374,7 +374,7 @@
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inVolume) )
             throw new TaLibArgumentException("MARKETFI peek: BadParam", RetCode.BadParam);
          MarketfiStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* A zero-volume bar would divide by zero. Neither reference guards
           * it -- they emit +/-Inf, or NaN when the range is zero too -- but
           * issue #112 settled that a successful call never emits NaN or Inf,

--- a/ta_codegen/output/java/fragments/Core_MAX.java
+++ b/ta_codegen/output/java/fragments/Core_MAX.java
@@ -543,7 +543,7 @@
             throw new TaLibArgumentException("MAX peek: BadParam", RetCode.BadParam);
          MaxStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MAXINDEX.java
@@ -443,7 +443,7 @@
             throw new TaLibArgumentException("MAXINDEX peek: BadParam", RetCode.BadParam);
          MaxindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MEDPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_MEDPRICE.java
@@ -318,7 +318,7 @@
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
             throw new TaLibArgumentException("MEDPRICE peek: BadParam", RetCode.BadParam);
          MedpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow) / 2.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_MFI.java
+++ b/ta_codegen/output/java/fragments/Core_MFI.java
@@ -651,7 +651,7 @@
          double posFlow = 0.0;
          double negFlow = 0.0;
          double posClamped = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double negSumMF = sp.negSumMF;
          int nullRun = sp.nullRun;
          double posSumMF = sp.posSumMF;

--- a/ta_codegen/output/java/fragments/Core_MIDPOINT.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPOINT.java
@@ -623,7 +623,7 @@
          MidpointStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MIDPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_MIDPRICE.java
@@ -644,7 +644,7 @@
          MidpriceStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MIN.java
+++ b/ta_codegen/output/java/fragments/Core_MIN.java
@@ -540,7 +540,7 @@
             throw new TaLibArgumentException("MIN peek: BadParam", RetCode.BadParam);
          MinStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;

--- a/ta_codegen/output/java/fragments/Core_MININDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MININDEX.java
@@ -443,7 +443,7 @@
             throw new TaLibArgumentException("MININDEX peek: BadParam", RetCode.BadParam);
          MinindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;

--- a/ta_codegen/output/java/fragments/Core_MINMAX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAX.java
@@ -648,8 +648,8 @@
          MinmaxStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         double cur_outMax = sp.cur_outMax;
-         double cur_outMin = sp.cur_outMin;
+         double cur_outMax = 0.0;
+         double cur_outMin = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
+++ b/ta_codegen/output/java/fragments/Core_MINMAXINDEX.java
@@ -516,8 +516,8 @@
          MinmaxindexStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         int cur_outMaxIdx = sp.cur_outMaxIdx;
-         int cur_outMinIdx = sp.cur_outMinIdx;
+         int cur_outMaxIdx = 0;
+         int cur_outMinIdx = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;

--- a/ta_codegen/output/java/fragments/Core_MOM.java
+++ b/ta_codegen/output/java/fragments/Core_MOM.java
@@ -398,7 +398,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MOM peek: BadParam", RetCode.BadParam);
          MomStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/java/fragments/Core_MULT.java
+++ b/ta_codegen/output/java/fragments/Core_MULT.java
@@ -310,7 +310,7 @@
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("MULT peek: BadParam", RetCode.BadParam);
          MultStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 * inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_NATR.java
+++ b/ta_codegen/output/java/fragments/Core_NATR.java
@@ -662,7 +662,7 @@
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;

--- a/ta_codegen/output/java/fragments/Core_NVI.java
+++ b/ta_codegen/output/java/fragments/Core_NVI.java
@@ -394,7 +394,7 @@
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempNVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevNVI = sp.prevNVI;
          tempClose = inClose;
          tempVolume = inVolume;

--- a/ta_codegen/output/java/fragments/Core_OBV.java
+++ b/ta_codegen/output/java/fragments/Core_OBV.java
@@ -334,7 +334,7 @@
             throw new TaLibArgumentException("OBV peek: BadParam", RetCode.BadParam);
          ObvStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevOBV = sp.prevOBV;
          tempReal = inReal;
          if( tempReal > sp.prevReal ) {

--- a/ta_codegen/output/java/fragments/Core_PVI.java
+++ b/ta_codegen/output/java/fragments/Core_PVI.java
@@ -394,7 +394,7 @@
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempPVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevPVI = sp.prevPVI;
          tempClose = inClose;
          tempVolume = inVolume;

--- a/ta_codegen/output/java/fragments/Core_QSTICK.java
+++ b/ta_codegen/output/java/fragments/Core_QSTICK.java
@@ -446,7 +446,7 @@
             throw new TaLibArgumentException("QSTICK peek: BadParam", RetCode.BadParam);
          QstickStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/fragments/Core_RMA.java
+++ b/ta_codegen/output/java/fragments/Core_RMA.java
@@ -478,7 +478,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("RMA peek: BadParam", RetCode.BadParam);
          RmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevRMA = sp.prevRMA;
          prevRMA = Math.fma(sp.wBeta, prevRMA, sp.wAlpha * inReal);
          cur_outReal = prevRMA;

--- a/ta_codegen/output/java/fragments/Core_ROC.java
+++ b/ta_codegen/output/java/fragments/Core_ROC.java
@@ -412,7 +412,7 @@
             throw new TaLibArgumentException("ROC peek: BadParam", RetCode.BadParam);
          RocStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/java/fragments/Core_ROCP.java
+++ b/ta_codegen/output/java/fragments/Core_ROCP.java
@@ -410,7 +410,7 @@
             throw new TaLibArgumentException("ROCP peek: BadParam", RetCode.BadParam);
          RocpStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/java/fragments/Core_ROCR.java
+++ b/ta_codegen/output/java/fragments/Core_ROCR.java
@@ -413,7 +413,7 @@
             throw new TaLibArgumentException("ROCR peek: BadParam", RetCode.BadParam);
          RocrStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/java/fragments/Core_ROCR100.java
+++ b/ta_codegen/output/java/fragments/Core_ROCR100.java
@@ -415,7 +415,7 @@
             throw new TaLibArgumentException("ROCR100 peek: BadParam", RetCode.BadParam);
          Rocr100Stream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {

--- a/ta_codegen/output/java/fragments/Core_RSI.java
+++ b/ta_codegen/output/java/fragments/Core_RSI.java
@@ -619,7 +619,7 @@
          RsiStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;

--- a/ta_codegen/output/java/fragments/Core_SAR.java
+++ b/ta_codegen/output/java/fragments/Core_SAR.java
@@ -733,7 +733,7 @@
          double prevHigh = 0.0;
          double prevLow = 0.0;
          double af = sp.af;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;

--- a/ta_codegen/output/java/fragments/Core_SAREXT.java
+++ b/ta_codegen/output/java/fragments/Core_SAREXT.java
@@ -987,7 +987,7 @@
          double prevLow = 0.0;
          double afLong = sp.afLong;
          double afShort = sp.afShort;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;

--- a/ta_codegen/output/java/fragments/Core_SIN.java
+++ b/ta_codegen/output/java/fragments/Core_SIN.java
@@ -293,7 +293,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SIN peek: BadParam", RetCode.BadParam);
          SinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sin(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_SINH.java
+++ b/ta_codegen/output/java/fragments/Core_SINH.java
@@ -291,7 +291,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SINH peek: BadParam", RetCode.BadParam);
          SinhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sinh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_SMA.java
+++ b/ta_codegen/output/java/fragments/Core_SMA.java
@@ -417,7 +417,7 @@
             throw new TaLibArgumentException("SMA peek: BadParam", RetCode.BadParam);
          SmaStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/fragments/Core_SMI.java
+++ b/ta_codegen/output/java/fragments/Core_SMI.java
@@ -983,8 +983,8 @@
          double den = 0.0;
          double halfDen = 0.0;
          double smiValue = 0.0;
-         double cur_outSMI = sp.cur_outSMI;
-         double cur_outSMISignal = sp.cur_outSMISignal;
+         double cur_outSMI = 0.0;
+         double cur_outSMISignal = 0.0;
          double emaFastDen = sp.emaFastDen;
          double emaFastNum = sp.emaFastNum;
          double emaSlowDen = sp.emaSlowDen;

--- a/ta_codegen/output/java/fragments/Core_SQRT.java
+++ b/ta_codegen/output/java/fragments/Core_SQRT.java
@@ -293,7 +293,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SQRT peek: BadParam", RetCode.BadParam);
          SqrtStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sqrt(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_SUB.java
+++ b/ta_codegen/output/java/fragments/Core_SUB.java
@@ -303,7 +303,7 @@
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("SUB peek: BadParam", RetCode.BadParam);
          SubStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 - inReal1;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_SUM.java
+++ b/ta_codegen/output/java/fragments/Core_SUM.java
@@ -392,7 +392,7 @@
             throw new TaLibArgumentException("SUM peek: BadParam", RetCode.BadParam);
          SumStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/fragments/Core_SUPERTREND.java
+++ b/ta_codegen/output/java/fragments/Core_SUPERTREND.java
@@ -738,8 +738,8 @@
          double basicUpper = 0.0;
          double basicLower = 0.0;
          double closeToday = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
-         double cur_outReal = sp.cur_outReal;
+         int cur_outInteger = 0;
+         double cur_outReal = 0.0;
          double finalLower = sp.finalLower;
          double finalUpper = sp.finalUpper;
          int isUptrend = sp.isUptrend;

--- a/ta_codegen/output/java/fragments/Core_T3.java
+++ b/ta_codegen/output/java/fragments/Core_T3.java
@@ -649,7 +649,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("T3 peek: BadParam", RetCode.BadParam);
          T3Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double e1 = sp.e1;
          double e2 = sp.e2;
          double e3 = sp.e3;

--- a/ta_codegen/output/java/fragments/Core_TAN.java
+++ b/ta_codegen/output/java/fragments/Core_TAN.java
@@ -295,7 +295,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TAN peek: BadParam", RetCode.BadParam);
          TanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.tan(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_TANH.java
+++ b/ta_codegen/output/java/fragments/Core_TANH.java
@@ -293,7 +293,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TANH peek: BadParam", RetCode.BadParam);
          TanhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.tanh(inReal);
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_TEMA.java
+++ b/ta_codegen/output/java/fragments/Core_TEMA.java
@@ -567,7 +567,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TEMA peek: BadParam", RetCode.BadParam);
          TemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;

--- a/ta_codegen/output/java/fragments/Core_TRANGE.java
+++ b/ta_codegen/output/java/fragments/Core_TRANGE.java
@@ -410,7 +410,7 @@
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;
          tempHT = inHigh;

--- a/ta_codegen/output/java/fragments/Core_TRIX.java
+++ b/ta_codegen/output/java/fragments/Core_TRIX.java
@@ -521,7 +521,7 @@
             throw new TaLibArgumentException("TRIX peek: BadParam", RetCode.BadParam);
          TrixStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;

--- a/ta_codegen/output/java/fragments/Core_TSF.java
+++ b/ta_codegen/output/java/fragments/Core_TSF.java
@@ -608,7 +608,7 @@
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;

--- a/ta_codegen/output/java/fragments/Core_TYPPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_TYPPRICE.java
@@ -320,7 +320,7 @@
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("TYPPRICE peek: BadParam", RetCode.BadParam);
          TyppriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose) / 3.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_ULTOSC.java
+++ b/ta_codegen/output/java/fragments/Core_ULTOSC.java
@@ -901,7 +901,7 @@
          double b1Total = sp.b1Total;
          double b2Total = sp.b2Total;
          double b3Total = sp.b3Total;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          int term_Idx = sp.term_Idx;
          int trailingPos1 = sp.trailingPos1;

--- a/ta_codegen/output/java/fragments/Core_VAR.java
+++ b/ta_codegen/output/java/fragments/Core_VAR.java
@@ -621,7 +621,7 @@
          double meanValue1 = 0.0;
          double variance = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double periodTotal1 = sp.periodTotal1;

--- a/ta_codegen/output/java/fragments/Core_VWAP.java
+++ b/ta_codegen/output/java/fragments/Core_VWAP.java
@@ -496,7 +496,7 @@
          double typPrice = 0.0;
          double volume = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          double vwap = sp.vwap;

--- a/ta_codegen/output/java/fragments/Core_VWMA.java
+++ b/ta_codegen/output/java/fragments/Core_VWMA.java
@@ -508,7 +508,7 @@
          double tempPV = 0.0;
          double tempV = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          int pkSlot0 = -1;

--- a/ta_codegen/output/java/fragments/Core_WAD.java
+++ b/ta_codegen/output/java/fragments/Core_WAD.java
@@ -453,7 +453,7 @@
          WadStream sp = this;
          double close = 0.0;
          double trueExtreme = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sum = sp.sum;
          close = inClose;
          if( close > sp.prevClose ) {

--- a/ta_codegen/output/java/fragments/Core_WCLPRICE.java
+++ b/ta_codegen/output/java/fragments/Core_WCLPRICE.java
@@ -320,7 +320,7 @@
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("WCLPRICE peek: BadParam", RetCode.BadParam);
          WclpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (Math.fma(inClose, 2.0, inHigh + inLow)) / 4.0;
          return cur_outReal;
       }

--- a/ta_codegen/output/java/fragments/Core_WILLR.java
+++ b/ta_codegen/output/java/fragments/Core_WILLR.java
@@ -673,7 +673,7 @@
             throw new TaLibArgumentException("WILLR peek: BadParam", RetCode.BadParam);
          WillrStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;

--- a/ta_codegen/output/java/fragments/Core_WMA.java
+++ b/ta_codegen/output/java/fragments/Core_WMA.java
@@ -603,7 +603,7 @@
          int rw = 0;
          double tempReal = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodSub = sp.periodSub;
          double periodSum = sp.periodSum;
          double trailingValue = sp.trailingValue;

--- a/ta_codegen/output/java/fragments/Core_ZLEMA.java
+++ b/ta_codegen/output/java/fragments/Core_ZLEMA.java
@@ -508,7 +508,7 @@
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ZLEMA peek: BadParam", RetCode.BadParam);
          ZlemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
@@ -9,7 +9,7 @@ package io.github.talib;
  */
 public final class BuildStamp {
     /** Digest of the generated {@code Core} method text this build carries. */
-    public static final String GENCODE_DIGEST = "8e97b43fb3854650";
+    public static final String GENCODE_DIGEST = "d292d591540ed51e";
 
     private BuildStamp() {
     }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -1175,7 +1175,7 @@ public final class Core {
          double medianPrice = 0.0;
          double osc = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int oscBuffer_Idx = sp.oscBuffer_Idx;
          double sumFast = sp.sumFast;
          double sumSignal = sp.sumSignal;
@@ -2209,9 +2209,9 @@ public final class Core {
          double tempMiddle = 0.0;
          double tempLower = 0.0;
          double tempReal = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double periodTotalLower = sp.periodTotalLower;
          double periodTotalMiddle = sp.periodTotalMiddle;
          double periodTotalUpper = sp.periodTotalUpper;
@@ -2923,7 +2923,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ACOS peek: BadParam", RetCode.BadParam);
          AcosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.acos(inReal);
          return cur_outReal;
       }
@@ -3456,7 +3456,7 @@ public final class Core {
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          high = inHigh;
          low = inLow;
          tmp = high - low;
@@ -3971,7 +3971,7 @@ public final class Core {
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("ADD peek: BadParam", RetCode.BadParam);
          AddStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 + inReal1;
          return cur_outReal;
       }
@@ -4709,7 +4709,7 @@ public final class Core {
          double close = 0.0;
          double tmp = 0.0;
          double ad = sp.ad;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double fastEMA = sp.fastEMA;
          double slowEMA = sp.slowEMA;
          high = inHigh;
@@ -5945,7 +5945,7 @@ public final class Core {
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevADX = sp.prevADX;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;
@@ -7782,7 +7782,7 @@ public final class Core {
          AoStream sp = this;
          double medianPrice = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumFast = sp.sumFast;
          double sumSlow = sp.sumSlow;
          int pkSlot0 = -1;
@@ -9376,8 +9376,8 @@ public final class Core {
             throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
          AroonStream sp = this;
          double tmp = 0.0;
-         double cur_outAroonDown = sp.cur_outAroonDown;
-         double cur_outAroonUp = sp.cur_outAroonUp;
+         double cur_outAroonDown = 0.0;
+         double cur_outAroonUp = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -10312,7 +10312,7 @@ public final class Core {
          AroonoscStream sp = this;
          double tmp = 0.0;
          double aroon = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -11024,7 +11024,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ASIN peek: BadParam", RetCode.BadParam);
          AsinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.asin(inReal);
          return cur_outReal;
       }
@@ -11463,7 +11463,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ATAN peek: BadParam", RetCode.BadParam);
          AtanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.atan(inReal);
          return cur_outReal;
       }
@@ -12201,7 +12201,7 @@ public final class Core {
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;
@@ -12927,7 +12927,7 @@ public final class Core {
          double todaySum = 0.0;
          double todayDev = 0.0;
          int i = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          pkSlot0 = sp.winPos_i;
@@ -13473,7 +13473,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("AVGPRICE peek: BadParam", RetCode.BadParam);
          AvgpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose + inOpen) / 4;
          return cur_outReal;
       }
@@ -15811,7 +15811,7 @@ public final class Core {
          double S_y = sp.S_y;
          double S_yy = sp.S_yy;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double last_price_x = sp.last_price_x;
@@ -17046,7 +17046,7 @@ public final class Core {
             throw new TaLibArgumentException("BOP peek: BadParam", RetCode.BadParam);
          BopStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* BOP is a fraction of the bar's own range, so it is scale-free and the
           * divisor only has to be positive. An exact test, not the fixed
           * TA_IS_ZERO_OR_NEG band it used to be: the range carries the quote unit,
@@ -17768,7 +17768,7 @@ public final class Core {
          double theAverage = 0.0;
          double lastValue = 0.0;
          int j = 0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          lastValue = (inHigh + inLow + inClose) / 3;
@@ -18567,7 +18567,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL2CROWS peek: BadParam", RetCode.BadParam);
          Cdl2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -19349,7 +19349,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3BLACKCROWS peek: BadParam", RetCode.BadParam);
          Cdl3blackcrowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -20182,7 +20182,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3INSIDE peek: BadParam", RetCode.BadParam);
          Cdl3insideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -20996,7 +20996,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3LINESTRIKE peek: BadParam", RetCode.BadParam);
          Cdl3linestrikeStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;
@@ -21706,7 +21706,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3OUTSIDE peek: BadParam", RetCode.BadParam);
          Cdl3outsideStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 0 - 1 && sp.lag1_inClose > sp.lag2_inOpen && sp.lag1_inOpen < sp.lag2_inClose && inClose > sp.lag1_inClose || ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 1 && sp.lag1_inOpen > sp.lag2_inClose && sp.lag1_inClose < sp.lag2_inOpen && inClose < sp.lag1_inClose ) {
             /* white engulfs black */
             /* third candle higher */
@@ -22551,7 +22551,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3STARSINSOUTH peek: BadParam", RetCode.BadParam);
          Cdl3starsinsouthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -23650,7 +23650,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDL3WHITESOLDIERS peek: BadParam", RetCode.BadParam);
          Cdl3whitesoldiersStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -24702,7 +24702,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLABANDONEDBABY peek: BadParam", RetCode.BadParam);
          CdlabandonedbabyStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -25778,7 +25778,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLADVANCEBLOCK peek: BadParam", RetCode.BadParam);
          CdladvanceblockStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -26774,7 +26774,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLBELTHOLD peek: BadParam", RetCode.BadParam);
          CdlbeltholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -27553,7 +27553,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLBREAKAWAY peek: BadParam", RetCode.BadParam);
          CdlbreakawayStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -28338,7 +28338,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCLOSINGMARUBOZU peek: BadParam", RetCode.BadParam);
          CdlclosingmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -29124,7 +29124,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCONCEALBABYSWALL peek: BadParam", RetCode.BadParam);
          CdlconcealbabyswallStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -29956,7 +29956,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLCOUNTERATTACK peek: BadParam", RetCode.BadParam);
          CdlcounterattackStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -30762,7 +30762,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDARKCLOUDCOVER peek: BadParam", RetCode.BadParam);
          CdldarkcloudcoverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -31475,7 +31475,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDOJI peek: BadParam", RetCode.BadParam);
          CdldojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -32234,7 +32234,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDOJISTAR peek: BadParam", RetCode.BadParam);
          CdldojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -33042,7 +33042,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLDRAGONFLYDOJI peek: BadParam", RetCode.BadParam);
          CdldragonflydojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -33748,7 +33748,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLENGULFING peek: BadParam", RetCode.BadParam);
          CdlengulfingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((inClose >= inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && (inClose >= sp.lag1_inOpen && inOpen < sp.lag1_inClose || inClose > sp.lag1_inOpen && inOpen <= sp.lag1_inClose) || ((inClose >= inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && (inOpen >= sp.lag1_inClose && inClose < sp.lag1_inOpen || inOpen > sp.lag1_inClose && inClose <= sp.lag1_inOpen) ) {
             /* white engulfs black */
             /* black engulfs white */
@@ -34555,7 +34555,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLEVENINGDOJISTAR peek: BadParam", RetCode.BadParam);
          CdleveningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -35491,7 +35491,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLEVENINGSTAR peek: BadParam", RetCode.BadParam);
          CdleveningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -36348,7 +36348,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLGAPSIDESIDEWHITE peek: BadParam", RetCode.BadParam);
          CdlgapsidesidewhiteStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;
@@ -37172,7 +37172,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLGRAVESTONEDOJI peek: BadParam", RetCode.BadParam);
          CdlgravestonedojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -38050,7 +38050,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHAMMER peek: BadParam", RetCode.BadParam);
          CdlhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -39041,7 +39041,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHANGINGMAN peek: BadParam", RetCode.BadParam);
          CdlhangingmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -39967,7 +39967,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHARAMI peek: BadParam", RetCode.BadParam);
          CdlharamiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -40843,7 +40843,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHARAMICROSS peek: BadParam", RetCode.BadParam);
          CdlharamicrossStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -41688,7 +41688,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHIGHWAVE peek: BadParam", RetCode.BadParam);
          CdlhighwaveStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -42473,7 +42473,7 @@ public final class Core {
             throw new TaLibArgumentException("CDLHIKKAKE peek: BadParam", RetCode.BadParam);
          CdlhikkakeStream sp = this;
          int cd = sp.cd;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternResult = sp.patternResult;
          double savedHigh = sp.savedHigh;
          double savedLow = sp.savedLow;
@@ -43325,7 +43325,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHIKKAKEMOD peek: BadParam", RetCode.BadParam);
          CdlhikkakemodStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int patternCount = sp.patternCount;
          double patternHigh = sp.patternHigh;
          double patternLow = sp.patternLow;
@@ -44190,7 +44190,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLHOMINGPIGEON peek: BadParam", RetCode.BadParam);
          CdlhomingpigeonStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -45048,7 +45048,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLIDENTICAL3CROWS peek: BadParam", RetCode.BadParam);
          Cdlidentical3crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;
@@ -45920,7 +45920,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLINNECK peek: BadParam", RetCode.BadParam);
          CdlinneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -46772,7 +46772,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLINVERTEDHAMMER peek: BadParam", RetCode.BadParam);
          CdlinvertedhammerStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -47642,7 +47642,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLKICKING peek: BadParam", RetCode.BadParam);
          CdlkickingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -48482,7 +48482,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLKICKINGBYLENGTH peek: BadParam", RetCode.BadParam);
          CdlkickingbylengthStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -49292,7 +49292,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLADDERBOTTOM peek: BadParam", RetCode.BadParam);
          CdlladderbottomStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
          int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
          double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -50085,7 +50085,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLONGLEGGEDDOJI peek: BadParam", RetCode.BadParam);
          CdllongleggeddojiStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -50848,7 +50848,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLLONGLINE peek: BadParam", RetCode.BadParam);
          CdllonglineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -51622,7 +51622,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMARUBOZU peek: BadParam", RetCode.BadParam);
          CdlmarubozuStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -52367,7 +52367,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMATCHINGLOW peek: BadParam", RetCode.BadParam);
          CdlmatchinglowStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;
@@ -53216,7 +53216,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMATHOLD peek: BadParam", RetCode.BadParam);
          CdlmatholdStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -54201,7 +54201,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMORNINGDOJISTAR peek: BadParam", RetCode.BadParam);
          CdlmorningdojistarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -55145,7 +55145,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLMORNINGSTAR peek: BadParam", RetCode.BadParam);
          CdlmorningstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -55998,7 +55998,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLONNECK peek: BadParam", RetCode.BadParam);
          CdlonneckStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -56780,7 +56780,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLPIERCING peek: BadParam", RetCode.BadParam);
          CdlpiercingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -57594,7 +57594,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLRICKSHAWMAN peek: BadParam", RetCode.BadParam);
          CdlrickshawmanStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -58506,7 +58506,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLRISEFALL3METHODS peek: BadParam", RetCode.BadParam);
          Cdlrisefall3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -59446,7 +59446,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSEPARATINGLINES peek: BadParam", RetCode.BadParam);
          CdlseparatinglinesStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -60345,7 +60345,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSHOOTINGSTAR peek: BadParam", RetCode.BadParam);
          CdlshootingstarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -61189,7 +61189,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSHORTLINE peek: BadParam", RetCode.BadParam);
          CdlshortlineStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -61912,7 +61912,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSPINNINGTOP peek: BadParam", RetCode.BadParam);
          CdlspinningtopStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
          int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
          double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -62788,7 +62788,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSTALLEDPATTERN peek: BadParam", RetCode.BadParam);
          CdlstalledpatternStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -63698,7 +63698,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLSTICKSANDWICH peek: BadParam", RetCode.BadParam);
          CdlsticksandwichStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Equal_rangeType = sp.cs_Equal_rangeType;
          int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
          double Equal_factor = sp.cs_Equal_factor;
@@ -64510,7 +64510,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTAKURI peek: BadParam", RetCode.BadParam);
          CdltakuriStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -65318,7 +65318,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTASUKIGAP peek: BadParam", RetCode.BadParam);
          CdltasukigapStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int Near_rangeType = sp.cs_Near_rangeType;
          int Near_avgPeriod = sp.cs_Near_avgPeriod;
          double Near_factor = sp.cs_Near_factor;
@@ -66130,7 +66130,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTHRUSTING peek: BadParam", RetCode.BadParam);
          CdlthrustingStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -66925,7 +66925,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLTRISTAR peek: BadParam", RetCode.BadParam);
          CdltristarStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
          int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
          double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -67740,7 +67740,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLUNIQUE3RIVER peek: BadParam", RetCode.BadParam);
          Cdlunique3riverStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -68589,7 +68589,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLUPSIDEGAP2CROWS peek: BadParam", RetCode.BadParam);
          Cdlupsidegap2crowsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
          int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
          double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -69340,7 +69340,7 @@ public final class Core {
          if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("CDLXSIDEGAP3METHODS peek: BadParam", RetCode.BadParam);
          Cdlxsidegap3methodsStream sp = this;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          if( ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) && /* 1st and 2nd of same color */
              ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - ((inClose >= inOpen) ? 1 : 0 - 1) && /* 3rd opposite color */
              inOpen < Math.max(sp.lag1_inClose, sp.lag1_inOpen) &&  /* 3rd opens within 2nd rb */
@@ -69871,7 +69871,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("CEIL peek: BadParam", RetCode.BadParam);
          CeilStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.ceil(inReal);
          return cur_outReal;
       }
@@ -70617,7 +70617,7 @@ public final class Core {
          double close = 0.0;
          double tmp = 0.0;
          double mfv = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumMFV = sp.sumMFV;
          double sumVol = sp.sumVol;
          sumMFV -= sp.cb_mfv_flow[sp.mfv_Idx];
@@ -71527,7 +71527,7 @@ public final class Core {
          CmoStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;
@@ -72454,7 +72454,7 @@ public final class Core {
          double sum = 0.0;
          double diff = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double downSum = sp.downSum;
          int nullRun = sp.nullRun;
          double prevValue = sp.prevValue;
@@ -73591,7 +73591,7 @@ public final class Core {
          double tempReal = 0.0;
          int windowStart = 0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double shiftX = sp.shiftX;
          double shiftY = sp.shiftY;
@@ -74617,7 +74617,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("COS peek: BadParam", RetCode.BadParam);
          CosStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.cos(inReal);
          return cur_outReal;
       }
@@ -75055,7 +75055,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("COSH peek: BadParam", RetCode.BadParam);
          CoshStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.cosh(inReal);
          return cur_outReal;
       }
@@ -75725,7 +75725,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("DEMA peek: BadParam", RetCode.BadParam);
          DemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          if( sp.optInTimePeriod == 1 ) {
@@ -76332,7 +76332,7 @@ public final class Core {
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("DIV peek: BadParam", RetCode.BadParam);
          DivStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 / inReal1;
          return cur_outReal;
       }
@@ -77056,9 +77056,9 @@ public final class Core {
          DonchianStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-         double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-         double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+         double cur_outRealLowerBand = 0.0;
+         double cur_outRealMiddleBand = 0.0;
+         double cur_outRealUpperBand = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -78305,7 +78305,7 @@ public final class Core {
          double diffM = 0.0;
          double minusDI = 0.0;
          double plusDI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevClose = sp.prevClose;
          double prevHigh = sp.prevHigh;
          double prevLow = sp.prevLow;
@@ -80218,7 +80218,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("EMA peek: BadParam", RetCode.BadParam);
          EmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          if( sp.optInTimePeriod == 1 ) {
             cur_outReal = inReal;
@@ -80750,7 +80750,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("EXP peek: BadParam", RetCode.BadParam);
          ExpStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.exp(inReal);
          return cur_outReal;
       }
@@ -81186,7 +81186,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("FLOOR peek: BadParam", RetCode.BadParam);
          FloorStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.floor(inReal);
          return cur_outReal;
       }
@@ -84391,7 +84391,7 @@ public final class Core {
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -86359,7 +86359,7 @@ public final class Core {
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -88382,8 +88382,8 @@ public final class Core {
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outInPhase = sp.cur_outInPhase;
-         double cur_outQuadrature = sp.cur_outQuadrature;
+         double cur_outInPhase = 0.0;
+         double cur_outQuadrature = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double periodWMASub = sp.periodWMASub;
          double periodWMASum = sp.periodWMASum;
@@ -90361,8 +90361,8 @@ public final class Core {
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outLeadSine = sp.cur_outLeadSine;
-         double cur_outSine = sp.cur_outSine;
+         double cur_outLeadSine = 0.0;
+         double cur_outSine = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double period = sp.period;
          double periodWMASub = sp.periodWMASub;
@@ -92482,7 +92482,7 @@ public final class Core {
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
          double iTrend2 = sp.iTrend2;
@@ -94743,7 +94743,7 @@ public final class Core {
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
          double Im = sp.Im;
          double Re = sp.Re;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int daysInTrend = sp.daysInTrend;
          int hilbertIdx = sp.hilbertIdx;
          double iTrend1 = sp.iTrend1;
@@ -97332,7 +97332,7 @@ public final class Core {
          double tempReal = 0.0;
          double tempReal2 = 0.0;
          double periodROC = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          double prevKAMA = sp.prevKAMA;
          double sumROC1 = sp.sumROC1;
@@ -99318,7 +99318,7 @@ public final class Core {
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;
@@ -100461,7 +100461,7 @@ public final class Core {
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;
@@ -101597,7 +101597,7 @@ public final class Core {
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;
@@ -102728,7 +102728,7 @@ public final class Core {
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;
@@ -103554,7 +103554,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("LN peek: BadParam", RetCode.BadParam);
          LnStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.log(inReal);
          return cur_outReal;
       }
@@ -103998,7 +103998,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("LOG10 peek: BadParam", RetCode.BadParam);
          Log10Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.log10(inReal);
          return cur_outReal;
       }
@@ -106165,9 +106165,9 @@ public final class Core {
          MacdStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;
@@ -108255,9 +108255,9 @@ public final class Core {
          MacdfixStream sp = this;
          double macdValue = 0.0;
          double tempReal = 0.0;
-         double cur_outMACD = sp.cur_outMACD;
-         double cur_outMACDHist = sp.cur_outMACDHist;
-         double cur_outMACDSignal = sp.cur_outMACDSignal;
+         double cur_outMACD = 0.0;
+         double cur_outMACDHist = 0.0;
+         double cur_outMACDSignal = 0.0;
          double prevFast = sp.prevFast;
          double prevSignal = sp.prevSignal;
          double prevSlow = sp.prevSlow;
@@ -109799,8 +109799,8 @@ public final class Core {
          double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
          double I1ForOddPrev2 = sp.I1ForOddPrev2;
          double I1ForOddPrev3 = sp.I1ForOddPrev3;
-         double cur_outFAMA = sp.cur_outFAMA;
-         double cur_outMAMA = sp.cur_outMAMA;
+         double cur_outFAMA = 0.0;
+         double cur_outMAMA = 0.0;
          double fama = sp.fama;
          int hilbertIdx = sp.hilbertIdx;
          double mama = sp.mama;
@@ -111103,7 +111103,7 @@ public final class Core {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inVolume) )
             throw new TaLibArgumentException("MARKETFI peek: BadParam", RetCode.BadParam);
          MarketfiStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* A zero-volume bar would divide by zero. Neither reference guards
           * it -- they emit +/-Inf, or NaN when the range is zero too -- but
           * issue #112 settled that a successful call never emits NaN or Inf,
@@ -112914,7 +112914,7 @@ public final class Core {
             throw new TaLibArgumentException("MAX peek: BadParam", RetCode.BadParam);
          MaxStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -113649,7 +113649,7 @@ public final class Core {
             throw new TaLibArgumentException("MAXINDEX peek: BadParam", RetCode.BadParam);
          MaxindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -114249,7 +114249,7 @@ public final class Core {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
             throw new TaLibArgumentException("MEDPRICE peek: BadParam", RetCode.BadParam);
          MedpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow) / 2.0;
          return cur_outReal;
       }
@@ -115059,7 +115059,7 @@ public final class Core {
          double posFlow = 0.0;
          double negFlow = 0.0;
          double posClamped = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double negSumMF = sp.negSumMF;
          int nullRun = sp.nullRun;
          double posSumMF = sp.posSumMF;
@@ -116086,7 +116086,7 @@ public final class Core {
          MidpointStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -117096,7 +117096,7 @@ public final class Core {
          MidpriceStream sp = this;
          double tmpLow = 0.0;
          double tmpHigh = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -118015,7 +118015,7 @@ public final class Core {
             throw new TaLibArgumentException("MIN peek: BadParam", RetCode.BadParam);
          MinStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;
@@ -118748,7 +118748,7 @@ public final class Core {
             throw new TaLibArgumentException("MININDEX peek: BadParam", RetCode.BadParam);
          MinindexStream sp = this;
          double tmp = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
+         int cur_outInteger = 0;
          int i = sp.i;
          double lowest = sp.lowest;
          int lowestIdx = sp.lowestIdx;
@@ -119678,8 +119678,8 @@ public final class Core {
          MinmaxStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         double cur_outMax = sp.cur_outMax;
-         double cur_outMin = sp.cur_outMin;
+         double cur_outMax = 0.0;
+         double cur_outMin = 0.0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -120586,8 +120586,8 @@ public final class Core {
          MinmaxindexStream sp = this;
          double tmpHigh = 0.0;
          double tmpLow = 0.0;
-         int cur_outMaxIdx = sp.cur_outMaxIdx;
-         int cur_outMinIdx = sp.cur_outMinIdx;
+         int cur_outMaxIdx = 0;
+         int cur_outMinIdx = 0;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -124122,7 +124122,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("MOM peek: BadParam", RetCode.BadParam);
          MomStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {
@@ -124659,7 +124659,7 @@ public final class Core {
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("MULT peek: BadParam", RetCode.BadParam);
          MultStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 * inReal1;
          return cur_outReal;
       }
@@ -125477,7 +125477,7 @@ public final class Core {
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevATR = sp.prevATR;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;
@@ -126273,7 +126273,7 @@ public final class Core {
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempNVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevNVI = sp.prevNVI;
          tempClose = inClose;
          tempVolume = inVolume;
@@ -126855,7 +126855,7 @@ public final class Core {
             throw new TaLibArgumentException("OBV peek: BadParam", RetCode.BadParam);
          ObvStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevOBV = sp.prevOBV;
          tempReal = inReal;
          if( tempReal > sp.prevReal ) {
@@ -130938,7 +130938,7 @@ public final class Core {
          double tempClose = 0.0;
          double tempVolume = 0.0;
          double tempPVI = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevPVI = sp.prevPVI;
          tempClose = inClose;
          tempVolume = inVolume;
@@ -132367,7 +132367,7 @@ public final class Core {
             throw new TaLibArgumentException("QSTICK peek: BadParam", RetCode.BadParam);
          QstickStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
@@ -133099,7 +133099,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("RMA peek: BadParam", RetCode.BadParam);
          RmaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevRMA = sp.prevRMA;
          prevRMA = Math.fma(sp.wBeta, prevRMA, sp.wAlpha * inReal);
          cur_outReal = prevRMA;
@@ -133728,7 +133728,7 @@ public final class Core {
             throw new TaLibArgumentException("ROC peek: BadParam", RetCode.BadParam);
          RocStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {
@@ -134380,7 +134380,7 @@ public final class Core {
             throw new TaLibArgumentException("ROCP peek: BadParam", RetCode.BadParam);
          RocpStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {
@@ -135035,7 +135035,7 @@ public final class Core {
             throw new TaLibArgumentException("ROCR peek: BadParam", RetCode.BadParam);
          RocrStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {
@@ -135692,7 +135692,7 @@ public final class Core {
             throw new TaLibArgumentException("ROCR100 peek: BadParam", RetCode.BadParam);
          Rocr100Stream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
          if( sp.ringCap_trailingIdx == 0 ) {
@@ -136553,7 +136553,7 @@ public final class Core {
          RsiStream sp = this;
          double tempValue1 = 0.0;
          double tempValue2 = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevGain = sp.prevGain;
          double prevLoss = sp.prevLoss;
          double prevValue = sp.prevValue;
@@ -137643,7 +137643,7 @@ public final class Core {
          double prevHigh = 0.0;
          double prevLow = 0.0;
          double af = sp.af;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;
@@ -139249,7 +139249,7 @@ public final class Core {
          double prevLow = 0.0;
          double afLong = sp.afLong;
          double afShort = sp.afShort;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double ep = sp.ep;
          int isLong = sp.isLong;
          double newHigh = sp.newHigh;
@@ -140268,7 +140268,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SIN peek: BadParam", RetCode.BadParam);
          SinStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sin(inReal);
          return cur_outReal;
       }
@@ -140704,7 +140704,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SINH peek: BadParam", RetCode.BadParam);
          SinhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sinh(inReal);
          return cur_outReal;
       }
@@ -141266,7 +141266,7 @@ public final class Core {
             throw new TaLibArgumentException("SMA peek: BadParam", RetCode.BadParam);
          SmaStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
@@ -142476,8 +142476,8 @@ public final class Core {
          double den = 0.0;
          double halfDen = 0.0;
          double smiValue = 0.0;
-         double cur_outSMI = sp.cur_outSMI;
-         double cur_outSMISignal = sp.cur_outSMISignal;
+         double cur_outSMI = 0.0;
+         double cur_outSMISignal = 0.0;
          double emaFastDen = sp.emaFastDen;
          double emaFastNum = sp.emaFastNum;
          double emaSlowDen = sp.emaSlowDen;
@@ -143430,7 +143430,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("SQRT peek: BadParam", RetCode.BadParam);
          SqrtStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.sqrt(inReal);
          return cur_outReal;
       }
@@ -148124,7 +148124,7 @@ public final class Core {
          if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
             throw new TaLibArgumentException("SUB peek: BadParam", RetCode.BadParam);
          SubStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = inReal0 - inReal1;
          return cur_outReal;
       }
@@ -148669,7 +148669,7 @@ public final class Core {
             throw new TaLibArgumentException("SUM peek: BadParam", RetCode.BadParam);
          SumStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodTotal = sp.periodTotal;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;
@@ -149630,8 +149630,8 @@ public final class Core {
          double basicUpper = 0.0;
          double basicLower = 0.0;
          double closeToday = 0.0;
-         int cur_outInteger = sp.cur_outInteger;
-         double cur_outReal = sp.cur_outReal;
+         int cur_outInteger = 0;
+         double cur_outReal = 0.0;
          double finalLower = sp.finalLower;
          double finalUpper = sp.finalUpper;
          int isUptrend = sp.isUptrend;
@@ -150766,7 +150766,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("T3 peek: BadParam", RetCode.BadParam);
          T3Stream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double e1 = sp.e1;
          double e2 = sp.e2;
          double e3 = sp.e3;
@@ -151412,7 +151412,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TAN peek: BadParam", RetCode.BadParam);
          TanStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.tan(inReal);
          return cur_outReal;
       }
@@ -151850,7 +151850,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TANH peek: BadParam", RetCode.BadParam);
          TanhStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = Math.tanh(inReal);
          return cur_outReal;
       }
@@ -152562,7 +152562,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("TEMA peek: BadParam", RetCode.BadParam);
          TemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;
@@ -153299,7 +153299,7 @@ public final class Core {
          double tempCY = 0.0;
          double tempLT = 0.0;
          double tempHT = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          /* Find the greatest of the 3 values. */
          tempLT = inLow;
          tempHT = inHigh;
@@ -155469,7 +155469,7 @@ public final class Core {
             throw new TaLibArgumentException("TRIX peek: BadParam", RetCode.BadParam);
          TrixStream sp = this;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevEMA1 = sp.prevEMA1;
          double prevEMA2 = sp.prevEMA2;
          double prevEMA3 = sp.prevEMA3;
@@ -156352,7 +156352,7 @@ public final class Core {
          double SumXY = sp.SumXY;
          double SumY = sp.SumY;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int j = sp.j;
          double sumAbs = sp.sumAbs;
          int today = sp.today;
@@ -157209,7 +157209,7 @@ public final class Core {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("TYPPRICE peek: BadParam", RetCode.BadParam);
          TyppriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (inHigh + inLow + inClose) / 3.0;
          return cur_outReal;
       }
@@ -158268,7 +158268,7 @@ public final class Core {
          double b1Total = sp.b1Total;
          double b2Total = sp.b2Total;
          double b3Total = sp.b3Total;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int nullRun = sp.nullRun;
          int term_Idx = sp.term_Idx;
          int trailingPos1 = sp.trailingPos1;
@@ -159523,7 +159523,7 @@ public final class Core {
          double meanValue1 = 0.0;
          double variance = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          int i = sp.i;
          int j = sp.j;
          double periodTotal1 = sp.periodTotal1;
@@ -160596,7 +160596,7 @@ public final class Core {
          double typPrice = 0.0;
          double volume = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          double vwap = sp.vwap;
@@ -161547,7 +161547,7 @@ public final class Core {
          double tempPV = 0.0;
          double tempV = 0.0;
          double tempReal = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sumPV = sp.sumPV;
          double sumV = sp.sumV;
          int pkSlot0 = -1;
@@ -162327,7 +162327,7 @@ public final class Core {
          WadStream sp = this;
          double close = 0.0;
          double trueExtreme = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double sum = sp.sum;
          close = inClose;
          if( close > sp.prevClose ) {
@@ -162898,7 +162898,7 @@ public final class Core {
          if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
             throw new TaLibArgumentException("WCLPRICE peek: BadParam", RetCode.BadParam);
          WclpriceStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          cur_outReal = (Math.fma(inClose, 2.0, inHigh + inLow)) / 4.0;
          return cur_outReal;
       }
@@ -163729,7 +163729,7 @@ public final class Core {
             throw new TaLibArgumentException("WILLR peek: BadParam", RetCode.BadParam);
          WillrStream sp = this;
          double tmp = 0.0;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
@@ -164752,7 +164752,7 @@ public final class Core {
          int rw = 0;
          double tempReal = 0.0;
          int barsSinceReseed = sp.barsSinceReseed;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double periodSub = sp.periodSub;
          double periodSum = sp.periodSum;
          double trailingValue = sp.trailingValue;
@@ -165795,7 +165795,7 @@ public final class Core {
          if( !Double.isFinite(inReal) )
             throw new TaLibArgumentException("ZLEMA peek: BadParam", RetCode.BadParam);
          ZlemaStream sp = this;
-         double cur_outReal = sp.cur_outReal;
+         double cur_outReal = 0.0;
          double prevMA = sp.prevMA;
          int pkSlot0 = -1;
          double pkVal0 = 0.0;

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -846,7 +846,7 @@ class Core {
              double medianPrice = 0.0;
              double osc = 0.0;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int oscBuffer_Idx = sp.oscBuffer_Idx;
              double sumFast = sp.sumFast;
              double sumSignal = sp.sumSignal;
@@ -1880,9 +1880,9 @@ class Core {
              double tempMiddle = 0.0;
              double tempLower = 0.0;
              double tempReal = 0.0;
-             double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-             double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-             double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+             double cur_outRealLowerBand = 0.0;
+             double cur_outRealMiddleBand = 0.0;
+             double cur_outRealUpperBand = 0.0;
              double periodTotalLower = sp.periodTotalLower;
              double periodTotalMiddle = sp.periodTotalMiddle;
              double periodTotalUpper = sp.periodTotalUpper;
@@ -2594,7 +2594,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("ACOS peek: BadParam", RetCode.BadParam);
              AcosStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.acos(inReal);
              return cur_outReal;
           }
@@ -3127,7 +3127,7 @@ class Core {
              double close = 0.0;
              double tmp = 0.0;
              double ad = sp.ad;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              high = inHigh;
              low = inLow;
              tmp = high - low;
@@ -3642,7 +3642,7 @@ class Core {
              if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
                 throw new TaLibArgumentException("ADD peek: BadParam", RetCode.BadParam);
              AddStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = inReal0 + inReal1;
              return cur_outReal;
           }
@@ -4380,7 +4380,7 @@ class Core {
              double close = 0.0;
              double tmp = 0.0;
              double ad = sp.ad;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double fastEMA = sp.fastEMA;
              double slowEMA = sp.slowEMA;
              high = inHigh;
@@ -5616,7 +5616,7 @@ class Core {
              double diffM = 0.0;
              double minusDI = 0.0;
              double plusDI = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevADX = sp.prevADX;
              double prevClose = sp.prevClose;
              double prevHigh = sp.prevHigh;
@@ -7453,7 +7453,7 @@ class Core {
              AoStream sp = this;
              double medianPrice = 0.0;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double sumFast = sp.sumFast;
              double sumSlow = sp.sumSlow;
              int pkSlot0 = -1;
@@ -9047,8 +9047,8 @@ class Core {
                 throw new TaLibArgumentException("AROON peek: BadParam", RetCode.BadParam);
              AroonStream sp = this;
              double tmp = 0.0;
-             double cur_outAroonDown = sp.cur_outAroonDown;
-             double cur_outAroonUp = sp.cur_outAroonUp;
+             double cur_outAroonDown = 0.0;
+             double cur_outAroonUp = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -9983,7 +9983,7 @@ class Core {
              AroonoscStream sp = this;
              double tmp = 0.0;
              double aroon = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -10695,7 +10695,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("ASIN peek: BadParam", RetCode.BadParam);
              AsinStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.asin(inReal);
              return cur_outReal;
           }
@@ -11134,7 +11134,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("ATAN peek: BadParam", RetCode.BadParam);
              AtanStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.atan(inReal);
              return cur_outReal;
           }
@@ -11872,7 +11872,7 @@ class Core {
              double tempCY = 0.0;
              double tempLT = 0.0;
              double tempHT = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevATR = sp.prevATR;
              /* Find the greatest of the 3 values. */
              tempLT = inLow;
@@ -12598,7 +12598,7 @@ class Core {
              double todaySum = 0.0;
              double todayDev = 0.0;
              int i = 0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              pkSlot0 = sp.winPos_i;
@@ -13144,7 +13144,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("AVGPRICE peek: BadParam", RetCode.BadParam);
              AvgpriceStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = (inHigh + inLow + inClose + inOpen) / 4;
              return cur_outReal;
           }
@@ -15482,7 +15482,7 @@ class Core {
              double S_y = sp.S_y;
              double S_yy = sp.S_yy;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int i = sp.i;
              int j = sp.j;
              double last_price_x = sp.last_price_x;
@@ -16717,7 +16717,7 @@ class Core {
                 throw new TaLibArgumentException("BOP peek: BadParam", RetCode.BadParam);
              BopStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              /* BOP is a fraction of the bar's own range, so it is scale-free and the
               * divisor only has to be positive. An exact test, not the fixed
               * TA_IS_ZERO_OR_NEG band it used to be: the range carries the quote unit,
@@ -17439,7 +17439,7 @@ class Core {
              double theAverage = 0.0;
              double lastValue = 0.0;
              int j = 0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              lastValue = (inHigh + inLow + inClose) / 3;
@@ -18238,7 +18238,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL2CROWS peek: BadParam", RetCode.BadParam);
              Cdl2crowsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -19020,7 +19020,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3BLACKCROWS peek: BadParam", RetCode.BadParam);
              Cdl3blackcrowsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
              int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
              double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -19853,7 +19853,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3INSIDE peek: BadParam", RetCode.BadParam);
              Cdl3insideStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -20667,7 +20667,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3LINESTRIKE peek: BadParam", RetCode.BadParam);
              Cdl3linestrikeStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Near_rangeType = sp.cs_Near_rangeType;
              int Near_avgPeriod = sp.cs_Near_avgPeriod;
              double Near_factor = sp.cs_Near_factor;
@@ -21377,7 +21377,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3OUTSIDE peek: BadParam", RetCode.BadParam);
              Cdl3outsideStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              if( ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 0 - 1 && sp.lag1_inClose > sp.lag2_inOpen && sp.lag1_inOpen < sp.lag2_inClose && inClose > sp.lag1_inClose || ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == 1 && sp.lag1_inOpen > sp.lag2_inClose && sp.lag1_inClose < sp.lag2_inOpen && inClose < sp.lag1_inClose ) {
                 /* white engulfs black */
                 /* third candle higher */
@@ -22222,7 +22222,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3STARSINSOUTH peek: BadParam", RetCode.BadParam);
              Cdl3starsinsouthStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -23321,7 +23321,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDL3WHITESOLDIERS peek: BadParam", RetCode.BadParam);
              Cdl3whitesoldiersStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -24373,7 +24373,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLABANDONEDBABY peek: BadParam", RetCode.BadParam);
              CdlabandonedbabyStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -25449,7 +25449,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLADVANCEBLOCK peek: BadParam", RetCode.BadParam);
              CdladvanceblockStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -26445,7 +26445,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLBELTHOLD peek: BadParam", RetCode.BadParam);
              CdlbeltholdStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -27224,7 +27224,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLBREAKAWAY peek: BadParam", RetCode.BadParam);
              CdlbreakawayStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -28009,7 +28009,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLCLOSINGMARUBOZU peek: BadParam", RetCode.BadParam);
              CdlclosingmarubozuStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -28795,7 +28795,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLCONCEALBABYSWALL peek: BadParam", RetCode.BadParam);
              CdlconcealbabyswallStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
              int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
              double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -29627,7 +29627,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLCOUNTERATTACK peek: BadParam", RetCode.BadParam);
              CdlcounterattackStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -30433,7 +30433,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLDARKCLOUDCOVER peek: BadParam", RetCode.BadParam);
              CdldarkcloudcoverStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -31146,7 +31146,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLDOJI peek: BadParam", RetCode.BadParam);
              CdldojiStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -31905,7 +31905,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLDOJISTAR peek: BadParam", RetCode.BadParam);
              CdldojistarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -32713,7 +32713,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLDRAGONFLYDOJI peek: BadParam", RetCode.BadParam);
              CdldragonflydojiStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -33419,7 +33419,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLENGULFING peek: BadParam", RetCode.BadParam);
              CdlengulfingStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              if( ((inClose >= inOpen) ? 1 : 0 - 1) == 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - 1 && (inClose >= sp.lag1_inOpen && inOpen < sp.lag1_inClose || inClose > sp.lag1_inOpen && inOpen <= sp.lag1_inClose) || ((inClose >= inOpen) ? 1 : 0 - 1) == 0 - 1 && ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 1 && (inOpen >= sp.lag1_inClose && inClose < sp.lag1_inOpen || inOpen > sp.lag1_inClose && inClose <= sp.lag1_inOpen) ) {
                 /* white engulfs black */
                 /* black engulfs white */
@@ -34226,7 +34226,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLEVENINGDOJISTAR peek: BadParam", RetCode.BadParam);
              CdleveningdojistarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -35162,7 +35162,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLEVENINGSTAR peek: BadParam", RetCode.BadParam);
              CdleveningstarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -36019,7 +36019,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLGAPSIDESIDEWHITE peek: BadParam", RetCode.BadParam);
              CdlgapsidesidewhiteStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Equal_rangeType = sp.cs_Equal_rangeType;
              int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
              double Equal_factor = sp.cs_Equal_factor;
@@ -36843,7 +36843,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLGRAVESTONEDOJI peek: BadParam", RetCode.BadParam);
              CdlgravestonedojiStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -37721,7 +37721,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHAMMER peek: BadParam", RetCode.BadParam);
              CdlhammerStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -38712,7 +38712,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHANGINGMAN peek: BadParam", RetCode.BadParam);
              CdlhangingmanStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -39638,7 +39638,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHARAMI peek: BadParam", RetCode.BadParam);
              CdlharamiStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -40514,7 +40514,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHARAMICROSS peek: BadParam", RetCode.BadParam);
              CdlharamicrossStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -41359,7 +41359,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHIGHWAVE peek: BadParam", RetCode.BadParam);
              CdlhighwaveStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -42144,7 +42144,7 @@ class Core {
                 throw new TaLibArgumentException("CDLHIKKAKE peek: BadParam", RetCode.BadParam);
              CdlhikkakeStream sp = this;
              int cd = sp.cd;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int patternResult = sp.patternResult;
              double savedHigh = sp.savedHigh;
              double savedLow = sp.savedLow;
@@ -42996,7 +42996,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHIKKAKEMOD peek: BadParam", RetCode.BadParam);
              CdlhikkakemodStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int patternCount = sp.patternCount;
              double patternHigh = sp.patternHigh;
              double patternLow = sp.patternLow;
@@ -43861,7 +43861,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLHOMINGPIGEON peek: BadParam", RetCode.BadParam);
              CdlhomingpigeonStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -44719,7 +44719,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLIDENTICAL3CROWS peek: BadParam", RetCode.BadParam);
              Cdlidentical3crowsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Equal_rangeType = sp.cs_Equal_rangeType;
              int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
              double Equal_factor = sp.cs_Equal_factor;
@@ -45591,7 +45591,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLINNECK peek: BadParam", RetCode.BadParam);
              CdlinneckStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -46443,7 +46443,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLINVERTEDHAMMER peek: BadParam", RetCode.BadParam);
              CdlinvertedhammerStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -47313,7 +47313,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLKICKING peek: BadParam", RetCode.BadParam);
              CdlkickingStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -48153,7 +48153,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLKICKINGBYLENGTH peek: BadParam", RetCode.BadParam);
              CdlkickingbylengthStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -48963,7 +48963,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLLADDERBOTTOM peek: BadParam", RetCode.BadParam);
              CdlladderbottomStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int ShadowVeryShort_rangeType = sp.cs_ShadowVeryShort_rangeType;
              int ShadowVeryShort_avgPeriod = sp.cs_ShadowVeryShort_avgPeriod;
              double ShadowVeryShort_factor = sp.cs_ShadowVeryShort_factor;
@@ -49756,7 +49756,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLLONGLEGGEDDOJI peek: BadParam", RetCode.BadParam);
              CdllongleggeddojiStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -50519,7 +50519,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLLONGLINE peek: BadParam", RetCode.BadParam);
              CdllonglineStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -51293,7 +51293,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLMARUBOZU peek: BadParam", RetCode.BadParam);
              CdlmarubozuStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -52038,7 +52038,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLMATCHINGLOW peek: BadParam", RetCode.BadParam);
              CdlmatchinglowStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Equal_rangeType = sp.cs_Equal_rangeType;
              int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
              double Equal_factor = sp.cs_Equal_factor;
@@ -52887,7 +52887,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLMATHOLD peek: BadParam", RetCode.BadParam);
              CdlmatholdStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -53872,7 +53872,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLMORNINGDOJISTAR peek: BadParam", RetCode.BadParam);
              CdlmorningdojistarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -54816,7 +54816,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLMORNINGSTAR peek: BadParam", RetCode.BadParam);
              CdlmorningstarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -55669,7 +55669,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLONNECK peek: BadParam", RetCode.BadParam);
              CdlonneckStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -56451,7 +56451,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLPIERCING peek: BadParam", RetCode.BadParam);
              CdlpiercingStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -57265,7 +57265,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLRICKSHAWMAN peek: BadParam", RetCode.BadParam);
              CdlrickshawmanStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -58177,7 +58177,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLRISEFALL3METHODS peek: BadParam", RetCode.BadParam);
              Cdlrisefall3methodsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -59117,7 +59117,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSEPARATINGLINES peek: BadParam", RetCode.BadParam);
              CdlseparatinglinesStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -60016,7 +60016,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSHOOTINGSTAR peek: BadParam", RetCode.BadParam);
              CdlshootingstarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -60860,7 +60860,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSHORTLINE peek: BadParam", RetCode.BadParam);
              CdlshortlineStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -61583,7 +61583,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSPINNINGTOP peek: BadParam", RetCode.BadParam);
              CdlspinningtopStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyShort_rangeType = sp.cs_BodyShort_rangeType;
              int BodyShort_avgPeriod = sp.cs_BodyShort_avgPeriod;
              double BodyShort_factor = sp.cs_BodyShort_factor;
@@ -62459,7 +62459,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSTALLEDPATTERN peek: BadParam", RetCode.BadParam);
              CdlstalledpatternStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -63369,7 +63369,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLSTICKSANDWICH peek: BadParam", RetCode.BadParam);
              CdlsticksandwichStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Equal_rangeType = sp.cs_Equal_rangeType;
              int Equal_avgPeriod = sp.cs_Equal_avgPeriod;
              double Equal_factor = sp.cs_Equal_factor;
@@ -64181,7 +64181,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLTAKURI peek: BadParam", RetCode.BadParam);
              CdltakuriStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -64989,7 +64989,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLTASUKIGAP peek: BadParam", RetCode.BadParam);
              CdltasukigapStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int Near_rangeType = sp.cs_Near_rangeType;
              int Near_avgPeriod = sp.cs_Near_avgPeriod;
              double Near_factor = sp.cs_Near_factor;
@@ -65801,7 +65801,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLTHRUSTING peek: BadParam", RetCode.BadParam);
              CdlthrustingStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -66596,7 +66596,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLTRISTAR peek: BadParam", RetCode.BadParam);
              CdltristarStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyDoji_rangeType = sp.cs_BodyDoji_rangeType;
              int BodyDoji_avgPeriod = sp.cs_BodyDoji_avgPeriod;
              double BodyDoji_factor = sp.cs_BodyDoji_factor;
@@ -67411,7 +67411,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLUNIQUE3RIVER peek: BadParam", RetCode.BadParam);
              Cdlunique3riverStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -68260,7 +68260,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLUPSIDEGAP2CROWS peek: BadParam", RetCode.BadParam);
              Cdlupsidegap2crowsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int BodyLong_rangeType = sp.cs_BodyLong_rangeType;
              int BodyLong_avgPeriod = sp.cs_BodyLong_avgPeriod;
              double BodyLong_factor = sp.cs_BodyLong_factor;
@@ -69011,7 +69011,7 @@ class Core {
              if( !Double.isFinite(inOpen) || !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("CDLXSIDEGAP3METHODS peek: BadParam", RetCode.BadParam);
              Cdlxsidegap3methodsStream sp = this;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              if( ((sp.lag2_inClose >= sp.lag2_inOpen) ? 1 : 0 - 1) == ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) && /* 1st and 2nd of same color */
                  ((sp.lag1_inClose >= sp.lag1_inOpen) ? 1 : 0 - 1) == 0 - ((inClose >= inOpen) ? 1 : 0 - 1) && /* 3rd opposite color */
                  inOpen < Math.max(sp.lag1_inClose, sp.lag1_inOpen) &&  /* 3rd opens within 2nd rb */
@@ -69542,7 +69542,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("CEIL peek: BadParam", RetCode.BadParam);
              CeilStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.ceil(inReal);
              return cur_outReal;
           }
@@ -70288,7 +70288,7 @@ class Core {
              double close = 0.0;
              double tmp = 0.0;
              double mfv = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double sumMFV = sp.sumMFV;
              double sumVol = sp.sumVol;
              sumMFV -= sp.cb_mfv_flow[sp.mfv_Idx];
@@ -71198,7 +71198,7 @@ class Core {
              CmoStream sp = this;
              double tempValue1 = 0.0;
              double tempValue2 = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevGain = sp.prevGain;
              double prevLoss = sp.prevLoss;
              double prevValue = sp.prevValue;
@@ -72125,7 +72125,7 @@ class Core {
              double sum = 0.0;
              double diff = 0.0;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double downSum = sp.downSum;
              int nullRun = sp.nullRun;
              double prevValue = sp.prevValue;
@@ -73262,7 +73262,7 @@ class Core {
              double tempReal = 0.0;
              int windowStart = 0;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double shiftX = sp.shiftX;
              double shiftY = sp.shiftY;
@@ -74288,7 +74288,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("COS peek: BadParam", RetCode.BadParam);
              CosStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.cos(inReal);
              return cur_outReal;
           }
@@ -74726,7 +74726,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("COSH peek: BadParam", RetCode.BadParam);
              CoshStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.cosh(inReal);
              return cur_outReal;
           }
@@ -75396,7 +75396,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("DEMA peek: BadParam", RetCode.BadParam);
              DemaStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevEMA1 = sp.prevEMA1;
              double prevEMA2 = sp.prevEMA2;
              if( sp.optInTimePeriod == 1 ) {
@@ -76003,7 +76003,7 @@ class Core {
              if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
                 throw new TaLibArgumentException("DIV peek: BadParam", RetCode.BadParam);
              DivStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = inReal0 / inReal1;
              return cur_outReal;
           }
@@ -76727,9 +76727,9 @@ class Core {
              DonchianStream sp = this;
              double tmpLow = 0.0;
              double tmpHigh = 0.0;
-             double cur_outRealLowerBand = sp.cur_outRealLowerBand;
-             double cur_outRealMiddleBand = sp.cur_outRealMiddleBand;
-             double cur_outRealUpperBand = sp.cur_outRealUpperBand;
+             double cur_outRealLowerBand = 0.0;
+             double cur_outRealMiddleBand = 0.0;
+             double cur_outRealUpperBand = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -77976,7 +77976,7 @@ class Core {
              double diffM = 0.0;
              double minusDI = 0.0;
              double plusDI = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevClose = sp.prevClose;
              double prevHigh = sp.prevHigh;
              double prevLow = sp.prevLow;
@@ -79889,7 +79889,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("EMA peek: BadParam", RetCode.BadParam);
              EmaStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevMA = sp.prevMA;
              if( sp.optInTimePeriod == 1 ) {
                 cur_outReal = inReal;
@@ -80421,7 +80421,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("EXP peek: BadParam", RetCode.BadParam);
              ExpStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.exp(inReal);
              return cur_outReal;
           }
@@ -80857,7 +80857,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("FLOOR peek: BadParam", RetCode.BadParam);
              FloorStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.floor(inReal);
              return cur_outReal;
           }
@@ -84062,7 +84062,7 @@ class Core {
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
              double Re = sp.Re;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int hilbertIdx = sp.hilbertIdx;
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
@@ -86030,7 +86030,7 @@ class Core {
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
              double Re = sp.Re;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int hilbertIdx = sp.hilbertIdx;
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
@@ -88053,8 +88053,8 @@ class Core {
              double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
-             double cur_outInPhase = sp.cur_outInPhase;
-             double cur_outQuadrature = sp.cur_outQuadrature;
+             double cur_outInPhase = 0.0;
+             double cur_outQuadrature = 0.0;
              int hilbertIdx = sp.hilbertIdx;
              double periodWMASub = sp.periodWMASub;
              double periodWMASum = sp.periodWMASum;
@@ -90032,8 +90032,8 @@ class Core {
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
              double Re = sp.Re;
-             double cur_outLeadSine = sp.cur_outLeadSine;
-             double cur_outSine = sp.cur_outSine;
+             double cur_outLeadSine = 0.0;
+             double cur_outSine = 0.0;
              int hilbertIdx = sp.hilbertIdx;
              double period = sp.period;
              double periodWMASub = sp.periodWMASub;
@@ -92153,7 +92153,7 @@ class Core {
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
              double Re = sp.Re;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int hilbertIdx = sp.hilbertIdx;
              double iTrend1 = sp.iTrend1;
              double iTrend2 = sp.iTrend2;
@@ -94414,7 +94414,7 @@ class Core {
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
              double Im = sp.Im;
              double Re = sp.Re;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int daysInTrend = sp.daysInTrend;
              int hilbertIdx = sp.hilbertIdx;
              double iTrend1 = sp.iTrend1;
@@ -97003,7 +97003,7 @@ class Core {
              double tempReal = 0.0;
              double tempReal2 = 0.0;
              double periodROC = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int nullRun = sp.nullRun;
              double prevKAMA = sp.prevKAMA;
              double sumROC1 = sp.sumROC1;
@@ -98989,7 +98989,7 @@ class Core {
              double SumXY = sp.SumXY;
              double SumY = sp.SumY;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double sumAbs = sp.sumAbs;
              int today = sp.today;
@@ -100132,7 +100132,7 @@ class Core {
              double SumXY = sp.SumXY;
              double SumY = sp.SumY;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double sumAbs = sp.sumAbs;
              int today = sp.today;
@@ -101268,7 +101268,7 @@ class Core {
              double SumXY = sp.SumXY;
              double SumY = sp.SumY;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double sumAbs = sp.sumAbs;
              int today = sp.today;
@@ -102399,7 +102399,7 @@ class Core {
              double SumXY = sp.SumXY;
              double SumY = sp.SumY;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double sumAbs = sp.sumAbs;
              int today = sp.today;
@@ -103225,7 +103225,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("LN peek: BadParam", RetCode.BadParam);
              LnStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.log(inReal);
              return cur_outReal;
           }
@@ -103669,7 +103669,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("LOG10 peek: BadParam", RetCode.BadParam);
              Log10Stream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.log10(inReal);
              return cur_outReal;
           }
@@ -105836,9 +105836,9 @@ class Core {
              MacdStream sp = this;
              double macdValue = 0.0;
              double tempReal = 0.0;
-             double cur_outMACD = sp.cur_outMACD;
-             double cur_outMACDHist = sp.cur_outMACDHist;
-             double cur_outMACDSignal = sp.cur_outMACDSignal;
+             double cur_outMACD = 0.0;
+             double cur_outMACDHist = 0.0;
+             double cur_outMACDSignal = 0.0;
              double prevFast = sp.prevFast;
              double prevSignal = sp.prevSignal;
              double prevSlow = sp.prevSlow;
@@ -107926,9 +107926,9 @@ class Core {
              MacdfixStream sp = this;
              double macdValue = 0.0;
              double tempReal = 0.0;
-             double cur_outMACD = sp.cur_outMACD;
-             double cur_outMACDHist = sp.cur_outMACDHist;
-             double cur_outMACDSignal = sp.cur_outMACDSignal;
+             double cur_outMACD = 0.0;
+             double cur_outMACDHist = 0.0;
+             double cur_outMACDSignal = 0.0;
              double prevFast = sp.prevFast;
              double prevSignal = sp.prevSignal;
              double prevSlow = sp.prevSlow;
@@ -109470,8 +109470,8 @@ class Core {
              double I1ForEvenPrev3 = sp.I1ForEvenPrev3;
              double I1ForOddPrev2 = sp.I1ForOddPrev2;
              double I1ForOddPrev3 = sp.I1ForOddPrev3;
-             double cur_outFAMA = sp.cur_outFAMA;
-             double cur_outMAMA = sp.cur_outMAMA;
+             double cur_outFAMA = 0.0;
+             double cur_outMAMA = 0.0;
              double fama = sp.fama;
              int hilbertIdx = sp.hilbertIdx;
              double mama = sp.mama;
@@ -110774,7 +110774,7 @@ class Core {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inVolume) )
                 throw new TaLibArgumentException("MARKETFI peek: BadParam", RetCode.BadParam);
              MarketfiStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              /* A zero-volume bar would divide by zero. Neither reference guards
               * it -- they emit +/-Inf, or NaN when the range is zero too -- but
               * issue #112 settled that a successful call never emits NaN or Inf,
@@ -112585,7 +112585,7 @@ class Core {
                 throw new TaLibArgumentException("MAX peek: BadParam", RetCode.BadParam);
              MaxStream sp = this;
              double tmp = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -113320,7 +113320,7 @@ class Core {
                 throw new TaLibArgumentException("MAXINDEX peek: BadParam", RetCode.BadParam);
              MaxindexStream sp = this;
              double tmp = 0.0;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -113920,7 +113920,7 @@ class Core {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) )
                 throw new TaLibArgumentException("MEDPRICE peek: BadParam", RetCode.BadParam);
              MedpriceStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = (inHigh + inLow) / 2.0;
              return cur_outReal;
           }
@@ -114730,7 +114730,7 @@ class Core {
              double posFlow = 0.0;
              double negFlow = 0.0;
              double posClamped = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double negSumMF = sp.negSumMF;
              int nullRun = sp.nullRun;
              double posSumMF = sp.posSumMF;
@@ -115757,7 +115757,7 @@ class Core {
              MidpointStream sp = this;
              double tmpLow = 0.0;
              double tmpHigh = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -116767,7 +116767,7 @@ class Core {
              MidpriceStream sp = this;
              double tmpLow = 0.0;
              double tmpHigh = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -117686,7 +117686,7 @@ class Core {
                 throw new TaLibArgumentException("MIN peek: BadParam", RetCode.BadParam);
              MinStream sp = this;
              double tmp = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int i = sp.i;
              double lowest = sp.lowest;
              int lowestIdx = sp.lowestIdx;
@@ -118419,7 +118419,7 @@ class Core {
                 throw new TaLibArgumentException("MININDEX peek: BadParam", RetCode.BadParam);
              MinindexStream sp = this;
              double tmp = 0.0;
-             int cur_outInteger = sp.cur_outInteger;
+             int cur_outInteger = 0;
              int i = sp.i;
              double lowest = sp.lowest;
              int lowestIdx = sp.lowestIdx;
@@ -119349,8 +119349,8 @@ class Core {
              MinmaxStream sp = this;
              double tmpHigh = 0.0;
              double tmpLow = 0.0;
-             double cur_outMax = sp.cur_outMax;
-             double cur_outMin = sp.cur_outMin;
+             double cur_outMax = 0.0;
+             double cur_outMin = 0.0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -120257,8 +120257,8 @@ class Core {
              MinmaxindexStream sp = this;
              double tmpHigh = 0.0;
              double tmpLow = 0.0;
-             int cur_outMaxIdx = sp.cur_outMaxIdx;
-             int cur_outMinIdx = sp.cur_outMinIdx;
+             int cur_outMaxIdx = 0;
+             int cur_outMinIdx = 0;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -123793,7 +123793,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("MOM peek: BadParam", RetCode.BadParam);
              MomStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              if( sp.ringCap_trailingIdx == 0 ) {
@@ -124330,7 +124330,7 @@ class Core {
              if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
                 throw new TaLibArgumentException("MULT peek: BadParam", RetCode.BadParam);
              MultStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = inReal0 * inReal1;
              return cur_outReal;
           }
@@ -125148,7 +125148,7 @@ class Core {
              double tempCY = 0.0;
              double tempLT = 0.0;
              double tempHT = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevATR = sp.prevATR;
              /* Find the greatest of the 3 values. */
              tempLT = inLow;
@@ -125944,7 +125944,7 @@ class Core {
              double tempClose = 0.0;
              double tempVolume = 0.0;
              double tempNVI = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevNVI = sp.prevNVI;
              tempClose = inClose;
              tempVolume = inVolume;
@@ -126526,7 +126526,7 @@ class Core {
                 throw new TaLibArgumentException("OBV peek: BadParam", RetCode.BadParam);
              ObvStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevOBV = sp.prevOBV;
              tempReal = inReal;
              if( tempReal > sp.prevReal ) {
@@ -130609,7 +130609,7 @@ class Core {
              double tempClose = 0.0;
              double tempVolume = 0.0;
              double tempPVI = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevPVI = sp.prevPVI;
              tempClose = inClose;
              tempVolume = inVolume;
@@ -132038,7 +132038,7 @@ class Core {
                 throw new TaLibArgumentException("QSTICK peek: BadParam", RetCode.BadParam);
              QstickStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double periodTotal = sp.periodTotal;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
@@ -132770,7 +132770,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("RMA peek: BadParam", RetCode.BadParam);
              RmaStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevRMA = sp.prevRMA;
              prevRMA = Math.fma(sp.wBeta, prevRMA, sp.wAlpha * inReal);
              cur_outReal = prevRMA;
@@ -133399,7 +133399,7 @@ class Core {
                 throw new TaLibArgumentException("ROC peek: BadParam", RetCode.BadParam);
              RocStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              if( sp.ringCap_trailingIdx == 0 ) {
@@ -134051,7 +134051,7 @@ class Core {
                 throw new TaLibArgumentException("ROCP peek: BadParam", RetCode.BadParam);
              RocpStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              if( sp.ringCap_trailingIdx == 0 ) {
@@ -134706,7 +134706,7 @@ class Core {
                 throw new TaLibArgumentException("ROCR peek: BadParam", RetCode.BadParam);
              RocrStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              if( sp.ringCap_trailingIdx == 0 ) {
@@ -135363,7 +135363,7 @@ class Core {
                 throw new TaLibArgumentException("ROCR100 peek: BadParam", RetCode.BadParam);
              Rocr100Stream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
              if( sp.ringCap_trailingIdx == 0 ) {
@@ -136224,7 +136224,7 @@ class Core {
              RsiStream sp = this;
              double tempValue1 = 0.0;
              double tempValue2 = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevGain = sp.prevGain;
              double prevLoss = sp.prevLoss;
              double prevValue = sp.prevValue;
@@ -137314,7 +137314,7 @@ class Core {
              double prevHigh = 0.0;
              double prevLow = 0.0;
              double af = sp.af;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double ep = sp.ep;
              int isLong = sp.isLong;
              double newHigh = sp.newHigh;
@@ -138920,7 +138920,7 @@ class Core {
              double prevLow = 0.0;
              double afLong = sp.afLong;
              double afShort = sp.afShort;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double ep = sp.ep;
              int isLong = sp.isLong;
              double newHigh = sp.newHigh;
@@ -139939,7 +139939,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("SIN peek: BadParam", RetCode.BadParam);
              SinStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.sin(inReal);
              return cur_outReal;
           }
@@ -140375,7 +140375,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("SINH peek: BadParam", RetCode.BadParam);
              SinhStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.sinh(inReal);
              return cur_outReal;
           }
@@ -140937,7 +140937,7 @@ class Core {
                 throw new TaLibArgumentException("SMA peek: BadParam", RetCode.BadParam);
              SmaStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double periodTotal = sp.periodTotal;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
@@ -142147,8 +142147,8 @@ class Core {
              double den = 0.0;
              double halfDen = 0.0;
              double smiValue = 0.0;
-             double cur_outSMI = sp.cur_outSMI;
-             double cur_outSMISignal = sp.cur_outSMISignal;
+             double cur_outSMI = 0.0;
+             double cur_outSMISignal = 0.0;
              double emaFastDen = sp.emaFastDen;
              double emaFastNum = sp.emaFastNum;
              double emaSlowDen = sp.emaSlowDen;
@@ -143101,7 +143101,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("SQRT peek: BadParam", RetCode.BadParam);
              SqrtStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.sqrt(inReal);
              return cur_outReal;
           }
@@ -147795,7 +147795,7 @@ class Core {
              if( !Double.isFinite(inReal0) || !Double.isFinite(inReal1) )
                 throw new TaLibArgumentException("SUB peek: BadParam", RetCode.BadParam);
              SubStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = inReal0 - inReal1;
              return cur_outReal;
           }
@@ -148340,7 +148340,7 @@ class Core {
                 throw new TaLibArgumentException("SUM peek: BadParam", RetCode.BadParam);
              SumStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double periodTotal = sp.periodTotal;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
@@ -149301,8 +149301,8 @@ class Core {
              double basicUpper = 0.0;
              double basicLower = 0.0;
              double closeToday = 0.0;
-             int cur_outInteger = sp.cur_outInteger;
-             double cur_outReal = sp.cur_outReal;
+             int cur_outInteger = 0;
+             double cur_outReal = 0.0;
              double finalLower = sp.finalLower;
              double finalUpper = sp.finalUpper;
              int isUptrend = sp.isUptrend;
@@ -150437,7 +150437,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("T3 peek: BadParam", RetCode.BadParam);
              T3Stream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double e1 = sp.e1;
              double e2 = sp.e2;
              double e3 = sp.e3;
@@ -151083,7 +151083,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("TAN peek: BadParam", RetCode.BadParam);
              TanStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.tan(inReal);
              return cur_outReal;
           }
@@ -151521,7 +151521,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("TANH peek: BadParam", RetCode.BadParam);
              TanhStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = Math.tanh(inReal);
              return cur_outReal;
           }
@@ -152233,7 +152233,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("TEMA peek: BadParam", RetCode.BadParam);
              TemaStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevEMA1 = sp.prevEMA1;
              double prevEMA2 = sp.prevEMA2;
              double prevEMA3 = sp.prevEMA3;
@@ -152970,7 +152970,7 @@ class Core {
              double tempCY = 0.0;
              double tempLT = 0.0;
              double tempHT = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              /* Find the greatest of the 3 values. */
              tempLT = inLow;
              tempHT = inHigh;
@@ -155140,7 +155140,7 @@ class Core {
                 throw new TaLibArgumentException("TRIX peek: BadParam", RetCode.BadParam);
              TrixStream sp = this;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevEMA1 = sp.prevEMA1;
              double prevEMA2 = sp.prevEMA2;
              double prevEMA3 = sp.prevEMA3;
@@ -156023,7 +156023,7 @@ class Core {
              double SumXY = sp.SumXY;
              double SumY = sp.SumY;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int j = sp.j;
              double sumAbs = sp.sumAbs;
              int today = sp.today;
@@ -156880,7 +156880,7 @@ class Core {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("TYPPRICE peek: BadParam", RetCode.BadParam);
              TyppriceStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = (inHigh + inLow + inClose) / 3.0;
              return cur_outReal;
           }
@@ -157939,7 +157939,7 @@ class Core {
              double b1Total = sp.b1Total;
              double b2Total = sp.b2Total;
              double b3Total = sp.b3Total;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int nullRun = sp.nullRun;
              int term_Idx = sp.term_Idx;
              int trailingPos1 = sp.trailingPos1;
@@ -159194,7 +159194,7 @@ class Core {
              double meanValue1 = 0.0;
              double variance = 0.0;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              int i = sp.i;
              int j = sp.j;
              double periodTotal1 = sp.periodTotal1;
@@ -160267,7 +160267,7 @@ class Core {
              double typPrice = 0.0;
              double volume = 0.0;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double sumPV = sp.sumPV;
              double sumV = sp.sumV;
              double vwap = sp.vwap;
@@ -161218,7 +161218,7 @@ class Core {
              double tempPV = 0.0;
              double tempV = 0.0;
              double tempReal = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double sumPV = sp.sumPV;
              double sumV = sp.sumV;
              int pkSlot0 = -1;
@@ -161998,7 +161998,7 @@ class Core {
              WadStream sp = this;
              double close = 0.0;
              double trueExtreme = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double sum = sp.sum;
              close = inClose;
              if( close > sp.prevClose ) {
@@ -162569,7 +162569,7 @@ class Core {
              if( !Double.isFinite(inHigh) || !Double.isFinite(inLow) || !Double.isFinite(inClose) )
                 throw new TaLibArgumentException("WCLPRICE peek: BadParam", RetCode.BadParam);
              WclpriceStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              cur_outReal = (Math.fma(inClose, 2.0, inHigh + inLow)) / 4.0;
              return cur_outReal;
           }
@@ -163400,7 +163400,7 @@ class Core {
                 throw new TaLibArgumentException("WILLR peek: BadParam", RetCode.BadParam);
              WillrStream sp = this;
              double tmp = 0.0;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double diff = sp.diff;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
@@ -164423,7 +164423,7 @@ class Core {
              int rw = 0;
              double tempReal = 0.0;
              int barsSinceReseed = sp.barsSinceReseed;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double periodSub = sp.periodSub;
              double periodSum = sp.periodSum;
              double trailingValue = sp.trailingValue;
@@ -165466,7 +165466,7 @@ class Core {
              if( !Double.isFinite(inReal) )
                 throw new TaLibArgumentException("ZLEMA peek: BadParam", RetCode.BadParam);
              ZlemaStream sp = this;
-             double cur_outReal = sp.cur_outReal;
+             double cur_outReal = 0.0;
              double prevMA = sp.prevMA;
              int pkSlot0 = -1;
              double pkVal0 = 0.0;
@@ -165734,7 +165734,7 @@ class Core {
 
 public class TaCodegenServe {
     static Core core = new Core();
-    static final String SPLICED_GENCODE_DIGEST = "8e97b43fb3854650";
+    static final String SPLICED_GENCODE_DIGEST = "d292d591540ed51e";
     static final int MAX_ARRAY_SIZE = 200000;
     static double[] refOpen = new double[MAX_ARRAY_SIZE];
     static double[] refHigh = new double[MAX_ARRAY_SIZE];


### PR DESCRIPTION
Implements the ruling in #343: the managed peek frames stop seeding output locals they provably overwrite.

## What changes

`streaming::peek_seed_is_dead` is a conservative write-before-read query over the already-built peek-transition IR (83 lines, read-only — it rewrites nothing). At the declaration site, `java_stream.rs` / `csharp_stream.rs` replace `double cur_X = sp.cur_X;` with the type default when every mentioning path provably writes the local first. 176 of 177 seeds go; IMI keeps its one, because its sole store sits inside the period loop and the IR cannot prove a loop body runs.

The safety is one-sided: any unrecognised construct falls to `ReadOrUnknown` → keep the seed → today's behaviour. A new IR construct cannot break this pass; it can only make it miss an opportunity.

The generated diff is exclusively seed lines (`double cur_X = 0.0;` / `int cur_X = 0;`) plus the build-stamp digests. Nothing else moved. The managed backends now tell the same story Rust already does — a peek commits nothing, so the previous bar's output is never an input to it.

## Why this is `refactor(`, not `perf(`

There is no measurable perf, and the issue's own "close if it folds" bar was written on a perf premise. **That bar is superseded by the explicit ruling in #343, not met** — this lands as hygiene under the same standard as `46577145f` (the `c_hygiene` phase, which shipped on zero instruction-level change).

The measurement that killed the perf claim, for the record: `stream_ab --lang=java --call=peek`, 6 interleaved rounds × 500k iters, 179 rows — median +0.06%, sd 0.535. The control that settles it: MA and MAVP, dispatch functions that never carried a seed, report the same ≈−1.2% drift as touched rows, and the byte-identical `--call=update` frames spread *wider* (sd 0.645) than the touched peek frames. The effect is inside HotSpot's layout-noise floor. C# is unmeasured — neither bench tool has a C# lane.

## Gate, and its blind direction

`no_managed_peek_seeds_a_dead_output_local` sweeps both managed backends with non-vacuity floors (>150 swept, >150 seed-free) and pins the kept set to exactly `{imi}`. Sabotage-proved in both directions: forcing the analysis false reddens the seed-free floor; forcing it true reddens the exact set.

What the gate cannot do: `seeded == {imi}` pins the pass's *output*. It catches a seed growing back and it catches IMI being wrongly dropped, but it cannot catch a *different* function being wrongly dropped — that direction rests entirely on the runtime peek-vs-update legs (`stream_verify`, `StreamApiTest`). The exact-set assertion is a regression pin, not a correctness proof.

## Verification

- `generate` clean at head (181 functions — RMA and ZLEMA landed since the prototype; both frames are swept and seed-free, and the `{imi}` pin still holds without edits).
- Full generator suite green, gate included.
- `servers` + cross-language stream verify: C / Rust / C# zero mismatches; Java shows only the known Temurin-on-macOS libm tolerance-lane baseline (HT_TRENDMODE), unchanged from dev on the same machine.
- `StreamApiTest` all pass.
