### PR TITLE
fix(stoch,kama): divide by the value the guard tests, and bound the efficiency ratio (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ See [github commits](https://github.com/TA-Lib/ta-lib/commits) for complete list
 - (#243) STDDEV and BBANDS returned exactly 0 for a standard deviation that was small but non-zero. In rare cases, was making the bands "collapse" on the middle line.
 - (#244) MFI returned 0 instead of the index whenever the window summed to less than 1.0. Also, no longer returns values slightly outside 0-100 (clamps the epsilon errors).
 - (#253) Fix many TA_IS_ZERO vs TA_IS_ZERO_SCALED choices. Numerically better for edge cases, like very small inputs (<10e-8) or mostly flat input prices.
+- (#390) STOCH and STOCHF returned `inf` or `NaN` while reporting success, for prices near the bottom of the double range. A close sitting on the window high now comes out as exactly 100.
+- (#390) KAMA could return values outside the range of the prices it was smoothing, and ER values above 1. Both come from the same efficiency ratio exceeding its own maximum when floating-point drift left the running sum of price movement below the net move it bounds. The ratio is now clamped, making ER a hard 0..1.
 
 ## [0.7.1] 2026-07-03
 ### Added

--- a/src/ta_func/ta_ER.c
+++ b/src/ta_func/ta_ER.c
@@ -107,16 +107,19 @@ TA_LIB_API TA_RetCode TA_ER( int    startIdx,
     *
     *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
     *
+    * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+    * clamp to 1.0 is what makes the declared range a bound rather than a
+    * hope -- and in kama.c what keeps its recurrence a convex combination.
+    *
     * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
     * two stay bit-identical -- the KAMA-reconstruction differential in
-    * test_composite2.c exists to keep it that way. Two guards are
+    * test_composite2.c exists to keep it that way. Three more guards are
     * load-bearing and shared with kama.c:
     *
     *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-    *     would give 1.0000000000000002. The comparison is against the
-    *     SIGNED numerator, so it only fires on up-moves; on sustained
-    *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-    *     "fix" this with fabs -- it changes TA_KAMA's output.
+    *     would give 1.0000000000000002, on up-moves. It compares against
+    *     the SIGNED numerator, so it is false for every down move: it
+    *     bounds nothing on its own, which is what the clamp is for.
     *   - a genuinely flat window is recognized by COUNTING exactly-zero
     *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
     *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -125,13 +128,10 @@ TA_LIB_API TA_RetCode TA_ER( int    startIdx,
     *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
     *     price-carrying sum).
     *
-    * A third guard is the denominator test: the division runs only where
-    * sumROC1 is exactly positive. The clamp above cannot serve as it,
-    * because it compares against the SIGNED numerator and so is false for
-    * every down move -- and a subtract-then-add sum can reach 0.0, or
-    * below it, on a window that is not flat, when a term absorbed on the
-    * way in is subtracted later at full precision. Without the guard those
-    * bars divide by zero.
+    * The third is the denominator test (#385): a subtract-then-add sum can
+    * reach 0.0, or below it, on a window that is not flat. The clamp
+    * subsumes it numerically, so it is held by the structural sweep over
+    * divisors, not by any value test.
     *
     * The subtract-then-add update order matches TA_SUM's recurrence,
     * which is what makes the composite differential bit-exact. The
@@ -187,7 +187,12 @@ TA_LIB_API TA_RetCode TA_ER( int    startIdx,
       outReal[0] = 1.0;
    } else 
    {
-      outReal[0] = fabs(periodROC / sumROC1);
+      tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
+      outReal[0] = tempReal;
    }
    outIdx = 1;
    today += 1;
@@ -225,7 +230,12 @@ TA_LIB_API TA_RetCode TA_ER( int    startIdx,
          outReal[outIdx++] = 1.0;
       } else 
       {
-         outReal[outIdx++] = fabs(periodROC / sumROC1);
+         tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
+         outReal[outIdx++] = tempReal;
       }
       today += 1;
    }
@@ -308,7 +318,12 @@ TA_RetCode TA_S_ER( int    startIdx,
       outReal[0] = 1.0;
    } else 
    {
-      outReal[0] = fabs(periodROC / sumROC1);
+      tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
+      outReal[0] = tempReal;
    }
    outIdx = 1;
    today += 1;
@@ -337,7 +352,12 @@ TA_RetCode TA_S_ER( int    startIdx,
          outReal[outIdx++] = 1.0;
       } else 
       {
-         outReal[outIdx++] = fabs(periodROC / sumROC1);
+         tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
+         outReal[outIdx++] = tempReal;
       }
       today += 1;
    }
@@ -415,7 +435,12 @@ static void TA_ER_StepImpl( struct TA_ER_Stream *sp, double inReal, double *outR
       *outReal= 1.0;
    } else 
    {
-      *outReal= fabs(periodROC / sp->sumROC1);
+      tempReal = fabs(periodROC / sp->sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
+      *outReal= tempReal;
    }
    sp->cur_outReal = *outReal;
    sp->lag1_inReal = inReal;
@@ -468,16 +493,19 @@ static TA_RetCode TA_ER_OpenImpl( struct TA_ER_Stream **stream, const double inR
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -486,13 +514,10 @@ static TA_RetCode TA_ER_OpenImpl( struct TA_ER_Stream **stream, const double inR
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -548,7 +573,12 @@ static TA_RetCode TA_ER_OpenImpl( struct TA_ER_Stream **stream, const double inR
          outReal[0 * outStride] = 1.0;
       } else 
       {
-         outReal[0 * outStride] = fabs(periodROC / sumROC1);
+         tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
+         outReal[0 * outStride] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -586,7 +616,12 @@ static TA_RetCode TA_ER_OpenImpl( struct TA_ER_Stream **stream, const double inR
             outReal[outIdx++ * outStride] = 1.0;
          } else 
          {
-            outReal[outIdx++ * outStride] = fabs(periodROC / sumROC1);
+            tempReal = fabs(periodROC / sumROC1);
+            if( tempReal > 1.0 )
+            {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++ * outStride] = tempReal;
          }
          today += 1;
       }
@@ -725,7 +760,12 @@ TA_LIB_API TA_RetCode TA_ER_Peek( const TA_ER_Stream *stream, double inReal, dou
       *outReal= 1.0;
    } else 
    {
-      *outReal= fabs(periodROC / sumROC1);
+      tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
+      *outReal= tempReal;
    }
    return TA_SUCCESS;
 }

--- a/src/ta_func/ta_KAMA.c
+++ b/src/ta_func/ta_KAMA.c
@@ -67,6 +67,9 @@
  *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
  *                forced the fastest adaptation on any instrument quoted small
  *                enough to fall under it.
+ *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+ *                let it exceed its own mathematical maximum, and the squared
+ *                smoothing constant then amplified instead of averaging.
  */
 
 TA_LIB_API int TA_KAMA_Lookback( int optInTimePeriod )
@@ -214,21 +217,14 @@ TA_LIB_API TA_RetCode TA_KAMA( int    startIdx,
    trailingValue = tempReal2;
    /* Calculate the efficiency ratio.
     *
-    * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-    * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-    * sit beside it was not -- it declared the window flat, and forced the
-    * fastest adaptation, for every window of an instrument quoted below it
-    * (issue #253). A genuinely flat window is now recognized by the exact bar
-    * count above instead.
+    * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+    * clamp it: past 1 the squared smoothing constant amplifies instead of
+    * averaging and the recurrence below stops being a convex combination.
     *
-    * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-    * beside it compares against the SIGNED numerator, so it is false whenever
-    * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-    * add/subtract of fabs terms, so an addend absorbed on the way in and
-    * subtracted later at full precision drives it to exactly 0.0 on a window
-    * that is not flat; without this clause that bar divides by zero and the
-    * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-    * carried until #350).
+    * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+    * +Inf onto the same 1.0 -- so a value test written against it would pass
+    * with it deleted. Keep it anyway: the divisor sweep requires a division to
+    * be dominated by a test of its own divisor against a literal zero.
     */
    if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
    {
@@ -236,6 +232,10 @@ TA_LIB_API TA_RetCode TA_KAMA( int    startIdx,
    } else 
    {
       tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
    }
    /* Calculate the smoothing constant */
    tempReal = fma(tempReal, constDiff, constMax);
@@ -290,6 +290,10 @@ TA_LIB_API TA_RetCode TA_KAMA( int    startIdx,
       } else 
       {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = fma(tempReal, constDiff, constMax);
@@ -344,6 +348,10 @@ TA_LIB_API TA_RetCode TA_KAMA( int    startIdx,
       } else 
       {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = fma(tempReal, constDiff, constMax);
@@ -463,6 +471,10 @@ TA_RetCode TA_S_KAMA( int    startIdx,
    } else 
    {
       tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
    }
    tempReal = fma(tempReal, constDiff, constMax);
    tempReal *= tempReal;
@@ -493,6 +505,10 @@ TA_RetCode TA_S_KAMA( int    startIdx,
       } else 
       {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
       }
       tempReal = fma(tempReal, constDiff, constMax);
       tempReal *= tempReal;
@@ -527,6 +543,10 @@ TA_RetCode TA_S_KAMA( int    startIdx,
       } else 
       {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
       }
       tempReal = fma(tempReal, constDiff, constMax);
       tempReal *= tempReal;
@@ -621,6 +641,10 @@ static void TA_KAMA_StepImpl( struct TA_KAMA_Stream *sp, double inReal, double *
    } else 
    {
       tempReal = fabs(periodROC / sp->sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
    }
    /* Calculate the smoothing constant */
    tempReal = fma(tempReal, sp->constDiff, sp->constMax);
@@ -782,21 +806,14 @@ static TA_RetCode TA_KAMA_OpenImpl( struct TA_KAMA_Stream **stream, const double
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
       {
@@ -804,6 +821,10 @@ static TA_RetCode TA_KAMA_OpenImpl( struct TA_KAMA_Stream **stream, const double
       } else 
       {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+         {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = fma(tempReal, constDiff, constMax);
@@ -858,6 +879,10 @@ static TA_RetCode TA_KAMA_OpenImpl( struct TA_KAMA_Stream **stream, const double
          } else 
          {
             tempReal = fabs(periodROC / sumROC1);
+            if( tempReal > 1.0 )
+            {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = fma(tempReal, constDiff, constMax);
@@ -912,6 +937,10 @@ static TA_RetCode TA_KAMA_OpenImpl( struct TA_KAMA_Stream **stream, const double
          } else 
          {
             tempReal = fabs(periodROC / sumROC1);
+            if( tempReal > 1.0 )
+            {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = fma(tempReal, constDiff, constMax);
@@ -1073,6 +1102,10 @@ TA_LIB_API TA_RetCode TA_KAMA_Peek( const TA_KAMA_Stream *stream, double inReal,
    } else 
    {
       tempReal = fabs(periodROC / sumROC1);
+      if( tempReal > 1.0 )
+      {
+         tempReal = 1.0;
+      }
    }
    /* Calculate the smoothing constant */
    tempReal = fma(tempReal, sp->constDiff, sp->constMax);

--- a/src/ta_func/ta_STOCH.c
+++ b/src/ta_func/ta_STOCH.c
@@ -65,6 +65,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
  *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
 TA_LIB_API int TA_STOCH_Lookback( int optInFastK_Period, int optInSlowK_Period, TA_MAType optInSlowK_MAType, int optInSlowD_Period, TA_MAType optInSlowD_MAType )
@@ -118,7 +121,6 @@ TA_LIB_API TA_RetCode TA_STOCH( int    startIdx,
    double lowest;
    double highest;
    double tmp;
-   double diff;
    double *tempBuffer;
    int outIdx;
    int lowestIdx;
@@ -247,7 +249,6 @@ TA_LIB_API TA_RetCode TA_STOCH( int    startIdx,
    lowestIdx = highestIdx;
    lowest = 0.0;
    highest = lowest;
-   diff = highest;
    /* Allocate a temporary buffer large enough to
     * store the K.
     *
@@ -291,12 +292,10 @@ TA_LIB_API TA_RetCode TA_STOCH( int    startIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = inHigh[today];
@@ -314,24 +313,24 @@ TA_LIB_API TA_RetCode TA_STOCH( int    startIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
       {
-         tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+         tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
       } else 
       {
          tempBuffer[outIdx++] = 0.0;
@@ -410,7 +409,6 @@ TA_RetCode TA_S_STOCH( int    startIdx,
    double lowest;
    double highest;
    double tmp;
-   double diff;
    double *tempBuffer;
    int outIdx;
    int lowestIdx;
@@ -486,7 +484,6 @@ TA_RetCode TA_S_STOCH( int    startIdx,
    lowestIdx = highestIdx;
    lowest = 0.0;
    highest = lowest;
-   diff = highest;
    bufferIsAllocated = 0;
    if( 0 || 0 || 0 )
    {
@@ -519,12 +516,10 @@ TA_RetCode TA_S_STOCH( int    startIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       tmp = (double)inHigh[today];
       if( highestIdx < trailingIdx )
@@ -541,16 +536,14 @@ TA_RetCode TA_S_STOCH( int    startIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
       {
-         tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+         tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
       } else 
       {
          tempBuffer[outIdx++] = 0.0;
@@ -605,7 +598,6 @@ struct TA_STOCH_Stream {
    TA_MAType optInSlowD_MAType;
    double lowest;
    double highest;
-   double diff;
    int lowestIdx;
    int highestIdx;
    int trailingIdx;
@@ -666,12 +658,10 @@ static TA_RetCode TA_STOCH_StepImpl( struct TA_STOCH_Stream *sp, double inHigh, 
             sp->lowest = tmp;
          }
       }
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    } else if( tmp <= sp->lowest )
    {
       sp->lowestIdx = sp->today;
       sp->lowest = tmp;
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    }
    /* Set the highest high */
    tmp = sp->x_inHigh[sp->today & sp->xMask];
@@ -689,24 +679,24 @@ static TA_RetCode TA_STOCH_StepImpl( struct TA_STOCH_Stream *sp, double inHigh, 
             sp->highest = tmp;
          }
       }
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    } else if( tmp >= sp->highest )
    {
       sp->highestIdx = sp->today;
       sp->highest = tmp;
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    }
-   /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-    * machine-flat window leaves a sub-epsilon residue that an exact check
-    * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-    * range against ITS OWN two extremes, not against a fixed band: the range
-    * carries the quote unit, so a constant put against it answers "flat" for
-    * every window of an instrument quoted below it and zeroed the whole
-    * output (issue #253).
+   /* Divide by the range itself and scale after: the guard has to test the
+    * very expression the division uses, or a scaling step can carry a
+    * guarded-non-zero into a zero divisor.
+    *
+    * The band is the range against ITS OWN two extremes, not a fixed
+    * constant: the range carries the quote unit, so a constant answers
+    * "flat" for every window of an instrument quoted below it (issue #253).
+    * It absorbs the machine-flat window an exact test would divide into
+    * [0,100] noise (issue #107 / STOCHRSI).
     */
    if( !TA_IS_ZERO_SCALED(sp->highest - sp->lowest, fabs(sp->highest) + fabs(sp->lowest)) )
    {
-      cur_tempBuffer = (sp->x_inClose[sp->today & sp->xMask] - sp->lowest) / sp->diff;
+      cur_tempBuffer = (sp->x_inClose[sp->today & sp->xMask] - sp->lowest) / (sp->highest - sp->lowest) * 100.0;
    } else 
    {
       cur_tempBuffer = 0.0;
@@ -798,7 +788,6 @@ static TA_RetCode TA_STOCH_OpenImpl( struct TA_STOCH_Stream **stream, const doub
       double lowest;
       double highest;
       double tmp;
-      double diff;
       double *tempBuffer;
       int outIdx;
       int lowestIdx;
@@ -886,7 +875,6 @@ static TA_RetCode TA_STOCH_OpenImpl( struct TA_STOCH_Stream **stream, const doub
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -929,12 +917,10 @@ static TA_RetCode TA_STOCH_OpenImpl( struct TA_STOCH_Stream **stream, const doub
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest )
          {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -952,24 +938,24 @@ static TA_RetCode TA_STOCH_OpenImpl( struct TA_STOCH_Stream **stream, const doub
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest )
          {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
          {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else 
          {
             tempBuffer[outIdx++] = 0.0;
@@ -1069,7 +1055,6 @@ static TA_RetCode TA_STOCH_OpenImpl( struct TA_STOCH_Stream **stream, const doub
       sp->optInSlowD_MAType = optInSlowD_MAType;
       sp->lowest = lowest;
       sp->highest = highest;
-      sp->diff = diff;
       sp->lowestIdx = lowestIdx;
       sp->highestIdx = highestIdx;
       sp->trailingIdx = trailingIdx;
@@ -1175,7 +1160,6 @@ TA_LIB_API TA_RetCode TA_STOCH_Peek( const TA_STOCH_Stream *stream, double inHig
    double cur_tempBuffer = 0.0;
    double cur_outSlowD = 0.0;
    double tmp;
-   double diff;
    double highest;
    int highestIdx;
    int i;
@@ -1195,7 +1179,6 @@ TA_LIB_API TA_RetCode TA_STOCH_Peek( const TA_STOCH_Stream *stream, double inHig
 
    if( !stream || !outSlowK || !outSlowD ) return TA_BAD_PARAM;
    if( !TA_IS_FINITE( inHigh ) || !TA_IS_FINITE( inLow ) || !TA_IS_FINITE( inClose ) ) return TA_BAD_PARAM;
-   diff = sp->diff;
    highest = sp->highest;
    highestIdx = sp->highestIdx;
    i = sp->i;
@@ -1237,12 +1220,10 @@ TA_LIB_API TA_RetCode TA_STOCH_Peek( const TA_STOCH_Stream *stream, double inHig
             lowest = tmp;
          }
       }
-      diff = (highest - lowest) / 100.0;
    } else if( tmp <= lowest )
    {
       lowestIdx = today;
       lowest = tmp;
-      diff = (highest - lowest) / 100.0;
    }
    /* Set the highest high */
    tmp = ((today & sp->xMask) != pkSlot0) ? x_inHigh[today & sp->xMask] : pkVal0;
@@ -1260,24 +1241,24 @@ TA_LIB_API TA_RetCode TA_STOCH_Peek( const TA_STOCH_Stream *stream, double inHig
             highest = tmp;
          }
       }
-      diff = (highest - lowest) / 100.0;
    } else if( tmp >= highest )
    {
       highestIdx = today;
       highest = tmp;
-      diff = (highest - lowest) / 100.0;
    }
-   /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-    * machine-flat window leaves a sub-epsilon residue that an exact check
-    * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-    * range against ITS OWN two extremes, not against a fixed band: the range
-    * carries the quote unit, so a constant put against it answers "flat" for
-    * every window of an instrument quoted below it and zeroed the whole
-    * output (issue #253).
+   /* Divide by the range itself and scale after: the guard has to test the
+    * very expression the division uses, or a scaling step can carry a
+    * guarded-non-zero into a zero divisor.
+    *
+    * The band is the range against ITS OWN two extremes, not a fixed
+    * constant: the range carries the quote unit, so a constant answers
+    * "flat" for every window of an instrument quoted below it (issue #253).
+    * It absorbs the machine-flat window an exact test would divide into
+    * [0,100] noise (issue #107 / STOCHRSI).
     */
    if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
    {
-      cur_tempBuffer = ((((today & sp->xMask) != pkSlot2) ? x_inClose[today & sp->xMask] : pkVal2) - lowest) / diff;
+      cur_tempBuffer = ((((today & sp->xMask) != pkSlot2) ? x_inClose[today & sp->xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
    } else 
    {
       cur_tempBuffer = 0.0;

--- a/src/ta_func/ta_STOCHF.c
+++ b/src/ta_func/ta_STOCHF.c
@@ -67,6 +67,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
  *               already answered above it, and the shape reads like #269.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
 TA_LIB_API int TA_STOCHF_Lookback( int optInFastK_Period, int optInFastD_Period, TA_MAType optInFastD_MAType )
@@ -108,7 +111,6 @@ TA_LIB_API TA_RetCode TA_STOCHF( int    startIdx,
    double lowest;
    double highest;
    double tmp;
-   double diff;
    double *tempBuffer;
    int outIdx;
    int lowestIdx;
@@ -227,7 +229,6 @@ TA_LIB_API TA_RetCode TA_STOCHF( int    startIdx,
    lowestIdx = highestIdx;
    lowest = 0.0;
    highest = lowest;
-   diff = highest;
    /* Allocate a temporary buffer large enough to
     * store the K.
     *
@@ -271,12 +272,10 @@ TA_LIB_API TA_RetCode TA_STOCHF( int    startIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = inHigh[today];
@@ -294,24 +293,24 @@ TA_LIB_API TA_RetCode TA_STOCHF( int    startIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
       {
-         tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+         tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
       } else 
       {
          tempBuffer[outIdx++] = 0.0;
@@ -371,7 +370,6 @@ TA_RetCode TA_S_STOCHF( int    startIdx,
    double lowest;
    double highest;
    double tmp;
-   double diff;
    double *tempBuffer;
    int outIdx;
    int lowestIdx;
@@ -437,7 +435,6 @@ TA_RetCode TA_S_STOCHF( int    startIdx,
    lowestIdx = highestIdx;
    lowest = 0.0;
    highest = lowest;
-   diff = highest;
    bufferIsAllocated = 0;
    if( 0 || 0 || 0 )
    {
@@ -470,12 +467,10 @@ TA_RetCode TA_S_STOCHF( int    startIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       tmp = (double)inHigh[today];
       if( highestIdx < trailingIdx )
@@ -492,16 +487,14 @@ TA_RetCode TA_S_STOCHF( int    startIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest) / 100.0;
       } else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest) / 100.0;
       }
       if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
       {
-         tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+         tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
       } else 
       {
          tempBuffer[outIdx++] = 0.0;
@@ -543,7 +536,6 @@ struct TA_STOCHF_Stream {
    TA_MAType optInFastD_MAType;
    double lowest;
    double highest;
-   double diff;
    int lowestIdx;
    int highestIdx;
    int trailingIdx;
@@ -603,12 +595,10 @@ static TA_RetCode TA_STOCHF_StepImpl( struct TA_STOCHF_Stream *sp, double inHigh
             sp->lowest = tmp;
          }
       }
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    } else if( tmp <= sp->lowest )
    {
       sp->lowestIdx = sp->today;
       sp->lowest = tmp;
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    }
    /* Set the highest high */
    tmp = sp->x_inHigh[sp->today & sp->xMask];
@@ -626,24 +616,24 @@ static TA_RetCode TA_STOCHF_StepImpl( struct TA_STOCHF_Stream *sp, double inHigh
             sp->highest = tmp;
          }
       }
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    } else if( tmp >= sp->highest )
    {
       sp->highestIdx = sp->today;
       sp->highest = tmp;
-      sp->diff = (sp->highest - sp->lowest) / 100.0;
    }
-   /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-    * machine-flat window leaves a sub-epsilon residue that an exact check
-    * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-    * range against ITS OWN two extremes, not against a fixed band: the range
-    * carries the quote unit, so a constant put against it answers "flat" for
-    * every window of an instrument quoted below it and zeroed the whole
-    * output (issue #253).
+   /* Divide by the range itself and scale after: the guard has to test the
+    * very expression the division uses, or a scaling step can carry a
+    * guarded-non-zero into a zero divisor.
+    *
+    * The band is the range against ITS OWN two extremes, not a fixed
+    * constant: the range carries the quote unit, so a constant answers
+    * "flat" for every window of an instrument quoted below it (issue #253).
+    * It absorbs the machine-flat window an exact test would divide into
+    * [0,100] noise (issue #107 / STOCHRSI).
     */
    if( !TA_IS_ZERO_SCALED(sp->highest - sp->lowest, fabs(sp->highest) + fabs(sp->lowest)) )
    {
-      cur_tempBuffer = (sp->x_inClose[sp->today & sp->xMask] - sp->lowest) / sp->diff;
+      cur_tempBuffer = (sp->x_inClose[sp->today & sp->xMask] - sp->lowest) / (sp->highest - sp->lowest) * 100.0;
    } else 
    {
       cur_tempBuffer = 0.0;
@@ -719,7 +709,6 @@ static TA_RetCode TA_STOCHF_OpenImpl( struct TA_STOCHF_Stream **stream, const do
       double lowest;
       double highest;
       double tmp;
-      double diff;
       double *tempBuffer;
       int outIdx;
       int lowestIdx;
@@ -805,7 +794,6 @@ static TA_RetCode TA_STOCHF_OpenImpl( struct TA_STOCHF_Stream **stream, const do
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -848,12 +836,10 @@ static TA_RetCode TA_STOCHF_OpenImpl( struct TA_STOCHF_Stream **stream, const do
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest )
          {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -871,24 +857,24 @@ static TA_RetCode TA_STOCHF_OpenImpl( struct TA_STOCHF_Stream **stream, const do
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest )
          {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
          {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else 
          {
             tempBuffer[outIdx++] = 0.0;
@@ -954,7 +940,6 @@ static TA_RetCode TA_STOCHF_OpenImpl( struct TA_STOCHF_Stream **stream, const do
       sp->optInFastD_MAType = optInFastD_MAType;
       sp->lowest = lowest;
       sp->highest = highest;
-      sp->diff = diff;
       sp->lowestIdx = lowestIdx;
       sp->highestIdx = highestIdx;
       sp->trailingIdx = trailingIdx;
@@ -1059,7 +1044,6 @@ TA_LIB_API TA_RetCode TA_STOCHF_Peek( const TA_STOCHF_Stream *stream, double inH
    double cur_tempBuffer = 0.0;
    double cur_outFastD = 0.0;
    double tmp;
-   double diff;
    double highest;
    int highestIdx;
    int i;
@@ -1079,7 +1063,6 @@ TA_LIB_API TA_RetCode TA_STOCHF_Peek( const TA_STOCHF_Stream *stream, double inH
 
    if( !stream || !outFastK || !outFastD ) return TA_BAD_PARAM;
    if( !TA_IS_FINITE( inHigh ) || !TA_IS_FINITE( inLow ) || !TA_IS_FINITE( inClose ) ) return TA_BAD_PARAM;
-   diff = sp->diff;
    highest = sp->highest;
    highestIdx = sp->highestIdx;
    i = sp->i;
@@ -1121,12 +1104,10 @@ TA_LIB_API TA_RetCode TA_STOCHF_Peek( const TA_STOCHF_Stream *stream, double inH
             lowest = tmp;
          }
       }
-      diff = (highest - lowest) / 100.0;
    } else if( tmp <= lowest )
    {
       lowestIdx = today;
       lowest = tmp;
-      diff = (highest - lowest) / 100.0;
    }
    /* Set the highest high */
    tmp = ((today & sp->xMask) != pkSlot0) ? x_inHigh[today & sp->xMask] : pkVal0;
@@ -1144,24 +1125,24 @@ TA_LIB_API TA_RetCode TA_STOCHF_Peek( const TA_STOCHF_Stream *stream, double inH
             highest = tmp;
          }
       }
-      diff = (highest - lowest) / 100.0;
    } else if( tmp >= highest )
    {
       highestIdx = today;
       highest = tmp;
-      diff = (highest - lowest) / 100.0;
    }
-   /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-    * machine-flat window leaves a sub-epsilon residue that an exact check
-    * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-    * range against ITS OWN two extremes, not against a fixed band: the range
-    * carries the quote unit, so a constant put against it answers "flat" for
-    * every window of an instrument quoted below it and zeroed the whole
-    * output (issue #253).
+   /* Divide by the range itself and scale after: the guard has to test the
+    * very expression the division uses, or a scaling step can carry a
+    * guarded-non-zero into a zero divisor.
+    *
+    * The band is the range against ITS OWN two extremes, not a fixed
+    * constant: the range carries the quote unit, so a constant answers
+    * "flat" for every window of an instrument quoted below it (issue #253).
+    * It absorbs the machine-flat window an exact test would divide into
+    * [0,100] noise (issue #107 / STOCHRSI).
     */
    if( !TA_IS_ZERO_SCALED(highest - lowest, fabs(highest) + fabs(lowest)) )
    {
-      cur_tempBuffer = ((((today & sp->xMask) != pkSlot2) ? x_inClose[today & sp->xMask] : pkVal2) - lowest) / diff;
+      cur_tempBuffer = ((((today & sp->xMask) != pkSlot2) ? x_inClose[today & sp->xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
    } else 
    {
       cur_tempBuffer = 0.0;

--- a/src/tools/ta_regtest/CLAUDE.md
+++ b/src/tools/ta_regtest/CLAUDE.md
@@ -546,7 +546,8 @@ Scope rules (deliberate):
 
 - **period == 1 is out of scope** — 0.6.4 rejects it or has period-1 OOB bugs —
   so periods are floored at 2 and period-1 is validated by the non-0.6.4
-  comparisons. At period ≥ 2 there are **no waivers**.
+  comparisons. At period ≥ 2 there is **no blanket slack**: every exemption is
+  a manifest tolerance or a named skip.
 - **Subset tolerance is 0.6.4-only:** post-0.6.4 functions are skipped via
   `ta_064_serve`'s `list_functions`. Any non-0.6.4 comparison must instead
   require an exact function-set match.
@@ -571,6 +572,16 @@ Scope rules (deliberate):
   index or it does not. The new behaviour is pinned separately by `test_mfi.c`
   against two external oracles plus a bit-identity sweep over power-of-two volume
   scales. Reported as `mfi-skipped:`.
+- **KAMA per-case skip:** v0.6.4's efficiency ratio is decided by its running
+  sum's residue rather than by the window — on a flat window (#253), and where
+  absorption puts that residue at the scale of the window's own sum, which sends
+  v0.6.4's ratio outside [0,1] (#390). Gated on `fuzz_kama_064_blind()`, whose
+  predicate is computed from the inputs alone; the mechanism is stated there.
+  KAMA has no manifest entry, so every other case is held to the blanket 1e-9
+  FMA re-baseline bound, which is what absorbs the ULP-scale ratio changes the
+  clamp introduces; the skip covers only what leaves that bound. The same skip
+  drops the STOCH/STOCHF vectors that smooth with `MAType=KAMA`, whose
+  Fast-K series this gate cannot examine. Reported as `kama-skipped:`.
 - The oracle is reopened and retried once if it dies, so one latent 0.6.4 crash
   cannot sink the run.
 

--- a/src/tools/ta_regtest/ta_test_func/test_composite2.c
+++ b/src/tools/ta_regtest/ta_test_func/test_composite2.c
@@ -1228,10 +1228,14 @@ static ErrorNumber test_er_differential( const TA_History *history )
             if( nullRun >= n )
                sum = 0.0;
             mom = momP[i];
-            if( sum <= mom )
+            if( sum <= 0.0 || sum <= mom )
                ref[i] = 1.0;
             else
+            {
                ref[i] = fabs( mom / sum );
+               if( ref[i] > 1.0 )
+                  ref[i] = 1.0;
+            }
             if( memcmp( &out[i], &ref[i], sizeof(TA_Real) ) != 0 )
             {
                printf( "ER differential Fail [start %d n %d] bar %d: fused %.17g "
@@ -1307,7 +1311,7 @@ static ErrorNumber test_er_pins_and_edges( const TA_History *history )
    double err;
    const char *mode;
    unsigned int p;
-   int i, nbOver, nbBars = (int)history->nbBars;
+   int i, nbMirror, nbBars = (int)history->nbBars;
 
    rc = TA_ER( 0, nbBars - 1, history->close, 10, &beg, &nb, out );
    if( rc != TA_SUCCESS || beg != 10 || nb != nbBars - 10 )
@@ -1386,8 +1390,8 @@ static ErrorNumber test_er_pins_and_edges( const TA_History *history )
       }
    }
 
-   /* Monotone UP: the clamp fires (sum == mom in exact math; FP can nudge
-    * the raw ratio above 1) => exactly 1.0 everywhere. */
+   /* Monotone UP: the signed comparison fires (sum == mom in exact math; FP
+    * can nudge the raw ratio above 1) => exactly 1.0 everywhere. */
    for( i = 0; i < 64; i++ )
       buf[i] = 100.0 + (double)i * 0.7;
    rc = TA_ER( 0, 63, buf, 10, &beg, &nb, out );
@@ -1398,53 +1402,97 @@ static ErrorNumber test_er_pins_and_edges( const TA_History *history )
       if( out[i] != 1.0 )
       {
          printf( "ER monotone-up Fail bar %d: %.17g != exact 1.0 -- the signed "
-                 "clamp did not fire\n", (int)beg + i, out[i] );
+                 "comparison did not fire\n", (int)beg + i, out[i] );
          return TA_TESTUTIL_TFRR_BAD_CALCULATION;
       }
    }
 
-   /* Monotone DOWN: the clamp compares against the SIGNED numerator, so it
-    * never fires here and the raw fabs ratio is free to exceed 1.0 by a few
-    * ULP. A uniform decrement does not show it -- the sum comes out exactly
-    * equal to the net move on every window, so the band is satisfied under
-    * the fabs clamp `er.c` forbids just as well. These two alternating
-    * decrements put 24 of the 54 outputs strictly above 1.0, which is what
-    * the forbidden edit would pin back to exactly 1.0.
+   /* Monotone DOWN: `sum <= mom` compares against the SIGNED numerator, so it
+    * cannot fire on a decline. Nothing but the clamp bounds the ratio here,
+    * and these two alternating decrements are chosen because the running sum
+    * lands a few ULP under the net move -- unclamped, most outputs come out
+    * strictly above 1.0, which is above the ratio's own maximum.
     *
-    * So: the band, AND a count of bars that are strictly greater than 1.0.
-    * The count is the discriminating half; the band is what keeps it honest
-    * about the magnitude. */
+    * Two assertions, failing for different reasons if the clamp is removed:
+    * every output is EXACTLY 1.0, and the series mirrored through zero
+    * returns bit-identical output. ER is sign-symmetric in exact arithmetic
+    * (negation is exact, and both |net| and the path sum are built from
+    * magnitudes), so the signed comparison is the only asymmetry the body
+    * has; mirroring turns this decline into an advance, where the comparison
+    * DOES fire. The exact-1.0 assertion is what gates the clamp here (unclamped,
+    * most outputs exceed 1.0); the mirror pins sign symmetry, a separate
+    * property. Neither rules out a body that always answers 1.0 -- the zigzag
+    * leg above does, requiring an exact 0.0. */
    for( i = 0; i < 64; i++ )
       buf[i] = ( i == 0 ) ? 77.04
                           : buf[i-1] - ( ( i & 1 ) ? 1.8512 : 1.9002 );
    rc = TA_ER( 0, 63, buf, 10, &beg, &nb, out );
-   if( rc != TA_SUCCESS )
+   if( rc != TA_SUCCESS || nb <= 0 )
       return TA_TESTUTIL_TFRR_BAD_RETCODE;
-   nbOver = 0;
    for( i = 0; i < (int)nb; i++ )
    {
-      if( !(out[i] > 1.0 - 1e-12 && out[i] < 1.0 + 1e-12) )
+      if( out[i] != 1.0 )
       {
-         printf( "ER monotone-down Fail bar %d: %.17g outside 1 +- 1e-12\n",
-                 (int)beg + i, out[i] );
+         printf( "ER monotone-down Fail bar %d: %.17g != exact 1.0 -- the ratio "
+                 "exceeded its own maximum\n", (int)beg + i, out[i] );
          return TA_TESTUTIL_TFRR_BAD_CALCULATION;
       }
-      if( out[i] > 1.0 )
-         nbOver++;
    }
-   if( nbOver == 0 )
+   for( i = 0; i < 64; i++ )
+      buf[i] = -buf[i];
+   rc = TA_ER( 0, 63, buf, 10, &beg, &nbMirror, ref );
+   if( rc != TA_SUCCESS || nbMirror != nb )
+      return TA_TESTUTIL_TFRR_BAD_RETCODE;
+   if( memcmp( out, ref, (size_t)nb * sizeof(TA_Real) ) != 0 )
    {
-      printf( "ER monotone-down Fail: no output exceeded 1.0 -- the clamp is "
-              "no longer asymmetric, or the series stopped discriminating\n" );
+      for( i = 0; i < (int)nb; i++ )
+         if( memcmp( &out[i], &ref[i], sizeof(TA_Real) ) != 0 ) break;
+      printf( "ER sign-mirror Fail bar %d: ER(x)=%.17g != ER(-x)=%.17g -- the "
+              "signed comparison leaked into the value\n",
+              (int)beg + i, out[i], ref[i] );
       return TA_TESTUTIL_TFRR_BAD_CALCULATION;
    }
 
-   /* Zero denominator on a window that is NOT flat. A step absorbed on the
-    * way into the running sum is subtracted later at full precision, so the
-    * sum can reach exactly 0.0 while live terms remain in the window. Paired
-    * with a down move the clamp is false (`0.0 <= negative`), and without
-    * er.c's `sumROC1 <= 0.0` guard the division returns +Inf. The nullRun
-    * purge does not cover this: the window is not flat. */
+   /* KAMA carries the same clamp, and nothing else in the tree observes it: the
+    * ER/KAMA reconstruction differential runs on the reference series, where the
+    * ratio never exceeds 1, so it is green either way. Sign symmetry is what the
+    * clamp buys -- KAMA is exactly sign-symmetric but for the signed comparison,
+    * which fires only on advances -- so mirror the decline above through zero and
+    * require bit-identical negation. Unclamped, 25 of 54 bars break it. */
+   for( i = 0; i < 64; i++ )
+      buf[i] = ( i == 0 ) ? 77.04
+                          : buf[i-1] - ( ( i & 1 ) ? 1.8512 : 1.9002 );
+   rc = TA_KAMA( 0, 63, buf, 10, &beg, &nb, out );
+   if( rc != TA_SUCCESS || nb <= 0 )
+      return TA_TESTUTIL_TFRR_BAD_RETCODE;
+   for( i = 0; i < 64; i++ )
+      buf[i] = -buf[i];
+   rc = TA_KAMA( 0, 63, buf, 10, &beg, &nbMirror, ref );
+   if( rc != TA_SUCCESS || nbMirror != nb )
+      return TA_TESTUTIL_TFRR_BAD_RETCODE;
+   for( i = 0; i < (int)nb; i++ )
+   {
+      TA_Real negated = -ref[i];
+      if( memcmp( &out[i], &negated, sizeof(TA_Real) ) != 0 )
+      {
+         printf( "KAMA sign-mirror Fail bar %d: KAMA(x)=%.17g != -KAMA(-x)=%.17g -- "
+                 "the efficiency ratio left [0,1] on the decline\n",
+                 (int)beg + i, out[i], negated );
+         return TA_TESTUTIL_TFRR_BAD_CALCULATION;
+      }
+   }
+
+   /* Degenerate denominator on a window that is NOT flat. A step absorbed on
+    * the way into the running sum is subtracted later at full precision, so
+    * the sum can reach exactly 0.0 while live terms remain in the window, and
+    * the signed comparison is false against a down move (`0.0 <= negative`).
+    * The nullRun purge does not cover it: the window is not flat.
+    *
+    * Two mechanisms answer these bars -- `sumROC1 <= 0.0` returns 1.0 before
+    * dividing, the clamp maps the +Inf onto the same 1.0 -- so the assertion is
+    * an EXACT 1.0, not a band: drop the clamp and a neighbouring bar whose sum
+    * is tiny-but-positive comes back 1.0000000000000004. A band wide enough to
+    * absorb that would gate neither. */
    buf[0] = 1.0e16;
    buf[1] = 0.0;
    buf[2] = -1.0;
@@ -1457,10 +1505,10 @@ static ErrorNumber test_er_pins_and_edges( const TA_History *history )
       return TA_TESTUTIL_TFRR_BAD_RETCODE;
    for( i = 0; i < (int)nb; i++ )
    {
-      if( !TA_IS_FINITE( out[i] ) || out[i] > 1.0 + 1e-12 )
+      if( out[i] != 1.0 )
       {
-         printf( "ER zero-denominator Fail bar %d: %.17g -- the path sum "
-                 "reached 0.0 on a live window\n", (int)beg + i, out[i] );
+         printf( "ER zero-denominator Fail bar %d: %.17g != exact 1.0 -- the path "
+                 "sum reached 0.0 on a live window\n", (int)beg + i, out[i] );
          return TA_TESTUTIL_TFRR_BAD_CALCULATION;
       }
    }

--- a/src/tools/ta_regtest/ta_test_func/test_kdj.c
+++ b/src/tools/ta_regtest/ta_test_func/test_kdj.c
@@ -120,9 +120,7 @@ typedef struct { KdjArm arm; int n; int m1; int m2; int bar;
  *    stochastic, then `ti_wilders(m1)` and `ti_wilders(m2)`, then 3K-2D. This
  *    is the only arm with an INDEPENDENT WILDER KERNEL: wilders.c seeds with
  *    the simple average of the first `period` values exactly as TA_RMA does,
- *    then steps (x-v)*(1/n)+v where TA_RMA steps wAlpha*x + wBeta*v. Its raw
- *    stochastic is independent too -- 100*((close-min)/(max-min)) against our
- *    divide by (max-min)/100.
+ *    then steps (x-v)*(1/n)+v where TA_RMA steps wAlpha*x + wBeta*v.
  *  KDJ_ARM_TS -- trading-signals 8.3.0, in TypeScript, on node v22.21.1.
  *    `StochasticOscillator` computes the whole indicator including an
  *    INDEPENDENTLY IMPLEMENTED J line (`stochJ: 3 * stochK - 2 * stochD`) and

--- a/src/tools/ta_regtest/ta_test_legacy.c
+++ b/src/tools/ta_regtest/ta_test_legacy.c
@@ -85,13 +85,16 @@
  *       treatment in CORREL and BETA, the O(1) sliding-sum LINEARREG family,
  *       TA_WMA's re-anchored weighted totals -- which APO and PPO inherit
  *       through TA_MA(TA_MAType_WMA), the only two rows here that move for a
- *       change to a function they merely dispatch to -- and the two-coefficient
+ *       change to a function they merely dispatch to -- the two-coefficient
  *       Wilder step (ATR, NATR), which is (a) and (b) at once: the arithmetic
- *       form changed AND the result fuses.
+ *       form changed AND the result fuses -- and %K dividing by the window
+ *       range rather than by a copy pre-scaled by 1/100 (STOCH, STOCHF), which
+ *       is what makes a close on the window high exactly 100.0. STOCH's rows
+ *       cover its fma-inheriting alt case too; #390 is simply the larger.
  *
- * A blanket contract bound would buy unearned slack: CCI, IMI, KAMA, MACD,
- * MACDEXT and STOCHF are all bit-exact against v0.6.4 on this series,
- * their divergences needing the fuzz corpus's extreme magnitudes to appear.
+ * A blanket contract bound would buy unearned slack: CCI, IMI, KAMA, MACD and
+ * MACDEXT are all bit-exact against v0.6.4 on this series, their divergences
+ * needing the fuzz corpus's extreme magnitudes to appear.
  *
  * ONE PRINCIPLED EXCEPTION TO "3x MEASURED": a function reaching a libm routine
  * that is not correctly rounded gets a floor of 8 ULP at its own output
@@ -135,6 +138,8 @@ static const TA_LegacyTol LEGACY_TOL[] =
    { "APO",                 1e-13 },  /* #255  measured 4.26e-14            */
    { "PPO",                 1e-13 },  /* #255  measured 3.90e-14            */
    { "LINEARREG_SLOPE",     2e-12 },  /* #103  measured 3.49e-13             */
+   { "STOCH",               3e-13 },  /* #390  measured 8.53e-14             */
+   { "STOCHF",              2e-13 },  /* #390  measured 4.26e-14             */
    /* Sized at the frozen periods (14 and 19) and only there: unlike the rows
     * above, this divergence is output-proportional and grows with the period,
     * so a re-freeze that adds a longer-period case has to re-measure. */
@@ -143,12 +148,9 @@ static const TA_LegacyTol LEGACY_TOL[] =
 
    /* --- (a) explicit fma() adoption, PR #96 ------------------------------
     * Verified per row: ADOSC, T3, TEMA, DEMA, SAREXT, EMA, SAR, TRIX, MACDFIX
-    * and MAMA contain fma() directly. MA, MAVP and STOCH contain none and
-    * inherit it one dispatch hop away -- MA through its EMA/DEMA/TEMA/T3/MAMA
-    * arms, MAVP through MA, STOCH through the MAType=EMA smoothing of its alt
-    * case (its all-SMA default is bit-exact against v0.6.4). Worth stating
-    * because "STOCH diverges from v0.6.4" looks unexplained until you notice
-    * the parameter set doing it. */
+    * and MAMA contain fma() directly. MA and MAVP contain none and inherit it
+    * one dispatch hop away -- MA through its EMA/DEMA/TEMA/T3/MAMA arms, MAVP
+    * through MA. */
    { "ADOSC",               3e-08 },  /* measured 7.45e-09, output ~4.3e6    */
    { "T3",                  4e-13 },  /* measured 1.28e-13                   */
    { "TEMA",                3e-13 },  /* measured 9.95e-14                   */
@@ -159,7 +161,6 @@ static const TA_LegacyTol LEGACY_TOL[] =
    { "MAVP",                5e-14 },  /* measured 1.42e-14, via MA->EMA      */
    { "SAR",                 5e-14 },  /* measured 1.42e-14                   */
    { "TRIX",                4e-14 },  /* measured 1.11e-14                   */
-   { "STOCH",               3e-14 },  /* measured 7.11e-15, alt/EMA arm only */
    { "MACDFIX",             4e-15 },  /* measured 1.33e-15                   */
 
    /* --- (a) plus the 8-ULP libm floor (atan-derived output) -------------- */

--- a/src/tools/ta_regtest/test_codegen.c
+++ b/src/tools/ta_regtest/test_codegen.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <float.h>
 #include <time.h>
 
 /* Display flag set by ta_regtest.c --no-guarded */
@@ -5487,7 +5488,7 @@ typedef struct {
     double       maxFmaRel;   /* largest FMA-tolerated relative divergence observed (evidence vs the 1e-9 contract) */
     long long    stochRsiSkipped; /* STOCHRSI cases skipped: intentionally diverges from 0.6.4 (issue #107) */
     long long    mfiSkipped;      /* MFI cases skipped: v0.6.4 categorically wrong there (issue #244) */
-    long long    kamaSkipped;     /* KAMA (and KAMA-smoothed STOCH/STOCHF): v0.6.4 divides residue (issue #253) */
+    long long    kamaSkipped;     /* KAMA (and KAMA-smoothed STOCH/STOCHF): v0.6.4 divides residue (#253, #390) */
     long long    ultoscSkipped;   /* ULTOSC: same (issue #253) */
     long long    varianceSkipped; /* VAR/STDDEV/BBANDS cases skipped: cancellation-free variance re-baseline (issue #118) */
     long long    xySkipped;      /* CORREL/BETA cases skipped: same re-baseline over two series (issue #242) */
@@ -6114,31 +6115,52 @@ static int fuzz_mfi_064_blind( const double *h, const double *l,
  * answers it exactly by counting flat bars, so the two differ there and only
  * there.
  *
- * A case is not compared when any window KAMA evaluates is exactly flat, or
- * when the true sum is inside v0.6.4's band. Two-pass on purpose, like
- * fuzz_mfi_064_blind: the predicate must not re-run the algorithm under test.
- * The scan starts at the first bar with a full window rather than at the call's
- * startIdx, because a divergence at one bar is carried forward by prevKAMA. */
+ * That residue drives a second divergence, which is #390 rather than #253. Once
+ * it is comparable to the window's own true sum the accumulator can report a
+ * total below the window's net move, and v0.6.4 then divides out a ratio above
+ * 1 -- its mathematical maximum -- and smooths with a constant outside the
+ * adaptive range. On the EXTREME shape that reaches an output outside the hull
+ * of an all-positive input, from an OVERLAP-flagged function. The fix clamps
+ * the ratio, so the two differ exactly where v0.6.4's ratio left [0,1].
+ *
+ * A case is not compared when any window KAMA evaluates is exactly flat, when
+ * the true sum is inside v0.6.4's band, or when absorption can put the residue
+ * at the scale of the true sum. Two-pass on purpose, like fuzz_mfi_064_blind:
+ * the predicate must not re-run the algorithm under test -- it recomputes each
+ * window's sum fresh and tracks the running maximum, neither of which is what
+ * the library does. The scan starts at the first bar with a full window rather
+ * than at the call's startIdx, because a divergence at one bar is carried
+ * forward by prevKAMA. */
 static int fuzz_kama_064_blind( const double *x, int n, int period, int s, int e )
 {
     int t, j;
+    double everSeen = 0.0;             /* largest |1-bar change| so far */
 
     (void)s;
     if( period < 2 ) return 0;         /* period 1 is a copy of the input */
     if( e >= n ) e = n - 1;
 
+    for( t = 1; t < period && t < n; t++ )
+    {
+        double d = fabs( x[t] - x[t-1] );
+        if( d > everSeen ) everSeen = d;
+    }
+
     for( t = period; t <= e; t++ )
     {
-        double sum = 0.0;
+        double sum = 0.0, d;
         int flat = 1;
+        d = fabs( x[t] - x[t-1] );
+        if( d > everSeen ) everSeen = d;
         for( j = t - period + 1; j <= t; j++ )
         {
-            double d = x[j] - x[j-1];
-            if( d != 0.0 ) flat = 0;
-            sum += fabs(d);
+            double c = x[j] - x[j-1];
+            if( c != 0.0 ) flat = 0;
+            sum += fabs(c);
         }
         if( flat ) return 1;
         if( sum < 1e-14 ) return 1;    /* v0.6.4's band, on the true sum */
+        if( everSeen * DBL_EPSILON >= sum ) return 1;   /* absorption (#390) */
     }
     return 0;
 }
@@ -6809,7 +6831,9 @@ ErrorNumber fuzz_ref064(const char *functionFilter)
                ctx.stochRsiSkipped);
     if( ctx.kamaSkipped > 0 )
         printf("kama-skipped: %lld case(s) where v0.6.4's efficiency ratio is decided by"
-               " accumulator residue on a flat window (issue #253) -- KAMA itself, and the"
+               " accumulator residue rather than by the window -- on a flat window (issue"
+               " #253), or where absorption puts the residue at the scale of the window's"
+               " own sum and v0.6.4's ratio leaves [0,1] (issue #390). KAMA itself, and the"
                " STOCH/STOCHF vectors that smooth with MAType=KAMA, whose series this gate"
                " cannot examine. Every other case was compared bit-exact\n",
                ctx.kamaSkipped);

--- a/ta_codegen/generator/tests/divisor_guard_suite.rs
+++ b/ta_codegen/generator/tests/divisor_guard_suite.rs
@@ -124,30 +124,19 @@ const ANNOTATED: &[(&str, &str, &str, &str)] = &[
     // it. KAMA below is the contrast -- it carries `sumROC1`, so the same reasoning
     // does not reach it.
     ("VWMA", "tempV", "unguarded by decision: stateless per bar", "nan_inf_output"),
-
-    // OPEN, and reported by the scaled-derivation arm rather than the accumulator one.
-    // `stoch.c:230` guards `highest - lowest` and `:231` divides by `diff`, which
-    // `:189` sets to `(highest - lowest)/100.0`. The scaling is what breaks the
-    // inference: a denormal range leaves `highest - lowest` non-zero while `diff`
-    // underflows to exactly 0.0, so the guard says "not flat" and the division is by
-    // zero. Measured on the released library in #390 -- TA_SUCCESS with inf/nan
-    // written for well-formed OHLC. Moving the guard onto `diff` changes STOCH's
-    // output on those windows, so it is a decision about the function, not a patch to
-    // make a sweep green; `the_scaled_arm_clears_when_the_guard_moves_to_the_divisor`
-    // pins that this row disappears once that decision is made.
-    ("STOCH", "diff", "OPEN: guard tests the pre-scaled range; see #390", ""),
-    ("STOCHF", "diff", "OPEN: guard tests the pre-scaled range; see #390", ""),
 ];
 
 /// Variables assigned, inside a loop, from an expression that MULTIPLIES OR DIVIDES
 /// something — mapped to the variables that expression reads.
 ///
-/// This is the second defect shape, and it is not the accumulator one. STOCH guards
-/// `highest - lowest` and then divides by `diff`, where `diff = (highest-lowest)/100.0`
-/// (`stoch.c:189,230-231`). Scaling can send a non-zero quantity to exactly 0.0 by
-/// underflow, so a guard on the pre-scaled value does not establish what the division
-/// needs — the divisor is a different number. Addition and subtraction are excluded:
-/// they cannot turn a guarded-non-zero into a zero divisor the way a scaling can.
+/// This is the second defect shape, and it is not the accumulator one. STOCH used to
+/// guard `highest - lowest` while dividing by a copy of it scaled by 1/100 (#390).
+/// Scaling can send a non-zero quantity to exactly 0.0 by underflow, so a guard on the
+/// pre-scaled value does not establish what the division needs — the divisor is a
+/// different number. `the_scaled_arm_fires_on_a_scaled_divisor_and_not_otherwise`
+/// reconstructs that shape; no shipped function carries it now. Addition and
+/// subtraction are excluded: they cannot turn a guarded-non-zero into a zero divisor
+/// the way a scaling can.
 fn scaled_derivations(f: &FuncDef) -> Vec<(String, HashSet<String>)> {
     fn scaling_reads(e: &Expr) -> Option<HashSet<String>> {
         match e {
@@ -790,65 +779,237 @@ fn annotation_reasons_still_hold() {
     }
 }
 
-/// The scaled-derivation arm must go quiet when the guard moves to the divisor.
+/// The scaled-derivation arm must fire on the defect and go quiet without it.
 ///
-/// Same requirement as the ER and VORTEX self-tests, in the other direction: those
-/// prove the sweep goes loud on a reintroduced defect, this one proves it goes QUIET
-/// on the fix. Without it, a check that flags every scaled divisor unconditionally
-/// would look identical to one that reasons about the guard.
+/// Same shape as the ER and VORTEX self-tests, but in both directions, because this
+/// arm has no shipped instance to point at: #390 removed the last one by giving STOCH
+/// the range itself as its divisor. A check that flagged every scaled divisor
+/// unconditionally would satisfy the "fires" half and be worthless, so the two
+/// "goes quiet" halves are what pin it: one to respecting a guard that dominates
+/// the divisor, one to checking that the guard tests what the divisor was scaled
+/// from.
 #[test]
-fn the_scaled_arm_clears_when_the_guard_moves_to_the_divisor() {
+fn the_scaled_arm_fires_on_a_scaled_divisor_and_not_otherwise() {
     let funcs = load();
     let stoch = funcs.iter().find(|f| f.name == "STOCH").expect("STOCH is in the tree");
 
+    // As shipped, %K divides by `highest - lowest` -- the very expression its guard
+    // tests -- so there is nothing to scale and the sweep is silent.
     assert!(
-        findings_for(stoch).iter().any(|f| f.divisor == "diff"
-            && f.kind == FindingKind::ScaledFromGuarded),
-        "STOCH ships guarding `highest - lowest` while dividing by `diff`; the sweep \
-         should say so"
+        !findings_for(stoch).iter().any(|f| f.kind == FindingKind::ScaledFromGuarded),
+        "STOCH ships dividing by the guarded range itself; the sweep should be silent"
     );
 
-    // Rewrite the guard's subject from `highest - lowest` to `diff` — the fix #390
-    // suggests — and the finding must disappear.
-    let mut fixed = stoch.clone();
-    guard_on_diff(&mut fixed.body);
-    guard_on_diff(&mut fixed.private_body);
+    // Reintroduce the pre-#390 shape: a loop-local scaled by 1/100, divided by while
+    // the guard still tests the unscaled range.
+    let mut broken = stoch.clone();
+    divide_by_a_scaled_copy(&mut broken.body);
+    divide_by_a_scaled_copy(&mut broken.private_body);
     assert!(
-        !findings_for(&fixed).iter().any(|f| f.divisor == "diff"),
-        "the sweep still flags `diff` after the guard was moved onto it — the check is \
-         not reading the guard, it is flagging every scaled divisor"
+        findings_for(&broken)
+            .iter()
+            .any(|f| f.divisor == "diff" && f.kind == FindingKind::ScaledFromGuarded),
+        "the sweep did not flag a divisor scaled from the guarded value -- it cannot \
+         see the defect class this arm exists for"
+    );
+
+    // And with a test of that scaled divisor ADDED in front of the range guard, the
+    // finding must go. This is the half that pins the arm to READING the guard: strip
+    // its `!guarded` check and this assertion fails, because the range guard is still
+    // there to be scaled from. The first check cannot serve -- shipped STOCH divides
+    // by an expression rather than a variable, so this arm never examines it at all.
+    let mut repaired = broken.clone();
+    also_guard_on_diff(&mut repaired.body);
+    also_guard_on_diff(&mut repaired.private_body);
+    assert!(
+        !findings_for(&repaired).iter().any(|f| f.divisor == "diff"),
+        "the sweep still flags `diff` after the guard was moved onto it -- the check \
+         is not reading the guard, it is flagging every scaled divisor"
+    );
+
+    // And a scaled divisor whose SOURCE nothing guards is not this defect: the
+    // inference the arm reports is "a guard proves the pre-scaled value non-zero",
+    // so with no such guard there is nothing to mis-infer from. Without this, an
+    // arm that flagged every unguarded scaled divisor would pass the two above.
+    let mut unrelated = stoch.clone();
+    scale_from_an_unguarded_source(&mut unrelated.body);
+    scale_from_an_unguarded_source(&mut unrelated.private_body);
+    assert!(
+        !findings_for(&unrelated).iter().any(|f| f.divisor == "diff"),
+        "the sweep flagged a divisor scaled from a value no guard tests -- it is \
+         reporting every scaled divisor, not the guard/divisor mismatch"
     );
 }
 
-/// Replace `TA_IS_ZERO_SCALED(highest-lowest, ...)` with a plain zero test on `diff`.
-fn guard_on_diff(body: &mut [Statement]) {
-    fn fix(e: &Expr) -> Expr {
-        if let Expr::FuncCall(name, args) = e {
-            if name.contains("IS_ZERO") && args.iter().any(|a| names(a).contains("highest")) {
-                return Expr::BinOp(
-                    Box::new(Expr::Var("diff".to_string())),
-                    BinOp::Eq,
-                    Box::new(Expr::Literal(0.0)),
-                );
+/// Same injection as `divide_by_a_scaled_copy`, but `diff` is scaled from `tmp`,
+/// which no guard in the body tests.
+fn scale_from_an_unguarded_source(body: &mut [Statement]) {
+    divide_by_a_scaled_copy(body);
+    fn retarget(body: &mut Vec<Statement>) {
+        for st in body.iter_mut() {
+            match st {
+                Statement::Assign { target: Expr::Var(t), value, .. } if t == "diff" => {
+                    *value = Expr::BinOp(
+                        Box::new(Expr::Var("tmp".to_string())),
+                        BinOp::Div,
+                        Box::new(Expr::Literal(100.0)),
+                    );
+                }
+                Statement::While { body, .. }
+                | Statement::DoWhile { body, .. }
+                | Statement::For { body, .. }
+                | Statement::ForC { body, .. }
+                | Statement::Block { body } => retarget(body),
+                Statement::If { then_body, else_body, .. } => {
+                    retarget(then_body);
+                    retarget(else_body);
+                }
+                _ => {}
             }
         }
-        if let Expr::Not(inner) = e {
-            return Expr::Not(Box::new(fix(inner)));
+    }
+    for st in body.iter_mut() {
+        match st {
+            Statement::While { body, .. }
+            | Statement::DoWhile { body, .. }
+            | Statement::For { body, .. }
+            | Statement::ForC { body, .. }
+            | Statement::Block { body } => retarget(body),
+            Statement::If { then_body, else_body, .. } => {
+                retarget(then_body);
+                retarget(else_body);
+            }
+            _ => {}
         }
-        e.clone()
+    }
+}
+
+/// ADD `diff != 0.0` in front of the range guard, keeping it.
+///
+/// Conjoining rather than replacing is what makes the caller discriminating. Replace
+/// the range guard and both mechanisms stop applying at once -- the divisor becomes
+/// tested AND its source stops being tested -- so the finding disappears either way
+/// and the assertion cannot say which one did it. Kept, only the divisor test is new.
+fn also_guard_on_diff(body: &mut [Statement]) {
+    fn guards_the_range(e: &Expr) -> bool {
+        match e {
+            Expr::FuncCall(name, args) => {
+                name.contains("IS_ZERO") && args.iter().any(|a| names(a).contains("highest"))
+            }
+            Expr::BinOp(l, _, r) => guards_the_range(l) || guards_the_range(r),
+            Expr::Not(i) => guards_the_range(i),
+            _ => false,
+        }
     }
     for st in body.iter_mut() {
         match st {
             Statement::If { condition, then_body, else_body, .. } => {
-                *condition = fix(condition);
-                guard_on_diff(then_body);
-                guard_on_diff(else_body);
+                if guards_the_range(condition) {
+                    *condition = Expr::BinOp(
+                        Box::new(Expr::BinOp(
+                            Box::new(Expr::Var("diff".to_string())),
+                            BinOp::NotEq,
+                            Box::new(Expr::Literal(0.0)),
+                        )),
+                        BinOp::And,
+                        Box::new(condition.clone()),
+                    );
+                }
+                also_guard_on_diff(then_body);
+                also_guard_on_diff(else_body);
             }
             Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
             | Statement::For { body, .. }
             | Statement::ForC { body, .. }
-            | Statement::Block { body } => guard_on_diff(body),
+            | Statement::Block { body } => also_guard_on_diff(body),
+            _ => {}
+        }
+    }
+}
+
+/// Rewrite `num / (highest - lowest)` into `num / diff`, preceded by
+/// `diff = (highest - lowest) / 100.0` -- the divisor shape #390 removed.
+fn divide_by_a_scaled_copy(body: &mut [Statement]) {
+    fn is_range(e: &Expr) -> bool {
+        matches!(e, Expr::BinOp(l, BinOp::Sub, r)
+            if matches!(**l, Expr::Var(ref v) if v == "highest")
+                && matches!(**r, Expr::Var(ref v) if v == "lowest"))
+    }
+    fn rewrite(e: &Expr, hit: &mut bool) -> Expr {
+        match e {
+            Expr::BinOp(l, BinOp::Div, r) if is_range(r) => {
+                *hit = true;
+                Expr::BinOp(
+                    Box::new(rewrite(l, hit)),
+                    BinOp::Div,
+                    Box::new(Expr::Var("diff".to_string())),
+                )
+            }
+            Expr::BinOp(l, op, r) => {
+                Expr::BinOp(Box::new(rewrite(l, hit)), op.clone(), Box::new(rewrite(r, hit)))
+            }
+            _ => e.clone(),
+        }
+    }
+    fn scale_assign() -> Statement {
+        Statement::Assign {
+            target: Expr::Var("diff".to_string()),
+            value: Expr::BinOp(
+                Box::new(Expr::BinOp(
+                    Box::new(Expr::Var("highest".to_string())),
+                    BinOp::Sub,
+                    Box::new(Expr::Var("lowest".to_string())),
+                )),
+                BinOp::Div,
+                Box::new(Expr::Literal(100.0)),
+            ),
+            compound: false,
+        }
+    }
+    fn walk(body: &mut Vec<Statement>) {
+        let mut inject = Vec::new();
+        for (i, st) in body.iter_mut().enumerate() {
+            match st {
+                Statement::If { then_body, else_body, .. } => {
+                    let mut hit = false;
+                    for b in [&mut *then_body, &mut *else_body] {
+                        for inner in b.iter_mut() {
+                            if let Statement::Assign { value, .. } = inner {
+                                *value = rewrite(value, &mut hit);
+                            }
+                        }
+                    }
+                    if hit {
+                        inject.push(i);
+                    }
+                    walk(then_body);
+                    walk(else_body);
+                }
+                Statement::While { body, .. }
+                | Statement::DoWhile { body, .. }
+                | Statement::For { body, .. }
+                | Statement::ForC { body, .. }
+                | Statement::Block { body } => walk(body),
+                _ => {}
+            }
+        }
+        for i in inject.into_iter().rev() {
+            body.insert(i, scale_assign());
+        }
+    }
+    // `body` is a slice here, so recurse into the owned Vecs the statements hold.
+    for st in body.iter_mut() {
+        match st {
+            Statement::While { body, .. }
+            | Statement::DoWhile { body, .. }
+            | Statement::For { body, .. }
+            | Statement::ForC { body, .. }
+            | Statement::Block { body } => walk(body),
+            Statement::If { then_body, else_body, .. } => {
+                walk(then_body);
+                walk(else_body);
+            }
             _ => {}
         }
     }

--- a/ta_codegen/generator/tests/divisor_guard_suite.rs
+++ b/ta_codegen/generator/tests/divisor_guard_suite.rs
@@ -845,7 +845,7 @@ fn the_scaled_arm_fires_on_a_scaled_divisor_and_not_otherwise() {
 /// which no guard in the body tests.
 fn scale_from_an_unguarded_source(body: &mut [Statement]) {
     divide_by_a_scaled_copy(body);
-    fn retarget(body: &mut Vec<Statement>) {
+    fn retarget(body: &mut [Statement]) {
         for st in body.iter_mut() {
             match st {
                 Statement::Assign { target: Expr::Var(t), value, .. } if t == "diff" => {

--- a/ta_codegen/input/er/er.c
+++ b/ta_codegen/input/er/er.c
@@ -34,16 +34,19 @@ TA_RetCode er(int startIdx, int endIdx,
     *
     *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
     *
+    * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+    * clamp to 1.0 is what makes the declared range a bound rather than a
+    * hope -- and in kama.c what keeps its recurrence a convex combination.
+    *
     * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
     * two stay bit-identical -- the KAMA-reconstruction differential in
-    * test_composite2.c exists to keep it that way. Two guards are
+    * test_composite2.c exists to keep it that way. Three more guards are
     * load-bearing and shared with kama.c:
     *
     *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-    *     would give 1.0000000000000002. The comparison is against the
-    *     SIGNED numerator, so it only fires on up-moves; on sustained
-    *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-    *     "fix" this with fabs -- it changes TA_KAMA's output.
+    *     would give 1.0000000000000002, on up-moves. It compares against
+    *     the SIGNED numerator, so it is false for every down move: it
+    *     bounds nothing on its own, which is what the clamp is for.
     *   - a genuinely flat window is recognized by COUNTING exactly-zero
     *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
     *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -52,13 +55,10 @@ TA_RetCode er(int startIdx, int endIdx,
     *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
     *     price-carrying sum).
     *
-    * A third guard is the denominator test: the division runs only where
-    * sumROC1 is exactly positive. The clamp above cannot serve as it,
-    * because it compares against the SIGNED numerator and so is false for
-    * every down move -- and a subtract-then-add sum can reach 0.0, or
-    * below it, on a window that is not flat, when a term absorbed on the
-    * way in is subtracted later at full precision. Without the guard those
-    * bars divide by zero.
+    * The third is the denominator test (#385): a subtract-then-add sum can
+    * reach 0.0, or below it, on a window that is not flat. The clamp
+    * subsumes it numerically, so it is held by the structural sweep over
+    * divisors, not by any value test.
     *
     * The subtract-then-add update order matches TA_SUM's recurrence,
     * which is what makes the composite differential bit-exact. The
@@ -111,7 +111,12 @@ TA_RetCode er(int startIdx, int endIdx,
    if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
       outReal[0] = 1.0;
    else
-      outReal[0] = fabs( periodROC / sumROC1 );
+   {
+      tempReal = fabs( periodROC / sumROC1 );
+      if( tempReal > 1.0 )
+         tempReal = 1.0;
+      outReal[0] = tempReal;
+   }
    outIdx = 1;
    today++;
 
@@ -147,7 +152,12 @@ TA_RetCode er(int startIdx, int endIdx,
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
          outReal[outIdx++] = 1.0;
       else
-         outReal[outIdx++] = fabs( periodROC / sumROC1 );
+      {
+         tempReal = fabs( periodROC / sumROC1 );
+         if( tempReal > 1.0 )
+            tempReal = 1.0;
+         outReal[outIdx++] = tempReal;
+      }
       today++;
    }
 

--- a/ta_codegen/input/er/er.md
+++ b/ta_codegen/input/er/er.md
@@ -12,7 +12,7 @@ This is exactly the efficiency ratio [`KAMA`](/functions/kama) computes internal
 
 Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
 
-The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+The output is a hard 0..1 — the net move can never exceed the path travelled.
 
 TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
 

--- a/ta_codegen/input/kama/kama.c
+++ b/ta_codegen/input/kama/kama.c
@@ -23,6 +23,9 @@
  *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
  *                forced the fastest adaptation on any instrument quoted small
  *                enough to fall under it.
+ *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+ *                let it exceed its own mathematical maximum, and the squared
+ *                smoothing constant then amplified instead of averaging.
  */
 
 int kama_lookback(int optInTimePeriod)
@@ -140,26 +143,23 @@ TA_RetCode kama(int startIdx, int endIdx,
 
    /* Calculate the efficiency ratio.
     *
-    * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-    * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-    * sit beside it was not -- it declared the window flat, and forced the
-    * fastest adaptation, for every window of an instrument quoted below it
-    * (issue #253). A genuinely flat window is now recognized by the exact bar
-    * count above instead.
+    * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+    * clamp it: past 1 the squared smoothing constant amplifies instead of
+    * averaging and the recurrence below stops being a convex combination.
     *
-    * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-    * beside it compares against the SIGNED numerator, so it is false whenever
-    * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-    * add/subtract of fabs terms, so an addend absorbed on the way in and
-    * subtracted later at full precision drives it to exactly 0.0 on a window
-    * that is not flat; without this clause that bar divides by zero and the
-    * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-    * carried until #350).
+    * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+    * +Inf onto the same 1.0 -- so a value test written against it would pass
+    * with it deleted. Keep it anyway: the divisor sweep requires a division to
+    * be dominated by a test of its own divisor against a literal zero.
     */
    if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
       tempReal = 1.0;
    else
+   {
       tempReal = fabs(periodROC/sumROC1);
+      if( tempReal > 1.0 )
+         tempReal = 1.0;
+   }
 
    /* Calculate the smoothing constant */
    tempReal  = (tempReal*constDiff)+constMax;
@@ -215,7 +215,11 @@ TA_RetCode kama(int startIdx, int endIdx,
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
          tempReal = 1.0;
       else
+      {
          tempReal = fabs(periodROC/sumROC1);
+         if( tempReal > 1.0 )
+            tempReal = 1.0;
+      }
 
       /* Calculate the smoothing constant */
       tempReal  = (tempReal*constDiff)+constMax;
@@ -271,7 +275,11 @@ TA_RetCode kama(int startIdx, int endIdx,
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC )
          tempReal = 1.0;
       else
+      {
          tempReal = fabs(periodROC / sumROC1);
+         if( tempReal > 1.0 )
+            tempReal = 1.0;
+      }
 
       /* Calculate the smoothing constant */
       tempReal  = (tempReal*constDiff)+constMax;

--- a/ta_codegen/input/kama/kama.md
+++ b/ta_codegen/input/kama/kama.md
@@ -13,6 +13,7 @@ KAMA[t] = KAMA[t-1] + SC*(price[t] - KAMA[t-1])
 ## Notes
 
 - A period of 1 performs no smoothing: the output is a copy of the input, consistent with `MA(period=1)` for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.
+- The output never leaves the range of the prices it has seen.
 
 ## Inputs
 

--- a/ta_codegen/input/stoch/stoch.c
+++ b/ta_codegen/input/stoch/stoch.c
@@ -21,6 +21,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
  *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  *
  */
 
@@ -54,7 +57,7 @@ TA_RetCode stoch(int startIdx, int endIdx,
    double outSlowD[])
 {
    TA_RetCode retCode;
-   double lowest, highest, tmp, diff;
+   double lowest, highest, tmp;
    double *tempBuffer;
    int outIdx, lowestIdx, highestIdx;
    int lookbackTotal, lookbackK, lookbackKSlow, lookbackDSlow;
@@ -136,7 +139,7 @@ TA_RetCode stoch(int startIdx, int endIdx,
    trailingIdx = startIdx-lookbackTotal;
    today       = trailingIdx+lookbackK;
    lowestIdx   = highestIdx = -1;
-   diff = highest = lowest  = 0.0;
+   highest = lowest = 0.0;
 
    /* Allocate a temporary buffer large enough to
     * store the K.
@@ -186,13 +189,11 @@ TA_RetCode stoch(int startIdx, int endIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest)/100.0;
       }
       else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest)/100.0;
       }
 
       /* Set the highest high */
@@ -211,24 +212,24 @@ TA_RetCode stoch(int startIdx, int endIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest)/100.0;
       }
       else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest)/100.0;
       }
 
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253). */
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI). */
       if( !TA_IS_ZERO_SCALED(highest-lowest, fabs(highest)+fabs(lowest)) )
-         tempBuffer[outIdx++] = (inClose[today]-lowest)/diff;
+         tempBuffer[outIdx++] = ((inClose[today]-lowest)/(highest-lowest))*100.0;
       else
          tempBuffer[outIdx++] = 0.0;
 

--- a/ta_codegen/input/stochf/stochf.c
+++ b/ta_codegen/input/stochf/stochf.c
@@ -23,6 +23,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
  *               already answered above it, and the shape reads like #269.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  *
  */
 
@@ -51,7 +54,7 @@ TA_RetCode stochf(int startIdx, int endIdx,
    double outFastD[])
 {
    TA_RetCode retCode;
-   double lowest, highest, tmp, diff;
+   double lowest, highest, tmp;
    double *tempBuffer;
    int outIdx, lowestIdx, highestIdx;
    int lookbackTotal, lookbackK, lookbackFastD;
@@ -133,7 +136,7 @@ TA_RetCode stochf(int startIdx, int endIdx,
    trailingIdx = startIdx-lookbackTotal;
    today       = trailingIdx+lookbackK;
    lowestIdx   = highestIdx = -1;
-   diff = highest = lowest  = 0.0;
+   highest = lowest = 0.0;
 
    /* Allocate a temporary buffer large enough to
     * store the K.
@@ -183,13 +186,11 @@ TA_RetCode stochf(int startIdx, int endIdx,
                lowest = tmp;
             }
          }
-         diff = (highest - lowest)/100.0;
       }
       else if( tmp <= lowest )
       {
          lowestIdx = today;
          lowest = tmp;
-         diff = (highest - lowest)/100.0;
       }
 
       /* Set the highest high */
@@ -208,24 +209,24 @@ TA_RetCode stochf(int startIdx, int endIdx,
                highest = tmp;
             }
          }
-         diff = (highest - lowest)/100.0;
       }
       else if( tmp >= highest )
       {
          highestIdx = today;
          highest = tmp;
-         diff = (highest - lowest)/100.0;
       }
 
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253). */
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI). */
       if( !TA_IS_ZERO_SCALED(highest-lowest, fabs(highest)+fabs(lowest)) )
-         tempBuffer[outIdx++] = (inClose[today]-lowest)/diff;
+         tempBuffer[outIdx++] = ((inClose[today]-lowest)/(highest-lowest))*100.0;
       else
          tempBuffer[outIdx++] = 0.0;
 

--- a/ta_codegen/output/c/tools/ta_codegen_serve.c
+++ b/ta_codegen/output/c/tools/ta_codegen_serve.c
@@ -5504,7 +5504,6 @@ static int sv_steq_TA_STOCH( const struct TA_STOCH_Stream *a, const struct TA_ST
    if( a->optInSlowD_MAType != b->optInSlowD_MAType ) { *w = "optInSlowD_MAType"; return 1; }
    if( sv_xtier_ne(a->lowest, b->lowest, z) ) { *w = "lowest"; return 1; }
    if( sv_xtier_ne(a->highest, b->highest, z) ) { *w = "highest"; return 1; }
-   if( sv_xtier_ne(a->diff, b->diff, z) ) { *w = "diff"; return 1; }
    if( a->lowestIdx != b->lowestIdx ) { *w = "lowestIdx"; return 1; }
    if( a->highestIdx != b->highestIdx ) { *w = "highestIdx"; return 1; }
    if( a->trailingIdx != b->trailingIdx ) { *w = "trailingIdx"; return 1; }
@@ -5551,7 +5550,6 @@ static int sv_steq_TA_STOCHF( const struct TA_STOCHF_Stream *a, const struct TA_
    if( a->optInFastD_MAType != b->optInFastD_MAType ) { *w = "optInFastD_MAType"; return 1; }
    if( sv_xtier_ne(a->lowest, b->lowest, z) ) { *w = "lowest"; return 1; }
    if( sv_xtier_ne(a->highest, b->highest, z) ) { *w = "highest"; return 1; }
-   if( sv_xtier_ne(a->diff, b->diff, z) ) { *w = "diff"; return 1; }
    if( a->lowestIdx != b->lowestIdx ) { *w = "lowestIdx"; return 1; }
    if( a->highestIdx != b->highestIdx ) { *w = "highestIdx"; return 1; }
    if( a->trailingIdx != b->trailingIdx ) { *w = "trailingIdx"; return 1; }

--- a/ta_codegen/output/csharp/library/src/Core_ER.cs
+++ b/ta_codegen/output/csharp/library/src/Core_ER.cs
@@ -119,16 +119,19 @@ public partial class Core
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -137,13 +140,10 @@ public partial class Core
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -192,7 +192,11 @@ public partial class Core
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.Abs(periodROC / sumROC1);
+         tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -224,7 +228,11 @@ public partial class Core
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.Abs(periodROC / sumROC1);
+            tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -295,7 +303,11 @@ public partial class Core
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.Abs(periodROC / sumROC1);
+         tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -318,7 +330,11 @@ public partial class Core
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.Abs(periodROC / sumROC1);
+            tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -340,7 +356,7 @@ public partial class Core
    /// <code>
    /// `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
    /// Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-   /// The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+   /// The output is a hard 0..1 — the net move can never exceed the path travelled.
    /// TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
    /// </code>
    /// <list type="bullet">
@@ -410,7 +426,7 @@ public partial class Core
    /// <code>
    /// `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
    /// Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-   /// The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+   /// The output is a hard 0..1 — the net move can never exceed the path travelled.
    /// TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
    /// </code>
    /// <list type="bullet">
@@ -628,7 +644,11 @@ public partial class Core
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             cur_outReal = 1.0;
          } else {
-            cur_outReal = Math.Abs(periodROC / sumROC1);
+            tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            cur_outReal = tempReal;
          }
          return cur_outReal;
       }
@@ -685,7 +705,11 @@ public partial class Core
       if( sp.sumROC1 <= 0.0 || sp.sumROC1 <= periodROC ) {
          sp.cur_outReal = 1.0;
       } else {
-         sp.cur_outReal = Math.Abs(periodROC / sp.sumROC1);
+         tempReal = Math.Abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         sp.cur_outReal = tempReal;
       }
       sp.lag1_inReal = inReal;
       sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
@@ -734,16 +758,19 @@ public partial class Core
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -752,13 +779,10 @@ public partial class Core
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -807,7 +831,11 @@ public partial class Core
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0 * outStride] = 1.0;
       } else {
-         outReal[0 * outStride] = Math.Abs(periodROC / sumROC1);
+         tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0 * outStride] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -839,7 +867,11 @@ public partial class Core
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++ * outStride] = 1.0;
          } else {
-            outReal[outIdx++ * outStride] = Math.Abs(periodROC / sumROC1);
+            tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++ * outStride] = tempReal;
          }
          today += 1;
       }

--- a/ta_codegen/output/csharp/library/src/Core_KAMA.cs
+++ b/ta_codegen/output/csharp/library/src/Core_KAMA.cs
@@ -67,6 +67,9 @@ public partial class Core
     *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
     *                forced the fastest adaptation on any instrument quoted small
     *                enough to fall under it.
+    *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+    *                let it exceed its own mathematical maximum, and the squared
+    *                smoothing constant then amplified instead of averaging.
     */
    /// <summary>
    /// Number of leading input bars <c>KAMA</c> consumes before it can produce
@@ -218,26 +221,22 @@ public partial class Core
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
@@ -286,6 +285,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
@@ -334,6 +336,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
@@ -436,6 +441,9 @@ public partial class Core
          tempReal = 1.0;
       } else {
          tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
       tempReal *= tempReal;
@@ -460,6 +468,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -488,6 +499,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -513,6 +527,7 @@ public partial class Core
    /// </code>
    /// <list type="bullet">
    /// <item><description>A period of 1 performs no smoothing: the output is a copy of the input, consistent with <c>MA(period=1)</c> for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</description></item>
+   /// <item><description>The output never leaves the range of the prices it has seen.</description></item>
    /// </list>
    /// <para>
    /// Values are written only where the indicator is defined. The returned
@@ -580,6 +595,7 @@ public partial class Core
    /// </code>
    /// <list type="bullet">
    /// <item><description>A period of 1 performs no smoothing: the output is a copy of the input, consistent with <c>MA(period=1)</c> for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</description></item>
+   /// <item><description>The output never leaves the range of the prices it has seen.</description></item>
    /// </list>
    /// <para>
    /// This is the <c>float[]</c> overload: input elements are widened to
@@ -810,6 +826,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.FusedMultiplyAdd(tempReal, sp.constDiff, sp.constMax);
@@ -884,6 +903,9 @@ public partial class Core
          tempReal = 1.0;
       } else {
          tempReal = Math.Abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.FusedMultiplyAdd(tempReal, sp.constDiff, sp.constMax);
@@ -1028,26 +1050,22 @@ public partial class Core
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.Abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
@@ -1096,6 +1114,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);
@@ -1144,6 +1165,9 @@ public partial class Core
             tempReal = 1.0;
          } else {
             tempReal = Math.Abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.FusedMultiplyAdd(tempReal, constDiff, constMax);

--- a/ta_codegen/output/csharp/library/src/Core_STOCH.cs
+++ b/ta_codegen/output/csharp/library/src/Core_STOCH.cs
@@ -65,6 +65,9 @@ public partial class Core
     *               small enough to fall under it.
     *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
     *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+    *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+    *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+    *               range that the guard still called "not flat".
     */
    /// <summary>
    /// Number of leading input bars <c>STOCH</c> consumes before it can produce
@@ -148,7 +151,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -271,7 +273,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -303,11 +304,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -322,22 +321,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -402,7 +401,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -469,7 +467,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       bufferIsAllocated = 1;
       tempBuffer = new double[(int)((endIdx - today + 1) * 1)];
@@ -486,11 +483,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -504,14 +499,12 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -766,7 +759,6 @@ public partial class Core
       internal MAType optInSlowD_MAType;
       internal double lowest;
       internal double highest;
-      internal double diff;
       internal int lowestIdx;
       internal int highestIdx;
       internal int trailingIdx;
@@ -820,7 +812,6 @@ public partial class Core
          this.optInSlowD_MAType = other.optInSlowD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -888,7 +879,6 @@ public partial class Core
          double cur_outSlowD = 0.0;
          double cur_outSlowK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -929,11 +919,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -948,22 +936,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -1020,11 +1008,9 @@ public partial class Core
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -1039,22 +1025,22 @@ public partial class Core
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.Abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.Abs(sp.highest) + Math.Abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -1075,7 +1061,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -1207,7 +1192,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -1239,11 +1223,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -1258,22 +1240,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -1352,7 +1334,6 @@ public partial class Core
       sp.optInSlowD_MAType = optInSlowD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;

--- a/ta_codegen/output/csharp/library/src/Core_STOCHF.cs
+++ b/ta_codegen/output/csharp/library/src/Core_STOCHF.cs
@@ -67,6 +67,9 @@ public partial class Core
     *               small enough to fall under it.
     *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
     *               already answered above it, and the shape reads like #269.
+    *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+    *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+    *               range that the guard still called "not flat".
     */
    /// <summary>
    /// Number of leading input bars <c>STOCHF</c> consumes before it can produce
@@ -130,7 +133,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -241,7 +243,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -273,11 +274,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -292,22 +291,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -361,7 +360,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -416,7 +414,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       bufferIsAllocated = 1;
       tempBuffer = new double[(int)((endIdx - today + 1) * 1)];
@@ -433,11 +430,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -451,14 +446,12 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -689,7 +682,6 @@ public partial class Core
       internal MAType optInFastD_MAType;
       internal double lowest;
       internal double highest;
-      internal double diff;
       internal int lowestIdx;
       internal int highestIdx;
       internal int trailingIdx;
@@ -740,7 +732,6 @@ public partial class Core
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -807,7 +798,6 @@ public partial class Core
          double cur_outFastD = 0.0;
          double cur_outFastK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -848,11 +838,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -867,22 +855,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -938,11 +926,9 @@ public partial class Core
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -957,22 +943,22 @@ public partial class Core
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.Abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.Abs(sp.highest) + Math.Abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -992,7 +978,6 @@ public partial class Core
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       Span<double> tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -1112,7 +1097,6 @@ public partial class Core
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -1144,11 +1128,9 @@ public partial class Core
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -1163,22 +1145,22 @@ public partial class Core
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.Abs(highest - lowest) <= 0.00000000000001 * (Math.Abs(highest) + Math.Abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -1240,7 +1222,6 @@ public partial class Core
       sp.optInFastD_MAType = optInFastD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;

--- a/ta_codegen/output/java/fragments/Core_ER.java
+++ b/ta_codegen/output/java/fragments/Core_ER.java
@@ -71,16 +71,19 @@
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -89,13 +92,10 @@
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -144,7 +144,11 @@
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -176,7 +180,11 @@
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -245,7 +253,11 @@
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -268,7 +280,11 @@
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -288,7 +304,7 @@
     * <pre>{@code
     * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
     * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-    * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+    * The output is a hard 0..1 — the net move can never exceed the path travelled.
     * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
     * }</pre>
     * <p><b>Notes</b>
@@ -361,7 +377,7 @@
     * <pre>{@code
     * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
     * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-    * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+    * The output is a hard 0..1 — the net move can never exceed the path travelled.
     * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
     * }</pre>
     * <p><b>Notes</b>
@@ -571,7 +587,11 @@
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             cur_outReal = 1.0;
          } else {
-            cur_outReal = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            cur_outReal = tempReal;
          }
          return cur_outReal;
       }
@@ -637,7 +657,11 @@
       if( sp.sumROC1 <= 0.0 || sp.sumROC1 <= periodROC ) {
          sp.cur_outReal = 1.0;
       } else {
-         sp.cur_outReal = Math.abs(periodROC / sp.sumROC1);
+         tempReal = Math.abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         sp.cur_outReal = tempReal;
       }
       sp.lag1_inReal = inReal;
       sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
@@ -683,16 +707,19 @@
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -701,13 +728,10 @@
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -756,7 +780,11 @@
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0 * outStride] = 1.0;
       } else {
-         outReal[0 * outStride] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0 * outStride] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -788,7 +816,11 @@
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++ * outStride] = 1.0;
          } else {
-            outReal[outIdx++ * outStride] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++ * outStride] = tempReal;
          }
          today += 1;
       }

--- a/ta_codegen/output/java/fragments/Core_KAMA.java
+++ b/ta_codegen/output/java/fragments/Core_KAMA.java
@@ -23,6 +23,9 @@
  *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
  *                forced the fastest adaptation on any instrument quoted small
  *                enough to fall under it.
+ *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+ *                let it exceed its own mathematical maximum, and the squared
+ *                smoothing constant then amplified instead of averaging.
  */
 
    /**
@@ -168,26 +171,22 @@
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -236,6 +235,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -284,6 +286,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -384,6 +389,9 @@
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       tempReal = Math.fma(tempReal, constDiff, constMax);
       tempReal *= tempReal;
@@ -408,6 +416,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.fma(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -436,6 +447,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.fma(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -460,6 +474,7 @@
     * <p><b>Notes</b>
     * <ul>
     * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+    * <li>The output never leaves the range of the prices it has seen.</li>
     * </ul>
     * <p>Values are written only where the indicator is defined. The returned
     * {@link OutRange} says where they start and how many there are; nothing
@@ -527,6 +542,7 @@
     * <p><b>Notes</b>
     * <ul>
     * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+    * <li>The output never leaves the range of the prices it has seen.</li>
     * </ul>
     * <p>This is the {@code float[]} overload. The arithmetic is performed in
     * {@code double} before being written to the {@code double[]} output, so a
@@ -745,6 +761,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -828,6 +847,9 @@
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -969,26 +991,22 @@
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -1037,6 +1055,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -1085,6 +1106,9 @@
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);

--- a/ta_codegen/output/java/fragments/Core_STOCH.java
+++ b/ta_codegen/output/java/fragments/Core_STOCH.java
@@ -21,6 +21,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
  *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
    /**
@@ -101,7 +104,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -217,7 +219,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -249,11 +250,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -268,22 +267,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -346,7 +345,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -409,7 +407,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       if( false || false || false ) {
          tempBuffer = outSlowK;
@@ -430,11 +427,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -448,14 +443,12 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -701,7 +694,6 @@
       MAType optInSlowD_MAType;
       double lowest;
       double highest;
-      double diff;
       int lowestIdx;
       int highestIdx;
       int trailingIdx;
@@ -752,7 +744,6 @@
          this.optInSlowD_MAType = other.optInSlowD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -813,7 +804,6 @@
          double cur_outSlowD = 0.0;
          double cur_outSlowK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -854,11 +844,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -873,22 +861,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -979,11 +967,9 @@
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -998,22 +984,22 @@
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -1031,7 +1017,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -1159,7 +1144,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -1191,11 +1175,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -1210,22 +1192,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -1298,7 +1280,6 @@
       sp.optInSlowD_MAType = optInSlowD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;

--- a/ta_codegen/output/java/fragments/Core_STOCHF.java
+++ b/ta_codegen/output/java/fragments/Core_STOCHF.java
@@ -23,6 +23,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
  *               already answered above it, and the shape reads like #269.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
    /**
@@ -83,7 +86,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -189,7 +191,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -221,11 +222,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -240,22 +239,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -307,7 +306,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -360,7 +358,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       if( false || false || false ) {
          tempBuffer = outFastK;
@@ -381,11 +378,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -399,14 +394,12 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -622,7 +615,6 @@
       MAType optInFastD_MAType;
       double lowest;
       double highest;
-      double diff;
       int lowestIdx;
       int highestIdx;
       int trailingIdx;
@@ -670,7 +662,6 @@
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -730,7 +721,6 @@
          double cur_outFastD = 0.0;
          double cur_outFastK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -771,11 +761,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -790,22 +778,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -895,11 +883,9 @@
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -914,22 +900,22 @@
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -946,7 +932,6 @@
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -1064,7 +1049,6 @@
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -1096,11 +1080,9 @@
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -1115,22 +1097,22 @@
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -1189,7 +1171,6 @@
       sp.optInFastD_MAType = optInFastD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/BuildStamp.java
@@ -9,7 +9,7 @@ package io.github.talib;
  */
 public final class BuildStamp {
     /** Digest of the generated {@code Core} method text this build carries. */
-    public static final String GENCODE_DIGEST = "d762214e84a18d9a";
+    public static final String GENCODE_DIGEST = "729a925b515bcb19";
 
     private BuildStamp() {
     }

--- a/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
+++ b/ta_codegen/output/java/library/src/main/java/io/github/talib/Core.java
@@ -82430,16 +82430,19 @@ public final class Core {
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -82448,13 +82451,10 @@ public final class Core {
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -82503,7 +82503,11 @@ public final class Core {
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -82535,7 +82539,11 @@ public final class Core {
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -82604,7 +82612,11 @@ public final class Core {
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0] = 1.0;
       } else {
-         outReal[0] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -82627,7 +82639,11 @@ public final class Core {
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++] = 1.0;
          } else {
-            outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++] = tempReal;
          }
          today += 1;
       }
@@ -82647,7 +82663,7 @@ public final class Core {
     * <pre>{@code
     * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
     * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-    * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+    * The output is a hard 0..1 — the net move can never exceed the path travelled.
     * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
     * }</pre>
     * <p><b>Notes</b>
@@ -82720,7 +82736,7 @@ public final class Core {
     * <pre>{@code
     * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
     * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-    * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+    * The output is a hard 0..1 — the net move can never exceed the path travelled.
     * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
     * }</pre>
     * <p><b>Notes</b>
@@ -82930,7 +82946,11 @@ public final class Core {
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             cur_outReal = 1.0;
          } else {
-            cur_outReal = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            cur_outReal = tempReal;
          }
          return cur_outReal;
       }
@@ -82996,7 +83016,11 @@ public final class Core {
       if( sp.sumROC1 <= 0.0 || sp.sumROC1 <= periodROC ) {
          sp.cur_outReal = 1.0;
       } else {
-         sp.cur_outReal = Math.abs(periodROC / sp.sumROC1);
+         tempReal = Math.abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         sp.cur_outReal = tempReal;
       }
       sp.lag1_inReal = inReal;
       sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
@@ -83042,16 +83066,19 @@ public final class Core {
        *
        *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
        *
+       * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+       * clamp to 1.0 is what makes the declared range a bound rather than a
+       * hope -- and in kama.c what keeps its recurrence a convex combination.
+       *
        * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
        * two stay bit-identical -- the KAMA-reconstruction differential in
-       * test_composite2.c exists to keep it that way. Two guards are
+       * test_composite2.c exists to keep it that way. Three more guards are
        * load-bearing and shared with kama.c:
        *
        *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-       *     would give 1.0000000000000002. The comparison is against the
-       *     SIGNED numerator, so it only fires on up-moves; on sustained
-       *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-       *     "fix" this with fabs -- it changes TA_KAMA's output.
+       *     would give 1.0000000000000002, on up-moves. It compares against
+       *     the SIGNED numerator, so it is false for every down move: it
+       *     bounds nothing on its own, which is what the clamp is for.
        *   - a genuinely flat window is recognized by COUNTING exactly-zero
        *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
        *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -83060,13 +83087,10 @@ public final class Core {
        *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
        *     price-carrying sum).
        *
-       * A third guard is the denominator test: the division runs only where
-       * sumROC1 is exactly positive. The clamp above cannot serve as it,
-       * because it compares against the SIGNED numerator and so is false for
-       * every down move -- and a subtract-then-add sum can reach 0.0, or
-       * below it, on a window that is not flat, when a term absorbed on the
-       * way in is subtracted later at full precision. Without the guard those
-       * bars divide by zero.
+       * The third is the denominator test (#385): a subtract-then-add sum can
+       * reach 0.0, or below it, on a window that is not flat. The clamp
+       * subsumes it numerically, so it is held by the structural sweep over
+       * divisors, not by any value test.
        *
        * The subtract-then-add update order matches TA_SUM's recurrence,
        * which is what makes the composite differential bit-exact. The
@@ -83115,7 +83139,11 @@ public final class Core {
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          outReal[0 * outStride] = 1.0;
       } else {
-         outReal[0 * outStride] = Math.abs(periodROC / sumROC1);
+         tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
+         outReal[0 * outStride] = tempReal;
       }
       outIdx = 1;
       today += 1;
@@ -83147,7 +83175,11 @@ public final class Core {
          if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
             outReal[outIdx++ * outStride] = 1.0;
          } else {
-            outReal[outIdx++ * outStride] = Math.abs(periodROC / sumROC1);
+            tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
+            outReal[outIdx++ * outStride] = tempReal;
          }
          today += 1;
       }
@@ -102800,6 +102832,9 @@ public final class Core {
  *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
  *                forced the fastest adaptation on any instrument quoted small
  *                enough to fall under it.
+ *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+ *                let it exceed its own mathematical maximum, and the squared
+ *                smoothing constant then amplified instead of averaging.
  */
 
    /**
@@ -102945,26 +102980,22 @@ public final class Core {
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103013,6 +103044,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103061,6 +103095,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103161,6 +103198,9 @@ public final class Core {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       tempReal = Math.fma(tempReal, constDiff, constMax);
       tempReal *= tempReal;
@@ -103185,6 +103225,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.fma(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -103213,6 +103256,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          tempReal = Math.fma(tempReal, constDiff, constMax);
          tempReal *= tempReal;
@@ -103237,6 +103283,7 @@ public final class Core {
     * <p><b>Notes</b>
     * <ul>
     * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+    * <li>The output never leaves the range of the prices it has seen.</li>
     * </ul>
     * <p>Values are written only where the indicator is defined. The returned
     * {@link OutRange} says where they start and how many there are; nothing
@@ -103304,6 +103351,7 @@ public final class Core {
     * <p><b>Notes</b>
     * <ul>
     * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+    * <li>The output never leaves the range of the prices it has seen.</li>
     * </ul>
     * <p>This is the {@code float[]} overload. The arithmetic is performed in
     * {@code double} before being written to the {@code double[]} output, so a
@@ -103522,6 +103570,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -103605,6 +103656,9 @@ public final class Core {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sp.sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -103746,26 +103800,22 @@ public final class Core {
       trailingValue = tempReal2;
       /* Calculate the efficiency ratio.
        *
-       * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-       * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-       * sit beside it was not -- it declared the window flat, and forced the
-       * fastest adaptation, for every window of an instrument quoted below it
-       * (issue #253). A genuinely flat window is now recognized by the exact bar
-       * count above instead.
+       * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+       * clamp it: past 1 the squared smoothing constant amplifies instead of
+       * averaging and the recurrence below stops being a convex combination.
        *
-       * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-       * beside it compares against the SIGNED numerator, so it is false whenever
-       * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-       * add/subtract of fabs terms, so an addend absorbed on the way in and
-       * subtracted later at full precision drives it to exactly 0.0 on a window
-       * that is not flat; without this clause that bar divides by zero and the
-       * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-       * carried until #350).
+       * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+       * +Inf onto the same 1.0 -- so a value test written against it would pass
+       * with it deleted. Keep it anyway: the divisor sweep requires a division to
+       * be dominated by a test of its own divisor against a literal zero.
        */
       if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
          tempReal = 1.0;
       } else {
          tempReal = Math.abs(periodROC / sumROC1);
+         if( tempReal > 1.0 ) {
+            tempReal = 1.0;
+         }
       }
       /* Calculate the smoothing constant */
       tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103814,6 +103864,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103862,6 +103915,9 @@ public final class Core {
             tempReal = 1.0;
          } else {
             tempReal = Math.abs(periodROC / sumROC1);
+            if( tempReal > 1.0 ) {
+               tempReal = 1.0;
+            }
          }
          /* Calculate the smoothing constant */
          tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -155142,6 +155198,9 @@ public final class Core {
  *               small enough to fall under it.
  *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
  *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
    /**
@@ -155222,7 +155281,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -155338,7 +155396,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -155370,11 +155427,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -155389,22 +155444,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -155467,7 +155522,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -155530,7 +155584,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       if( false || false || false ) {
          tempBuffer = outSlowK;
@@ -155551,11 +155604,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -155569,14 +155620,12 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -155822,7 +155871,6 @@ public final class Core {
       MAType optInSlowD_MAType;
       double lowest;
       double highest;
-      double diff;
       int lowestIdx;
       int highestIdx;
       int trailingIdx;
@@ -155873,7 +155921,6 @@ public final class Core {
          this.optInSlowD_MAType = other.optInSlowD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -155934,7 +155981,6 @@ public final class Core {
          double cur_outSlowD = 0.0;
          double cur_outSlowK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -155975,11 +156021,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -155994,22 +156038,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -156100,11 +156144,9 @@ public final class Core {
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -156119,22 +156161,22 @@ public final class Core {
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -156152,7 +156194,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -156280,7 +156321,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -156312,11 +156352,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -156331,22 +156369,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -156419,7 +156457,6 @@ public final class Core {
       sp.optInSlowD_MAType = optInSlowD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;
@@ -156556,6 +156593,9 @@ public final class Core {
  *               small enough to fall under it.
  *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
  *               already answered above it, and the shape reads like #269.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
    /**
@@ -156616,7 +156656,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -156722,7 +156761,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -156754,11 +156792,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -156773,22 +156809,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -156840,7 +156876,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -156893,7 +156928,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       bufferIsAllocated = 0;
       if( false || false || false ) {
          tempBuffer = outFastK;
@@ -156914,11 +156948,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          tmp = (double)inHigh[today];
          if( highestIdx < trailingIdx ) {
@@ -156932,14 +156964,12 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -157155,7 +157185,6 @@ public final class Core {
       MAType optInFastD_MAType;
       double lowest;
       double highest;
-      double diff;
       int lowestIdx;
       int highestIdx;
       int trailingIdx;
@@ -157203,7 +157232,6 @@ public final class Core {
          this.optInFastD_MAType = other.optInFastD_MAType;
          this.lowest = other.lowest;
          this.highest = other.highest;
-         this.diff = other.diff;
          this.lowestIdx = other.lowestIdx;
          this.highestIdx = other.highestIdx;
          this.trailingIdx = other.trailingIdx;
@@ -157263,7 +157291,6 @@ public final class Core {
          double cur_outFastD = 0.0;
          double cur_outFastK = 0.0;
          double tmp = 0.0;
-         double diff = sp.diff;
          double highest = sp.highest;
          int highestIdx = sp.highestIdx;
          int i = sp.i;
@@ -157304,11 +157331,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -157323,22 +157348,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+            cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
          } else {
             cur_tempBuffer = 0.0;
          }
@@ -157428,11 +157453,9 @@ public final class Core {
                sp.lowest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp <= sp.lowest ) {
          sp.lowestIdx = sp.today;
          sp.lowest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
       /* Set the highest high */
       tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -157447,22 +157470,22 @@ public final class Core {
                sp.highest = tmp;
             }
          }
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       } else if( tmp >= sp.highest ) {
          sp.highestIdx = sp.today;
          sp.highest = tmp;
-         sp.diff = (sp.highest - sp.lowest) / 100.0;
       }
-      /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-       * machine-flat window leaves a sub-epsilon residue that an exact check
-       * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-       * range against ITS OWN two extremes, not against a fixed band: the range
-       * carries the quote unit, so a constant put against it answers "flat" for
-       * every window of an instrument quoted below it and zeroed the whole
-       * output (issue #253).
+      /* Divide by the range itself and scale after: the guard has to test the
+       * very expression the division uses, or a scaling step can carry a
+       * guarded-non-zero into a zero divisor.
+       *
+       * The band is the range against ITS OWN two extremes, not a fixed
+       * constant: the range carries the quote unit, so a constant answers
+       * "flat" for every window of an instrument quoted below it (issue #253).
+       * It absorbs the machine-flat window an exact test would divide into
+       * [0,100] noise (issue #107 / STOCHRSI).
        */
       if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+         cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
       } else {
          cur_tempBuffer = 0.0;
       }
@@ -157479,7 +157502,6 @@ public final class Core {
       double lowest = 0;
       double highest = 0;
       double tmp = 0;
-      double diff = 0;
       double[] tempBuffer;
       int outIdx = 0;
       int lowestIdx = 0;
@@ -157597,7 +157619,6 @@ public final class Core {
       lowestIdx = highestIdx;
       lowest = 0.0;
       highest = lowest;
-      diff = highest;
       /* Allocate a temporary buffer large enough to
        * store the K.
        *
@@ -157629,11 +157650,9 @@ public final class Core {
                   lowest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp <= lowest ) {
             lowestIdx = today;
             lowest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
          /* Set the highest high */
          tmp = inHigh[today];
@@ -157648,22 +157667,22 @@ public final class Core {
                   highest = tmp;
                }
             }
-            diff = (highest - lowest) / 100.0;
          } else if( tmp >= highest ) {
             highestIdx = today;
             highest = tmp;
-            diff = (highest - lowest) / 100.0;
          }
-         /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-          * machine-flat window leaves a sub-epsilon residue that an exact check
-          * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-          * range against ITS OWN two extremes, not against a fixed band: the range
-          * carries the quote unit, so a constant put against it answers "flat" for
-          * every window of an instrument quoted below it and zeroed the whole
-          * output (issue #253).
+         /* Divide by the range itself and scale after: the guard has to test the
+          * very expression the division uses, or a scaling step can carry a
+          * guarded-non-zero into a zero divisor.
+          *
+          * The band is the range against ITS OWN two extremes, not a fixed
+          * constant: the range carries the quote unit, so a constant answers
+          * "flat" for every window of an instrument quoted below it (issue #253).
+          * It absorbs the machine-flat window an exact test would divide into
+          * [0,100] noise (issue #107 / STOCHRSI).
           */
          if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-            tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+            tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
          } else {
             tempBuffer[outIdx++] = 0.0;
          }
@@ -157722,7 +157741,6 @@ public final class Core {
       sp.optInFastD_MAType = optInFastD_MAType;
       sp.lowest = lowest;
       sp.highest = highest;
-      sp.diff = diff;
       sp.lowestIdx = lowestIdx;
       sp.highestIdx = highestIdx;
       sp.trailingIdx = trailingIdx;

--- a/ta_codegen/output/java/tools/TaCodegenServe.java
+++ b/ta_codegen/output/java/tools/TaCodegenServe.java
@@ -82101,16 +82101,19 @@ class Core {
            *
            *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
            *
+           * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+           * clamp to 1.0 is what makes the declared range a bound rather than a
+           * hope -- and in kama.c what keeps its recurrence a convex combination.
+           *
            * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
            * two stay bit-identical -- the KAMA-reconstruction differential in
-           * test_composite2.c exists to keep it that way. Two guards are
+           * test_composite2.c exists to keep it that way. Three more guards are
            * load-bearing and shared with kama.c:
            *
            *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-           *     would give 1.0000000000000002. The comparison is against the
-           *     SIGNED numerator, so it only fires on up-moves; on sustained
-           *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-           *     "fix" this with fabs -- it changes TA_KAMA's output.
+           *     would give 1.0000000000000002, on up-moves. It compares against
+           *     the SIGNED numerator, so it is false for every down move: it
+           *     bounds nothing on its own, which is what the clamp is for.
            *   - a genuinely flat window is recognized by COUNTING exactly-zero
            *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
            *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -82119,13 +82122,10 @@ class Core {
            *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
            *     price-carrying sum).
            *
-           * A third guard is the denominator test: the division runs only where
-           * sumROC1 is exactly positive. The clamp above cannot serve as it,
-           * because it compares against the SIGNED numerator and so is false for
-           * every down move -- and a subtract-then-add sum can reach 0.0, or
-           * below it, on a window that is not flat, when a term absorbed on the
-           * way in is subtracted later at full precision. Without the guard those
-           * bars divide by zero.
+           * The third is the denominator test (#385): a subtract-then-add sum can
+           * reach 0.0, or below it, on a window that is not flat. The clamp
+           * subsumes it numerically, so it is held by the structural sweep over
+           * divisors, not by any value test.
            *
            * The subtract-then-add update order matches TA_SUM's recurrence,
            * which is what makes the composite differential bit-exact. The
@@ -82174,7 +82174,11 @@ class Core {
           if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
              outReal[0] = 1.0;
           } else {
-             outReal[0] = Math.abs(periodROC / sumROC1);
+             tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
+             outReal[0] = tempReal;
           }
           outIdx = 1;
           today += 1;
@@ -82206,7 +82210,11 @@ class Core {
              if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
                 outReal[outIdx++] = 1.0;
              } else {
-                outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+                tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
+                outReal[outIdx++] = tempReal;
              }
              today += 1;
           }
@@ -82275,7 +82283,11 @@ class Core {
           if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
              outReal[0] = 1.0;
           } else {
-             outReal[0] = Math.abs(periodROC / sumROC1);
+             tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
+             outReal[0] = tempReal;
           }
           outIdx = 1;
           today += 1;
@@ -82298,7 +82310,11 @@ class Core {
              if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
                 outReal[outIdx++] = 1.0;
              } else {
-                outReal[outIdx++] = Math.abs(periodROC / sumROC1);
+                tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
+                outReal[outIdx++] = tempReal;
              }
              today += 1;
           }
@@ -82318,7 +82334,7 @@ class Core {
         * <pre>{@code
         * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
         * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-        * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+        * The output is a hard 0..1 — the net move can never exceed the path travelled.
         * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
         * }</pre>
         * <p><b>Notes</b>
@@ -82391,7 +82407,7 @@ class Core {
         * <pre>{@code
         * `ER[t] = |close[t] − close[t−P]| / Σ |close[k] − close[k−1]|` over the same `P` bars.
         * Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
-        * The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+        * The output is a hard 0..1 — the net move can never exceed the path travelled.
         * TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
         * }</pre>
         * <p><b>Notes</b>
@@ -82601,7 +82617,11 @@ class Core {
              if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
                 cur_outReal = 1.0;
              } else {
-                cur_outReal = Math.abs(periodROC / sumROC1);
+                tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
+                cur_outReal = tempReal;
              }
              return cur_outReal;
           }
@@ -82667,7 +82687,11 @@ class Core {
           if( sp.sumROC1 <= 0.0 || sp.sumROC1 <= periodROC ) {
              sp.cur_outReal = 1.0;
           } else {
-             sp.cur_outReal = Math.abs(periodROC / sp.sumROC1);
+             tempReal = Math.abs(periodROC / sp.sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
+             sp.cur_outReal = tempReal;
           }
           sp.lag1_inReal = inReal;
           sp.ring_trailingIdx_inReal[sp.ringPos_trailingIdx] = inReal;
@@ -82713,16 +82737,19 @@ class Core {
            *
            *   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
            *
+           * The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+           * clamp to 1.0 is what makes the declared range a bound rather than a
+           * hope -- and in kama.c what keeps its recurrence a convex combination.
+           *
            * This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
            * two stay bit-identical -- the KAMA-reconstruction differential in
-           * test_composite2.c exists to keep it that way. Two guards are
+           * test_composite2.c exists to keep it that way. Three more guards are
            * load-bearing and shared with kama.c:
            *
            *   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-           *     would give 1.0000000000000002. The comparison is against the
-           *     SIGNED numerator, so it only fires on up-moves; on sustained
-           *     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-           *     "fix" this with fabs -- it changes TA_KAMA's output.
+           *     would give 1.0000000000000002, on up-moves. It compares against
+           *     the SIGNED numerator, so it is false for every down move: it
+           *     bounds nothing on its own, which is what the clamp is for.
            *   - a genuinely flat window is recognized by COUNTING exactly-zero
            *     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
            *     running sum's rounding residue), after which `0 <= 0` pins the
@@ -82731,13 +82758,10 @@ class Core {
            *     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
            *     price-carrying sum).
            *
-           * A third guard is the denominator test: the division runs only where
-           * sumROC1 is exactly positive. The clamp above cannot serve as it,
-           * because it compares against the SIGNED numerator and so is false for
-           * every down move -- and a subtract-then-add sum can reach 0.0, or
-           * below it, on a window that is not flat, when a term absorbed on the
-           * way in is subtracted later at full precision. Without the guard those
-           * bars divide by zero.
+           * The third is the denominator test (#385): a subtract-then-add sum can
+           * reach 0.0, or below it, on a window that is not flat. The clamp
+           * subsumes it numerically, so it is held by the structural sweep over
+           * divisors, not by any value test.
            *
            * The subtract-then-add update order matches TA_SUM's recurrence,
            * which is what makes the composite differential bit-exact. The
@@ -82786,7 +82810,11 @@ class Core {
           if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
              outReal[0 * outStride] = 1.0;
           } else {
-             outReal[0 * outStride] = Math.abs(periodROC / sumROC1);
+             tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
+             outReal[0 * outStride] = tempReal;
           }
           outIdx = 1;
           today += 1;
@@ -82818,7 +82846,11 @@ class Core {
              if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
                 outReal[outIdx++ * outStride] = 1.0;
              } else {
-                outReal[outIdx++ * outStride] = Math.abs(periodROC / sumROC1);
+                tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
+                outReal[outIdx++ * outStride] = tempReal;
              }
              today += 1;
           }
@@ -102471,6 +102503,9 @@ class Core {
      *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
      *                forced the fastest adaptation on any instrument quoted small
      *                enough to fall under it.
+     *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+     *                let it exceed its own mathematical maximum, and the squared
+     *                smoothing constant then amplified instead of averaging.
      */
 
        /**
@@ -102616,26 +102651,22 @@ class Core {
           trailingValue = tempReal2;
           /* Calculate the efficiency ratio.
            *
-           * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-           * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-           * sit beside it was not -- it declared the window flat, and forced the
-           * fastest adaptation, for every window of an instrument quoted below it
-           * (issue #253). A genuinely flat window is now recognized by the exact bar
-           * count above instead.
+           * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+           * clamp it: past 1 the squared smoothing constant amplifies instead of
+           * averaging and the recurrence below stops being a convex combination.
            *
-           * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-           * beside it compares against the SIGNED numerator, so it is false whenever
-           * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-           * add/subtract of fabs terms, so an addend absorbed on the way in and
-           * subtracted later at full precision drives it to exactly 0.0 on a window
-           * that is not flat; without this clause that bar divides by zero and the
-           * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-           * carried until #350).
+           * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+           * +Inf onto the same 1.0 -- so a value test written against it would pass
+           * with it deleted. Keep it anyway: the divisor sweep requires a division to
+           * be dominated by a test of its own divisor against a literal zero.
            */
           if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
              tempReal = 1.0;
           } else {
              tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
           }
           /* Calculate the smoothing constant */
           tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -102684,6 +102715,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              /* Calculate the smoothing constant */
              tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -102732,6 +102766,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              /* Calculate the smoothing constant */
              tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -102832,6 +102869,9 @@ class Core {
              tempReal = 1.0;
           } else {
              tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
           }
           tempReal = Math.fma(tempReal, constDiff, constMax);
           tempReal *= tempReal;
@@ -102856,6 +102896,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              tempReal = Math.fma(tempReal, constDiff, constMax);
              tempReal *= tempReal;
@@ -102884,6 +102927,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              tempReal = Math.fma(tempReal, constDiff, constMax);
              tempReal *= tempReal;
@@ -102908,6 +102954,7 @@ class Core {
         * <p><b>Notes</b>
         * <ul>
         * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+        * <li>The output never leaves the range of the prices it has seen.</li>
         * </ul>
         * <p>Values are written only where the indicator is defined. The returned
         * {@link OutRange} says where they start and how many there are; nothing
@@ -102975,6 +103022,7 @@ class Core {
         * <p><b>Notes</b>
         * <ul>
         * <li>A period of 1 performs no smoothing: the output is a copy of the input, consistent with {@code MA(period=1)} for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.</li>
+        * <li>The output never leaves the range of the prices it has seen.</li>
         * </ul>
         * <p>This is the {@code float[]} overload. The arithmetic is performed in
         * {@code double} before being written to the {@code double[]} output, so a
@@ -103193,6 +103241,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              /* Calculate the smoothing constant */
              tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -103276,6 +103327,9 @@ class Core {
              tempReal = 1.0;
           } else {
              tempReal = Math.abs(periodROC / sp.sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
           }
           /* Calculate the smoothing constant */
           tempReal = Math.fma(tempReal, sp.constDiff, sp.constMax);
@@ -103417,26 +103471,22 @@ class Core {
           trailingValue = tempReal2;
           /* Calculate the efficiency ratio.
            *
-           * The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-           * both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-           * sit beside it was not -- it declared the window flat, and forced the
-           * fastest adaptation, for every window of an instrument quoted below it
-           * (issue #253). A genuinely flat window is now recognized by the exact bar
-           * count above instead.
+           * The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+           * clamp it: past 1 the squared smoothing constant amplifies instead of
+           * averaging and the recurrence below stops being a convex combination.
            *
-           * `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-           * beside it compares against the SIGNED numerator, so it is false whenever
-           * periodROC < 0 and cannot stand in for one. sumROC1 is a running
-           * add/subtract of fabs terms, so an addend absorbed on the way in and
-           * subtracted later at full precision drives it to exactly 0.0 on a window
-           * that is not flat; without this clause that bar divides by zero and the
-           * +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-           * carried until #350).
+           * `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+           * +Inf onto the same 1.0 -- so a value test written against it would pass
+           * with it deleted. Keep it anyway: the divisor sweep requires a division to
+           * be dominated by a test of its own divisor against a literal zero.
            */
           if( sumROC1 <= 0.0 || sumROC1 <= periodROC ) {
              tempReal = 1.0;
           } else {
              tempReal = Math.abs(periodROC / sumROC1);
+             if( tempReal > 1.0 ) {
+                tempReal = 1.0;
+             }
           }
           /* Calculate the smoothing constant */
           tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103485,6 +103535,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              /* Calculate the smoothing constant */
              tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -103533,6 +103586,9 @@ class Core {
                 tempReal = 1.0;
              } else {
                 tempReal = Math.abs(periodROC / sumROC1);
+                if( tempReal > 1.0 ) {
+                   tempReal = 1.0;
+                }
              }
              /* Calculate the smoothing constant */
              tempReal = Math.fma(tempReal, constDiff, constMax);
@@ -154813,6 +154869,9 @@ class Core {
      *               small enough to fall under it.
      *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
      *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+     *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+     *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+     *               range that the guard still called "not flat".
      */
 
        /**
@@ -154893,7 +154952,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -155009,7 +155067,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           /* Allocate a temporary buffer large enough to
            * store the K.
            *
@@ -155041,11 +155098,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = inHigh[today];
@@ -155060,22 +155115,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -155138,7 +155193,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -155201,7 +155255,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           bufferIsAllocated = 0;
           if( false || false || false ) {
              tempBuffer = outSlowK;
@@ -155222,11 +155275,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              tmp = (double)inHigh[today];
              if( highestIdx < trailingIdx ) {
@@ -155240,14 +155291,12 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -155493,7 +155542,6 @@ class Core {
           MAType optInSlowD_MAType;
           double lowest;
           double highest;
-          double diff;
           int lowestIdx;
           int highestIdx;
           int trailingIdx;
@@ -155544,7 +155592,6 @@ class Core {
              this.optInSlowD_MAType = other.optInSlowD_MAType;
              this.lowest = other.lowest;
              this.highest = other.highest;
-             this.diff = other.diff;
              this.lowestIdx = other.lowestIdx;
              this.highestIdx = other.highestIdx;
              this.trailingIdx = other.trailingIdx;
@@ -155605,7 +155652,6 @@ class Core {
              double cur_outSlowD = 0.0;
              double cur_outSlowK = 0.0;
              double tmp = 0.0;
-             double diff = sp.diff;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -155646,11 +155692,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -155665,22 +155709,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+                cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
              } else {
                 cur_tempBuffer = 0.0;
              }
@@ -155771,11 +155815,9 @@ class Core {
                    sp.lowest = tmp;
                 }
              }
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           } else if( tmp <= sp.lowest ) {
              sp.lowestIdx = sp.today;
              sp.lowest = tmp;
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           }
           /* Set the highest high */
           tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -155790,22 +155832,22 @@ class Core {
                    sp.highest = tmp;
                 }
              }
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           } else if( tmp >= sp.highest ) {
              sp.highestIdx = sp.today;
              sp.highest = tmp;
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           }
-          /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-           * machine-flat window leaves a sub-epsilon residue that an exact check
-           * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-           * range against ITS OWN two extremes, not against a fixed band: the range
-           * carries the quote unit, so a constant put against it answers "flat" for
-           * every window of an instrument quoted below it and zeroed the whole
-           * output (issue #253).
+          /* Divide by the range itself and scale after: the guard has to test the
+           * very expression the division uses, or a scaling step can carry a
+           * guarded-non-zero into a zero divisor.
+           *
+           * The band is the range against ITS OWN two extremes, not a fixed
+           * constant: the range carries the quote unit, so a constant answers
+           * "flat" for every window of an instrument quoted below it (issue #253).
+           * It absorbs the machine-flat window an exact test would divide into
+           * [0,100] noise (issue #107 / STOCHRSI).
            */
           if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-             cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+             cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
           } else {
              cur_tempBuffer = 0.0;
           }
@@ -155823,7 +155865,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -155951,7 +155992,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           /* Allocate a temporary buffer large enough to
            * store the K.
            *
@@ -155983,11 +156023,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = inHigh[today];
@@ -156002,22 +156040,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -156090,7 +156128,6 @@ class Core {
           sp.optInSlowD_MAType = optInSlowD_MAType;
           sp.lowest = lowest;
           sp.highest = highest;
-          sp.diff = diff;
           sp.lowestIdx = lowestIdx;
           sp.highestIdx = highestIdx;
           sp.trailingIdx = trailingIdx;
@@ -156227,6 +156264,9 @@ class Core {
      *               small enough to fall under it.
      *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
      *               already answered above it, and the shape reads like #269.
+     *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+     *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+     *               range that the guard still called "not flat".
      */
 
        /**
@@ -156287,7 +156327,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -156393,7 +156432,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           /* Allocate a temporary buffer large enough to
            * store the K.
            *
@@ -156425,11 +156463,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = inHigh[today];
@@ -156444,22 +156480,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -156511,7 +156547,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -156564,7 +156599,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           bufferIsAllocated = 0;
           if( false || false || false ) {
              tempBuffer = outFastK;
@@ -156585,11 +156619,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              tmp = (double)inHigh[today];
              if( highestIdx < trailingIdx ) {
@@ -156603,14 +156635,12 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = ((double)inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -156826,7 +156856,6 @@ class Core {
           MAType optInFastD_MAType;
           double lowest;
           double highest;
-          double diff;
           int lowestIdx;
           int highestIdx;
           int trailingIdx;
@@ -156874,7 +156903,6 @@ class Core {
              this.optInFastD_MAType = other.optInFastD_MAType;
              this.lowest = other.lowest;
              this.highest = other.highest;
-             this.diff = other.diff;
              this.lowestIdx = other.lowestIdx;
              this.highestIdx = other.highestIdx;
              this.trailingIdx = other.trailingIdx;
@@ -156934,7 +156962,6 @@ class Core {
              double cur_outFastD = 0.0;
              double cur_outFastK = 0.0;
              double tmp = 0.0;
-             double diff = sp.diff;
              double highest = sp.highest;
              int highestIdx = sp.highestIdx;
              int i = sp.i;
@@ -156975,11 +157002,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = ((today & sp.xMask) != pkSlot0) ? sp.x_inHigh[today & sp.xMask] : pkVal0;
@@ -156994,22 +157019,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / diff;
+                cur_tempBuffer = ((((today & sp.xMask) != pkSlot2) ? sp.x_inClose[today & sp.xMask] : pkVal2) - lowest) / (highest - lowest) * 100.0;
              } else {
                 cur_tempBuffer = 0.0;
              }
@@ -157099,11 +157124,9 @@ class Core {
                    sp.lowest = tmp;
                 }
              }
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           } else if( tmp <= sp.lowest ) {
              sp.lowestIdx = sp.today;
              sp.lowest = tmp;
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           }
           /* Set the highest high */
           tmp = sp.x_inHigh[sp.today & sp.xMask];
@@ -157118,22 +157141,22 @@ class Core {
                    sp.highest = tmp;
                 }
              }
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           } else if( tmp >= sp.highest ) {
              sp.highestIdx = sp.today;
              sp.highest = tmp;
-             sp.diff = (sp.highest - sp.lowest) / 100.0;
           }
-          /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-           * machine-flat window leaves a sub-epsilon residue that an exact check
-           * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-           * range against ITS OWN two extremes, not against a fixed band: the range
-           * carries the quote unit, so a constant put against it answers "flat" for
-           * every window of an instrument quoted below it and zeroed the whole
-           * output (issue #253).
+          /* Divide by the range itself and scale after: the guard has to test the
+           * very expression the division uses, or a scaling step can carry a
+           * guarded-non-zero into a zero divisor.
+           *
+           * The band is the range against ITS OWN two extremes, not a fixed
+           * constant: the range carries the quote unit, so a constant answers
+           * "flat" for every window of an instrument quoted below it (issue #253).
+           * It absorbs the machine-flat window an exact test would divide into
+           * [0,100] noise (issue #107 / STOCHRSI).
            */
           if( !(Math.abs(sp.highest - sp.lowest) <= 0.00000000000001 * (Math.abs(sp.highest) + Math.abs(sp.lowest))) ) {
-             cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / sp.diff;
+             cur_tempBuffer = (sp.x_inClose[sp.today & sp.xMask] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
           } else {
              cur_tempBuffer = 0.0;
           }
@@ -157150,7 +157173,6 @@ class Core {
           double lowest = 0;
           double highest = 0;
           double tmp = 0;
-          double diff = 0;
           double[] tempBuffer;
           int outIdx = 0;
           int lowestIdx = 0;
@@ -157268,7 +157290,6 @@ class Core {
           lowestIdx = highestIdx;
           lowest = 0.0;
           highest = lowest;
-          diff = highest;
           /* Allocate a temporary buffer large enough to
            * store the K.
            *
@@ -157300,11 +157321,9 @@ class Core {
                       lowest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp <= lowest ) {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
              /* Set the highest high */
              tmp = inHigh[today];
@@ -157319,22 +157338,22 @@ class Core {
                       highest = tmp;
                    }
                 }
-                diff = (highest - lowest) / 100.0;
              } else if( tmp >= highest ) {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
              }
-             /* Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-              * machine-flat window leaves a sub-epsilon residue that an exact check
-              * would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-              * range against ITS OWN two extremes, not against a fixed band: the range
-              * carries the quote unit, so a constant put against it answers "flat" for
-              * every window of an instrument quoted below it and zeroed the whole
-              * output (issue #253).
+             /* Divide by the range itself and scale after: the guard has to test the
+              * very expression the division uses, or a scaling step can carry a
+              * guarded-non-zero into a zero divisor.
+              *
+              * The band is the range against ITS OWN two extremes, not a fixed
+              * constant: the range carries the quote unit, so a constant answers
+              * "flat" for every window of an instrument quoted below it (issue #253).
+              * It absorbs the machine-flat window an exact test would divide into
+              * [0,100] noise (issue #107 / STOCHRSI).
               */
              if( !(Math.abs(highest - lowest) <= 0.00000000000001 * (Math.abs(highest) + Math.abs(lowest))) ) {
-                tempBuffer[outIdx++] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx++] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
              } else {
                 tempBuffer[outIdx++] = 0.0;
              }
@@ -157393,7 +157412,6 @@ class Core {
           sp.optInFastD_MAType = optInFastD_MAType;
           sp.lowest = lowest;
           sp.highest = highest;
-          sp.diff = diff;
           sp.lowestIdx = lowestIdx;
           sp.highestIdx = highestIdx;
           sp.trailingIdx = trailingIdx;
@@ -179011,7 +179029,7 @@ class Core {
 
 public class TaCodegenServe {
     static Core core = new Core();
-    static final String SPLICED_GENCODE_DIGEST = "d762214e84a18d9a";
+    static final String SPLICED_GENCODE_DIGEST = "729a925b515bcb19";
     static final int MAX_ARRAY_SIZE = 200000;
     static double[] refOpen = new double[MAX_ARRAY_SIZE];
     static double[] refHigh = new double[MAX_ARRAY_SIZE];

--- a/ta_codegen/output/rust/library/src/ta_func/er.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/er.rs
@@ -133,16 +133,19 @@ impl Core {
         //
         //   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
         //
+        // The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+        // clamp to 1.0 is what makes the declared range a bound rather than a
+        // hope -- and in kama.c what keeps its recurrence a convex combination.
+        //
         // This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
         // two stay bit-identical -- the KAMA-reconstruction differential in
-        // test_composite2.c exists to keep it that way. Two guards are
+        // test_composite2.c exists to keep it that way. Three more guards are
         // load-bearing and shared with kama.c:
         //
         //   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-        //     would give 1.0000000000000002. The comparison is against the
-        //     SIGNED numerator, so it only fires on up-moves; on sustained
-        //     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-        //     "fix" this with fabs -- it changes TA_KAMA's output.
+        //     would give 1.0000000000000002, on up-moves. It compares against
+        //     the SIGNED numerator, so it is false for every down move: it
+        //     bounds nothing on its own, which is what the clamp is for.
         //   - a genuinely flat window is recognized by COUNTING exactly-zero
         //     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
         //     running sum's rounding residue), after which `0 <= 0` pins the
@@ -151,13 +154,10 @@ impl Core {
         //     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
         //     price-carrying sum).
         //
-        // A third guard is the denominator test: the division runs only where
-        // sumROC1 is exactly positive. The clamp above cannot serve as it,
-        // because it compares against the SIGNED numerator and so is false for
-        // every down move -- and a subtract-then-add sum can reach 0.0, or
-        // below it, on a window that is not flat, when a term absorbed on the
-        // way in is subtracted later at full precision. Without the guard those
-        // bars divide by zero.
+        // The third is the denominator test (#385): a subtract-then-add sum can
+        // reach 0.0, or below it, on a window that is not flat. The clamp
+        // subsumes it numerically, so it is held by the structural sweep over
+        // divisors, not by any value test.
         //
         // The subtract-then-add update order matches TA_SUM's recurrence,
         // which is what makes the composite differential bit-exact. The
@@ -203,7 +203,11 @@ impl Core {
         if sumROC1 <= 0.0 || sumROC1 <= periodROC {
             outReal[0] = 1.0;
         } else {
-            outReal[0] = (periodROC / sumROC1).abs();
+            tempReal = (periodROC / sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
+            outReal[0] = tempReal;
         }
         outIdx = 1;
         today += 1;
@@ -234,7 +238,11 @@ impl Core {
                 outReal[outIdx] = 1.0;
                 outIdx += 1;
             } else {
-                outReal[outIdx] = (periodROC / sumROC1).abs();
+                tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
+                outReal[outIdx] = tempReal;
                 outIdx += 1;
             }
             today += 1;
@@ -419,7 +427,11 @@ impl Core {
         if sp.sumROC1 <= 0.0 || sp.sumROC1 <= periodROC {
             (*outReal) = 1.0;
         } else {
-            (*outReal) = (periodROC / sp.sumROC1).abs();
+            tempReal = (periodROC / sp.sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
+            (*outReal) = tempReal;
         }
         sp.cur_outReal = (*outReal);
         sp.lag1_inReal = inReal;
@@ -473,16 +485,19 @@ impl Core {
         //
         //   ER[t] = |c[t] - c[t-P]| / SUM(k = t-P+1 .. t) |c[k] - c[k-1]|
         //
+        // The ratio is in [0,1] in exact arithmetic, but sumROC1 drifts, so the
+        // clamp to 1.0 is what makes the declared range a bound rather than a
+        // hope -- and in kama.c what keeps its recurrence a convex combination.
+        //
         // This is a lift of TA_KAMA's inner efficiency ratio (kama.c) so the
         // two stay bit-identical -- the KAMA-reconstruction differential in
-        // test_composite2.c exists to keep it that way. Two guards are
+        // test_composite2.c exists to keep it that way. Three more guards are
         // load-bearing and shared with kama.c:
         //
         //   - `sumROC1 <= periodROC` pins the ratio to exactly 1.0 where FP
-        //     would give 1.0000000000000002. The comparison is against the
-        //     SIGNED numerator, so it only fires on up-moves; on sustained
-        //     declines the raw fabs ratio can exceed 1.0 by a few ULP. Do NOT
-        //     "fix" this with fabs -- it changes TA_KAMA's output.
+        //     would give 1.0000000000000002, on up-moves. It compares against
+        //     the SIGNED numerator, so it is false for every down move: it
+        //     bounds nothing on its own, which is what the clamp is for.
         //   - a genuinely flat window is recognized by COUNTING exactly-zero
         //     one-bar changes (nullRun >= P forces sumROC1 to 0.0, purging the
         //     running sum's rounding residue), after which `0 <= 0` pins the
@@ -491,13 +506,10 @@ impl Core {
         //     gate (ER is homogeneous of degree 0, and a fixed 1e-14 met a
         //     price-carrying sum).
         //
-        // A third guard is the denominator test: the division runs only where
-        // sumROC1 is exactly positive. The clamp above cannot serve as it,
-        // because it compares against the SIGNED numerator and so is false for
-        // every down move -- and a subtract-then-add sum can reach 0.0, or
-        // below it, on a window that is not flat, when a term absorbed on the
-        // way in is subtracted later at full precision. Without the guard those
-        // bars divide by zero.
+        // The third is the denominator test (#385): a subtract-then-add sum can
+        // reach 0.0, or below it, on a window that is not flat. The clamp
+        // subsumes it numerically, so it is held by the structural sweep over
+        // divisors, not by any value test.
         //
         // The subtract-then-add update order matches TA_SUM's recurrence,
         // which is what makes the composite differential bit-exact. The
@@ -543,7 +555,11 @@ impl Core {
         if sumROC1 <= 0.0 || sumROC1 <= periodROC {
             outReal[(0 * outStride) as usize] = 1.0;
         } else {
-            outReal[(0 * outStride) as usize] = (periodROC / sumROC1).abs();
+            tempReal = (periodROC / sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
+            outReal[(0 * outStride) as usize] = tempReal;
         }
         outIdx = 1;
         today += 1;
@@ -573,7 +589,11 @@ impl Core {
             if sumROC1 <= 0.0 || sumROC1 <= periodROC {
                 outReal[({ let _v = outIdx; outIdx += 1; _v } * outStride) as usize] = 1.0;
             } else {
-                outReal[({ let _v = outIdx; outIdx += 1; _v } * outStride) as usize] = (periodROC / sumROC1).abs();
+                tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
+                outReal[({ let _v = outIdx; outIdx += 1; _v } * outStride) as usize] = tempReal;
             }
             today += 1;
         }
@@ -797,7 +817,11 @@ impl ErStream {
             if sumROC1 <= 0.0 || sumROC1 <= periodROC {
                 (*outReal) = 1.0;
             } else {
-                (*outReal) = (periodROC / sumROC1).abs();
+                tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
+                (*outReal) = tempReal;
             }
         }
         Ok(outReal)

--- a/ta_codegen/output/rust/library/src/ta_func/kama.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/kama.rs
@@ -65,6 +65,9 @@
  *                the fixed TA_IS_ZERO band beside the efficiency ratio, which
  *                forced the fastest adaptation on any instrument quoted small
  *                enough to fall under it.
+ *  090626 MF,CC  Fix #390. Clamp the efficiency ratio to 1. A drifted sumROC1
+ *                let it exceed its own mathematical maximum, and the squared
+ *                smoothing constant then amplified instead of averaging.
  */
 
 // Import types from parent module
@@ -252,25 +255,21 @@ impl Core {
         trailingValue = tempReal2;
         // Calculate the efficiency ratio.
         //
-        // The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-        // both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-        // sit beside it was not -- it declared the window flat, and forced the
-        // fastest adaptation, for every window of an instrument quoted below it
-        // (issue #253). A genuinely flat window is now recognized by the exact bar
-        // count above instead.
+        // The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+        // clamp it: past 1 the squared smoothing constant amplifies instead of
+        // averaging and the recurrence below stops being a convex combination.
         //
-        // `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-        // beside it compares against the SIGNED numerator, so it is false whenever
-        // periodROC < 0 and cannot stand in for one. sumROC1 is a running
-        // add/subtract of fabs terms, so an addend absorbed on the way in and
-        // subtracted later at full precision drives it to exactly 0.0 on a window
-        // that is not flat; without this clause that bar divides by zero and the
-        // +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-        // carried until #350).
+        // `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+        // +Inf onto the same 1.0 -- so a value test written against it would pass
+        // with it deleted. Keep it anyway: the divisor sweep requires a division to
+        // be dominated by a test of its own divisor against a literal zero.
         if sumROC1 <= 0.0 || sumROC1 <= periodROC {
             tempReal = 1.0;
         } else {
             tempReal = (periodROC / sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
         }
         // Calculate the smoothing constant
         tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -313,6 +312,9 @@ impl Core {
                 tempReal = 1.0;
             } else {
                 tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
             }
             // Calculate the smoothing constant
             tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -357,6 +359,9 @@ impl Core {
                 tempReal = 1.0;
             } else {
                 tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
             }
             // Calculate the smoothing constant
             tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -555,6 +560,9 @@ impl Core {
             tempReal = 1.0;
         } else {
             tempReal = (periodROC / sp.sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
         }
         // Calculate the smoothing constant
         tempReal = (tempReal as f64).mul_add(sp.constDiff, sp.constMax);
@@ -701,25 +709,21 @@ impl Core {
         trailingValue = tempReal2;
         // Calculate the efficiency ratio.
         //
-        // The only threshold is `sumROC1 <= periodROC`, and it is scale-consistent:
-        // both sides carry the quote unit. The fixed TA_IS_ZERO band that used to
-        // sit beside it was not -- it declared the window flat, and forced the
-        // fastest adaptation, for every window of an instrument quoted below it
-        // (issue #253). A genuinely flat window is now recognized by the exact bar
-        // count above instead.
+        // The ratio cannot exceed 1 in exact arithmetic, but sumROC1 drifts, so
+        // clamp it: past 1 the squared smoothing constant amplifies instead of
+        // averaging and the recurrence below stops being a convex combination.
         //
-        // `sumROC1 <= 0.0` is the denominator test and must stay FIRST: the clamp
-        // beside it compares against the SIGNED numerator, so it is false whenever
-        // periodROC < 0 and cannot stand in for one. sumROC1 is a running
-        // add/subtract of fabs terms, so an addend absorbed on the way in and
-        // subtracted later at full precision drives it to exactly 0.0 on a window
-        // that is not flat; without this clause that bar divides by zero and the
-        // +Inf poisons prevKAMA for the rest of the call (#385, the same shape ER
-        // carried until #350).
+        // `sumROC1 <= 0.0` (#385) is now numerically redundant -- the clamp maps its
+        // +Inf onto the same 1.0 -- so a value test written against it would pass
+        // with it deleted. Keep it anyway: the divisor sweep requires a division to
+        // be dominated by a test of its own divisor against a literal zero.
         if sumROC1 <= 0.0 || sumROC1 <= periodROC {
             tempReal = 1.0;
         } else {
             tempReal = (periodROC / sumROC1).abs();
+            if tempReal > 1.0 {
+                tempReal = 1.0;
+            }
         }
         // Calculate the smoothing constant
         tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -762,6 +766,9 @@ impl Core {
                 tempReal = 1.0;
             } else {
                 tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
             }
             // Calculate the smoothing constant
             tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -806,6 +813,9 @@ impl Core {
                 tempReal = 1.0;
             } else {
                 tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
             }
             // Calculate the smoothing constant
             tempReal = (tempReal as f64).mul_add(constDiff, constMax);
@@ -1047,6 +1057,9 @@ impl KamaStream {
                 tempReal = 1.0;
             } else {
                 tempReal = (periodROC / sumROC1).abs();
+                if tempReal > 1.0 {
+                    tempReal = 1.0;
+                }
             }
             // Calculate the smoothing constant
             tempReal = (tempReal as f64).mul_add(sp.constDiff, sp.constMax);

--- a/ta_codegen/output/rust/library/src/ta_func/stoch.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stoch.rs
@@ -63,6 +63,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Fix #269. Answer a rejected %D ma() before the copy, not after:
  *               the stale *outNBElement overran outSlowK by lookbackDSlow.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
 // Import types from parent module
@@ -192,7 +195,6 @@ impl Core {
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
-        let mut diff: f64 = 0.0_f64;
         let mut tempBuffer: Vec<f64> = Vec::new();
         let mut outIdx: usize = 0_usize;
         let mut lowestIdx: i32 = 0_i32;
@@ -273,7 +275,6 @@ impl Core {
         lowestIdx = highestIdx;
         lowest = 0.0;
         highest = lowest;
-        diff = highest;
         // Allocate a temporary buffer large enough to
         // store the K.
         //
@@ -304,11 +305,9 @@ impl Core {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = (today) as i32;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = inHigh[today];
@@ -323,21 +322,21 @@ impl Core {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = (today) as i32;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                tempBuffer[outIdx] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
                 outIdx += 1;
             } else {
                 tempBuffer[outIdx] = 0.0;
@@ -552,7 +551,6 @@ struct StochStreamState {
     optInSlowD_MAType: MAType,
     lowest: f64,
     highest: f64,
-    diff: f64,
     lowestIdx: i32,
     highestIdx: i32,
     trailingIdx: i32,
@@ -602,11 +600,9 @@ impl Core {
                     sp.lowest = tmp;
                 }
             }
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         } else if tmp <= sp.lowest {
             sp.lowestIdx = sp.today;
             sp.lowest = tmp;
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
         // Set the highest high
         tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
@@ -621,21 +617,21 @@ impl Core {
                     sp.highest = tmp;
                 }
             }
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         } else if tmp >= sp.highest {
             sp.highestIdx = sp.today;
             sp.highest = tmp;
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
-        // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-        // machine-flat window leaves a sub-epsilon residue that an exact check
-        // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-        // range against ITS OWN two extremes, not against a fixed band: the range
-        // carries the quote unit, so a constant put against it answers "flat" for
-        // every window of an instrument quoted below it and zeroed the whole
-        // output (issue #253).
+        // Divide by the range itself and scale after: the guard has to test the
+        // very expression the division uses, or a scaling step can carry a
+        // guarded-non-zero into a zero divisor.
+        //
+        // The band is the range against ITS OWN two extremes, not a fixed
+        // constant: the range carries the quote unit, so a constant answers
+        // "flat" for every window of an instrument quoted below it (issue #253).
+        // It absorbs the machine-flat window an exact test would divide into
+        // [0,100] noise (issue #107 / STOCHRSI).
         if !(((sp.highest - sp.lowest).abs() <= 1e-14 * ((sp.highest).abs() + (sp.lowest).abs()))) {
-            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / sp.diff;
+            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
         } else {
             cur_tempBuffer = 0.0;
         }
@@ -707,7 +703,6 @@ impl Core {
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
-        let mut diff: f64 = 0.0_f64;
         let mut tempBuffer: Vec<f64> = Vec::new();
         let mut outIdx: usize = 0_usize;
         let mut lowestIdx: i32 = 0_i32;
@@ -788,7 +783,6 @@ impl Core {
         lowestIdx = highestIdx;
         lowest = 0.0;
         highest = lowest;
-        diff = highest;
         // Allocate a temporary buffer large enough to
         // store the K.
         //
@@ -819,11 +813,9 @@ impl Core {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = (today) as i32;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = inHigh[today];
@@ -838,21 +830,21 @@ impl Core {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = (today) as i32;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                tempBuffer[outIdx] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
                 outIdx += 1;
             } else {
                 tempBuffer[outIdx] = 0.0;
@@ -932,7 +924,6 @@ impl Core {
             optInSlowD_MAType,
             lowest,
             highest,
-            diff,
             lowestIdx: (lowestIdx) as i32,
             highestIdx: (highestIdx) as i32,
             trailingIdx: (trailingIdx) as i32,
@@ -1146,7 +1137,6 @@ impl StochStream {
             let mut cur_tempBuffer: f64 = 0.0_f64;
             let mut cur_outSlowD: f64 = 0.0_f64;
             let mut tmp: f64 = 0.0_f64;
-            let mut diff = sp.diff;
             let mut highest = sp.highest;
             let mut highestIdx = sp.highestIdx;
             let mut i = sp.i;
@@ -1187,11 +1177,9 @@ impl StochStream {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = (if ((today & sp.xMask) as usize) != pkSlot0 { sp.x_inHigh[(today & sp.xMask) as usize] } else { pkVal0 });
@@ -1206,21 +1194,21 @@ impl StochStream {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                cur_tempBuffer = ((if ((today & sp.xMask) as usize) != pkSlot2 { sp.x_inClose[(today & sp.xMask) as usize] } else { pkVal2 }) - lowest) / diff;
+                cur_tempBuffer = ((if ((today & sp.xMask) as usize) != pkSlot2 { sp.x_inClose[(today & sp.xMask) as usize] } else { pkVal2 }) - lowest) / (highest - lowest) * 100.0;
             } else {
                 cur_tempBuffer = 0.0;
             }

--- a/ta_codegen/output/rust/library/src/ta_func/stochf.rs
+++ b/ta_codegen/output/rust/library/src/ta_func/stochf.rs
@@ -65,6 +65,9 @@
  *               small enough to fall under it.
  *  082726 MF,CC Drop the dead retCode block after the copy: the rejection is
  *               already answered above it, and the shape reads like #269.
+ *  090626 MF,CC Fix #390. Divide by the range, scale after: the hoisted
+ *               `(highest-lowest)/100.0` underflowed to 0.0 on a denormal
+ *               range that the guard still called "not flat".
  */
 
 // Import types from parent module
@@ -168,7 +171,6 @@ impl Core {
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
-        let mut diff: f64 = 0.0_f64;
         let mut tempBuffer: Vec<f64> = Vec::new();
         let mut outIdx: usize = 0_usize;
         let mut lowestIdx: i32 = 0_i32;
@@ -247,7 +249,6 @@ impl Core {
         lowestIdx = highestIdx;
         lowest = 0.0;
         highest = lowest;
-        diff = highest;
         // Allocate a temporary buffer large enough to
         // store the K.
         //
@@ -278,11 +279,9 @@ impl Core {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = (today) as i32;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = inHigh[today];
@@ -297,21 +296,21 @@ impl Core {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = (today) as i32;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                tempBuffer[outIdx] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
                 outIdx += 1;
             } else {
                 tempBuffer[outIdx] = 0.0;
@@ -505,7 +504,6 @@ struct StochfStreamState {
     optInFastD_MAType: MAType,
     lowest: f64,
     highest: f64,
-    diff: f64,
     lowestIdx: i32,
     highestIdx: i32,
     trailingIdx: i32,
@@ -554,11 +552,9 @@ impl Core {
                     sp.lowest = tmp;
                 }
             }
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         } else if tmp <= sp.lowest {
             sp.lowestIdx = sp.today;
             sp.lowest = tmp;
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
         // Set the highest high
         tmp = sp.x_inHigh[(sp.today & sp.xMask) as usize];
@@ -573,21 +569,21 @@ impl Core {
                     sp.highest = tmp;
                 }
             }
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         } else if tmp >= sp.highest {
             sp.highestIdx = sp.today;
             sp.highest = tmp;
-            sp.diff = (sp.highest - sp.lowest) / 100.0;
         }
-        // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-        // machine-flat window leaves a sub-epsilon residue that an exact check
-        // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-        // range against ITS OWN two extremes, not against a fixed band: the range
-        // carries the quote unit, so a constant put against it answers "flat" for
-        // every window of an instrument quoted below it and zeroed the whole
-        // output (issue #253).
+        // Divide by the range itself and scale after: the guard has to test the
+        // very expression the division uses, or a scaling step can carry a
+        // guarded-non-zero into a zero divisor.
+        //
+        // The band is the range against ITS OWN two extremes, not a fixed
+        // constant: the range carries the quote unit, so a constant answers
+        // "flat" for every window of an instrument quoted below it (issue #253).
+        // It absorbs the machine-flat window an exact test would divide into
+        // [0,100] noise (issue #107 / STOCHRSI).
         if !(((sp.highest - sp.lowest).abs() <= 1e-14 * ((sp.highest).abs() + (sp.lowest).abs()))) {
-            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / sp.diff;
+            cur_tempBuffer = (sp.x_inClose[(sp.today & sp.xMask) as usize] - sp.lowest) / (sp.highest - sp.lowest) * 100.0;
         } else {
             cur_tempBuffer = 0.0;
         }
@@ -650,7 +646,6 @@ impl Core {
         let mut lowest: f64 = 0.0_f64;
         let mut highest: f64 = 0.0_f64;
         let mut tmp: f64 = 0.0_f64;
-        let mut diff: f64 = 0.0_f64;
         let mut tempBuffer: Vec<f64> = Vec::new();
         let mut outIdx: usize = 0_usize;
         let mut lowestIdx: i32 = 0_i32;
@@ -729,7 +724,6 @@ impl Core {
         lowestIdx = highestIdx;
         lowest = 0.0;
         highest = lowest;
-        diff = highest;
         // Allocate a temporary buffer large enough to
         // store the K.
         //
@@ -760,11 +754,9 @@ impl Core {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = (today) as i32;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = inHigh[today];
@@ -779,21 +771,21 @@ impl Core {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = (today) as i32;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                tempBuffer[outIdx] = (inClose[today] - lowest) / diff;
+                tempBuffer[outIdx] = (inClose[today] - lowest) / (highest - lowest) * 100.0;
                 outIdx += 1;
             } else {
                 tempBuffer[outIdx] = 0.0;
@@ -860,7 +852,6 @@ impl Core {
             optInFastD_MAType,
             lowest,
             highest,
-            diff,
             lowestIdx: (lowestIdx) as i32,
             highestIdx: (highestIdx) as i32,
             trailingIdx: (trailingIdx) as i32,
@@ -1073,7 +1064,6 @@ impl StochfStream {
             let mut cur_tempBuffer: f64 = 0.0_f64;
             let mut cur_outFastD: f64 = 0.0_f64;
             let mut tmp: f64 = 0.0_f64;
-            let mut diff = sp.diff;
             let mut highest = sp.highest;
             let mut highestIdx = sp.highestIdx;
             let mut i = sp.i;
@@ -1114,11 +1104,9 @@ impl StochfStream {
                         lowest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp <= lowest {
                 lowestIdx = today;
                 lowest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
             // Set the highest high
             tmp = (if ((today & sp.xMask) as usize) != pkSlot0 { sp.x_inHigh[(today & sp.xMask) as usize] } else { pkVal0 });
@@ -1133,21 +1121,21 @@ impl StochfStream {
                         highest = tmp;
                     }
                 }
-                diff = (highest - lowest) / 100.0;
             } else if tmp >= highest {
                 highestIdx = today;
                 highest = tmp;
-                diff = (highest - lowest) / 100.0;
             }
-            // Calculate stochastic. The guard is not an exact `diff != 0.0`: a
-            // machine-flat window leaves a sub-epsilon residue that an exact check
-            // would divide into [0,100] noise (issue #107 / STOCHRSI). It is the
-            // range against ITS OWN two extremes, not against a fixed band: the range
-            // carries the quote unit, so a constant put against it answers "flat" for
-            // every window of an instrument quoted below it and zeroed the whole
-            // output (issue #253).
+            // Divide by the range itself and scale after: the guard has to test the
+            // very expression the division uses, or a scaling step can carry a
+            // guarded-non-zero into a zero divisor.
+            //
+            // The band is the range against ITS OWN two extremes, not a fixed
+            // constant: the range carries the quote unit, so a constant answers
+            // "flat" for every window of an instrument quoted below it (issue #253).
+            // It absorbs the machine-flat window an exact test would divide into
+            // [0,100] noise (issue #107 / STOCHRSI).
             if !(((highest - lowest).abs() <= 1e-14 * ((highest).abs() + (lowest).abs()))) {
-                cur_tempBuffer = ((if ((today & sp.xMask) as usize) != pkSlot2 { sp.x_inClose[(today & sp.xMask) as usize] } else { pkVal2 }) - lowest) / diff;
+                cur_tempBuffer = ((if ((today & sp.xMask) as usize) != pkSlot2 { sp.x_inClose[(today & sp.xMask) as usize] } else { pkVal2 }) - lowest) / (highest - lowest) * 100.0;
             } else {
                 cur_tempBuffer = 0.0;
             }

--- a/website/src/functions/er.md
+++ b/website/src/functions/er.md
@@ -15,7 +15,7 @@ This is exactly the efficiency ratio [`KAMA`](/functions/kama.md) computes inter
 
 Two guards, both shared with `KAMA`: a ratio that floating point would nudge just above 1.0 on a straight-line advance is pinned to exactly 1.0, and a dead-flat window (0/0) also reports 1.0 — a flat market therefore reads as "perfectly efficient", which is `KAMA`'s own convention and what keeps the two reconstructible from each other.
 
-The clamp compares against the *signed* net move, so it only fires on advances: on sustained declines the output may exceed 1.0 by a few ULP. The range is "0..1, may exceed 1 by a few ULP on sustained declines", not a hard bound.
+The output is a hard 0..1 — the net move can never exceed the path travelled.
 
 TC2000 documents a signed ×100 variant (−100..+100); the absolute 0..1 form here is the author's, StockCharts', LEAN's, backtrader's and pandas-ta's.
 

--- a/website/src/functions/kama.md
+++ b/website/src/functions/kama.md
@@ -16,6 +16,7 @@ KAMA[t] = KAMA[t-1] + SC*(price[t] - KAMA[t-1])
 ## Notes
 
 - A period of 1 performs no smoothing: the output is a copy of the input, consistent with `MA(period=1)` for every MAType. (The natural KAMA math at period 1 would degenerate to a fixed-alpha EMA because the efficiency ratio is always 1, so the copy is made explicit.) Allowed since 0.6.5.
+- The output never leaves the range of the prices it has seen.
 
 ## Inputs
 


### PR DESCRIPTION
Closes #390.

Two functions, one defect shape: a guard that does not establish what the arithmetic below it needs.

## STOCH / STOCHF

`%K` guarded `highest-lowest` and divided by `diff = (highest-lowest)/100.0`. A denormal range underflows `diff` to exactly `0.0` while the band still answers "not flat", so the division runs on zero — `inf`/`NaN` returned under `TA_SUCCESS`, which then poisons every later bar through the `%K`/`%D` smoothing.

Rather than add a second guard, this divides by the range itself and scales after. That hoist is a 2002 speed optimization and **no other library has it** — Tulip, ta-rs, cinar/indicator, finta, technicalindicators and yata all compute `(c-l)/(h-l)*100`. Matching them removes the mismatch structurally, deletes `diff` from the body *and* from the streaming handle, and makes the endpoints exact: a close on the window high is `x/x`, so `%K` is exactly `100.0`.

Measured over a magnitude sweep including denormals: **0 non-finite outputs** for well-formed bars where the old form gives 24, and 270,563 close-at-high cases all returning exactly `100.0`.

## KAMA / ER

The efficiency ratio `|periodROC|/sumROC1` cannot exceed 1 — `periodROC` telescopes over exactly the changes `sumROC1` sums. But `sumROC1` is kept by add-then-subtract, so absorption leaves it below the window it stands for and the raw ratio runs unbounded: **measured 1.1e18**, driving the squared smoothing constant to 4.4e35 and KAMA's output 43 decades outside the hull of its own inputs. Clamping restores the bound, so the constant stays in `(0,1)` and the recurrence is a convex combination again.

This overturns `er.c`'s standing *"do NOT fix this with fabs"*. That ruling was about value stability and was made without the unbounded case in evidence.

## Cost against v0.6.4

v0.6.4 has **neither** defect; #253 opened both while making the bands scale-relative — which it was right about, only the quantity the STOCH band tests moved off the divisor, unremarked.

- **STOCH/STOCHF need no new tolerance.** Their existing `FUZZ_064_TOL` rows absorb the change with four orders to spare (max observed 2.27e-12 against 1e-9).
- **KAMA needs one skip**, gated on the absorption condition and computed from the inputs alone: `kama-skipped` 1089 → 1139 of 166,852 comparisons. Every case it drops had v0.6.4 emitting a ratio outside `[0,1]` on the EXTREME shape — in the worst one, a negative output from an all-positive input, from a function flagged `TA_FUNC_FLG_OVERLAP`.

## Verification

Full C suite · generator `cargo test` · `--xlang-hash` (52,000 cases, four backends bit-identical) · `--codegen` against the frozen oracle (6 passed / 0 failed in each backend) · `fuzz-064` · `regen-check` on a clean tree.

`LEGACY_TOL` re-measured — STOCH 8.53e-14, STOCHF 4.26e-14 — and both rows moved to cause (b), whose prose the change made false where they were.

Two legs pin the clamp, each sabotage-proven by deleting it and watching them redden: a **KAMA sign-mirror** (KAMA is exactly sign-symmetric but for the signed comparison the clamp neutralizes) and an **exact-`1.0` predicate** on ER's zero-denominator leg. The divisor sweep's self-test (#392) now reconstructs the defect rather than pointing at STOCH, and pins all three of its mechanisms.

## Performance

Shipped-build A/B (`libta-lib.a`, separate TUs, no LTO), Zen 4 laptop, one function per process, min of 12 alternating rounds:

| | ratio |
|---|---|
| STOCH | 0.990 |
| STOCHF | 0.958 |
| KAMA | 1.050 |
| RSI / SMA / EMA / ATR / WILLR (controls) | 1.005 / 0.995 / 1.000 / 1.000 / 1.006 |

Controls inside ±0.6%. STOCH and STOCHF get slightly faster; the per-bar clamp costs KAMA about 5%. `ta_bench --language=c` was tried first and rejected: it reported STOCH +7.4% and STOCHF −18.0% from the identical edit, with spreads of 30–51% — the single-TU LTO inlining instability the `ta-bench` skill documents.

## Not fixed here

**CCI**, **CORREL** and **WILLR** carry the same guard/divisor mismatch and are out of scope. Reproduced through the shipped API: CCI returns 39 of 67 outputs `inf` under `TA_SUCCESS` at denormal quote scale; CORREL returns `NaN`; WILLR divides residue into the full range on the machine-flat window where STOCHF now returns zeros, despite being documented as bounded in `[-100, 0]`. Follow-up issue to come.

https://claude.ai/code/session_01Mxrh2CPbhZnLvtzepLeCwt
