### PR TITLE
fix(streaming): the unit-test helper borrows its body instead of consuming it

### DIFF
--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -10154,8 +10154,8 @@ mod tests {
         "cur_outReal"
     }
 
-    fn dead(body: Vec<Statement>) -> bool {
-        peek_seed_is_dead(&body, out_local())
+    fn dead(body: &[Statement]) -> bool {
+        peek_seed_is_dead(body, out_local())
     }
 
     fn ret_it() -> Statement {
@@ -10168,14 +10168,14 @@ mod tests {
 
     #[test]
     fn an_unconditional_write_ahead_of_every_read_drops_the_seed() {
-        assert!(dead(vec![assign(var(out_local()), var("t")), ret_it()]));
+        assert!(dead(&[assign(var(out_local()), var("t")), ret_it()]));
     }
 
     /// The frame's own early exit is rewritten to `return cur_x`, so an exit
     /// that computes nothing reads the seed and must keep it.
     #[test]
     fn an_early_exit_that_writes_nothing_keeps_the_seed() {
-        assert!(!dead(vec![
+        assert!(!dead(&[
             branch(var("degenerate"), vec![ret_it()], vec![]),
             assign(var(out_local()), var("t")),
         ]));
@@ -10185,7 +10185,7 @@ mod tests {
     /// path that skips it still reaches the unconditional write below.
     #[test]
     fn an_arm_that_writes_and_returns_leaves_the_fallthrough_provable() {
-        assert!(dead(vec![
+        assert!(dead(&[
             branch(
                 var("period1"),
                 vec![assign(var(out_local()), var("inReal")), ret_it()],
@@ -10197,7 +10197,7 @@ mod tests {
 
     #[test]
     fn an_else_arm_that_writes_and_returns_counts_the_same_as_a_then_arm() {
-        assert!(dead(vec![
+        assert!(dead(&[
             branch(
                 var("ok"),
                 vec![],
@@ -10209,7 +10209,7 @@ mod tests {
 
     #[test]
     fn both_arms_writing_drops_the_seed() {
-        assert!(dead(vec![branch(
+        assert!(dead(&[branch(
             var("odd"),
             vec![assign(var(out_local()), var("a"))],
             vec![assign(var(out_local()), var("b"))],
@@ -10220,7 +10220,7 @@ mod tests {
     /// path leaves the seed live for whatever reads it below.
     #[test]
     fn an_arm_that_writes_without_leaving_keeps_the_seed() {
-        assert!(!dead(vec![
+        assert!(!dead(&[
             branch(var("odd"), vec![assign(var(out_local()), var("a"))], vec![]),
             ret_it(),
         ]));
@@ -10228,7 +10228,7 @@ mod tests {
 
     #[test]
     fn a_compound_assignment_keeps_the_seed() {
-        assert!(!dead(vec![Statement::Assign {
+        assert!(!dead(&[Statement::Assign {
             target: var(out_local()),
             value: var("t"),
             compound: true,
@@ -10237,7 +10237,7 @@ mod tests {
 
     #[test]
     fn a_write_whose_value_reads_it_keeps_the_seed() {
-        assert!(!dead(vec![assign(
+        assert!(!dead(&[assign(
             var(out_local()),
             add(var(out_local()), Expr::IntLiteral(1)),
         )]));
@@ -10245,7 +10245,7 @@ mod tests {
 
     #[test]
     fn a_condition_that_reads_it_keeps_the_seed() {
-        assert!(!dead(vec![
+        assert!(!dead(&[
             branch(
                 le(var(out_local()), Expr::IntLiteral(0)),
                 vec![assign(var(out_local()), var("a"))],
@@ -10259,7 +10259,7 @@ mod tests {
     /// sits in the period loop, and a loop body is not provably entered.
     #[test]
     fn a_write_only_a_loop_body_makes_keeps_the_seed() {
-        assert!(!dead(vec![
+        assert!(!dead(&[
             Statement::ForC {
                 init: Box::new(assign(var("i"), Expr::IntLiteral(0))),
                 condition: le(var("i"), var("n")),
@@ -10274,7 +10274,7 @@ mod tests {
     /// which is data-picked: no arm is provably taken.
     #[test]
     fn a_write_only_a_switch_arm_makes_keeps_the_seed() {
-        assert!(!dead(vec![
+        assert!(!dead(&[
             Statement::Switch {
                 expr: var("maType"),
                 cases: vec![("0".to_string(), vec![assign(var(out_local()), var("sub"))])],
@@ -10288,7 +10288,7 @@ mod tests {
     /// keeps the seed rather than reasoning about a local nothing touches.
     #[test]
     fn a_body_that_never_mentions_it_keeps_the_seed() {
-        assert!(!dead(vec![assign(var("other"), var("t"))]));
+        assert!(!dead(&[assign(var("other"), var("t"))]));
     }
 
 }


### PR DESCRIPTION
dev `4c3a63db` fails the PR clippy gate on itself: `a2880f15`'s test helper `dead(body: Vec<Statement>)` trips 1.97's pedantic `needless_pass_by_value` (denied in the generator), and since it landed by direct push it never crossed the gate — every open PR's merge preview is red on it (first seen on #354's checks; reproduced locally on unmodified dev with `build.py clippy`).

One-line-shape fix: the helper takes `&[Statement]`, its twelve call sites pass `&[...]`. `cargo test --lib` 432 passed, `build.py clippy` clean (generator + generated crate). No generated output is touched.