### PR TITLE
refactor(rust_stream): a peek frame drops the cur_ local it never reads (#353)

### DIFF
--- a/ta_codegen/generator/src/backends/rust_stream.rs
+++ b/ta_codegen/generator/src/backends/rust_stream.rs
@@ -1321,12 +1321,32 @@ fn peek_frame_arm(
         other => Some(other),
     });
 
+    // A peek commits nothing, so `cur_<out>` never carries the previous bar's
+    // output into the transition; a frame that answers through its out-param
+    // never reads the local at all. C's dead-local hygiene (#344) deletes the
+    // whole local there — do the same here: the declaration and its stores go
+    // together, or the survivor would not compile (issue #353).
+    let dead_curs: Vec<(String, VarType)> = func
+        .outputs
+        .iter()
+        .map(|o| format!("cur_{}", o.name))
+        .filter(|n| {
+            locals.contains(n) && streaming::peek_local_is_never_read(&body_ir, n)
+        })
+        .map(|n| (n, VarType::Real))
+        .collect();
+    let body_ir = streaming::purge_dead_temp_stores(&body_ir, &dead_curs);
+    let dead_cur_names: HashSet<&str> = dead_curs.iter().map(|(n, _)| n.as_str()).collect();
+
     let mut out = String::new();
     for (name, ty) in &streaming::temps_used(&model.temps, &body_ir) {
         let (rty, default) = field_type_and_default(typing, name, ty, false);
         out.push_str(&decl_line(&pad, name, &rty, default.as_ref()));
     }
     for name in &locals {
+        if dead_cur_names.contains(name.as_str()) {
+            continue;
+        }
         let _ = writeln!(out, "{pad}let mut {name} = sp.{name};");
     }
     for sh in &pt.shadows {

--- a/ta_codegen/generator/src/streaming.rs
+++ b/ta_codegen/generator/src/streaming.rs
@@ -873,6 +873,23 @@ enum FirstUse {
     ReadOrUnknown,
 }
 
+/// Whether the peek transition never reads `var` at all — a wholly dead local
+/// (issue #353), where the declaration and every store to it go together.
+/// Distinct from [`peek_seed_is_dead`] below: that proves only the SEED value
+/// unread and keeps a local the frame still writes and reads; this one holds
+/// only when the frame answers through something else entirely, so the local
+/// has no reason to exist. A compound store's self-read does not rescue it:
+/// [`names_read`] counts only the RHS of the canonical `v op= e` shape, and a
+/// self-feeding chain nothing else reads is dead with the rest. Any mention
+/// shape the walker cannot model lands in the read set and keeps the local.
+/// Callers strip the stores with [`purge_dead_temp_stores`].
+#[must_use]
+pub fn peek_local_is_never_read(body: &[Statement], var: &str) -> bool {
+    let mut read = BTreeSet::new();
+    names_read(body, &mut read);
+    !read.contains(var)
+}
+
 /// Whether seeding `var` from the handle at the top of a peek frame is dead:
 /// every path that mentions it WRITES it before any read (issue #343). The
 /// analysis is deliberately conservative — a mention inside a loop or switch,

--- a/ta_codegen/generator/tests/rust_stream_suite.rs
+++ b/ta_codegen/generator/tests/rust_stream_suite.rs
@@ -481,6 +481,36 @@ fn rust_composed_copy_out_is_stride_guarded() {
     );
 }
 
+/// The `cur_<out>` locals a peek frame declares, in either shape — the type
+/// default (`let mut cur_x: f64 = 0.0_f64;`, most frames) or the handle seed
+/// (`let mut cur_x = sp.cur_x;`, none since #353 but the arm must see one
+/// growing back).
+fn cur_locals_declared(peek: &str) -> Vec<String> {
+    peek.lines()
+        .filter_map(|l| l.trim().strip_prefix("let mut cur_"))
+        .filter_map(|r| {
+            let end = r.find(|c: char| !(c.is_alphanumeric() || c == '_'))?;
+            Some(format!("cur_{}", &r[..end]))
+        })
+        .collect()
+}
+
+/// Does `hay` mention `word` at a word boundary? Plain `contains` would let
+/// `cur_outReal` shadow a mention of `cur_outRealUpper`.
+fn mentions_word(hay: &str, word: &str) -> bool {
+    hay.match_indices(word).any(|(i, _)| {
+        let before_ok = !hay[..i]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        let after_ok = !hay[i + word.len()..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        before_ok && after_ok
+    })
+}
+
 /// The handle's fixed-size accumulator fields: a `[f64; N]` member.
 fn rust_accumulator_fields(section: &str) -> BTreeSet<String> {
     section
@@ -509,6 +539,7 @@ fn no_rust_peek_copies_the_handle() {
     let mut swept = 0usize;
     let mut frames = 0usize;
     let mut stateless = 0usize;
+    let mut cur_readers = 0usize;
     let mut fully_shadowed: BTreeSet<String> = BTreeSet::new();
     let mut offenders: Vec<String> = Vec::new();
     for name in streaming_indicators() {
@@ -535,6 +566,32 @@ fn no_rust_peek_copies_the_handle() {
         for f in accs.iter().filter(|f| peek.contains(&format!("let mut {f} = sp.{f};"))) {
             offenders.push(format!("{name}: localizes {f}"));
         }
+        // A `cur_<out>` local the frame never reads is wholly dead: the frame
+        // answers through its out-param, so the declaration asserts a data flow
+        // that does not exist (issue #353; C deletes it too, #344). A read is
+        // any word-boundary mention besides the declaration itself and the
+        // target of a plain store — `return Ok(cur_x)` or an RHS use keeps the
+        // local legitimately, and rustc will never flag the dead one (lib.rs
+        // blanket-allows unused_variables/unused_assignments).
+        for cur in cur_locals_declared(peek) {
+            let read = peek.lines().any(|l| {
+                let t = l.trim();
+                if t.starts_with(&format!("let mut {cur}:"))
+                    || t.starts_with(&format!("let mut {cur} "))
+                {
+                    return false;
+                }
+                match t.strip_prefix(&format!("{cur} = ")) {
+                    Some(rhs) => mentions_word(rhs, &cur),
+                    None => mentions_word(t, &cur),
+                }
+            });
+            if read {
+                cur_readers += 1;
+            } else {
+                offenders.push(format!("{name}: declares dead local {cur}"));
+            }
+        }
         // The frame must READ an accumulator: a field it never names is
         // no evidence about the copy either way.
         if accs.iter().any(|f| peek.contains(&format!("{f}["))) {
@@ -558,6 +615,15 @@ fn no_rust_peek_copies_the_handle() {
         "only {} handle(s) have a peek frame that reads an accumulator — the sweep \
          is looking for something that is not there",
         fully_shadowed.len()
+    );
+    // Non-vacuity for the dead-`cur_` arm: frames that legitimately read the
+    // local they declare must exist in force, or the arm is sweeping air.
+    // 29 at issue #353 time — most cur_ declarations live in update frames,
+    // which this sweep does not enter.
+    assert!(
+        cur_readers > 20,
+        "only {cur_readers} peek frame(s) read the cur_ local they declare — the \
+         dead-local arm has nothing to discriminate against"
     );
     assert!(
         offenders.is_empty(),

--- a/ta_codegen/generator/tests/update_and_fill_suite.rs
+++ b/ta_codegen/generator/tests/update_and_fill_suite.rs
@@ -328,8 +328,8 @@ fn no_managed_handle_caches_the_multi_output_value() {
 /// nothing, so the previous bar's output is never an input to the transition,
 /// and the seed was one dead field load per output per call. Swept over both
 /// managed backends: C writes the output through an out-param and has no such
-/// local, while Rust's period-1 identity frames do still carry the shape and
-/// are not covered here. Exact-set in both
+/// local, and Rust deletes the wholly dead local outright — declaration and
+/// stores together (issue #353, gated in rust_stream_suite). Exact-set in both
 /// directions: a frame that grows a seed back fails, and so does a change
 /// that silently drops the one seed the analysis deliberately keeps — IMI,
 /// whose sole store sits inside the period loop, and the IR cannot prove a

--- a/ta_codegen/output/rust/library/src/ta_func/cmo.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/cmo.rs
@@ -942,13 +942,11 @@ impl CmoStream {
             let outReal = &mut outReal;
             let mut tempValue1: f64 = 0.0_f64;
             let mut tempValue2: f64 = 0.0_f64;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevGain = sp.prevGain;
             let mut prevLoss = sp.prevLoss;
             let mut prevValue = sp.prevValue;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             tempValue1 = inReal;

--- a/ta_codegen/output/rust/library/src/ta_func/dema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/dema.rs
@@ -815,12 +815,10 @@ impl DemaStream {
         {
             let sp = &self.state;
             let outReal = &mut outReal;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevEMA1 = sp.prevEMA1;
             let mut prevEMA2 = sp.prevEMA2;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             prevEMA1 = (inReal - prevEMA1 as f64).mul_add(sp.optInK_1, prevEMA1);

--- a/ta_codegen/output/rust/library/src/ta_func/ema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/ema.rs
@@ -701,11 +701,9 @@ impl EmaStream {
         {
             let sp = &self.state;
             let outReal = &mut outReal;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevMA = sp.prevMA;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             prevMA = (inReal - prevMA as f64).mul_add(sp.optInK_1, prevMA);

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -1026,7 +1026,6 @@ impl KamaStream {
             let mut tempReal: f64 = 0.0_f64;
             let mut tempReal2: f64 = 0.0_f64;
             let mut periodROC: f64 = 0.0_f64;
-            let mut cur_outReal = sp.cur_outReal;
             let mut nullRun = sp.nullRun;
             let mut prevKAMA = sp.prevKAMA;
             let mut sumROC1 = sp.sumROC1;
@@ -1035,7 +1034,6 @@ impl KamaStream {
             let mut pkVal0: f64 = 0.0_f64;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             if sp.ringCap_trailingIdx == 0 {

--- a/ta_codegen/output/rust/library/src/ta_func/rsi.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/rsi.rs
@@ -951,13 +951,11 @@ impl RsiStream {
             let outReal = &mut outReal;
             let mut tempValue1: f64 = 0.0_f64;
             let mut tempValue2: f64 = 0.0_f64;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevGain = sp.prevGain;
             let mut prevLoss = sp.prevLoss;
             let mut prevValue = sp.prevValue;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             tempValue1 = inReal as f64;

--- a/ta_codegen/output/rust/library/src/ta_func/t3.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/t3.rs
@@ -936,7 +936,6 @@ impl T3Stream {
         {
             let sp = &self.state;
             let outReal = &mut outReal;
-            let mut cur_outReal = sp.cur_outReal;
             let mut e1 = sp.e1;
             let mut e2 = sp.e2;
             let mut e3 = sp.e3;
@@ -945,7 +944,6 @@ impl T3Stream {
             let mut e6 = sp.e6;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             e1 = (sp.one_minus_k as f64).mul_add(e1, sp.k * inReal);

--- a/ta_codegen/output/rust/library/src/ta_func/tema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/tema.rs
@@ -875,13 +875,11 @@ impl TemaStream {
         {
             let sp = &self.state;
             let outReal = &mut outReal;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevEMA1 = sp.prevEMA1;
             let mut prevEMA2 = sp.prevEMA2;
             let mut prevEMA3 = sp.prevEMA3;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             prevEMA1 = (inReal - prevEMA1 as f64).mul_add(sp.optInK_1, prevEMA1);

--- a/ta_codegen/output/rust/library/src/ta_func/vwma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/vwma.rs
@@ -755,7 +755,6 @@ impl VwmaStream {
             let mut tempPV: f64 = 0.0_f64;
             let mut tempV: f64 = 0.0_f64;
             let mut tempReal: f64 = 0.0_f64;
-            let mut cur_outReal = sp.cur_outReal;
             let mut sumPV = sp.sumPV;
             let mut sumV = sp.sumV;
             let mut pkSlot0: usize = usize::MAX;
@@ -764,7 +763,6 @@ impl VwmaStream {
             let mut pkVal1: f64 = 0.0_f64;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             if sp.ringCap_trailingIdx == 0 {

--- a/ta_codegen/output/rust/library/src/ta_func/wma.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/wma.rs
@@ -978,7 +978,6 @@ impl WmaStream {
             let mut rw: usize = 0_usize;
             let mut tempReal: f64 = 0.0_f64;
             let mut barsSinceReseed = sp.barsSinceReseed;
-            let mut cur_outReal = sp.cur_outReal;
             let mut periodSub = sp.periodSub;
             let mut periodSum = sp.periodSum;
             let mut trailingValue = sp.trailingValue;
@@ -988,7 +987,6 @@ impl WmaStream {
             let mut pkVal1: f64 = 0.0_f64;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             if sp.ringCap_trailingIdx == 0 {

--- a/ta_codegen/output/rust/library/src/ta_func/zlema.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/zlema.rs
@@ -727,13 +727,11 @@ impl ZlemaStream {
         {
             let sp = &self.state;
             let outReal = &mut outReal;
-            let mut cur_outReal = sp.cur_outReal;
             let mut prevMA = sp.prevMA;
             let mut pkSlot0: usize = usize::MAX;
             let mut pkVal0: f64 = 0.0_f64;
             if sp.optInTimePeriod == 1 {
                 (*outReal) = inReal;
-                cur_outReal = (*outReal);
                 return Ok((*outReal));
             }
             if sp.ringCap_trailingIdx == 0 {


### PR DESCRIPTION
Implements #353: the ten Rust peek frames stop declaring an output local they never read.

## What changes

- `streaming::peek_local_is_never_read` — the stronger sibling of #343's `peek_seed_is_dead`: not "the seed value is unread" but "the local is unread, period", so the declaration and its stores go together (dropping only the initializer would leave the dead store behind, per the issue). Any mention shape the walker cannot model lands in the read set and keeps the local.
- `rust_stream.rs` filters the frame's `cur_<out>` locals through it and strips the surviving stores with the existing `purge_dead_temp_stores` fixpoint — the same machinery C's dead-local hygiene (#344) already trusts. `server_gen.rs` emits no Rust peek locals of its own (checked — it was the second consumer that bit #326).
- The generated diff is exactly the ten functions the issue names (CMO, DEMA, EMA, KAMA, RSI, T3, TEMA, VWMA, WMA, ZLEMA), −2 lines each: the `let mut cur_outReal = sp.cur_outReal;` seed and the period-1 arm's `cur_outReal = (*outReal);` store. Nothing else moved.
- The #351 gate docstring drops its Rust carve-out (dev `4c3a63db`): the managed pair, C and Rust now tell one story — a peek commits nothing, so no backend keeps a local asserting the previous bar's output feeds it.

## Gate

`no_rust_peek_copies_the_handle` grows a dead-`cur_` offender arm rather than a parallel test, per the issue. It sweeps **both** declaration shapes — the type default most frames carry (`let mut cur_x: f64 = 0.0_f64;`) and the handle seed none carry since this change — because the arm has to see either one growing back dead. Read detection is word-boundary (`cur_outReal` must not be satisfied by a mention of `cur_outRealUpperBand`), a plain store's target does not count as a read, and a store's RHS self-read does.

Non-vacuity: a floor of >20 frames that legitimately read the `cur_` local they declare (29 today; the floor caught its own first draft, which only matched the seed shape and swept zero frames after the fix — most `cur_` declarations live in update frames this sweep never enters).

Sabotage: forcing the emitter's analysis to `false` regrows exactly the ten seeds, and the arm names every one (`ema: declares dead local cur_outReal`, ×10). Restored, the suite is green.

## Verification

- Full generator suite and `build.py clippy` green on dev `ee28a826`.
- `--xlang-hash`: **Rust 298978 cases, 0 mismatches — bit-identical**, per the issue's bar. Managed legs unchanged (Java shows only the known Temurin-on-macOS HT_TRENDMODE tolerance baseline, zero added).
- `regen-check` clean — the committed outputs are exactly what the generator writes.
- No perf claim, per the issue: LLVM was already deleting the local. rustc never saw any of it (`lib.rs` blanket-allows `unused_variables`/`unused_assignments`), so the gate, not the compiler, holds the line.
